### PR TITLE
Print payload

### DIFF
--- a/x/emissions/module/api.go
+++ b/x/emissions/module/api.go
@@ -157,6 +157,7 @@ func generateInferences(functionId string, functionMethod string, param string, 
 }
 
 func makeApiCall(payload string) {
+	fmt.Println("Making Api Call, Payload: ", payload)
 	url := os.Getenv("BLOCKLESS_API_URL")
 	method := "POST"
 


### PR DESCRIPTION
On every api call, print the payload.