### PR TITLE
Fix overwriting topics on calls and demand

### DIFF
--- a/app/topics_handler.go
+++ b/app/topics_handler.go
@@ -36,7 +36,7 @@ func (th *TopicsHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 		for _, topic := range churnReadyTopics.Topics {
 			// Parallelize the inference and weight cadence checks
 			wg.Add(1)
-			go func(topic emissionstypes.Topic) {
+			go func(topic *emissionstypes.Topic) {
 				defer wg.Done()
 				// Check the cadence of inferences
 				if currentTime-topic.InferenceLastRan >= topic.InferenceCadence {
@@ -71,7 +71,7 @@ func (th *TopicsHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 
 					go generateWeights(weights, inferences, topic.WeightLogic, topic.WeightMethod, topic.Id)
 				}
-			}(*topic)
+			}(topic)
 		}
 		wg.Wait()
 		// Return the transactions as they came

--- a/x/emissions/module/demand.go
+++ b/x/emissions/module/demand.go
@@ -207,7 +207,6 @@ func ChurnRequestsGetActiveTopicsAndDemand(ctx sdk.Context, k keeper.Keeper, cur
 		fmt.Println("Error getting active topics: ", err)
 		return nil, cosmosMath.Uint{}, err
 	}
-
 	topicsActiveWithDemand := make([]state.Topic, 0)
 	topicBestPrices := make(map[TopicId]PriceAndReturn)
 	requestsToDrawDemandFrom := make(map[TopicId][]state.InferenceRequest, 0)
@@ -248,7 +247,6 @@ func ChurnRequestsGetActiveTopicsAndDemand(ctx sdk.Context, k keeper.Keeper, cur
 		fmt.Println("Error resetting churn ready topics: ", err)
 		return nil, cosmosMath.Uint{}, err
 	}
-
 	// Determine how many funds to draw from demand and Remove depleted/insufficiently funded requests
 	totalFundsToDrawFromDemand := cosmosMath.NewUint(0)
 	var topicsToSetChurn []*state.Topic
@@ -294,7 +292,8 @@ func ChurnRequestsGetActiveTopicsAndDemand(ctx sdk.Context, k keeper.Keeper, cur
 			numRequestsServed++
 		}
 		totalFundsToDrawFromDemand = totalFundsToDrawFromDemand.Add(bestPrice.Mul(cosmosMath.NewUint(uint64(numRequestsServed))))
-		topicsToSetChurn = append(topicsToSetChurn, &topic)
+		topicCopy := topic
+		topicsToSetChurn = append(topicsToSetChurn, &topicCopy)
 	}
 
 	// Set the topics as churn ready


### PR DESCRIPTION
* The go loop nature uses the same address on the iterator. So the value (instead of the ref) needs to be used, otherwise all go subroutines on iterations will use the same addr (that of the last element).
* Also happening on demand calcs.

This was causing that too many requests for a topic were made, and that other topics got none.
