### PR TITLE
changes default power reduction to 10^18

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,19 +2,22 @@ package app
 
 import (
 	_ "embed"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+
 	"github.com/allora-network/allora-chain/x/emissions"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
-	"io"
-	"os"
-	"path/filepath"
 
 	dbm "github.com/cosmos/cosmos-db"
 
 	"cosmossdk.io/core/appconfig"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
+	"cosmossdk.io/math"
 
 	storetypes "cosmossdk.io/store/types"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
@@ -24,6 +27,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -120,6 +125,7 @@ type AlloraApp struct {
 }
 
 func init() {
+	sdk.DefaultPowerReduction = math.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Issue with validator power reduction causing an over flow, with 10^18, we halted.

After researching, looks like it is an issue with the validator power reduction calculations, causing an overflow in CometBFT. 


Discussion
https://github.com/cosmos/cosmos-sdk/issues/8357


Sifchain, BNB Greenfield, Ethermint all 10^18

https://github.com/search?q=NewIntFromBigInt%28new%28big.Int%29.Exp%28big.NewInt%2810%29%2C+big.NewInt%2818%29%2C+nil%29%29&type=code