### PR TITLE
Added scores generation flow

### DIFF
--- a/x/emissions/module/rewards/reputer_rewards_test.go
+++ b/x/emissions/module/rewards/reputer_rewards_test.go
@@ -14,7 +14,7 @@ func (s *RewardsTestSuite) TestGetReputersRewards() {
 	block := int64(1003)
 
 	// Generate reputers data for tests
-	err := mockReputersData(s, topidId, block)
+	_, err := mockReputersData(s, topidId, block)
 	s.Require().NoError(err)
 
 	// Get reputer rewards
@@ -39,7 +39,7 @@ func (s *RewardsTestSuite) TestGetReputersRewards() {
 }
 
 // mockReputersData generates reputer scores, stakes and losses
-func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64) error {
+func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64) (types.ReputerValueBundles, error) {
 	reputerAddrs := []sdk.AccAddress{
 		s.addrs[0],
 		s.addrs[1],
@@ -59,9 +59,9 @@ func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64) error {
 
 	var reputerValueBundles types.ReputerValueBundles
 	for i, reputerAddr := range reputerAddrs {
-		err := s.emissionsKeeper.SetDelegatedStakeUponReputer(s.ctx, topicId, reputerAddr, stakes[i])
+		err := s.emissionsKeeper.AddStake(s.ctx, topicId, reputerAddr, stakes[i])
 		if err != nil {
-			return err
+			return types.ReputerValueBundles{}, err
 		}
 
 		scoreToAdd := types.Score{
@@ -72,7 +72,7 @@ func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64) error {
 		}
 		err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, block, scoreToAdd)
 		if err != nil {
-			return err
+			return types.ReputerValueBundles{}, err
 		}
 
 		reputerValueBundle := &types.ReputerValueBundle{
@@ -88,8 +88,8 @@ func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64) error {
 
 	err := s.emissionsKeeper.InsertValueBundles(s.ctx, topicId, block, reputerValueBundles)
 	if err != nil {
-		return err
+		return types.ReputerValueBundles{}, err
 	}
 
-	return nil
+	return reputerValueBundles, nil
 }

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -1,0 +1,133 @@
+package rewards
+
+import (
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func GenerateReputerScores(ctx sdk.Context, keeper keeper.Keeper, topicId uint64, block int64, reportedLosses types.ReputerValueBundles) ([]types.Score, error) {
+	// Get reputers informations
+	var reputerAddresses []sdk.AccAddress
+	var reputerStakes []float64
+	var reputerListeningCoefficients []float64
+	var losses [][]float64
+	for _, reportedLoss := range reportedLosses.ReputerValueBundles {
+		reputerAddr, err := sdk.AccAddressFromBech32(reportedLoss.Reputer)
+		if err != nil {
+			return []types.Score{}, err
+		}
+		reputerAddresses = append(reputerAddresses, reputerAddr)
+
+		// Get reputer topic stake
+		reputerStake, err := keeper.GetStakeOnTopicFromReputer(ctx, topicId, reputerAddr)
+		if err != nil {
+			return []types.Score{}, err
+		}
+		reputerStakes = append(reputerStakes, float64(reputerStake.BigInt().Int64()))
+
+		// Get reputer listening coefficient
+		res, err := keeper.GetListeningCoefficient(ctx, topicId, reputerAddr)
+		if err != nil {
+			return []types.Score{}, err
+		}
+		reputerListeningCoefficients = append(reputerListeningCoefficients, res.Coefficient)
+
+		// Get all reported losses from bundle
+		reputerLosses := ExtractValues(reportedLoss.ValueBundle)
+		losses = append(losses, reputerLosses)
+	}
+
+	// Get reputer output
+	scores, newCoefficients, err := GetAllReputersOutput(losses, reputerStakes, reputerListeningCoefficients, len(reputerStakes))
+	if err != nil {
+		return []types.Score{}, err
+	}
+
+	// Insert new coeffients and scores
+	var newScores []types.Score
+	for i, reputerAddr := range reputerAddresses {
+		err := keeper.SetListeningCoefficient(ctx, topicId, reputerAddr, types.ListeningCoefficient{Coefficient: newCoefficients[i]})
+		if err != nil {
+			return []types.Score{}, err
+		}
+
+		newScore := types.Score{
+			TopicId:     topicId,
+			BlockNumber: block,
+			Address:     reputerAddr.String(),
+			Score:       scores[i],
+		}
+		err = keeper.InsertReputerScore(ctx, topicId, block, newScore)
+		if err != nil {
+			return []types.Score{}, err
+		}
+		newScores = append(newScores, newScore)
+	}
+
+	return newScores, nil
+}
+
+func GenerateInferenceScores(ctx sdk.Context, keeper keeper.Keeper, topicId uint64, block int64, networkLosses types.ValueBundle) ([]types.Score, error) {
+	var newScores []types.Score
+	for _, oneOutLoss := range networkLosses.OneOutValues {
+		workerAddr, err := sdk.AccAddressFromBech32(oneOutLoss.Worker)
+		if err != nil {
+			return []types.Score{}, err
+		}
+
+		// Calculate new score
+		workerNewScore := GetWorkerScore(networkLosses.CombinedValue, oneOutLoss.Value)
+
+		newScore := types.Score{
+			TopicId:     topicId,
+			BlockNumber: block,
+			Address:     workerAddr.String(),
+			Score:       workerNewScore,
+		}
+		err = keeper.InsertWorkerInferenceScore(ctx, topicId, block, newScore)
+		if err != nil {
+			return []types.Score{}, err
+		}
+		newScores = append(newScores, newScore)
+	}
+	return newScores, nil
+}
+
+func GenerateForecastScores(ctx sdk.Context, keeper keeper.Keeper, topicId uint64, block int64, networkLosses types.ValueBundle) ([]types.Score, error) {
+	// Get worker scores for one out loss
+	var workersScoresOneOut []float64
+	for _, oneOutLoss := range networkLosses.OneOutValues {
+		workerScore := GetWorkerScore(networkLosses.CombinedValue, oneOutLoss.Value)
+		workersScoresOneOut = append(workersScoresOneOut, workerScore)
+	}
+
+	numForecasters := len(workersScoresOneOut)
+	fUniqueAgg := GetfUniqueAgg(float64(numForecasters))
+	var newScores []types.Score
+	for i, oneInNaiveLoss := range networkLosses.OneInNaiveValues {
+		workerAddr, err := sdk.AccAddressFromBech32(oneInNaiveLoss.Worker)
+		if err != nil {
+			return []types.Score{}, err
+		}
+
+		// Get worker score for one in loss
+		workerScoreOneIn := GetWorkerScore(networkLosses.NaiveValue, oneInNaiveLoss.Value)
+
+		// Calculate forecast score
+		workerFinalScore := GetFinalWorkerScoreForecastTask(workerScoreOneIn, workersScoresOneOut[i], fUniqueAgg)
+
+		newScore := types.Score{
+			TopicId:     topicId,
+			BlockNumber: block,
+			Address:     workerAddr.String(),
+			Score:       workerFinalScore,
+		}
+		err = keeper.InsertWorkerForecastScore(ctx, topicId, block, newScore)
+		if err != nil {
+			return []types.Score{}, err
+		}
+	}
+
+	return newScores, nil
+}

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -1,0 +1,70 @@
+package rewards_test
+
+import (
+	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
+)
+
+func (s *RewardsTestSuite) TestGetReputersScores() {
+	topidId := uint64(1)
+	block := int64(1003)
+
+	// Generate reputers data for tests
+	reportedLosses, err := mockReputersData(s, topidId, block)
+	s.Require().NoError(err)
+
+	// Generate new reputer scores
+	_, err = rewards.GenerateReputerScores(
+		s.ctx,
+		s.emissionsKeeper,
+		topidId,
+		block,
+		reportedLosses,
+	)
+	s.Require().NoError(err)
+
+	// TODO: Wait to merge the new losses types from kenny's PR before applying these tests (same for the other tests)
+	// expectedScores := []float64{456.49, 172.71, 211.93, 52.31, 124.10}
+	// for i, reputerScore := range scores {
+	// 	if math.Abs(reputerScore.Score-expectedScores[i]) > 1e-2 {
+	// 		s.Fail("Expected reward is not equal to the actual reward")
+	// 	}
+	// }
+}
+
+func (s *RewardsTestSuite) TestGetInferenceScores() {
+	topidId := uint64(1)
+	block := int64(1003)
+
+	// Generate workers data for tests
+	reportedLosses, err := mockNetworkLosses(s, topidId, block)
+	s.Require().NoError(err)
+
+	// Get inference scores
+	_, err = rewards.GenerateInferenceScores(
+		s.ctx,
+		s.emissionsKeeper,
+		topidId,
+		block,
+		reportedLosses,
+	)
+	s.Require().NoError(err)
+}
+
+func (s *RewardsTestSuite) TestGetForecastScores() {
+	topidId := uint64(1)
+	block := int64(1003)
+
+	// Generate workers data for tests
+	reportedLosses, err := mockNetworkLosses(s, topidId, block)
+	s.Require().NoError(err)
+
+	// Get inference scores
+	_, err = rewards.GenerateForecastScores(
+		s.ctx,
+		s.emissionsKeeper,
+		topidId,
+		block,
+		reportedLosses,
+	)
+	s.Require().NoError(err)
+}

--- a/x/emissions/module/rewards/worker_rewards_test.go
+++ b/x/emissions/module/rewards/worker_rewards_test.go
@@ -13,7 +13,7 @@ func (s *RewardsTestSuite) TestGetWorkersRewardsInferenceTask() {
 	s.Require().NoError(err)
 
 	// Generate last network loss
-	err = mockNetworkLosses(s, 1, 1003)
+	_, err = mockNetworkLosses(s, 1, 1003)
 	s.Require().NoError(err)
 
 	// Get worker rewards
@@ -35,7 +35,7 @@ func (s *RewardsTestSuite) TestGetWorkersRewardsForecastTask() {
 	s.Require().NoError(err)
 
 	// Generate last network loss
-	err = mockNetworkLosses(s, 1, 1003)
+	_, err = mockNetworkLosses(s, 1, 1003)
 	s.Require().NoError(err)
 
 	// Get worker rewards
@@ -51,7 +51,7 @@ func (s *RewardsTestSuite) TestGetWorkersRewardsForecastTask() {
 	s.Require().Equal(5, len(workerRewards))
 }
 
-func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) error {
+func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.ValueBundle, error) {
 	// Generate network losses
 	oneOutLosses := []*types.WorkerAttributedValue{
 		{
@@ -110,10 +110,10 @@ func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) error {
 	// Persist network losses
 	err := s.emissionsKeeper.InsertNetworkLossBundle(s.ctx, topicId, block, networkLosses)
 	if err != nil {
-		return err
+		return types.ValueBundle{}, err
 	}
 
-	return nil
+	return networkLosses, nil
 }
 
 func mockWorkerLastScores(s *RewardsTestSuite, topicId uint64) error {


### PR DESCRIPTION
These functions will be used right after a lead reputer insert all loss bundles and the network loss is generated. 