### PR TITLE
Fix ea 3-8 implementation and unit test

### DIFF
--- a/x/emissions/module/inference_synthesis/forecast_implied_inferences.go
+++ b/x/emissions/module/inference_synthesis/forecast_implied_inferences.go
@@ -70,7 +70,7 @@ func CalcForcastImpliedInferences(
 			w_ik := make(map[Worker]Weight, len(forecastElementsByInferer))
 
 			// Define variable to store maximum regret for forecast k
-			maxjRijk := float64(-1)
+			maxjRijk := float64(math.Inf(-1))
 			for j, el := range forecastElementsByInferer {
 				// Calculate the approximate forecast regret of the network inference
 				R_ik[j] = math.Log10(networkCombinedLoss / el.Value) // forecasted regrets R_ijk = log10(L_i / L_ijk)
@@ -81,7 +81,7 @@ func CalcForcastImpliedInferences(
 
 			// Calculate normalized forecasted regrets per forecaster R_ijk then weights w_ijk per forecaster
 			for j := range forecastElementsByInferer {
-				R_ik[j] = R_ik[j] / maxjRijk                         // \hatR_ijk = R_ijk / |max_{j'}(R_ijk)|
+				R_ik[j] = R_ik[j] / math.Abs(maxjRijk)               // \hatR_ijk = R_ijk / |max_{j'}(R_ijk)|
 				w_ijk, err := Gradient(pInferenceSynthesis, R_ik[j]) // w_ijk = φ'_p(\hatR_ijk)
 				if err != nil {
 					fmt.Println("Error calculating gradient: ", err)

--- a/x/emissions/module/inference_synthesis/forecast_implied_inferences_test.go
+++ b/x/emissions/module/inference_synthesis/forecast_implied_inferences_test.go
@@ -1,7 +1,6 @@
 package inference_synthesis_test
 
 import (
-	"log"
 	"math"
 
 	inference_synthesis "github.com/allora-network/allora-chain/x/emissions/module/inference_synthesis"
@@ -93,6 +92,32 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferences() {
 		expected            map[string]*emissions.Inference
 		expectedErr         error
 	}{
+
+		{ // Dummy Data
+			name: "simple example, two workers, one forecaster",
+			inferenceByWorker: map[string]*emissions.Inference{
+				"worker0": {Value: 1},
+				"worker1": {Value: 2},
+			},
+			forecasts: &emissions.Forecasts{
+				Forecasts: []*emissions.Forecast{
+					{
+						Forecaster: "forecaster0",
+						ForecastElements: []*emissions.ForecastElement{
+							{Inferer: "worker0", Value: 3},
+							{Inferer: "worker1", Value: 4},
+						},
+					},
+				},
+			},
+			networkCombinedLoss: 0.5,
+			epsilon:             1e-4,
+			pInferenceSynthesis: 2.0,
+			expected: map[string]*emissions.Inference{
+				"forecaster0": {Value: 1.4355951},
+			},
+			expectedErr: nil,
+		},
 		{ // ROW 1
 			name: "basic functionality, two workers, one forecaster",
 			inferenceByWorker: map[string]*emissions.Inference{
@@ -119,7 +144,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferences() {
 			expectedErr: nil,
 		},
 		{ // ROW 2
-			name: "basic functionality, two workers, two forecasters",
+			name: "basic functionality 2, two workers, two forecasters",
 			inferenceByWorker: map[string]*emissions.Inference{
 				"worker0": {Value: -0.2797477698393250},
 				"worker1": {Value: 0.26856211587161100},
@@ -164,7 +189,6 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferences() {
 				for key, expectedValue := range tc.expected {
 					actualValue, exists := result[key]
 					s.Require().True(exists, "Expected key does not exist in result map")
-					log.Printf("Expected value: %v, Actual value: %v, Epsilon: %v. Values should match within epsilon.", expectedValue.Value, actualValue.Value, 1e-5)
 					s.Require().InEpsilon(expectedValue.Value, actualValue.Value, 1e-5, "Values do not match for key: %s", key)
 				}
 			}

--- a/x/emissions/module/inference_synthesis/network_losses_test.go
+++ b/x/emissions/module/inference_synthesis/network_losses_test.go
@@ -35,7 +35,6 @@ func (s *InferenceSynthesisTestSuite) TestRunningWeightedAvgUpdate() {
 			expectedLoss:        inference_synthesis.WorkerRunningWeightedLoss{},
 			expectedErr:         emissions.ErrFractionDivideByZero,
 		},
-		// Add more test cases as needed
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
I found a couple of bugs in the implementation of `CalcForcastImpliedInferences`. Fix those bugs. Note that only the first test passes currently, the other two are pending a resolution of a dispute over what the correct output value should be for the equation. Diederik should be able to give final confirmation tomorrow morning.