### PR TITLE
Make reputer request be made if incomplete data

### DIFF
--- a/app/topics_handler.go
+++ b/app/topics_handler.go
@@ -132,19 +132,15 @@ func (th *TopicsHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 						reputerValueBundle, inferencesBlockHeight, err := synth.GetNetworkInferencesAtBlock(ctx, th.emissionsKeeper, topic.Id, nonceCopy.ReputerNonce.BlockHeight)
 						if err != nil {
 							fmt.Println("Error getting latest inferences at block: ", nonceCopy.ReputerNonce.BlockHeight, ", error: ", err)
-							continue
 						}
-						if reputerValueBundle == nil {
-							fmt.Println("Reputer value bundle is nil, skipping")
-							continue
-						}
+
 						blockDifference := currentBlockHeight - inferencesBlockHeight
 						previousBlockApproxTime, err := th.calculatePreviousBlockApproxTime(ctx, blockDifference)
 						if err != nil {
 							fmt.Println("Error calculating previous block approx time: ", err)
 							continue
 						}
-						fmt.Println("Requesting losses for topic: ", topic.Id, "reputer nonce: ", nonceCopy.ReputerNonce, "worker nonce: ", nonceCopy.ReputerNonce, "previous block approx time: ", previousBlockApproxTime)
+						fmt.Println("Requesting losses for topic: ", topic.Id, "reputer nonce: ", nonceCopy.ReputerNonce, "worker nonce: ", nonceCopy.WorkerNonce, "previous block approx time: ", previousBlockApproxTime)
 						go generateLosses(reputerValueBundle, topic.LossLogic, topic.LossMethod, topic.Id, *nonceCopy.ReputerNonce, *nonceCopy.WorkerNonce, previousBlockApproxTime)
 					}
 				} else {

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -318,14 +318,16 @@ func (k *Keeper) IsWorkerNonceUnfulfilled(ctx context.Context, topicId TopicId, 
 	}
 
 	if nonce == nil {
-		return false, errors.New("nil nonce provided")
+		return false, errors.New("nil worker nonce provided")
 	}
 	// Check if the nonce is present in the unfulfilled nonces
 	for _, n := range unfulfilledNonces.Nonces {
 		if n == nil {
-			return false, errors.New("nil nonce stored")
+			fmt.Println("warn: nil worker nonce stored")
+			continue
 		}
 		if n.BlockHeight == nonce.BlockHeight {
+			fmt.Println("Worker nonce found", nonce)
 			return true, nil
 		}
 	}
@@ -340,14 +342,20 @@ func (k *Keeper) IsReputerNonceUnfulfilled(ctx context.Context, topicId TopicId,
 	if err != nil {
 		return false, err
 	}
-
+	if nonce == nil {
+		return false, errors.New("nil reputer nonce provided")
+	}
 	// Check if the nonce is present in the unfulfilled nonces
 	for _, n := range unfulfilledNonces.Nonces {
+		if n == nil {
+			fmt.Println("warn: nil reputer nonce stored")
+			continue
+		}
 		if n.ReputerNonce.BlockHeight == nonce.BlockHeight {
+			fmt.Println("Reputer nonce found", nonce)
 			return true, nil
 		}
 	}
-
 	return false, nil
 }
 

--- a/x/emissions/keeper/msgserver/msg_server_losses.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses.go
@@ -3,6 +3,7 @@ package msgserver
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 
 	synth "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
@@ -39,7 +40,10 @@ func (ms msgServer) InsertBulkReputerPayload(
 	}
 	// Throw if worker nonce is unfulfilled -- can't report losses on something not yet committed
 	if workerNonceUnfulfilled {
+		fmt.Println("Reputer's worker nonce not yet fulfilled: ", msg.ReputerRequestNonce.WorkerNonce, " for reputer block: ", msg.ReputerRequestNonce.ReputerNonce)
 		return nil, types.ErrNonceStillUnfulfilled
+	} else {
+		fmt.Println("OK - Reputer's worker nonce already fulfilled: ", msg.ReputerRequestNonce.WorkerNonce, " for reputer block: ", msg.ReputerRequestNonce.ReputerNonce)
 	}
 
 	// Check if the reputer nonce is unfulfilled
@@ -49,6 +53,7 @@ func (ms msgServer) InsertBulkReputerPayload(
 	}
 	// Throw if already fulfilled -- can't return a response twice
 	if !reputerNonceUnfulfilled {
+		fmt.Println("Reputer nonce already fulfilled: ", msg.ReputerRequestNonce.ReputerNonce)
 		return nil, types.ErrNonceAlreadyFulfilled
 	}
 

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -95,8 +95,18 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 					return
 				}
 				// Add Reputer Nonces
-				previousNonce := emissionstypes.Nonce{BlockHeight: blockNumber}
-				err = am.keeper.AddReputerNonce(sdkCtx, topic.Id, &nextNonce, &previousNonce)
+				if blockNumber-topic.EpochLength > 0 {
+					ReputerReputerNonce := emissionstypes.Nonce{BlockHeight: blockNumber}
+					ReputerWorkerNonce := emissionstypes.Nonce{BlockHeight: blockNumber - topic.EpochLength}
+					err = am.keeper.AddReputerNonce(sdkCtx, topic.Id, &ReputerReputerNonce, &ReputerWorkerNonce)
+					if err != nil {
+						fmt.Println("Error adding reputer nonce: ", err)
+						return
+					}
+				} else {
+					fmt.Println("Not adding reputer nonce, too early in topic history", blockNumber, topic.EpochLength)
+				}
+
 			}
 		}(topic)
 	}


### PR DESCRIPTION
* CalcNetworkInferences to still return incomplete set if any of the calculations for ValueBundle components have an error, providing empty arrays instead (affects OneIn/Out mostly)
* Chain to make a request to reputers with incomplete ValueBundles if that's the case 
* Ensure requests to workers and reputer are made correctly 
     * workers block height `t`, reputers blocks `(t - EpochLength, t - 2*EpochLength)`, checking against subzero heights.
* Added two CalcNetworkInferences tests.
     * Incomplete data to still return data. 
          * **Here's a catch**: currently if no regrets are set, the `CalcOneInForecasterValues` fails bc regrets are no higher 
 than epsilon, thus having to use empty array. Is that the correct behaviour, or do we want to change the behaviour inside `CalcOneInForecasterValues` ?
     * Same inferer and forecaster test (prev test was done with different addreses, but may be the same) 
* Added logging - some of it may be eventually removed.