### PR TITLE
Diego/fix cli breaking active topics

### DIFF
--- a/x/emissions/keeper/queryserver/query_server_topics.go
+++ b/x/emissions/keeper/queryserver/query_server_topics.go
@@ -44,7 +44,7 @@ func (qs queryServer) GetActiveTopics(ctx context.Context, req *types.QueryActiv
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	topics := make([]*types.Topic, len(activeTopics))
+	topics := make([]*types.Topic, 0)
 	for _, topicId := range activeTopics {
 		topic, err := qs.k.GetTopic(ctx, topicId)
 		if err != nil {


### PR DESCRIPTION
Fix breaking cli when calling active-topics.

```
$ allorad query emissions active-topics '{"limit":"5"}'
Error: rpc error: code = Unknown desc = runtime error: invalid memory address or nil pointer dereference: panic
rpc error: code = Unknown desc = runtime error: invalid memory address or nil pointer dereference: panic

```

Creating the array with an estimated number based on topics to be inserted introduced an extra `nil` element which made the response break.