### PR TITLE
[ORA-1292] Additional keeper tests

### DIFF
--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
 	"github.com/allora-network/allora-chain/app/params"
 
 	cosmosMath "cosmossdk.io/math"
@@ -1645,7 +1646,7 @@ func (k *Keeper) AddChurnReadyTopic(ctx context.Context, topicId TopicId) error 
 	return k.churnReadyTopics.Set(ctx, topicId)
 }
 
-// returns a single churn ready topic for processing.
+// returns a single churn ready topic for processing. Order out is not guaranteed.
 // if there are no churn ready topics, returns the reserved topic id 0,
 // which cannot be used as a topic id - callers are responsible for checking
 // that the returned topic id is not 0.

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -2029,27 +2029,26 @@ func (k *Keeper) SendCoinsFromAccountToModule(ctx context.Context, senderAddr sd
 // Convert pagination.key from []bytes to uint64, if pagination is nil or [], len = 0
 // Get the limit from the pagination request, within acceptable bounds and defaulting as necessary
 func (k Keeper) CalcAppropriatePaginationForUint64Cursor(ctx context.Context, pagination *types.SimpleCursorPaginationRequest) (uint64, uint64, error) {
-	cursor := uint64(0)
 	defaultLimit, err := k.GetParamsDefaultLimit(ctx)
-	limit := pagination.Limit
 	if err != nil {
 		return uint64(0), uint64(0), err
 	}
+	limit := defaultLimit
+	cursor := uint64(0)
+
 	if pagination != nil {
 		if len(pagination.Key) > 0 {
 			cursor = binary.BigEndian.Uint64(pagination.Key)
 		}
-		if limit == 0 {
-			return defaultLimit, cursor, nil
-		} else {
-			maxLimit, err := k.GetParamsMaxLimit(ctx)
-			if err != nil {
-				return uint64(0), uint64(0), err
-			}
-			if limit > maxLimit {
-				limit = maxLimit
-			}
-			return limit, cursor, nil
+		if pagination.Limit > 0 {
+			limit = pagination.Limit
+		}
+		maxLimit, err := k.GetParamsMaxLimit(ctx)
+		if err != nil {
+			return uint64(0), uint64(0), err
+		}
+		if limit > maxLimit {
+			limit = maxLimit
 		}
 	}
 

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -1866,6 +1866,32 @@ func (s *KeeperTestSuite) TestInsertReputer() {
 	s.Require().True(isRegistered, "Reputer should be registered in each topic")
 }
 
+func (s *KeeperTestSuite) TestGetReputerByLibp2pKey() {
+	ctx := s.ctx // Use the context from the test suite
+	reputer := sdk.AccAddress("sampleReputerAddress")
+	topicId := uint64(501)
+	keeper := s.emissionsKeeper
+	reputerKey := "someLibP2PKey123"
+	reputerInfo := types.OffchainNode{
+		LibP2PKey:    reputerKey,
+		MultiAddress: "/ip4/127.0.0.1/tcp/4001",
+		Owner:        "cosmos1...",
+		NodeAddress:  "cosmosNodeAddress",
+		NodeId:       "nodeId123",
+	}
+
+	err := keeper.InsertReputer(ctx, topicId, reputer, reputerInfo)
+	s.Require().NoError(err)
+
+	actualReputer, err := keeper.GetReputerByLibp2pKey(ctx, reputerKey)
+	s.Require().NoError(err)
+	s.Require().Equal(reputerInfo, actualReputer)
+
+	nonExistentKey := "nonExistentKey123"
+	_, err = keeper.GetReputerByLibp2pKey(ctx, nonExistentKey)
+	s.Require().Error(err)
+}
+
 func (s *KeeperTestSuite) TestRemoveReputer() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
@@ -2179,6 +2205,8 @@ func (s *KeeperTestSuite) TestAddTopicFeeRevenueAndIncrementEpoch() {
 	s.Require().Equal(feeRev.Epoch, updatedFeeRev.Epoch, "Epoch should not be updated")
 	s.Require().Equal("300", updatedFeeRev.Revenue.String(), "Revenue in new epoch should match the additional amount")
 }
+
+/// TOPIC CHURN
 
 func (s *KeeperTestSuite) TestPopChurnReadyTopic() {
 	ctx := s.ctx

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -2183,14 +2183,22 @@ func (s *KeeperTestSuite) TestAddTopicFeeRevenueAndIncrementEpoch() {
 func (s *KeeperTestSuite) TestPopChurnReadyTopic() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
-	topicId := uint64(456)
+	topicId := uint64(123)
+	topicId2 := uint64(456)
 
 	err := keeper.AddChurnReadyTopic(ctx, topicId)
 	s.Require().NoError(err)
 
+	err = keeper.AddChurnReadyTopic(ctx, topicId2)
+	s.Require().NoError(err)
+
+	poppedId2, err := keeper.PopChurnReadyTopic(ctx)
+	s.Require().NoError(err)
+	s.Require().Equal(topicId, poppedId2)
+
 	poppedId, err := keeper.PopChurnReadyTopic(ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(topicId, poppedId)
+	s.Require().Equal(topicId2, poppedId)
 
 	// Ensure no topics remain
 	remainingId, err := keeper.PopChurnReadyTopic(ctx)

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -741,7 +741,7 @@ func (s *KeeperTestSuite) TestGetParamsEpsilon() {
 	// Set the parameter
 	params := types.Params{Epsilon: expectedValue}
 	err := keeper.SetParams(ctx, params)
-	s.Require().NoError(err) // Ensure no error occurred when setting params
+	s.Require().NoError(err)
 
 	// Get the parameter
 	actualValue, err := keeper.GetParamsEpsilon(ctx)
@@ -919,7 +919,6 @@ func (s *KeeperTestSuite) TestGetWorkerLatestInferenceByTopicId() {
 	err = keeper.InsertInferences(ctx, topicId, nonce2, inferences2)
 	s.Require().NoError(err, "Inserting inferences should not fail")
 
-	// Test successful retrieval of the inserted inference
 	retrievedInference, err := keeper.GetWorkerLatestInferenceByTopicId(ctx, topicId, workerAcc)
 	s.Require().NoError(err, "Retrieving an existing inference should not fail")
 	s.Require().Equal(newInference2, retrievedInference, "Retrieved inference should match the inserted one")
@@ -1907,7 +1906,7 @@ func (s *KeeperTestSuite) TestInsertReputer() {
 }
 
 func (s *KeeperTestSuite) TestGetReputerByLibp2pKey() {
-	ctx := s.ctx // Use the context from the test suite
+	ctx := s.ctx
 	reputer := sdk.AccAddress("sampleReputerAddress")
 	topicId := uint64(501)
 	keeper := s.emissionsKeeper
@@ -2822,14 +2821,12 @@ func (s *KeeperTestSuite) TestGetSetDeleteTopicRewardNonce() {
 /// UTILS
 
 func (s *KeeperTestSuite) TestCalcAppropriatePaginationForUint64Cursor() {
-	ctx := s.ctx                // Use the context from the test suite
-	keeper := s.emissionsKeeper // Use the keeper from the test suite
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
 
-	// Setup mock parameters
 	defaultLimit := uint64(20)
 	maxLimit := uint64(50)
 
-	// Simulate parameter setting for default and max limits
 	params := types.Params{
 		DefaultLimit: defaultLimit,
 		MaxLimit:     maxLimit,

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -2144,6 +2144,26 @@ func (s *KeeperTestSuite) TestTopicExists() {
 	s.Require().True(exists, "Topic should exist for a newly created topic ID")
 }
 
+func (s *KeeperTestSuite) TestGetTopic() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+
+	topicId := uint64(1)
+	metadata := "metadata"
+	_, err := keeper.GetTopic(ctx, topicId)
+	s.Require().Error(err, "Retrieving a non-existent topic should result in an error")
+
+	newTopic := types.Topic{Id: topicId, Metadata: metadata}
+
+	err = keeper.SetTopic(ctx, topicId, newTopic)
+	s.Require().NoError(err, "Setting a new topic should not fail")
+
+	retrievedTopic, err := keeper.GetTopic(ctx, topicId)
+	s.Require().NoError(err, "Retrieving an existent topic should not fail")
+	s.Require().Equal(newTopic, retrievedTopic, "Retrieved topic should match the set topic")
+	s.Require().Equal(newTopic.Metadata, retrievedTopic.Metadata, "Retrieved topic should match the set topic")
+}
+
 /// FEE REVENUE
 
 func (s *KeeperTestSuite) TestGetTopicFeeRevenue() {

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -740,6 +740,54 @@ func (s *KeeperTestSuite) TestGetParamsMinEpochLength() {
 	s.Require().Equal(expectedValue, actualValue)
 }
 
+func (s *KeeperTestSuite) TestGetParamsEpsilon() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+	expectedValue := alloraMath.MustNewDecFromString("0.1")
+
+	// Set the parameter
+	params := types.Params{Epsilon: expectedValue}
+	err := keeper.SetParams(ctx, params)
+	s.Require().NoError(err) // Ensure no error occurred when setting params
+
+	// Get the parameter
+	actualValue, err := keeper.GetParamsEpsilon(ctx)
+	s.Require().NoError(err)
+	s.Require().True(expectedValue.Equal(actualValue))
+}
+
+func (s *KeeperTestSuite) TestGetParamsTopicCreationFee() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+	expectedValue := cosmosMath.NewInt(1000)
+
+	// Set the parameter
+	params := types.Params{CreateTopicFee: expectedValue}
+	err := keeper.SetParams(ctx, params)
+	s.Require().NoError(err)
+
+	// Get the parameter
+	actualValue, err := keeper.GetParamsTopicCreationFee(ctx)
+	s.Require().NoError(err)
+	s.Require().True(expectedValue.Equal(actualValue))
+}
+
+func (s *KeeperTestSuite) TestGetParamsRegistrationFee() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+	expectedValue := cosmosMath.NewInt(500)
+
+	// Set the parameter
+	params := types.Params{RegistrationFee: expectedValue}
+	err := keeper.SetParams(ctx, params)
+	s.Require().NoError(err)
+
+	// Get the parameter
+	actualValue, err := keeper.GetParamsRegistrationFee(ctx)
+	s.Require().NoError(err)
+	s.Require().True(expectedValue.Equal(actualValue))
+}
+
 func (s *KeeperTestSuite) TestGetParamsMaxSamplesToScaleScores() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -74,9 +74,7 @@ func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }
 
-//////////////////////////////////////////////////////////////
-//                 WORKER NONCE TESTS                       //
-//////////////////////////////////////////////////////////////
+/// WORKER NONCE TESTS
 
 func (s *KeeperTestSuite) TestAddWorkerNonce() {
 	ctx := s.ctx
@@ -244,9 +242,7 @@ func (s *KeeperTestSuite) TestWorkerNonceLimitEnforcement() {
 	}
 }
 
-//////////////////////////////////////////////////////////////
-//                 REPUTER NONCE TESTS                      //
-//////////////////////////////////////////////////////////////
+/// REPUTER NONCE TESTS
 
 func (s *KeeperTestSuite) TestAddReputerNonce() {
 	ctx := s.ctx
@@ -398,9 +394,7 @@ func (s *KeeperTestSuite) TestReputerNonceLimitEnforcement() {
 	}
 }
 
-//////////////////////////////////////////////////////////////
-//                     REGRET TESTS                         //
-//////////////////////////////////////////////////////////////
+/// REGRET TESTS
 
 func (s *KeeperTestSuite) TestSetAndGetInfererNetworkRegret() {
 	ctx := s.ctx
@@ -640,9 +634,7 @@ func (s *KeeperTestSuite) TestDifferentTopicIdsYieldDifferentOneInForecasterNetw
 	s.Require().NotEqual(gotRegret1, gotRegret2, "Regrets from different topics should not be equal")
 }
 
-//////////////////////////////////////////////////////////////
-//                     PARAMS TESTS                         //
-//////////////////////////////////////////////////////////////
+/// PARAMS TESTS
 
 func (s *KeeperTestSuite) TestSetGetMaxTopicsPerBlock() {
 	ctx := s.ctx
@@ -852,9 +844,7 @@ func (s *KeeperTestSuite) TestGetParamsMaxRetriesToFulfilNoncesReputer() {
 	s.Require().Equal(expectedValue, actualValue, "The retrieved MaxRetriesToFulfilNoncesReputer should match the expected value")
 }
 
-//////////////////////////////////////////////////////////////
-//                 INFERENCES, FORECASTS                    //
-//////////////////////////////////////////////////////////////
+/// INFERENCES, FORECASTS
 
 func (s *KeeperTestSuite) TestGetInferencesAtBlock() {
 	ctx := s.ctx

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -2180,6 +2180,24 @@ func (s *KeeperTestSuite) TestAddTopicFeeRevenueAndIncrementEpoch() {
 	s.Require().Equal("300", updatedFeeRev.Revenue.String(), "Revenue in new epoch should match the additional amount")
 }
 
+func (s *KeeperTestSuite) TestPopChurnReadyTopic() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+	topicId := uint64(456)
+
+	err := keeper.AddChurnReadyTopic(ctx, topicId)
+	s.Require().NoError(err)
+
+	poppedId, err := keeper.PopChurnReadyTopic(ctx)
+	s.Require().NoError(err)
+	s.Require().Equal(topicId, poppedId)
+
+	// Ensure no topics remain
+	remainingId, err := keeper.PopChurnReadyTopic(ctx)
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(0), remainingId)
+}
+
 /// SCORES
 
 func (s *KeeperTestSuite) TestGetLatestScores() {


### PR DESCRIPTION
- GetParamsEpsilon
- GetParamsTopicCreationFee
- GetParamsRegistrationFee
- GetWorkerLatestInferenceByTopicId
- GetReputerByLibp2pKey
- GetTopic
- PopChurnReadyTopic
- AddChurnReadyTopic
- CalcAppropriatePaginationForUint64Cursor