### PR TITLE
[ORA-1313] Fix Staking Supply Bonded Tokens Bug, Add tests for relationship between inflation rate and higher rate of staking

### DIFF
--- a/x/mint/keeper/emissions.go
+++ b/x/mint/keeper/emissions.go
@@ -51,7 +51,7 @@ func GetLockedTokenSupply(
 // includes both tokens staked by cosmos validators (cosmos staking)
 // and tokens staked by reputers (allora staking)
 func GetNumStakedTokens(ctx context.Context, k Keeper) (math.Int, error) {
-	cosmosValidatorsStaked, err := k.StakingTokenSupply(ctx)
+	cosmosValidatorsStaked, err := k.CosmosValidatorStakedSupply(ctx)
 	if err != nil {
 		return math.Int{}, err
 	}

--- a/x/mint/keeper/emissions_test.go
+++ b/x/mint/keeper/emissions_test.go
@@ -28,7 +28,7 @@ func (s *IntegrationTestSuite) TestTotalEmissionPerTimestepSimple() {
 // we will test that in integration, for now just test the value is non
 // negative aka zero when you don't have stakers
 func (s *IntegrationTestSuite) TestGetNumStakedTokensNonNegative() {
-	s.stakingKeeper.EXPECT().StakingTokenSupply(s.ctx).Return(math.NewInt(0), nil)
+	s.stakingKeeper.EXPECT().TotalBondedTokens(s.ctx).Return(math.NewInt(0), nil)
 	s.emissionsKeeper.EXPECT().GetTotalStake(s.ctx).Return(math.NewUint(0), nil)
 	nst, err := keeper.GetNumStakedTokens(s.ctx, s.mintKeeper)
 	s.NoError(err)

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -104,8 +104,8 @@ func (k Keeper) AddEcosystemTokensMinted(ctx context.Context, minted math.Int) e
 
 // StakingTokenSupply implements an alias call to the underlying staking keeper's
 // StakingTokenSupply to be used in BeginBlocker.
-func (k Keeper) StakingTokenSupply(ctx context.Context) (math.Int, error) {
-	return k.stakingKeeper.StakingTokenSupply(ctx)
+func (k Keeper) CosmosValidatorStakedSupply(ctx context.Context) (math.Int, error) {
+	return k.stakingKeeper.TotalBondedTokens(ctx)
 }
 
 /// BANK KEEPER RELATED FUNCTIONS

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -79,8 +79,8 @@ func (s *IntegrationTestSuite) SetupTest() {
 
 func (s *IntegrationTestSuite) TestAliasFunctions() {
 	stakingTokenSupply := math.NewIntFromUint64(100000000000)
-	s.stakingKeeper.EXPECT().StakingTokenSupply(s.ctx).Return(stakingTokenSupply, nil)
-	tokenSupply, err := s.mintKeeper.StakingTokenSupply(s.ctx)
+	s.stakingKeeper.EXPECT().TotalBondedTokens(s.ctx).Return(stakingTokenSupply, nil)
+	tokenSupply, err := s.mintKeeper.CosmosValidatorStakedSupply(s.ctx)
 	s.Require().NoError(err)
 	s.Require().Equal(tokenSupply, stakingTokenSupply)
 

--- a/x/mint/module/abci.go
+++ b/x/mint/module/abci.go
@@ -33,6 +33,10 @@ func GetEmissionPerTimestep(
 	if circulatingSupply.IsNegative() {
 		circulatingSupply = math.ZeroInt()
 	}
+	// T_{total,i} = ecosystemMintableRemaining
+	// N_{staked,i} = networkStaked
+	// N_{circ,i} = circulatingSupply
+	// N_{total,i} = totalSupply
 	targetRewardEmissionPerUnitStakedToken,
 		err := keeper.GetTargetRewardEmissionPerUnitStakedToken(
 		params.FEmission,

--- a/x/mint/testutil/expected_keepers_mocks.go
+++ b/x/mint/testutil/expected_keepers_mocks.go
@@ -52,36 +52,20 @@ func (mr *MockStakingKeeperMockRecorder) BondedRatio(ctx interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BondedRatio", reflect.TypeOf((*MockStakingKeeper)(nil).BondedRatio), ctx)
 }
 
-// StakingTokenSupply mocks base method.
-func (m *MockStakingKeeper) StakingTokenSupply(ctx context.Context) (math.Int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StakingTokenSupply", ctx)
-	ret0, _ := ret[0].(math.Int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StakingTokenSupply indicates an expected call of StakingTokenSupply.
-func (mr *MockStakingKeeperMockRecorder) StakingTokenSupply(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StakingTokenSupply", reflect.TypeOf((*MockStakingKeeper)(nil).StakingTokenSupply), ctx)
-}
-
-// StakingTokenSupply mocks base method.
+// TotalBondedTokens mocks base method.
 func (m *MockStakingKeeper) TotalBondedTokens(ctx context.Context) (math.Int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StakingTokenSupply", ctx)
+	ret := m.ctrl.Call(m, "TotalBondedTokens", ctx)
 	ret0, _ := ret[0].(math.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// StakingTokenSupply indicates an expected call of StakingTokenSupply.
+// TotalBondedTokens indicates an expected call of StakingTokenSupply.
 func (mr *MockStakingKeeperMockRecorder) TotalBondedTokens(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StakingTokenSupply", reflect.TypeOf((*MockStakingKeeper)(nil).StakingTokenSupply), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalBondedTokens", reflect.TypeOf((*MockStakingKeeper)(nil).StakingTokenSupply), ctx)
 }
-
 
 // MockAccountKeeper is a mock of AccountKeeper interface.
 type MockAccountKeeper struct {

--- a/x/mint/testutil/expected_keepers_mocks.go
+++ b/x/mint/testutil/expected_keepers_mocks.go
@@ -64,7 +64,7 @@ func (m *MockStakingKeeper) TotalBondedTokens(ctx context.Context) (math.Int, er
 // TotalBondedTokens indicates an expected call of StakingTokenSupply.
 func (mr *MockStakingKeeperMockRecorder) TotalBondedTokens(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalBondedTokens", reflect.TypeOf((*MockStakingKeeper)(nil).StakingTokenSupply), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalBondedTokens", reflect.TypeOf((*MockStakingKeeper)(nil).TotalBondedTokens), ctx)
 }
 
 // MockAccountKeeper is a mock of AccountKeeper interface.

--- a/x/mint/testutil/expected_keepers_mocks.go
+++ b/x/mint/testutil/expected_keepers_mocks.go
@@ -67,6 +67,22 @@ func (mr *MockStakingKeeperMockRecorder) StakingTokenSupply(ctx interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StakingTokenSupply", reflect.TypeOf((*MockStakingKeeper)(nil).StakingTokenSupply), ctx)
 }
 
+// StakingTokenSupply mocks base method.
+func (m *MockStakingKeeper) TotalBondedTokens(ctx context.Context) (math.Int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StakingTokenSupply", ctx)
+	ret0, _ := ret[0].(math.Int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StakingTokenSupply indicates an expected call of StakingTokenSupply.
+func (mr *MockStakingKeeperMockRecorder) TotalBondedTokens(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StakingTokenSupply", reflect.TypeOf((*MockStakingKeeper)(nil).StakingTokenSupply), ctx)
+}
+
+
 // MockAccountKeeper is a mock of AccountKeeper interface.
 type MockAccountKeeper struct {
 	ctrl     *gomock.Controller

--- a/x/mint/types/expected_keepers.go
+++ b/x/mint/types/expected_keepers.go
@@ -2,6 +2,7 @@ package types // noalias
 
 import (
 	context "context"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 
 	"cosmossdk.io/core/address"
@@ -12,7 +13,7 @@ import (
 
 // StakingKeeper defines the expected staking keeper
 type StakingKeeper interface {
-	StakingTokenSupply(ctx context.Context) (math.Int, error)
+	TotalBondedTokens(ctx context.Context) (math.Int, error)
 }
 
 // AccountKeeper defines the contract required for account APIs.


### PR DESCRIPTION
* Fixes bug where we were calling `StakingTokenSupply` instead of `TotalBondedTokens` thinking that the former was the supply of tokens staked when in reality it's just the total supply of uAllo and we need to get TotalBondedTokens to get the number of staked tokens
* Adds a test to show that the target emission per unit stake goes down when the number of tokens staked goes up, but that the total inflation rate continues to go up because the total amount of tokens staked went up.