### PR TITLE
Silence warnings: go vet and staticcheck ./...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,7 @@ init:
 build:
 	mkdir -p $(BUILDDIR)/
 	GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/ github.com/allora-network/allora-chain/cmd/allorad
+
+lint:
+	go vet ./...
+	staticcheck ./...

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -2,10 +2,11 @@ package keeper
 
 import (
 	"context"
-	errorsmod "cosmossdk.io/errors"
 	"encoding/binary"
 	"errors"
 	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 
 	"github.com/allora-network/allora-chain/app/params"
 
@@ -689,14 +690,13 @@ func (k *Keeper) GetInferencesAtOrAfterBlock(ctx context.Context, topicId TopicI
 	defer iter.Close() // Ensure that resources are released
 
 	// Iterate through entries in descending order and collect all inferences after the specified block
-	for ; iter.Valid(); iter.Next() {
+	if iter.Valid() {
 		kv, err := iter.KeyValue()
 		if err != nil {
 			return nil, 0, err
 		}
 		currentBlockHeight = kv.Key.K2() // Current entry's block height
 		inferencesToReturn.Inferences = kv.Value.Inferences
-		break
 	}
 
 	// Return the collected inferences and the lowest block height at which they were found
@@ -717,14 +717,13 @@ func (k *Keeper) GetForecastsAtOrAfterBlock(ctx context.Context, topicId TopicId
 	}
 	defer iter.Close() // Ensure that resources are released
 
-	for ; iter.Valid(); iter.Next() {
+	if iter.Valid() {
 		kv, err := iter.KeyValue()
 		if err != nil {
 			return nil, 0, err
 		}
 		currentBlockHeight = kv.Key.K2() // Current entry's block height
 		forecastsToReturn.Forecasts = kv.Value.Forecasts
-		break
 	}
 
 	return &forecastsToReturn, currentBlockHeight, nil
@@ -983,6 +982,9 @@ func (k *Keeper) AddDelegateStake(ctx context.Context, topicId TopicId, delegato
 				delegator,
 				sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, pendingReward.SdkIntTrim())),
 			)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1143,6 +1145,9 @@ func (k *Keeper) RemoveDelegateStake(
 		return err
 	}
 	unStakeDec, err := alloraMath.NewDecFromSdkUint(unStake)
+	if err != nil {
+		return err
+	}
 	if stakePlacement.Amount.Lt(unStakeDec) {
 		return types.ErrIntegerUnderflowDelegateStakePlacement
 	}
@@ -1163,6 +1168,9 @@ func (k *Keeper) RemoveDelegateStake(
 			delegator,
 			sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, pendingReward.SdkIntTrim())),
 		)
+		if err != nil {
+			return err
+		}
 	}
 
 	newAmount, err := stakePlacement.Amount.Sub(unStakeDec)

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -2853,7 +2853,7 @@ func (s *KeeperTestSuite) TestCalcAppropriatePaginationForUint64Cursor() {
 
 	// Test 4: Limit exceeds maximum limit
 	pagination = &types.SimpleCursorPaginationRequest{Key: validKey, Limit: 60}
-	limit, cursor, err = keeper.CalcAppropriatePaginationForUint64Cursor(ctx, pagination)
+	limit, _, err = keeper.CalcAppropriatePaginationForUint64Cursor(ctx, pagination)
 	s.Require().NoError(err, "Handling limit exceeding maximum should not fail")
 	s.Require().Equal(maxLimit, limit, "Limit should be capped at the maximum limit")
 }
@@ -2893,6 +2893,7 @@ func (s *KeeperTestSuite) TestPruneRecordsAfterRewards() {
 		},
 	}
 	err = s.emissionsKeeper.InsertForecasts(s.ctx, topicId, nonce, expectedForecasts)
+	s.Require().NoError(err)
 
 	reputerLossBundles := types.ReputerValueBundles{}
 	err = s.emissionsKeeper.InsertReputerLossBundlesAtBlock(s.ctx, topicId, block, reputerLossBundles)

--- a/x/emissions/keeper/msgserver/msg_server_losses_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses_test.go
@@ -36,6 +36,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayload() {
 	}
 
 	_, err = msgServer.AddStake(ctx, addStakeMsg)
+	s.Require().NoError(err)
 
 	reputerNonce := &types.Nonce{
 		BlockHeight: 2,

--- a/x/emissions/keeper/msgserver/msg_server_registrations_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations_test.go
@@ -42,12 +42,14 @@ func (s *KeeperTestSuite) TestMsgRegisterReputer() {
 	require.NoError(err, "SendCoinsFromModuleToAccount should not return an error")
 
 	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topicId, reputerAddr)
+	require.NoError(err)
 	require.False(isReputerRegistered, "Reputer should not be registered in topic")
 
 	_, err = msgServer.Register(ctx, registerMsg)
 	require.NoError(err, "Registering reputer should not return an error")
 
 	isReputerRegistered, err = s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topicId, reputerAddr)
+	require.NoError(err)
 	require.True(isReputerRegistered, "Reputer should be registered in topic")
 }
 
@@ -88,6 +90,7 @@ func (s *KeeperTestSuite) TestMsgRemoveRegistration() {
 	require.NoError(err, "Registering reputer should not return an error")
 
 	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topicId, reputerAddr)
+	require.NoError(err)
 	require.True(isReputerRegistered, "Reputer should be registered in topic")
 
 	unregisterMsg := &types.MsgRemoveRegistration{
@@ -100,6 +103,7 @@ func (s *KeeperTestSuite) TestMsgRemoveRegistration() {
 	require.NoError(err, "Registering reputer should not return an error")
 
 	isReputerRegistered, err = s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topicId, reputerAddr)
+	require.NoError(err)
 	require.False(isReputerRegistered, "Reputer should be registered in topic")
 }
 

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -464,7 +464,7 @@ func (s *KeeperTestSuite) TestStartRemoveDelegateStake() {
 		Amount:  stakeAmount,
 	}
 
-	removalInfo, err := keeper.GetDelegateStakeRemovalByTopicAndAddress(ctx, topicId, reputerAddr, delegatorAddr)
+	_, err = keeper.GetDelegateStakeRemovalByTopicAndAddress(ctx, topicId, reputerAddr, delegatorAddr)
 	require.Error(err)
 
 	// Perform the stake removal initiation
@@ -473,7 +473,7 @@ func (s *KeeperTestSuite) TestStartRemoveDelegateStake() {
 	require.NotNil(response2, "Response should not be nil after successful stake removal initiation")
 
 	// Verification: Check if the removal has been queued
-	removalInfo, err = keeper.GetDelegateStakeRemovalByTopicAndAddress(ctx, topicId, reputerAddr, delegatorAddr)
+	removalInfo, err := keeper.GetDelegateStakeRemovalByTopicAndAddress(ctx, topicId, reputerAddr, delegatorAddr)
 	require.NoError(err)
 	require.NotNil(removalInfo, "Stake removal should be recorded in the state")
 }
@@ -651,6 +651,7 @@ func (s *KeeperTestSuite) TestRewardDelegateStake() {
 		Score:       score,
 	}
 	err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, block, scoreToAdd)
+	s.Require().NoError(err)
 
 	reputerValueBundle := &types.ReputerValueBundle{
 		ValueBundle: &types.ValueBundle{
@@ -702,6 +703,7 @@ func (s *KeeperTestSuite) TestRewardDelegateStake() {
 		Score:       score,
 	}
 	err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, newBlock, newScoreToAdd)
+	s.Require().NoError(err)
 
 	newReputerValueBundle := &types.ReputerValueBundle{
 		ValueBundle: &types.ValueBundle{

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
@@ -269,6 +269,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkWorkerAlreadyFullfilledNonce() {
 	workerMsg.WorkerDataBundles[0].Pubkey = hex.EncodeToString(workerPublicKeyBytes)
 
 	_, err = msgServer.InsertBulkWorkerPayload(ctx, workerMsg)
+	require.NoError(err)
 	_, err = msgServer.InsertBulkWorkerPayload(ctx, workerMsg)
 	require.ErrorIs(err, types.ErrNonceAlreadyFulfilled)
 }

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -47,7 +46,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 					fmt.Println("Error updating last inference ran: ", err)
 				}
 				// Add Worker Nonces
-				nextNonce := emissionstypes.Nonce{BlockHeight: blockHeight + topic.EpochLength}
+				nextNonce := types.Nonce{BlockHeight: blockHeight + topic.EpochLength}
 				err = am.keeper.AddWorkerNonce(sdkCtx, topic.Id, &nextNonce)
 				if err != nil {
 					fmt.Println("Error adding worker nonce: ", err)
@@ -55,8 +54,8 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 				}
 				// Add Reputer Nonces
 				if blockHeight-topic.EpochLength > 0 {
-					ReputerReputerNonce := emissionstypes.Nonce{BlockHeight: blockHeight}
-					ReputerWorkerNonce := emissionstypes.Nonce{BlockHeight: blockHeight - topic.EpochLength}
+					ReputerReputerNonce := types.Nonce{BlockHeight: blockHeight}
+					ReputerWorkerNonce := types.Nonce{BlockHeight: blockHeight - topic.EpochLength}
 					err = am.keeper.AddReputerNonce(sdkCtx, topic.Id, &ReputerReputerNonce, &ReputerWorkerNonce)
 					if err != nil {
 						fmt.Println("Error adding reputer nonce: ", err)

--- a/x/emissions/module/rewards/reputer_rewards.go
+++ b/x/emissions/module/rewards/reputer_rewards.go
@@ -173,6 +173,9 @@ func GetRewardForReputerFromTotalReward(
 			return nil, err
 		}
 		delegatorReward, err = delegatorReward.Quo(e18)
+		if err != nil {
+			return nil, err
+		}
 		if delegatorReward.Gt(alloraMath.NewDecFromInt64(0)) {
 			// update reward share
 			// new_share = current_share + (reward / total_stake)
@@ -189,6 +192,9 @@ func GetRewardForReputerFromTotalReward(
 				return nil, err
 			}
 			newShare, err := currentShare.Add(addShare)
+			if err != nil {
+				return nil, err
+			}
 			err = keeper.SetDelegateRewardPerShare(ctx, topicId, reputer, newShare)
 			if err != nil {
 				return nil, err
@@ -205,6 +211,9 @@ func GetRewardForReputerFromTotalReward(
 		}
 		// Send remain rewards to reputer
 		reputerRw, err := reward.Sub(delegatorReward)
+		if err != nil {
+			return nil, err
+		}
 		reputerRewards = append(reputerRewards, TaskRewards{
 			Address: reputerReward.Address,
 			Reward:  reputerRw,

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -6,7 +6,6 @@ import (
 	"cosmossdk.io/errors"
 	cosmosMath "cosmossdk.io/math"
 	"github.com/allora-network/allora-chain/app/params"
-	chainParams "github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/types"
@@ -168,7 +167,7 @@ func EmitRewards(ctx sdk.Context, k keeper.Keeper, blockHeight BlockHeight) erro
 		ctx,
 		types.AlloraRequestsAccountName,
 		mintTypes.EcosystemModuleName,
-		sdk.NewCoins(sdk.NewCoin(chainParams.DefaultBondDenom, cosmosMath.NewInt(sumRevenue.Sub(sumRevenueOfBottomTopics).BigInt().Int64()))))
+		sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(sumRevenue.Sub(sumRevenueOfBottomTopics).BigInt().Int64()))))
 	if err != nil {
 		fmt.Println("Error sending coins from module to module: ", err)
 		return err

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -3,7 +3,6 @@ package rewards_test
 import (
 	"encoding/hex"
 
-	cosmosMath "cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/types"
@@ -206,41 +205,6 @@ func (s *RewardsTestSuite) TestEnsureAllWorkersPresentWithheld() {
 			s.Failf("Value mismatch for worker %s: got %s, want %s", val.Worker, val.Value.String(), expectedVal)
 		}
 	}
-}
-
-// mockReputersData generates reputer stakes and losses
-func mockReputersScoresTestData(s *RewardsTestSuite, topicId uint64, block int64) (types.ReputerValueBundles, error) {
-	reputers := []sdk.AccAddress{
-		s.addrs[0],
-		s.addrs[1],
-		s.addrs[2],
-		s.addrs[3],
-		s.addrs[4],
-	}
-
-	var stakes = []cosmosMath.Uint{
-		cosmosMath.NewUint(1176644),
-		cosmosMath.NewUint(384623),
-		cosmosMath.NewUint(394676),
-		cosmosMath.NewUint(207999),
-		cosmosMath.NewUint(368582),
-	}
-
-	// Add stakes
-	for i, reputer := range reputers {
-		err := s.emissionsKeeper.AddStake(s.ctx, topicId, reputer, stakes[i])
-		if err != nil {
-			return types.ReputerValueBundles{}, err
-		}
-	}
-
-	reputerValueBundles := GenerateLossBundles(s, block, topicId, reputers)
-	err := s.emissionsKeeper.InsertReputerLossBundlesAtBlock(s.ctx, topicId, block, reputerValueBundles)
-	if err != nil {
-		return types.ReputerValueBundles{}, err
-	}
-
-	return reputerValueBundles, nil
 }
 
 func GenerateReputerLatestScores(s *RewardsTestSuite, reputers []sdk.AccAddress, blockHeight int64, topicId uint64) error {

--- a/x/emissions/module/rewards/worker_rewards.go
+++ b/x/emissions/module/rewards/worker_rewards.go
@@ -82,7 +82,7 @@ func GetWorkersRewardFractions(
 		// Get worker scores from the latest time steps
 		latestScoresFromLastestTimeSteps, err := k.GetInferenceScoresUntilBlock(ctx, topicId, blockHeight)
 		if err != nil {
-
+			return []sdk.AccAddress{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to get worker inference scores from the latest time steps")
 		}
 		var workerLastScoresDec []alloraMath.Dec
 		for _, score := range latestScoresFromLastestTimeSteps {
@@ -110,7 +110,7 @@ func GetWorkersRewardFractions(
 		// Get worker scores from the latest time steps
 		latestScoresFromLastestTimeSteps, err := k.GetForecastScoresUntilBlock(ctx, topicId, blockHeight)
 		if err != nil {
-
+			return []sdk.AccAddress{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to get worker forecast scores from the latest time steps")
 		}
 		var workerLastScoresDec []alloraMath.Dec
 		for _, score := range latestScoresFromLastestTimeSteps {

--- a/x/emissions/module/rewards/worker_rewards_test.go
+++ b/x/emissions/module/rewards/worker_rewards_test.go
@@ -29,6 +29,7 @@ func (s *RewardsTestSuite) TestGetWorkersRewardsInferenceTask() {
 		alloraMath.MustNewDecFromString("1.5"),
 		&networkLosses,
 	)
+	s.Require().NoError(err)
 	inferenceRewards, err := rewards.GetRewardPerWorker(
 		topicId,
 		rewards.WorkerInferenceRewardType,
@@ -61,6 +62,7 @@ func (s *RewardsTestSuite) TestGetWorkersRewardsForecastTask() {
 		alloraMath.MustNewDecFromString("1.5"),
 		&networkLosses,
 	)
+	s.Require().NoError(err)
 	forecastRewards, err := rewards.GetRewardPerWorker(
 		topicId,
 		rewards.WorkerForecastRewardType,

--- a/x/ibc/gmp/ibc_middleware.go
+++ b/x/ibc/gmp/ibc_middleware.go
@@ -3,9 +3,9 @@ package gmp
 import (
 	"encoding/json"
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
-	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"
@@ -96,7 +96,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	relayer sdk.AccAddress,
 ) ibcexported.Acknowledgement {
 	var data transfertypes.FungibleTokenPacketData
-	if err := types.ModuleCdc.UnmarshalJSON(packet.GetData(), &data); err != nil {
+	if err := transfertypes.ModuleCdc.UnmarshalJSON(packet.GetData(), &data); err != nil {
 		return channeltypes.NewErrorAcknowledgement(fmt.Errorf("cannot unmarshal ICS-20 transfer packet data"))
 	}
 
@@ -145,7 +145,7 @@ func (im IBCMiddleware) OnRecvPacket(
 		// we throw out the rest of the msg.Payload fields here, for better or worse
 		data.Memo = string(msg.Payload)
 		var dataBytes []byte
-		if dataBytes, err = types.ModuleCdc.MarshalJSON(&data); err != nil {
+		if dataBytes, err = transfertypes.ModuleCdc.MarshalJSON(&data); err != nil {
 			return channeltypes.NewErrorAcknowledgement(fmt.Errorf("cannot marshal ICS-20 post-processed transfer packet data"))
 		}
 		packet.Data = dataBytes


### PR DESCRIPTION
Silences all warnings from `go vet ./...` and `staticcheck ./...` except for deprecation warnings, and warnings in autogenerated protobuf code (.pulsar.go, .pb.go etc)
adds `make lint` command to run go vet and staticcheck for you.