### PR TITLE
Remove auto-activation on topic creation

### DIFF
--- a/integration/inference_request_test.go
+++ b/integration/inference_request_test.go
@@ -24,26 +24,7 @@ func CreateInferenceRequestOnTopic1(m TestMetadata) {
 	require.NoError(m.t, err)
 }
 
-func CheckTopic1Activated(m TestMetadata) {
-	// Fetch only active topics
-	pagi := &emissionstypes.QueryActiveTopicsRequest{
-		Pagination: &emissionstypes.SimpleCursorPaginationRequest{
-			Limit: 10,
-		},
-	}
-	activeTopics, err := m.n.QueryEmissions.GetActiveTopics(
-		m.ctx,
-		pagi)
-	require.NoError(m.t, err, "Fetching active topics should not produce an error")
-
-	// Verify the correct number of active topics is retrieved
-	// s.Require().Len(activeTopics, 2, "Should retrieve exactly two active topics")
-	require.Equal(m.t, len(activeTopics.Topics), 1, "Should retrieve exactly one active topics")
-}
-
 func InferenceRequestsChecks(m TestMetadata) {
 	m.t.Log("--- Check creating an Inference Request on Topic 1 ---")
 	CreateInferenceRequestOnTopic1(m)
-	m.t.Log("--- Check reactivating Topic 1 ---")
-	CheckTopic1Activated(m)
 }

--- a/integration/staking_test.go
+++ b/integration/staking_test.go
@@ -31,8 +31,26 @@ func StakeAliceAsReputerTopic1(m TestMetadata) {
 	require.True(m.t, aliceStaked.Amount.Equal(cosmosMath.NewUint(1000000)))
 }
 
+func CheckTopic1Activated(m TestMetadata) {
+	// Fetch only active topics
+	pagi := &emissionstypes.QueryActiveTopicsRequest{
+		Pagination: &emissionstypes.SimpleCursorPaginationRequest{
+			Limit: 10,
+		},
+	}
+	activeTopics, err := m.n.QueryEmissions.GetActiveTopics(
+		m.ctx,
+		pagi)
+	require.NoError(m.t, err, "Fetching active topics should not produce an error")
+
+	// Verify the correct number of active topics is retrieved
+	require.Equal(m.t, len(activeTopics.Topics), 1, "Should retrieve exactly one active topic")
+}
+
 // Register two actors and check their registrations went through
 func StakingChecks(m TestMetadata) {
 	m.t.Log("--- Staking Alice as Reputer ---")
 	StakeAliceAsReputerTopic1(m)
+	m.t.Log("--- Check reactivating Topic 1 ---")
+	CheckTopic1Activated(m)
 }

--- a/x/emissions/keeper/msgserver/msg_server_topics.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics.go
@@ -71,9 +71,6 @@ func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.MsgCreateNewT
 	if err := ms.k.SetTopic(ctx, id, topic); err != nil {
 		return nil, err
 	}
-	if err = ms.k.ActivateTopic(ctx, id); err != nil {
-		return nil, err
-	}
 	// Rather than set latest weight-adjustment timestamp of a topic to 0
 	// we do nothing, since no value in the map means zero
 

--- a/x/emissions/keeper/msgserver/msg_server_topics_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics_test.go
@@ -51,7 +51,7 @@ func (s *KeeperTestSuite) TestMsgCreateNewTopic() {
 			break
 		}
 	}
-	require.True(found, "Added topic not found in active topics")
+	require.False(found, "Added topic found in active topics")
 }
 
 func (s *KeeperTestSuite) TestUpdateTopicLossUpdateLastRan() {


### PR DESCRIPTION
Remove activation from topic creation. 
Moved activation check after reputer staking.

Tested on chain writing with 1 worker and 1 reputer.