### PR TITLE
Covering edge cases in Network Inference calc

### DIFF
--- a/app/topics_handler.go
+++ b/app/topics_handler.go
@@ -96,6 +96,7 @@ func (th *TopicsHandler) requestTopicReputers(ctx sdk.Context, topic emissionsty
 		reputerValueBundle, inferencesBlockHeight, err := synth.GetNetworkInferencesAtBlock(ctx, th.emissionsKeeper, topic.Id, nonceCopy.ReputerNonce.BlockHeight)
 		if err != nil {
 			fmt.Println("Error getting latest inferences at block: ", nonceCopy.ReputerNonce.BlockHeight, ", error: ", err)
+			continue
 		}
 
 		blockDifference := currentBlockHeight - inferencesBlockHeight

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -3,12 +3,13 @@ package inference_synthesis
 import (
 	"fmt"
 
+	errorsmod "cosmossdk.io/errors"
 	cosmosMath "cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
-
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	emissions "github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // Create a map from worker address to their inference or forecast-implied inference
@@ -578,53 +579,72 @@ func GetNetworkInferencesAtBlock(
 	topicId TopicId,
 	blockHeight BlockHeight,
 ) (*emissions.ValueBundle, BlockHeight, error) {
-	params, err := k.GetParams(ctx)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	reputerReportedLosses, _, err := k.GetReputerReportedLossesAtOrBeforeBlock(ctx, topicId, blockHeight)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	// Map list of stakesOnTopic to map of stakesByReputer
-	stakesByReputer := make(map[string]cosmosMath.Uint)
-	for _, bundle := range reputerReportedLosses.ReputerValueBundles {
-		stakeAmount, err := k.GetStakeOnReputerInTopic(ctx, topicId, sdk.AccAddress(bundle.ValueBundle.Reputer))
-		if err != nil {
-			return nil, 0, err
-		}
-		stakesByReputer[bundle.ValueBundle.Reputer] = stakeAmount
-	}
-
-	networkCombinedLoss, err := CalcCombinedNetworkLoss(stakesByReputer, reputerReportedLosses, params.Epsilon)
-	if err != nil {
-		return nil, 0, err
-	}
-
 	inferences, blockHeight, err := k.GetInferencesAtOrAfterBlock(ctx, topicId, blockHeight)
 	if err != nil {
 		return nil, 0, err
+	} else if len(inferences.Inferences) == 0 {
+		return nil, 0, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "no inferences found for topic %v at block %v", topicId, blockHeight)
 	}
+
 	forecasts, _, err := k.GetForecastsAtOrAfterBlock(ctx, topicId, blockHeight)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	networkInferences, err := CalcNetworkInferences(
-		ctx,
-		k,
-		topicId,
-		inferences,
-		forecasts,
-		networkCombinedLoss,
-		params.Epsilon,
-		params.PInferenceSynthesis,
-	)
-	if err != nil {
-		fmt.Println("Error calculating network inferences: ", err)
+	var networkInferences *emissions.ValueBundle
+	if len(inferences.Inferences) > 1 {
+		params, err := k.GetParams(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		reputerReportedLosses, _, err := k.GetReputerReportedLossesAtOrBeforeBlock(ctx, topicId, blockHeight)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		// Map list of stakesOnTopic to map of stakesByReputer
+		stakesByReputer := make(map[string]cosmosMath.Uint)
+		for _, bundle := range reputerReportedLosses.ReputerValueBundles {
+			stakeAmount, err := k.GetStakeOnReputerInTopic(ctx, topicId, sdk.AccAddress(bundle.ValueBundle.Reputer))
+			if err != nil {
+				return nil, 0, err
+			}
+			stakesByReputer[bundle.ValueBundle.Reputer] = stakeAmount
+		}
+
+		networkCombinedLoss, err := CalcCombinedNetworkLoss(stakesByReputer, reputerReportedLosses, params.Epsilon)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		networkInferences, err = CalcNetworkInferences(ctx, k, topicId, inferences, forecasts, networkCombinedLoss, params.Epsilon, params.PInferenceSynthesis)
+		if err != nil {
+			fmt.Println("Error calculating network inferences: ", err)
+			return nil, 0, err
+		}
+	} else {
+		// If there is only one valid inference, then the network inference is the same as the single inference
+		// For the forecasts to be meaningful, there should be at least 2 inferences
+		singleInference := inferences.Inferences[0]
+
+		networkInferences = &emissions.ValueBundle{
+			TopicId:       topicId,
+			CombinedValue: singleInference.Value,
+			InfererValues: []*emissions.WorkerAttributedValue{
+				{
+					Worker: singleInference.Inferer,
+					Value:  singleInference.Value,
+				},
+			},
+			ForecasterValues:       []*emissions.WorkerAttributedValue{},
+			NaiveValue:             singleInference.Value,
+			OneOutInfererValues:    []*emissions.WithheldWorkerAttributedValue{},
+			OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{},
+			OneInForecasterValues:  []*emissions.WorkerAttributedValue{},
+		}
 	}
+
 	// Even in case of error (partially filled data), the ValueBundle is returned
 	return networkInferences, blockHeight, err
 }

--- a/x/emissions/keeper/msgserver/msg_server_losses.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses.go
@@ -282,6 +282,11 @@ func (ms msgServer) FilterUnacceptedWorkersFromReputerValueBundle(
 		}
 	}
 
+	// If 1 inferer, there's no one-out inferer data to receive
+	if len(acceptedInfererValues) == 1 && len(acceptedOneOutInfererValues) > 0 {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "invalid one-out inferer values - there's just one inferer to report")
+	}
+
 	acceptedReputerValueBundle := &types.ReputerValueBundle{
 		ValueBundle: &types.ValueBundle{
 			TopicId:                reputerValueBundle.ValueBundle.TopicId,
@@ -297,11 +302,6 @@ func (ms msgServer) FilterUnacceptedWorkersFromReputerValueBundle(
 			CombinedValue:          reputerValueBundle.ValueBundle.CombinedValue,
 		},
 		Signature: reputerValueBundle.Signature,
-	}
-
-	// If 1 inferer, there's no one-out inferer data to receive
-	if len(acceptedInfererValues) == 1 && len(acceptedOneOutInfererValues) > 0 {
-		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "invalid one-out inferer values - there's just one inferer to report")
 	}
 
 	return acceptedReputerValueBundle, nil

--- a/x/emissions/keeper/msgserver/msg_server_losses.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses.go
@@ -3,15 +3,17 @@ package msgserver
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
-	l "log"
 
-	"cosmossdk.io/errors"
+	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
 	cosmosMath "cosmossdk.io/math"
 	synth "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // Called by reputer to submit their assessment of the quality of workers' work compared to ground truth
@@ -28,7 +30,7 @@ func (ms msgServer) InsertBulkReputerPayload(
 		return nil, err
 	}
 	if !topicExists {
-		return nil, types.ErrInvalidTopicId
+		return nil, types.ErrTopicDoesNotExist
 	}
 
 	/// Do filters upon the leader (the sender) first, then do checks on each reputer in the payload
@@ -42,7 +44,7 @@ func (ms msgServer) InsertBulkReputerPayload(
 	// Throw if worker nonce is unfulfilled -- can't report losses on something not yet committed
 	if workerNonceUnfulfilled {
 		fmt.Println("Reputer's worker nonce not yet fulfilled: ", msg.ReputerRequestNonce.WorkerNonce, " for reputer block: ", msg.ReputerRequestNonce.ReputerNonce)
-		return nil, errors.Wrap(types.ErrNonceStillUnfulfilled, "worker nonce")
+		return nil, errorsmod.Wrap(types.ErrNonceStillUnfulfilled, "worker nonce")
 	} else {
 		fmt.Println("OK - Reputer's worker nonce already fulfilled: ", msg.ReputerRequestNonce.WorkerNonce, " for reputer block: ", msg.ReputerRequestNonce.ReputerNonce)
 	}
@@ -55,7 +57,7 @@ func (ms msgServer) InsertBulkReputerPayload(
 	// Throw if already fulfilled -- can't return a response twice
 	if !reputerNonceUnfulfilled {
 		fmt.Println("Reputer nonce already fulfilled: ", msg.ReputerRequestNonce.ReputerNonce)
-		return nil, errors.Wrap(types.ErrNonceAlreadyFulfilled, "reputer nonce")
+		return nil, errorsmod.Wrap(types.ErrNonceAlreadyFulfilled, "reputer nonce")
 	}
 
 	params, err := ms.k.GetParams(ctx)
@@ -88,8 +90,6 @@ func (ms msgServer) InsertBulkReputerPayload(
 
 		// Check if we've seen this reputer already in this bulk payload
 		if _, ok := lossBundlesByReputer[bundle.ValueBundle.Reputer]; !ok {
-			l.Println("Reputer ", bundle.ValueBundle.Reputer, "not seen yet!")
-
 			// Check that the reputer is registered in the topic
 			isReputerRegistered, err := ms.k.IsReputerRegisteredInTopic(ctx, bundle.ValueBundle.TopicId, reputer)
 			if err != nil {
@@ -118,8 +118,7 @@ func (ms msgServer) InsertBulkReputerPayload(
 				return nil, err
 			}
 
-			/// Check signatures! throw if invalid!
-
+			// Check signatures - throw if invalid!
 			pk, err := hex.DecodeString(bundle.Pubkey)
 			if err != nil || len(pk) != secp256k1.PubKeySize {
 				return nil, types.ErrSignatureVerificationFailed
@@ -135,7 +134,6 @@ func (ms msgServer) InsertBulkReputerPayload(
 			/// If we do PoX-like anti-sybil procedure, would go here
 
 			/// Filtering done now, now write what we must for inclusion
-
 			lossBundlesByReputer[bundle.ValueBundle.Reputer] = filteredBundle
 
 			// Get the latest score for each reputer
@@ -222,7 +220,11 @@ func (ms msgServer) FilterUnacceptedWorkersFromReputerValueBundle(
 	// Get the accepted inferers of the associated worker response payload
 	inferences, err := ms.k.GetInferencesAtBlock(ctx, topicId, reputerRequestNonce.WorkerNonce.BlockHeight)
 	if err != nil {
-		return nil, err
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "no inferences found at block height")
+		} else {
+			return nil, err
+		}
 	}
 	acceptedInferersOfBatch := make(map[string]bool)
 	for _, inference := range inferences.Inferences {
@@ -232,16 +234,19 @@ func (ms msgServer) FilterUnacceptedWorkersFromReputerValueBundle(
 	// Get the accepted forecasters of the associated worker response payload
 	forecasts, err := ms.k.GetForecastsAtBlock(ctx, topicId, reputerRequestNonce.WorkerNonce.BlockHeight)
 	if err != nil {
-		return nil, err
+		// If no forecasts, we'll just assume there are 0 forecasters
+		if errors.Is(err, collections.ErrNotFound) {
+			forecasts = &types.Forecasts{Forecasts: make([]*types.Forecast, 0)}
+		} else {
+			return nil, err
+		}
 	}
-
 	acceptedForecastersOfBatch := make(map[string]bool)
 	for _, forecast := range forecasts.Forecasts {
 		acceptedForecastersOfBatch[forecast.Forecaster] = true
 	}
 
 	// Filter out values of unaccepted workers
-
 	acceptedInfererValues := make([]*types.WorkerAttributedValue, 0)
 	for _, workerVal := range reputerValueBundle.ValueBundle.InfererValues {
 		if _, ok := acceptedInferersOfBatch[workerVal.Worker]; ok {
@@ -293,5 +298,11 @@ func (ms msgServer) FilterUnacceptedWorkersFromReputerValueBundle(
 		},
 		Signature: reputerValueBundle.Signature,
 	}
+
+	// If 1 inferer, there's no one-out inferer data to receive
+	if len(acceptedInfererValues) == 1 && len(acceptedOneOutInfererValues) > 0 {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "invalid one-out inferer values - there's just one inferer to report")
+	}
+
 	return acceptedReputerValueBundle, nil
 }

--- a/x/emissions/keeper/msgserver/msg_server_losses_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses_test.go
@@ -225,8 +225,8 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayloadInvalid() {
 				Value:  alloraMath.NewDecFromInt64(100),
 			},
 		},
-		NaiveValue:             alloraMath.NewDecFromInt64(100),
-		OneOutInfererValues:    []*types.WithheldWorkerAttributedValue{},
+		NaiveValue:          alloraMath.NewDecFromInt64(100),
+		OneOutInfererValues: []*types.WithheldWorkerAttributedValue{},
 		OneOutForecasterValues: []*types.WithheldWorkerAttributedValue{
 			{
 				Worker: workerAddr.String(),

--- a/x/emissions/keeper/msgserver/msg_server_losses_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayload() {
@@ -93,13 +94,8 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayload() {
 				Value:  alloraMath.NewDecFromInt64(100),
 			},
 		},
-		NaiveValue: alloraMath.NewDecFromInt64(100),
-		OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
-			{
-				Worker: workerAddr.String(),
-				Value:  alloraMath.NewDecFromInt64(100),
-			},
-		},
+		NaiveValue:          alloraMath.NewDecFromInt64(100),
+		OneOutInfererValues: []*types.WithheldWorkerAttributedValue{},
 		OneOutForecasterValues: []*types.WithheldWorkerAttributedValue{
 			{
 				Worker: workerAddr.String(),
@@ -144,4 +140,150 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayload() {
 
 	_, err = msgServer.InsertBulkReputerPayload(ctx, lossesMsg)
 	require.NoError(err, "InsertBulkReputerPayload should not return an error")
+}
+
+func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayloadInvalid() {
+	ctx, msgServer := s.ctx, s.msgServer
+	require := s.Require()
+	keeper := s.emissionsKeeper
+
+	reputerPrivateKey := secp256k1.GenPrivKey()
+	reputerPublicKeyBytes := reputerPrivateKey.PubKey().Bytes()
+	reputerAddr := sdk.AccAddress(reputerPrivateKey.PubKey().Address())
+
+	workerPrivateKey := secp256k1.GenPrivKey()
+	workerAddr := sdk.AccAddress(workerPrivateKey.PubKey().Address())
+
+	minStake, err := keeper.GetParamsRequiredMinimumStake(ctx)
+	require.NoError(err)
+
+	minStakeScaled := minStake.Mul(inference_synthesis.CosmosUintOneE18())
+
+	topicId := s.commonStakingSetup(ctx, reputerAddr, workerAddr, minStakeScaled)
+
+	addStakeMsg := &types.MsgAddStake{
+		Sender:  reputerAddr.String(),
+		TopicId: topicId,
+		Amount:  minStakeScaled,
+	}
+
+	_, err = msgServer.AddStake(ctx, addStakeMsg)
+	s.Require().NoError(err)
+
+	reputerNonce := &types.Nonce{
+		BlockHeight: 2,
+	}
+	workerNonce := &types.Nonce{
+		BlockHeight: 1,
+	}
+
+	keeper.AddWorkerNonce(ctx, topicId, workerNonce)
+	keeper.FulfillWorkerNonce(ctx, topicId, workerNonce)
+	keeper.AddReputerNonce(ctx, topicId, reputerNonce, workerNonce)
+
+	// add in inference and forecast data
+	block := types.BlockHeight(1)
+	expectedInferences := types.Inferences{
+		Inferences: []*types.Inference{
+			{
+				Value:   alloraMath.NewDecFromInt64(1), // Assuming NewDecFromInt64 exists and is appropriate
+				Inferer: workerAddr.String(),
+			},
+		},
+	}
+
+	nonce := types.Nonce{BlockHeight: block} // Assuming block type cast to int64 if needed
+	err = keeper.InsertInferences(ctx, topicId, nonce, expectedInferences)
+	require.NoError(err, "InsertInferences should not return an error")
+
+	expectedForecasts := types.Forecasts{
+		Forecasts: []*types.Forecast{
+			{
+				TopicId:    topicId,
+				Forecaster: workerAddr.String(),
+			},
+		},
+	}
+
+	nonce = types.Nonce{BlockHeight: int64(block)}
+	err = keeper.InsertForecasts(ctx, topicId, nonce, expectedForecasts)
+	s.Require().NoError(err)
+
+	reputerValueBundle := &types.ValueBundle{
+		TopicId:       topicId,
+		Reputer:       reputerAddr.String(),
+		CombinedValue: alloraMath.NewDecFromInt64(100),
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: workerAddr.String(),
+				Value:  alloraMath.NewDecFromInt64(100),
+			},
+		},
+		ForecasterValues: []*types.WorkerAttributedValue{
+			{
+				Worker: workerAddr.String(),
+				Value:  alloraMath.NewDecFromInt64(100),
+			},
+		},
+		NaiveValue:             alloraMath.NewDecFromInt64(100),
+		OneOutInfererValues:    []*types.WithheldWorkerAttributedValue{},
+		OneOutForecasterValues: []*types.WithheldWorkerAttributedValue{
+			{
+				Worker: workerAddr.String(),
+				Value:  alloraMath.NewDecFromInt64(100),
+			},
+		},
+		OneInForecasterValues: []*types.WorkerAttributedValue{
+			{
+				Worker: workerAddr.String(),
+				Value:  alloraMath.NewDecFromInt64(100),
+			},
+		},
+		ReputerRequestNonce: &types.ReputerRequestNonce{
+			ReputerNonce: reputerNonce,
+			WorkerNonce:  workerNonce,
+		},
+	}
+
+	src := make([]byte, 0)
+	src, err = reputerValueBundle.XXX_Marshal(src, true)
+	require.NoError(err, "Marshall reputer value bundle should not return an error")
+
+	valueBundleSignature, err := reputerPrivateKey.Sign(src)
+	require.NoError(err, "Sign should not return an error")
+
+	// Create a MsgInsertBulkReputerPayload message
+	lossesMsg := &types.MsgInsertBulkReputerPayload{
+		Sender:  reputerAddr.String(),
+		TopicId: topicId,
+		ReputerRequestNonce: &types.ReputerRequestNonce{
+			ReputerNonce: reputerNonce,
+			WorkerNonce:  workerNonce,
+		},
+		ReputerValueBundles: []*types.ReputerValueBundle{
+			{
+				ValueBundle: reputerValueBundle,
+				Signature:   valueBundleSignature,
+				Pubkey:      hex.EncodeToString(reputerPublicKeyBytes),
+			},
+		},
+	}
+
+	// Send to the wrong topic should error
+	lossesMsg.TopicId = topicId + 999
+	_, err = msgServer.InsertBulkReputerPayload(ctx, lossesMsg)
+	require.ErrorIs(err, types.ErrTopicDoesNotExist)
+
+	// Fix topic
+	lossesMsg.TopicId = topicId
+
+	// Send bundle with one-out inference with just 1 inferer in topic-block
+	lossesMsg.ReputerValueBundles[0].ValueBundle.OneOutInfererValues = []*types.WithheldWorkerAttributedValue{
+		{
+			Worker: workerAddr.String(),
+			Value:  alloraMath.NewDecFromInt64(100),
+		},
+	}
+	_, err = msgServer.InsertBulkReputerPayload(ctx, lossesMsg)
+	require.ErrorIs(err, sdkerrors.ErrInvalidRequest)
 }

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -290,25 +290,25 @@ func GenerateRewardsDistributionByTopicParticipant(
 	}
 
 	// Calculate and Set the reputer scores
-	scores, err := GenerateReputerScores(sdk.UnwrapSDKContext(ctx), k, topicId, blockHeight, *bundles)
+	reputerScores, err := GenerateReputerScores(ctx, k, topicId, blockHeight, *bundles)
 	if err != nil {
 		return nil, err
 	}
 
 	// Calculate and Set the worker scores for their inference work
-	_, err = GenerateInferenceScores(sdk.UnwrapSDKContext(ctx), k, topicId, blockHeight, *lossBundles)
+	infererScores, err := GenerateInferenceScores(ctx, k, topicId, blockHeight, *lossBundles)
 	if err != nil {
 		return nil, err
 	}
 
 	// Calculate and Set the worker scores for their forecast work
-	_, err = GenerateForecastScores(sdk.UnwrapSDKContext(ctx), k, topicId, blockHeight, *lossBundles)
+	forecasterScores, err := GenerateForecastScores(ctx, k, topicId, blockHeight, *lossBundles)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get reputer participants' addresses and reward fractions to be used in the reward round for topic
-	reputers, reputersRewardFractions, err := GetReputersRewardFractions(ctx, k, topicId, moduleParams.PRewardSpread, scores)
+	reputers, reputersRewardFractions, err := GetReputersRewardFractions(ctx, k, topicId, moduleParams.PRewardSpread, reputerScores)
 	if err != nil {
 		return []TaskRewards{}, errors.Wrapf(err, "failed to get reputer reward round data")
 	}
@@ -334,7 +334,7 @@ func GenerateRewardsDistributionByTopicParticipant(
 		topicId,
 		blockHeight,
 		moduleParams.PRewardSpread,
-		lossBundles,
+		infererScores,
 	)
 	if err != nil {
 		return []TaskRewards{}, errors.Wrapf(err, "failed to get inferer reward fractions")
@@ -361,7 +361,7 @@ func GenerateRewardsDistributionByTopicParticipant(
 		topicId,
 		blockHeight,
 		moduleParams.PRewardSpread,
-		lossBundles,
+		forecasterScores,
 	)
 	if err != nil {
 		return []TaskRewards{}, errors.Wrapf(err, "failed to get forecaster reward fractions")

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -1101,7 +1101,7 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionWithOneInfererAndOneReputer
 		NaiveValue:             alloraMath.MustNewDecFromString("0.0116"),
 		InfererValues:          []*types.WorkerAttributedValue{{Worker: worker.String(), Value: alloraMath.MustNewDecFromString("0.0112")}},
 		ForecasterValues:       []*types.WorkerAttributedValue{},
-		OneOutInfererValues:    []*types.WithheldWorkerAttributedValue{{Worker: worker.String(), Value: alloraMath.MustNewDecFromString("0.0112")}},
+		OneOutInfererValues:    []*types.WithheldWorkerAttributedValue{},
 		OneOutForecasterValues: []*types.WithheldWorkerAttributedValue{},
 		OneInForecasterValues:  []*types.WorkerAttributedValue{},
 	}
@@ -1133,5 +1133,4 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionWithOneInfererAndOneReputer
 	// Trigger end block - rewards distribution
 	err = s.appModule.EndBlock(s.ctx)
 	s.Require().NoError(err)
-
 }

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -118,6 +118,24 @@ func GenerateReputerScores(
 // GenerateInferenceScores calculates and persists scores for workers based on their inference task performance.
 func GenerateInferenceScores(ctx sdk.Context, keeper keeper.Keeper, topicId uint64, block int64, networkLosses types.ValueBundle) ([]types.Score, error) {
 	var newScores []types.Score
+
+	// If there is only one inferer, set score to 0
+	// More than one inferer is required to have one-out losses
+	if len(networkLosses.InfererValues) == 1 {
+		newScore := types.Score{
+			TopicId:     topicId,
+			BlockNumber: block,
+			Address:     networkLosses.InfererValues[0].Worker,
+			Score:       alloraMath.ZeroDec(),
+		}
+		err := keeper.InsertWorkerInferenceScore(ctx, topicId, block, newScore)
+		if err != nil {
+			return []types.Score{}, errors.Wrapf(err, "Error inserting worker inference score")
+		}
+		newScores = append(newScores, newScore)
+		return newScores, nil
+	}
+
 	for _, oneOutLoss := range networkLosses.OneOutInfererValues {
 		workerAddr, err := sdk.AccAddressFromBech32(oneOutLoss.Worker)
 		if err != nil {
@@ -157,6 +175,25 @@ func GenerateForecastScores(
 	block int64,
 	networkLosses types.ValueBundle,
 ) ([]types.Score, error) {
+	var newScores []types.Score
+
+	// If there is only one forecaster, set score to 0
+	// More than one forecaster is required to have one-out losses
+	if len(networkLosses.ForecasterValues) == 1 {
+		newScore := types.Score{
+			TopicId:     topicId,
+			BlockNumber: block,
+			Address:     networkLosses.InfererValues[0].Worker,
+			Score:       alloraMath.ZeroDec(),
+		}
+		err := keeper.InsertWorkerInferenceScore(ctx, topicId, block, newScore)
+		if err != nil {
+			return []types.Score{}, errors.Wrapf(err, "Error inserting worker inference score")
+		}
+		newScores = append(newScores, newScore)
+		return newScores, nil
+	}
+
 	// Get worker scores for one out loss
 	var workersScoresOneOut []alloraMath.Dec
 	for _, oneOutLoss := range networkLosses.OneOutForecasterValues {
@@ -173,7 +210,7 @@ func GenerateForecastScores(
 	if err != nil {
 		return []types.Score{}, errors.Wrapf(err, "Error getting fUniqueAgg")
 	}
-	var newScores []types.Score
+
 	for i, oneInNaiveLoss := range networkLosses.OneInForecasterValues {
 		workerAddr, err := sdk.AccAddressFromBech32(oneInNaiveLoss.Worker)
 		if err != nil {


### PR DESCRIPTION
- In network inference calc: 
If 0 inference: throw error
If 1 inference: network inference == single inference
if  >1 inference: calc network inference

- In network loss calc: 
If 0 forecasts: continue calc
If 1 inference: no need for to reputer to send one-out loss

- In scores calc :
If 1 forecast or inferer: score will be zero

In the case of scores, I needed to add code to handle when one-out losses are not empty (which will happen when we have single participant cases). Previously, we were generating random one-out losses for single participant cases in our tests and we were considering them; now we just do not consider one-out/one-in losses in these cases and use zero as score.

Reference: https://linear.app/upshot/issue/ORA-1374/consensus-failure-rewards-number-ratio-invalid-slice-length