### PR TITLE
Diego/ora 1411 bug integ tests failing topic fund too low

### DIFF
--- a/integration/update_params_test.go
+++ b/integration/update_params_test.go
@@ -20,10 +20,14 @@ func checkIfAdmin(m TestMetadata, address string) bool {
 }
 
 // Test that whitelisted admin can successfully update params and others cannot
-func UpdateParamsChecks(m TestMetadata) emissionstypes.Params {
+func UpdateParamsChecks(m TestMetadata) {
 	// Ensure Alice is in the whitelist and Bob is not
 	require.True(m.t, checkIfAdmin(m, m.n.AliceAddr))
 	require.False(m.t, checkIfAdmin(m, m.n.BobAddr))
+
+	// Keep old params
+	oldParams := GetEmissionsParams(m)
+	oldEpsilon := oldParams.Epsilon
 
 	// Should succeed for Alice because she's a whitelist admin
 	newEpsilon := alloraMath.NewDecFinite(1, 99)
@@ -55,5 +59,18 @@ func UpdateParamsChecks(m TestMetadata) emissionstypes.Params {
 	// Check that the epsilon was updated by Alice successfully
 	updatedParams := GetEmissionsParams(m)
 	require.Equal(m.t, updatedParams.Epsilon.String(), newEpsilon.String())
-	return updatedParams
+
+	// Set the epsilon back to the original value
+	input = []alloraMath.Dec{oldEpsilon}
+	updateParamRequest = &emissionstypes.MsgUpdateParams{
+		Sender: m.n.AliceAddr,
+		Params: &emissionstypes.OptionalParams{
+			Epsilon: input,
+		},
+	}
+	txResp, err = m.n.Client.BroadcastTx(m.ctx, m.n.AliceAcc, updateParamRequest)
+	require.NoError(m.t, err)
+	_, err = m.n.Client.WaitForTx(m.ctx, txResp.TxHash)
+	require.NoError(m.t, err)
+
 }


### PR DESCRIPTION
This huge epsilon makes the funding of topic to fail, because no amount is bigger than that huge epsilon.

Note: other tests fail, but they fail in major-upgrade too. This just fixes that particular one.