### PR TITLE
Unlimit gas in Stress Test by setting limit auto

### DIFF
--- a/stress/chain/node_config.go
+++ b/stress/chain/node_config.go
@@ -57,6 +57,7 @@ func NewNode(t *testing.T, nc NodeConfig) (Node, error) {
 		cosmosclient.WithNodeAddress(nc.NodeRPCAddress),
 		cosmosclient.WithAddressPrefix(params.HumanCoinUnit),
 		cosmosclient.WithHome(nc.AlloraHomeDir),
+		cosmosclient.WithGas("auto"),
 	)
 	require.NoError(t, err)
 

--- a/stress/chain/node_config.go
+++ b/stress/chain/node_config.go
@@ -58,6 +58,7 @@ func NewNode(t *testing.T, nc NodeConfig) (Node, error) {
 		cosmosclient.WithAddressPrefix(params.HumanCoinUnit),
 		cosmosclient.WithHome(nc.AlloraHomeDir),
 		cosmosclient.WithGas("auto"),
+		cosmosclient.WithGasAdjustment(1.2),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
The stress tests were running out of gas, set the gas amount to auto and then add a multiplier of +20% so we can be sure we don't have out of gas issues

Tested by adding the following line to log info about successful transactions, seeing that transactions are successful with over 300k gas, and that there is a reasonable buffer between `GasWanted` and `GasUsed`

`fmt.Printf("tx response for broadcasting worker, err %v, gasUsed %v, gasWanted %v", err, txResp.GasUsed, txResp.GasWanted)`