### PR TITLE
validate bech32 strings on ingresses

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server_params.go
+++ b/x/emissions/keeper/msgserver/msg_server_params.go
@@ -7,6 +7,9 @@ import (
 )
 
 func (ms msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
+	if err := ms.k.ValidateStringIsBech32(msg.Sender); err != nil {
+		return nil, err
+	}
 	isAdmin, err := ms.k.IsWhitelistAdmin(ctx, msg.Sender)
 	if err != nil {
 		return nil, err

--- a/x/emissions/keeper/msgserver/msg_server_whitelist.go
+++ b/x/emissions/keeper/msgserver/msg_server_whitelist.go
@@ -15,6 +15,10 @@ func (ms msgServer) AddToWhitelistAdmin(ctx context.Context, msg *types.MsgAddTo
 	if !isAdmin {
 		return nil, types.ErrNotWhitelistAdmin
 	}
+	// Validate the address
+	if err := ms.k.ValidateStringIsBech32(msg.Address); err != nil {
+		return nil, err
+	}
 	// Add the address to the whitelist
 	err = ms.k.AddWhitelistAdmin(ctx, msg.Address)
 	if err != nil {
@@ -31,6 +35,10 @@ func (ms msgServer) RemoveFromWhitelistAdmin(ctx context.Context, msg *types.Msg
 	}
 	if !isAdmin {
 		return nil, types.ErrNotWhitelistAdmin
+	}
+	// Validate the address
+	if err := ms.k.ValidateStringIsBech32(msg.Address); err != nil {
+		return nil, err
 	}
 	// Remove the address from the whitelist
 	err = ms.k.RemoveWhitelistAdmin(ctx, msg.Address)

--- a/x/emissions/keeper/queryserver/query_server_registrations.go
+++ b/x/emissions/keeper/queryserver/query_server_registrations.go
@@ -44,6 +44,9 @@ func (qs queryServer) GetReputerAddressByP2PKey(ctx context.Context, req *types.
 }
 
 func (qs queryServer) IsWorkerRegisteredInTopicId(ctx context.Context, req *types.QueryIsWorkerRegisteredInTopicIdRequest) (*types.QueryIsWorkerRegisteredInTopicIdResponse, error) {
+	if err := qs.k.ValidateStringIsBech32(req.Address); err != nil {
+		return nil, err
+	}
 	isRegistered, err := qs.k.IsWorkerRegisteredInTopic(sdk.UnwrapSDKContext(ctx), req.TopicId, req.Address)
 	if err != nil {
 		return nil, err
@@ -53,6 +56,9 @@ func (qs queryServer) IsWorkerRegisteredInTopicId(ctx context.Context, req *type
 }
 
 func (qs queryServer) IsReputerRegisteredInTopicId(ctx context.Context, req *types.QueryIsReputerRegisteredInTopicIdRequest) (*types.QueryIsReputerRegisteredInTopicIdResponse, error) {
+	if err := qs.k.ValidateStringIsBech32(req.Address); err != nil {
+		return nil, err
+	}
 	isRegistered, err := qs.k.IsReputerRegisteredInTopic(sdk.UnwrapSDKContext(ctx), req.TopicId, req.Address)
 	if err != nil {
 		return nil, err

--- a/x/emissions/keeper/queryserver/query_server_stake.go
+++ b/x/emissions/keeper/queryserver/query_server_stake.go
@@ -3,6 +3,7 @@ package queryserver
 import (
 	"context"
 
+	"cosmossdk.io/errors"
 	cosmosMath "cosmossdk.io/math"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -23,6 +24,9 @@ func (qs queryServer) GetTotalStake(ctx context.Context, req *types.QueryTotalSt
 // including reputer's stake in themselves and stake delegated to them.
 // Also includes stake that is queued for removal.
 func (qs queryServer) GetReputerStakeInTopic(ctx context.Context, req *types.QueryReputerStakeInTopicRequest) (*types.QueryReputerStakeInTopicResponse, error) {
+	if err := qs.k.ValidateStringIsBech32(req.Address); err != nil {
+		return nil, err
+	}
 	stake, err := qs.k.GetStakeOnReputerInTopic(ctx, req.TopicId, req.Address)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -33,6 +37,9 @@ func (qs queryServer) GetReputerStakeInTopic(ctx context.Context, req *types.Que
 
 // Retrieves total delegate stake on a given reputer address in a given topic
 func (qs queryServer) GetDelegateStakeInTopicInReputer(ctx context.Context, req *types.QueryDelegateStakeInTopicInReputerRequest) (*types.QueryDelegateStakeInTopicInReputerResponse, error) {
+	if err := qs.k.ValidateStringIsBech32(req.ReputerAddress); err != nil {
+		return nil, err
+	}
 	stake, err := qs.k.GetDelegateStakeUponReputer(ctx, req.TopicId, req.ReputerAddress)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -42,6 +49,12 @@ func (qs queryServer) GetDelegateStakeInTopicInReputer(ctx context.Context, req 
 }
 
 func (qs queryServer) GetStakeFromDelegatorInTopicInReputer(ctx context.Context, req *types.QueryStakeFromDelegatorInTopicInReputerRequest) (*types.QueryStakeFromDelegatorInTopicInReputerResponse, error) {
+	if err := qs.k.ValidateStringIsBech32(req.ReputerAddress); err != nil {
+		return nil, errors.Wrapf(err, "reputer address")
+	}
+	if err := qs.k.ValidateStringIsBech32(req.DelegatorAddress); err != nil {
+		return nil, errors.Wrapf(err, "delegator address")
+	}
 	stake, err := qs.k.GetDelegateStakePlacement(ctx, req.TopicId, req.DelegatorAddress, req.ReputerAddress)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -51,6 +64,9 @@ func (qs queryServer) GetStakeFromDelegatorInTopicInReputer(ctx context.Context,
 }
 
 func (qs queryServer) GetStakeFromDelegatorInTopic(ctx context.Context, req *types.QueryStakeFromDelegatorInTopicRequest) (*types.QueryStakeFromDelegatorInTopicResponse, error) {
+	if err := qs.k.ValidateStringIsBech32(req.DelegatorAddress); err != nil {
+		return nil, err
+	}
 	stake, err := qs.k.GetStakeFromDelegatorInTopic(ctx, req.TopicId, req.DelegatorAddress)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/x/emissions/keeper/queryserver/query_server_stake_test.go
+++ b/x/emissions/keeper/queryserver/query_server_stake_test.go
@@ -27,10 +27,12 @@ func (s *KeeperTestSuite) TestGetReputerStakeInTopic() {
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
-	reputerAddr := PKS[0].Address().String()
-
+	reputer, err := sdk.AccAddressFromHexUnsafe(PKS[1].Address().String())
+	s.Require().NoError(err)
+	reputerAddr := reputer.String()
 	initialStake := cosmosMath.NewUint(250)
-	err := keeper.AddStake(ctx, topicId, reputerAddr, initialStake)
+
+	err = keeper.AddStake(ctx, topicId, reputerAddr, initialStake)
 	s.Require().NoError(err, "AddStake should not produce an error")
 
 	req := &types.QueryReputerStakeInTopicRequest{
@@ -49,11 +51,15 @@ func (s *KeeperTestSuite) TestGetDelegateStakeInTopicInReputer() {
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
-	delegatorAddr := PKS[0].Address().String()
-	reputerAddr := PKS[1].Address().String()
+	delegator, err := sdk.AccAddressFromHexUnsafe(PKS[0].Address().String())
+	s.Require().NoError(err)
+	delegatorAddr := delegator.String()
+	reputer, err := sdk.AccAddressFromHexUnsafe(PKS[1].Address().String())
+	s.Require().NoError(err)
+	reputerAddr := reputer.String()
 	initialStakeAmount := cosmosMath.NewUint(1000)
 
-	err := keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
+	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
 	s.Require().NoError(err, "AddDelegateStake should not produce an error")
 
 	req := &types.QueryDelegateStakeInTopicInReputerRequest{
@@ -73,11 +79,15 @@ func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopicInReputer() {
 	keeper := s.emissionsKeeper
 
 	topicId := uint64(123)
-	delegatorAddr := PKS[0].Address().String()
-	reputerAddr := PKS[1].Address().String()
+	delegator, err := sdk.AccAddressFromHexUnsafe(PKS[0].Address().String())
+	s.Require().NoError(err)
+	delegatorAddr := delegator.String()
+	reputer, err := sdk.AccAddressFromHexUnsafe(PKS[1].Address().String())
+	s.Require().NoError(err)
+	reputerAddr := reputer.String()
 	stakeAmount := cosmosMath.NewUint(50)
 
-	err := keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, stakeAmount)
+	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, stakeAmount)
 	s.Require().NoError(err, "AddDelegateStake should not produce an error")
 
 	req := &types.QueryStakeFromDelegatorInTopicInReputerRequest{
@@ -98,11 +108,13 @@ func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopic() {
 	keeper := s.emissionsKeeper
 
 	topicId := uint64(1)
-	delegatorAddr := sdk.AccAddress(PKS[0].Address()).String()
+	delegator, err := sdk.AccAddressFromHexUnsafe(PKS[0].Address().String())
+	s.Require().NoError(err)
+	delegatorAddr := delegator.String()
 	initialStakeAmount := cosmosMath.NewUint(500)
 	additionalStakeAmount := cosmosMath.NewUint(300)
 
-	err := keeper.AddDelegateStake(ctx, topicId, delegatorAddr, PKS[1].Address().String(), initialStakeAmount)
+	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, PKS[1].Address().String(), initialStakeAmount)
 	s.Require().NoError(err)
 
 	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, PKS[1].Address().String(), additionalStakeAmount)

--- a/x/emissions/keeper/queryserver/query_server_whitelist.go
+++ b/x/emissions/keeper/queryserver/query_server_whitelist.go
@@ -11,6 +11,9 @@ import (
 
 // Params defines the handler for the Query/Params RPC method.
 func (qs queryServer) IsWhitelistAdmin(ctx context.Context, req *types.QueryIsWhitelistAdminRequest) (*types.QueryIsWhitelistAdminResponse, error) {
+	if err := qs.k.ValidateStringIsBech32(req.Address); err != nil {
+		return nil, err
+	}
 	isAdmin, err := qs.k.IsWhitelistAdmin(ctx, req.Address)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
Adds validation for strings in all ingresses (msg and query server) that should be bech32.

Tests fixed in https://github.com/allora-network/allora-chain/pull/275