### PR TITLE
rm allorarequestaccountname

### DIFF
--- a/x/emissions/keeper/genesis.go
+++ b/x/emissions/keeper/genesis.go
@@ -10,12 +10,9 @@ import (
 
 // InitGenesis initializes the module state from a genesis state.
 func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) error {
-
 	// ensure the module account exists
 	stakingModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraStakingAccountName)
 	k.authKeeper.SetModuleAccount(ctx, stakingModuleAccount)
-	requestsModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraRequestsAccountName)
-	k.authKeeper.SetModuleAccount(ctx, requestsModuleAccount)
 	alloraRewardsModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraRewardsAccountName)
 	k.authKeeper.SetModuleAccount(ctx, alloraRewardsModuleAccount)
 	alloraPendingRewardsModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraPendingRewardForDelegatorAccountName)

--- a/x/emissions/keeper/inference_synthesis/inference_synthesis_test.go
+++ b/x/emissions/keeper/inference_synthesis/inference_synthesis_test.go
@@ -60,11 +60,10 @@ func (s *InferenceSynthesisTestSuite) SetupTest() {
 	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
 
 	maccPerms := map[string][]string{
-		"fee_collector":                 {"minter"},
-		"mint":                          {"minter"},
-		types.AlloraStakingAccountName:  {"burner", "minter", "staking"},
-		types.AlloraRequestsAccountName: {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName:  {"minter"},
+		"fee_collector":                {"minter"},
+		"mint":                         {"minter"},
+		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		types.AlloraRewardsAccountName: {"minter"},
 		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
 		"bonded_tokens_pool":                             {"burner", "staking"},
 		"not_bonded_tokens_pool":                         {"burner", "staking"},

--- a/x/emissions/keeper/msgserver/msg_server_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
 	"github.com/allora-network/allora-chain/x/emissions/module"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	mintTypes "github.com/allora-network/allora-chain/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -87,12 +86,10 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.addressCodec = addressCodec
 
 	maccPerms := map[string][]string{
-		"fee_collector":                                  {"minter"},
-		"mint":                                           {"minter"},
-		types.AlloraStakingAccountName:                   {"burner", "minter", "staking"},
-		types.AlloraRequestsAccountName:                  {"burner", "minter", "staking"},
-		mintTypes.EcosystemModuleName:                    {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName:                   {"minter"},
+		"fee_collector":                {"minter"},
+		"mint":                         {"minter"},
+		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		types.AlloraRewardsAccountName: {"minter"},
 		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
 		"bonded_tokens_pool":                             {"burner", "staking"},
 		"not_bonded_tokens_pool":                         {"burner", "staking"},

--- a/x/emissions/keeper/queryserver/query_server_test.go
+++ b/x/emissions/keeper/queryserver/query_server_test.go
@@ -80,12 +80,11 @@ func (s *KeeperTestSuite) SetupTest() {
 	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
 
 	maccPerms := map[string][]string{
-		"fee_collector":                                  {"minter"},
-		"mint":                                           {"minter"},
-		types.AlloraStakingAccountName:                   {"burner", "minter", "staking"},
-		types.AlloraRequestsAccountName:                  {"burner", "minter", "staking"},
-		mintTypes.EcosystemModuleName:                    {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName:                   {"minter"},
+		"fee_collector":                {"minter"},
+		"mint":                         {"minter"},
+		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		mintTypes.EcosystemModuleName:  {"burner", "minter", "staking"},
+		types.AlloraRewardsAccountName: {"minter"},
 		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
 		"bonded_tokens_pool":                             {"burner", "staking"},
 		"not_bonded_tokens_pool":                         {"burner", "staking"},

--- a/x/emissions/module/module_test.go
+++ b/x/emissions/module/module_test.go
@@ -57,11 +57,10 @@ func (s *ModuleTestSuite) SetupTest() {
 	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
 
 	maccPerms := map[string][]string{
-		"fee_collector":                 {"minter"},
-		"mint":                          {"minter"},
-		types.AlloraStakingAccountName:  {"burner", "minter", "staking"},
-		types.AlloraRequestsAccountName: {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName:  {"minter"},
+		"fee_collector":                {"minter"},
+		"mint":                         {"minter"},
+		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		types.AlloraRewardsAccountName: {"minter"},
 		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
 		"ecosystem":              {"minter"},
 		"bonded_tokens_pool":     {"burner", "staking"},

--- a/x/emissions/types/keys.go
+++ b/x/emissions/types/keys.go
@@ -6,7 +6,6 @@ const (
 	ModuleName                                 = "emissions"
 	StoreKey                                   = "emissions"
 	AlloraStakingAccountName                   = "allorastaking"
-	AlloraRequestsAccountName                  = "allorarequests"
 	AlloraRewardsAccountName                   = "allorarewards"
 	AlloraPendingRewardForDelegatorAccountName = "allorapendingrewards"
 )

--- a/x/mint/module/module_test.go
+++ b/x/mint/module/module_test.go
@@ -73,7 +73,6 @@ func (s *MintModuleTestSuite) SetupTest() {
 		emissionstypes.AlloraRewardsAccountName: nil,
 		emissionstypes.AlloraPendingRewardForDelegatorAccountName: nil,
 		emissionstypes.AlloraStakingAccountName:                   {"burner", "minter", "staking"},
-		emissionstypes.AlloraRequestsAccountName:                  {"burner", "minter", "staking"},
 		"bonded_tokens_pool":                                      {"burner", "staking"},
 		"not_bonded_tokens_pool":                                  {"burner", "staking"},
 		multiPerm:                                                 {"burner", "minter", "staking"},
@@ -180,7 +179,7 @@ func (s *MintModuleTestSuite) TestTotalStakeGoUpTargetEmissionPerUnitStakeGoDown
 	s.Require().True(ok)
 	err = s.bankKeeper.MintCoins(
 		s.ctx,
-		emissionstypes.AlloraRequestsAccountName,
+		"rando",
 		sdk.NewCoins(
 			sdk.NewCoin(
 				params.MintDenom,


### PR DESCRIPTION
`allorarequestaccountname` is now excessive and we can just use ecosystem bucket as the only escrow for circulating funds