### PR TITLE
Fix edge case zero combined loss

### DIFF
--- a/x/emissions/keeper/inference_synthesis/network_losses.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses.go
@@ -100,6 +100,10 @@ func CalcNetworkLosses(
 				fmt.Println("Error updating running weighted average for next combined loss: ", err)
 				return emissions.ValueBundle{}, err
 			}
+			// If the combined loss is zero, set it to epsilon to avoid divide by zero
+			if nextCombinedLoss.Loss.IsZero() {		
+				nextCombinedLoss.Loss = epsilon
+			}
 			runningWeightedCombinedLoss = nextCombinedLoss
 
 			// Not all reputers may have reported losses on the same set of inferers => important that the code below doesn't assume that!
@@ -245,11 +249,14 @@ func CalcCombinedNetworkLoss(
 			)
 			if err != nil {
 				fmt.Println("Error updating running weighted average for combined loss: ", err)
-				return alloraMath.ZeroDec(), err
+				return Loss{}, err
 			}
 			runningWeightedCombinedLoss = nextCombinedLoss
 		}
 	}
-
+	// If the combined loss is zero, set it to epsilon to avoid divide by zero
+	if runningWeightedCombinedLoss.Loss.IsZero() {
+		runningWeightedCombinedLoss.Loss = epsilon
+	}
 	return runningWeightedCombinedLoss.Loss, nil
 }

--- a/x/emissions/keeper/inference_synthesis/network_losses.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses.go
@@ -101,7 +101,7 @@ func CalcNetworkLosses(
 				return emissions.ValueBundle{}, err
 			}
 			// If the combined loss is zero, set it to epsilon to avoid divide by zero
-			if nextCombinedLoss.Loss.IsZero() {		
+			if nextCombinedLoss.Loss.IsZero() {
 				nextCombinedLoss.Loss = epsilon
 			}
 			runningWeightedCombinedLoss = nextCombinedLoss

--- a/x/emissions/keeper/inference_synthesis/network_losses_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses_test.go
@@ -176,6 +176,25 @@ func (s *InferenceSynthesisTestSuite) TestCalcCombinedNetworkLoss() {
 			expectedLoss: alloraMath.MustNewDecFromString(".000015456633"),
 			expectedErr:  nil,
 		},
+		{
+			name: "One reputer reporting a zero combined loss",
+			stakesByReputer: map[inference_synthesis.Worker]cosmosMath.Uint{
+				"worker1": inference_synthesis.CosmosUintOneE18(), // 1 token
+			},
+			reportedLosses: &emissions.ReputerValueBundles{
+				ReputerValueBundles: []*emissions.ReputerValueBundle{
+					{
+						ValueBundle: &emissions.ValueBundle{
+							Reputer:       "worker1",
+							CombinedValue: alloraMath.MustNewDecFromString("0"),
+						},
+					},
+				},
+			},
+			epsilon:      alloraMath.MustNewDecFromString("1e-4"),
+			expectedLoss: alloraMath.MustNewDecFromString("1e-4"), // Should be equal to epsilon
+			expectedErr:  nil,
+		},	
 	}
 
 	for _, tc := range tests {

--- a/x/emissions/keeper/inference_synthesis/network_losses_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses_test.go
@@ -194,7 +194,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcCombinedNetworkLoss() {
 			epsilon:      alloraMath.MustNewDecFromString("1e-4"),
 			expectedLoss: alloraMath.MustNewDecFromString("1e-4"), // Should be equal to epsilon
 			expectedErr:  nil,
-		},	
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
- Fallback stake-weighted combined loss to `epsilon` if it's equal to zero

Ticket: https://linear.app/upshot/issue/ORA-1391/no-weights-in-one-reputerlosses-breaks-the-calcnetworklosses