### PR TITLE
Covering edge cases for zero values in all reported losses

### DIFF
--- a/x/emissions/keeper/inference_synthesis/network_losses.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses.go
@@ -100,7 +100,6 @@ func CalcNetworkLosses(
 				fmt.Println("Error updating running weighted average for next combined loss: ", err)
 				return emissions.ValueBundle{}, err
 			}
-			// If the combined loss is zero, set it to epsilon to avoid divide by zero
 			if nextCombinedLoss.Loss.IsZero() {
 				nextCombinedLoss.Loss = epsilon
 			}
@@ -121,6 +120,9 @@ func CalcNetworkLosses(
 					fmt.Println("Error updating running weighted average for inferer: ", err)
 					return emissions.ValueBundle{}, err
 				}
+				if nextAvg.Loss.IsZero() {
+					nextAvg.Loss = epsilon
+				}
 				runningWeightedInfererLosses[loss.Worker] = &nextAvg
 			}
 
@@ -138,6 +140,9 @@ func CalcNetworkLosses(
 					fmt.Println("Error updating running weighted average for forecaster: ", err)
 					return emissions.ValueBundle{}, err
 				}
+				if nextAvg.Loss.IsZero() {
+					nextAvg.Loss = epsilon
+				}
 				runningWeightedForecasterLosses[loss.Worker] = &nextAvg
 			}
 
@@ -146,6 +151,9 @@ func CalcNetworkLosses(
 			if err != nil {
 				fmt.Println("Error updating running weighted average for naive loss: ", err)
 				return emissions.ValueBundle{}, err
+			}
+			if nextNaiveLoss.Loss.IsZero() {
+				nextNaiveLoss.Loss = epsilon
 			}
 			runningWeightedNaiveLoss = nextNaiveLoss
 
@@ -161,6 +169,9 @@ func CalcNetworkLosses(
 				if err != nil {
 					fmt.Println("Error updating running weighted average for one-out inferer: ", err)
 					return emissions.ValueBundle{}, err
+				}
+				if nextAvg.Loss.IsZero() {
+					nextAvg.Loss = epsilon
 				}
 				runningWeightedOneOutInfererLosses[loss.Worker] = &nextAvg
 			}
@@ -179,6 +190,9 @@ func CalcNetworkLosses(
 					fmt.Println("Error updating running weighted average for one-out forecaster: ", err)
 					return emissions.ValueBundle{}, err
 				}
+				if nextAvg.Loss.IsZero() {
+					nextAvg.Loss = epsilon
+				}
 				runningWeightedOneOutForecasterLosses[loss.Worker] = &nextAvg
 			}
 
@@ -195,6 +209,9 @@ func CalcNetworkLosses(
 				if err != nil {
 					fmt.Println("Error updating running weighted average for one-in forecaster: ", err)
 					return emissions.ValueBundle{}, err
+				}
+				if nextAvg.Loss.IsZero() {
+					nextAvg.Loss = epsilon
 				}
 				runningWeightedOneInForecasterLosses[loss.Worker] = &nextAvg
 			}

--- a/x/emissions/module/rewards/rewards_internal_test.go
+++ b/x/emissions/module/rewards/rewards_internal_test.go
@@ -368,6 +368,7 @@ func TestGetScoreFractions(t *testing.T) {
 		latestWorkerScores    []alloraMath.Dec
 		latestTimeStepsScores []alloraMath.Dec
 		pReward               alloraMath.Dec
+		epsilon               alloraMath.Dec
 		want                  []alloraMath.Dec
 		wantErr               bool
 	}{
@@ -384,6 +385,7 @@ func TestGetScoreFractions(t *testing.T) {
 				alloraMath.MustNewDecFromString("0.09719"), alloraMath.MustNewDecFromString("0.09675"), alloraMath.MustNewDecFromString("0.09418"),
 			},
 			pReward: alloraMath.MustNewDecFromString("1.5"),
+			epsilon: alloraMath.MustNewDecFromString("1e-4"),
 			want:    []alloraMath.Dec{alloraMath.MustNewDecFromString("0.07671471224853309"), alloraMath.MustNewDecFromString("0.055310145462117234"), alloraMath.MustNewDecFromString("0.09829388639227018"), alloraMath.MustNewDecFromString("0.21538198445289035"), alloraMath.MustNewDecFromString("0.5542992714441891")},
 			wantErr: false,
 		},
@@ -391,7 +393,7 @@ func TestGetScoreFractions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := rewards.GetScoreFractions(tt.latestWorkerScores, tt.latestTimeStepsScores, tt.pReward)
+			got, err := rewards.GetScoreFractions(tt.latestWorkerScores, tt.latestTimeStepsScores, tt.pReward, tt.epsilon)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetWorkerPortionOfRewards() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -607,10 +609,12 @@ func TestGetAllConsensusScores(t *testing.T) {
 	stakes := []alloraMath.Dec{alloraMath.MustNewDecFromString("1176644.37627"), alloraMath.MustNewDecFromString("384623.3607"), alloraMath.MustNewDecFromString("394676.13226"), alloraMath.MustNewDecFromString("207999.66194"), alloraMath.MustNewDecFromString("368582.76542")}
 	allListeningCoefficients := []alloraMath.Dec{alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("1.0")}
 	var numReputers int64 = 5
+	fTolerance := alloraMath.MustNewDecFromString("0.01")
+	epsilon := alloraMath.MustNewDecFromString("1e-4")
 	want := []alloraMath.Dec{alloraMath.MustNewDecFromString("0.0169833"), alloraMath.MustNewDecFromString("0.01706869"), alloraMath.MustNewDecFromString("0.016047"), alloraMath.MustNewDecFromString("0.01164"), alloraMath.MustNewDecFromString("0.01345")}
 	wantErr := false
 
-	got, err := rewards.GetAllConsensusScores(allLosses, stakes, allListeningCoefficients, numReputers)
+	got, err := rewards.GetAllConsensusScores(allLosses, stakes, allListeningCoefficients, numReputers, fTolerance, epsilon)
 	if (err != nil) != wantErr {
 		t.Errorf("GetAllConsensusScores() error = %v, wantErr %v", err, wantErr)
 		return
@@ -626,6 +630,8 @@ func (s *RewardsTestSuite) TestGetAllReputersOutput() {
 
 	params, err := s.emissionsKeeper.GetParams(s.ctx)
 	require.NoError(err)
+
+	fTolerance := alloraMath.MustNewDecFromString("0.01")
 
 	allLosses := [][]alloraMath.Dec{
 		{alloraMath.MustNewDecFromString("0.0112"), alloraMath.MustNewDecFromString("0.00231"), alloraMath.MustNewDecFromString("0.02274"), alloraMath.MustNewDecFromString("0.01299"), alloraMath.MustNewDecFromString("0.02515"), alloraMath.MustNewDecFromString("0.0185"), alloraMath.MustNewDecFromString("0.01018"), alloraMath.MustNewDecFromString("0.02105"), alloraMath.MustNewDecFromString("0.01041"), alloraMath.MustNewDecFromString("0.0183"), alloraMath.MustNewDecFromString("0.01022"), alloraMath.MustNewDecFromString("0.01333"), alloraMath.MustNewDecFromString("0.01298"), alloraMath.MustNewDecFromString("0.01023"), alloraMath.MustNewDecFromString("0.01268"), alloraMath.MustNewDecFromString("0.01381"), alloraMath.MustNewDecFromString("0.01731"), alloraMath.MustNewDecFromString("0.01238"), alloraMath.MustNewDecFromString("0.01168"), alloraMath.MustNewDecFromString("0.00929"), alloraMath.MustNewDecFromString("0.01212"), alloraMath.MustNewDecFromString("0.01806"), alloraMath.MustNewDecFromString("0.01901"), alloraMath.MustNewDecFromString("0.01828"), alloraMath.MustNewDecFromString("0.01522"), alloraMath.MustNewDecFromString("0.01833"), alloraMath.MustNewDecFromString("0.0101"), alloraMath.MustNewDecFromString("0.01224"), alloraMath.MustNewDecFromString("0.01226"), alloraMath.MustNewDecFromString("0.01474"), alloraMath.MustNewDecFromString("0.01218"), alloraMath.MustNewDecFromString("0.01604"), alloraMath.MustNewDecFromString("0.01149"), alloraMath.MustNewDecFromString("0.02075"), alloraMath.MustNewDecFromString("0.00818"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01127"), alloraMath.MustNewDecFromString("0.01495"), alloraMath.MustNewDecFromString("0.00689"), alloraMath.MustNewDecFromString("0.0108"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.0124"), alloraMath.MustNewDecFromString("0.01588"), alloraMath.MustNewDecFromString("0.01012"), alloraMath.MustNewDecFromString("0.01467"), alloraMath.MustNewDecFromString("0.0128"), alloraMath.MustNewDecFromString("0.01234"), alloraMath.MustNewDecFromString("0.0148"), alloraMath.MustNewDecFromString("0.01046"), alloraMath.MustNewDecFromString("0.01192"), alloraMath.MustNewDecFromString("0.01381"), alloraMath.MustNewDecFromString("0.01687"), alloraMath.MustNewDecFromString("0.01136"), alloraMath.MustNewDecFromString("0.01185"), alloraMath.MustNewDecFromString("0.01568"), alloraMath.MustNewDecFromString("0.00949"), alloraMath.MustNewDecFromString("0.01339")},
@@ -670,6 +676,8 @@ func (s *RewardsTestSuite) TestGetAllReputersOutput() {
 		numReputers,
 		params.LearningRate,
 		1,
+		fTolerance,
+		params.Epsilon,
 	)
 	require.NoError(err)
 
@@ -680,6 +688,8 @@ func (s *RewardsTestSuite) TestGetAllReputersOutput() {
 		numReputers,
 		params.LearningRate,
 		2,
+		fTolerance,
+		params.Epsilon,
 	)
 	require.NoError(err)
 
@@ -690,6 +700,8 @@ func (s *RewardsTestSuite) TestGetAllReputersOutput() {
 		numReputers,
 		params.LearningRate,
 		3,
+		fTolerance,
+		params.Epsilon,
 	)
 	require.NoError(err)
 

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -64,6 +64,11 @@ func GenerateReputerScores(
 		return []types.Score{}, errors.Wrapf(err, "Error getting GetParams")
 	}
 
+	topic, err := keeper.GetTopic(ctx, topicId)
+	if err != nil {
+		return []types.Score{}, errors.Wrapf(err, "Error getting GetTopic")
+	}
+
 	// Get reputer output
 	scores, newCoefficients, err := GetAllReputersOutput(
 		losses,
@@ -72,6 +77,8 @@ func GenerateReputerScores(
 		int64(len(reputerStakes)),
 		params.LearningRate,
 		params.GradientDescentMaxIters,
+		topic.FTolerance,
+		params.Epsilon,
 	)
 	if err != nil {
 		return []types.Score{}, errors.Wrapf(err, "Error getting GetAllReputersOutput")

--- a/x/emissions/module/rewards/worker_rewards.go
+++ b/x/emissions/module/rewards/worker_rewards.go
@@ -99,7 +99,11 @@ func GetWorkersRewardFractions(
 		scores = append(scores, workerLastScoresDec)
 	}
 
-	rewardFractions, err := GetScoreFractions(latestWorkerScores, flatten(scores), pRewardSpread)
+	epsilon, err := k.GetParamsEpsilon(ctx)
+	if err != nil {
+		return []string{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to get epsilon")
+	}
+	rewardFractions, err := GetScoreFractions(latestWorkerScores, flatten(scores), pRewardSpread, epsilon)
 	if err != nil {
 		return []string{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to get score fractions")
 	}


### PR DESCRIPTION
-> Covering edge cases where:
1) All reported inferer values are 0
2) All reported forecaster values are 0
...
Considering all properties of the Reputer Value Bundle. 

-> Critical fix where we start using the fTolerance from the topic instead of a mocked one. 

Ticket: https://linear.app/upshot/issue/ORA-1453/cover-edge-case-zero-values-in-all-reported-losses-values