### PR TITLE
[ORA-1456] [ORA-1449] Remove AlloraRequests Module Account

### DIFF
--- a/x/emissions/keeper/genesis.go
+++ b/x/emissions/keeper/genesis.go
@@ -10,12 +10,9 @@ import (
 
 // InitGenesis initializes the module state from a genesis state.
 func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) error {
-
 	// ensure the module account exists
 	stakingModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraStakingAccountName)
 	k.authKeeper.SetModuleAccount(ctx, stakingModuleAccount)
-	requestsModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraRequestsAccountName)
-	k.authKeeper.SetModuleAccount(ctx, requestsModuleAccount)
 	alloraRewardsModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraRewardsAccountName)
 	k.authKeeper.SetModuleAccount(ctx, alloraRewardsModuleAccount)
 	alloraPendingRewardsModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraPendingRewardForDelegatorAccountName)

--- a/x/emissions/keeper/inference_synthesis/inference_synthesis_test.go
+++ b/x/emissions/keeper/inference_synthesis/inference_synthesis_test.go
@@ -60,11 +60,10 @@ func (s *InferenceSynthesisTestSuite) SetupTest() {
 	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
 
 	maccPerms := map[string][]string{
-		"fee_collector":                 {"minter"},
-		"mint":                          {"minter"},
-		types.AlloraStakingAccountName:  {"burner", "minter", "staking"},
-		types.AlloraRequestsAccountName: {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName:  {"minter"},
+		"fee_collector":                {"minter"},
+		"mint":                         {"minter"},
+		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		types.AlloraRewardsAccountName: {"minter"},
 		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
 		"bonded_tokens_pool":                             {"burner", "staking"},
 		"not_bonded_tokens_pool":                         {"burner", "staking"},

--- a/x/emissions/keeper/msgserver/msg_server_demand.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand.go
@@ -6,6 +6,7 @@ import (
 	appParams "github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
+	minttypes "github.com/allora-network/allora-chain/x/mint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -35,7 +36,7 @@ func (ms msgServer) FundTopic(ctx context.Context, msg *types.MsgFundTopic) (*ty
 	// bank module does this for us in module SendCoins / subUnlockedCoins so we don't need to check
 	// Send funds
 	coins := sdk.NewCoins(sdk.NewCoin(appParams.DefaultBondDenom, msg.Amount))
-	err = ms.k.SendCoinsFromAccountToModule(ctx, msg.Sender, types.AlloraRequestsAccountName, coins)
+	err = ms.k.SendCoinsFromAccountToModule(ctx, msg.Sender, minttypes.EcosystemModuleName, coins)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/msgserver/msg_server_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
 	"github.com/allora-network/allora-chain/x/emissions/module"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	mintTypes "github.com/allora-network/allora-chain/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -87,12 +86,10 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.addressCodec = addressCodec
 
 	maccPerms := map[string][]string{
-		"fee_collector":                                  {"minter"},
-		"mint":                                           {"minter"},
-		types.AlloraStakingAccountName:                   {"burner", "minter", "staking"},
-		types.AlloraRequestsAccountName:                  {"burner", "minter", "staking"},
-		mintTypes.EcosystemModuleName:                    {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName:                   {"minter"},
+		"fee_collector":                {"minter"},
+		"mint":                         {"minter"},
+		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		types.AlloraRewardsAccountName: {"minter"},
 		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
 		"bonded_tokens_pool":                             {"burner", "staking"},
 		"not_bonded_tokens_pool":                         {"burner", "staking"},

--- a/x/emissions/keeper/msgserver/msg_server_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
 	"github.com/allora-network/allora-chain/x/emissions/module"
 	"github.com/allora-network/allora-chain/x/emissions/types"
+	minttypes "github.com/allora-network/allora-chain/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -91,6 +92,7 @@ func (s *KeeperTestSuite) SetupTest() {
 		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
 		types.AlloraRewardsAccountName: {"minter"},
 		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
+		minttypes.EcosystemModuleName:                    nil,
 		"bonded_tokens_pool":                             {"burner", "staking"},
 		"not_bonded_tokens_pool":                         {"burner", "staking"},
 		multiPerm:                                        {"burner", "minter", "staking"},

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -276,7 +276,7 @@ func (ms msgServer) InsertBulkWorkerPayload(ctx context.Context, msg *types.MsgI
 		BlockHeight: msg.Nonce.BlockHeight - topic.EpochLength,
 	}
 
-	ms.k.AddReputerNonce(ctx, topic.Id, msg.Nonce, workerNonce)
+	err = ms.k.AddReputerNonce(ctx, topic.Id, msg.Nonce, workerNonce)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/queryserver/query_server_test.go
+++ b/x/emissions/keeper/queryserver/query_server_test.go
@@ -80,12 +80,11 @@ func (s *KeeperTestSuite) SetupTest() {
 	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
 
 	maccPerms := map[string][]string{
-		"fee_collector":                                  {"minter"},
-		"mint":                                           {"minter"},
-		types.AlloraStakingAccountName:                   {"burner", "minter", "staking"},
-		types.AlloraRequestsAccountName:                  {"burner", "minter", "staking"},
-		mintTypes.EcosystemModuleName:                    {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName:                   {"minter"},
+		"fee_collector":                {"minter"},
+		"mint":                         {"minter"},
+		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		mintTypes.EcosystemModuleName:  {"burner", "minter", "staking"},
+		types.AlloraRewardsAccountName: {"minter"},
 		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
 		"bonded_tokens_pool":                             {"burner", "staking"},
 		"not_bonded_tokens_pool":                         {"burner", "staking"},

--- a/x/emissions/module/module_test.go
+++ b/x/emissions/module/module_test.go
@@ -57,11 +57,10 @@ func (s *ModuleTestSuite) SetupTest() {
 	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
 
 	maccPerms := map[string][]string{
-		"fee_collector":                 {"minter"},
-		"mint":                          {"minter"},
-		types.AlloraStakingAccountName:  {"burner", "minter", "staking"},
-		types.AlloraRequestsAccountName: {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName:  {"minter"},
+		"fee_collector":                {"minter"},
+		"mint":                         {"minter"},
+		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		types.AlloraRewardsAccountName: {"minter"},
 		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
 		"ecosystem":              {"minter"},
 		"bonded_tokens_pool":     {"burner", "staking"},

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -7,7 +7,6 @@ import (
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	mintTypes "github.com/allora-network/allora-chain/x/mint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -130,13 +129,12 @@ func GenerateRewardsDistributionByTopic(
 	}
 	// Filter out topics that are not reward-ready, inactivate if needed
 	// Update sum weight and revenue
-	weightsOfActiveTopics, sumWeight, sumRevenue, err := FilterAndInactivateTopicsUpdatingSums(
+	weightsOfActiveTopics, sumWeight, err := FilterAndInactivateTopicsUpdatingSums(
 		ctx,
 		k,
 		weights,
 		sortedTopics,
 		sumWeight,
-		totalRevenue,
 		totalReward,
 		blockHeight,
 	)
@@ -185,19 +183,6 @@ func GenerateRewardsDistributionByTopic(
 		}
 	}
 
-	// Send remaining collected inference request fees to the Ecosystem module account
-	// They will be paid out to reputers, workers, and validators
-	// according to the formulas in the beginblock of the mint module
-	err = k.SendCoinsFromModuleToModule(
-		ctx,
-		types.AlloraRequestsAccountName,
-		mintTypes.EcosystemModuleName,
-		sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(sumRevenue.Sub(sumRevenueOfBottomTopics).BigInt().Int64()))))
-	if err != nil {
-		ctx.Logger().Error("Error sending coins from module to module: ", err)
-		return nil, err
-	}
-
 	sortedTopTopics := alloraMath.GetSortedKeys(weightsOfTopActiveTopics)
 
 	weightOfTopTopics, err := sumWeight.Sub(sumWeightOfBottomTopics)
@@ -214,21 +199,17 @@ func GenerateRewardsDistributionByTopic(
 	return topicRewards, nil
 }
 
-func removeFromSumWeightAndRevenue(ctx sdk.Context, k keeper.Keeper, sumWeight alloraMath.Dec, sumRevenue cosmosMath.Int,
-	weight *alloraMath.Dec, topicId uint64) (alloraMath.Dec, cosmosMath.Int, error) {
+func removeFromSumWeightAndRevenue(
+	sumWeight alloraMath.Dec,
+	weight *alloraMath.Dec,
+) (alloraMath.Dec, error) {
 	// Update sum weight and revenue -- We won't be deducting fees from inactive topics, as we won't be churning them
 	// i.e. we'll neither emit their worker/reputer requests or calculate rewards for its participants this epoch
 	sumWeight, err := sumWeight.Sub(*weight)
 	if err != nil {
-		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to subtract weight from sum")
+		return alloraMath.Dec{}, errors.Wrapf(err, "failed to subtract weight from sum")
 	}
-	topicFeeRevenue, err := k.GetTopicFeeRevenue(ctx, topicId)
-	if err != nil {
-		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get topic fee revenue")
-	}
-	sumRevenue = sumRevenue.Sub(topicFeeRevenue.Revenue)
-
-	return sumWeight, sumRevenue, nil
+	return sumWeight, nil
 }
 
 func FilterAndInactivateTopicsUpdatingSums(
@@ -237,19 +218,17 @@ func FilterAndInactivateTopicsUpdatingSums(
 	weights map[uint64]*alloraMath.Dec,
 	sortedTopics []uint64,
 	sumWeight alloraMath.Dec,
-	sumRevenue cosmosMath.Int,
 	totalReward alloraMath.Dec,
 	blockHeight BlockHeight,
 ) (
 	map[uint64]*alloraMath.Dec,
 	alloraMath.Dec,
-	cosmosMath.Int,
 	error,
 ) {
 
 	minTopicWeight, err := k.GetParamsMinTopicWeight(ctx)
 	if err != nil {
-		return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get min topic weight")
+		return nil, alloraMath.Dec{}, errors.Wrapf(err, "failed to get min topic weight")
 	}
 
 	weightsOfActiveTopics := make(map[TopicId]*alloraMath.Dec)
@@ -275,14 +254,14 @@ func FilterAndInactivateTopicsUpdatingSums(
 		if weight.Lt(minTopicWeight) {
 			err = k.InactivateTopic(ctx, topicId)
 			if err != nil {
-				return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to inactivate topic")
+				return nil, alloraMath.Dec{}, errors.Wrapf(err, "failed to inactivate topic")
 			}
 
 			// This way we won't double count from this earlier epoch revenue the next time this topic is activated
 			// This must come after GetTopicFeeRevenue() is last called per topic because otherwise the returned revenue will be zero
 			err = k.ResetTopicFeeRevenue(ctx, topicId, blockHeight)
 			if err != nil {
-				return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to reset topic fee revenue")
+				return nil, alloraMath.Dec{}, errors.Wrapf(err, "failed to reset topic fee revenue")
 			}
 
 			// Update sum weight and revenue -- We won't be deducting fees from inactive topics, as we won't be churning them
@@ -291,15 +270,15 @@ func FilterAndInactivateTopicsUpdatingSums(
 			filterOutErrorMessage = "failed to remove inactivated from sum weight and revenue"
 		}
 		if filterOutTopic {
-			sumWeight, sumRevenue, err = removeFromSumWeightAndRevenue(ctx, k, sumWeight, sumRevenue, weight, topicId)
+			sumWeight, err = removeFromSumWeightAndRevenue(sumWeight, weight)
 			if err != nil {
-				return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, filterOutErrorMessage)
+				return nil, alloraMath.Dec{}, errors.Wrapf(err, filterOutErrorMessage)
 			}
 		} else {
 			weightsOfActiveTopics[topicId] = weight
 		}
 	}
-	return weightsOfActiveTopics, sumWeight, sumRevenue, nil
+	return weightsOfActiveTopics, sumWeight, nil
 }
 
 func CalcTopicRewards(

--- a/x/emissions/types/keys.go
+++ b/x/emissions/types/keys.go
@@ -6,7 +6,6 @@ const (
 	ModuleName                                 = "emissions"
 	StoreKey                                   = "emissions"
 	AlloraStakingAccountName                   = "allorastaking"
-	AlloraRequestsAccountName                  = "allorarequests"
 	AlloraRewardsAccountName                   = "allorarewards"
 	AlloraPendingRewardForDelegatorAccountName = "allorapendingrewards"
 )

--- a/x/mint/module/module_test.go
+++ b/x/mint/module/module_test.go
@@ -73,7 +73,6 @@ func (s *MintModuleTestSuite) SetupTest() {
 		emissionstypes.AlloraRewardsAccountName: nil,
 		emissionstypes.AlloraPendingRewardForDelegatorAccountName: nil,
 		emissionstypes.AlloraStakingAccountName:                   {"burner", "minter", "staking"},
-		emissionstypes.AlloraRequestsAccountName:                  {"burner", "minter", "staking"},
 		"bonded_tokens_pool":                                      {"burner", "staking"},
 		"not_bonded_tokens_pool":                                  {"burner", "staking"},
 		multiPerm:                                                 {"burner", "minter", "staking"},
@@ -182,7 +181,7 @@ func (s *MintModuleTestSuite) TestTotalStakeGoUpTargetEmissionPerUnitStakeGoDown
 	s.Require().True(ok)
 	err = s.bankKeeper.MintCoins(
 		s.ctx,
-		emissionstypes.AlloraRequestsAccountName,
+		"rando",
 		sdk.NewCoins(
 			sdk.NewCoin(
 				params.MintDenom,

--- a/x/mint/module/module_test.go
+++ b/x/mint/module/module_test.go
@@ -40,6 +40,7 @@ import (
 const (
 	multiPerm  = "multiple permissions account"
 	randomPerm = "random permission"
+	thirdParty = "third_party"
 )
 
 type MintModuleTestSuite struct {
@@ -67,7 +68,7 @@ func (s *MintModuleTestSuite) SetupTest() {
 
 	maccPerms := map[string][]string{
 		"fee_collector":                         nil,
-		"third_party":                           {"minter"},
+		thirdParty:                              {"minter"},
 		"ecosystem":                             {"burner", "minter", "staking"},
 		"mint":                                  {"minter"},
 		emissionstypes.AlloraRewardsAccountName: nil,
@@ -181,7 +182,7 @@ func (s *MintModuleTestSuite) TestTotalStakeGoUpTargetEmissionPerUnitStakeGoDown
 	s.Require().True(ok)
 	err = s.bankKeeper.MintCoins(
 		s.ctx,
-		"rando",
+		thirdParty,
 		sdk.NewCoins(
 			sdk.NewCoin(
 				params.MintDenom,
@@ -368,7 +369,7 @@ func (s *MintModuleTestSuite) TestTokensAreMintedIfInferenceRequestFeesNotEnough
 	s.Require().True(ok)
 	err = s.bankKeeper.MintCoins(
 		s.ctx,
-		"third_party",
+		thirdParty,
 		sdk.NewCoins(
 			sdk.NewCoin(
 				sdk.DefaultBondDenom,


### PR DESCRIPTION
Removes the alloraRequests module account, and sends payments directly to the ecosystem bucket instead.

Built off of @kpeluso's work in and closes #276 however that PR was built against a different PR that hasn't yet been merged and might be superseded by @guilherme-brandao's work. So this PR is a git diff patch applied against major-upgrade and with the tests and compiler errors fixed.