### PR TITLE
[ORA-1413] Remove fmt.Print statements

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -2,14 +2,13 @@ package app
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"os"
 	"strings"
-
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type BlocklessRequest struct {
@@ -47,6 +46,7 @@ type LossesPayload struct {
 }
 
 func generateLossesRequest(
+	ctx sdk.Context,
 	inferences *emissionstypes.ValueBundle,
 	functionId string,
 	functionMethod string,
@@ -58,7 +58,7 @@ func generateLossesRequest(
 
 	inferencesPayloadJSON, err := json.Marshal(inferences)
 	if err != nil {
-		fmt.Println("Error marshalling JSON:", err)
+		ctx.Logger().Warn("Error marshalling JSON:", err)
 		return
 	}
 
@@ -100,7 +100,7 @@ func generateLossesRequest(
 
 	payload, err := json.Marshal(calcWeightsReq)
 	if err != nil {
-		fmt.Println("Error marshalling outer JSON:", err)
+		ctx.Logger().Warn("Error marshalling outer JSON:", err)
 		return
 	}
 	payloadStr := string(payload)
@@ -108,6 +108,7 @@ func generateLossesRequest(
 }
 
 func generateInferencesRequest(
+	ctx sdk.Context,
 	functionId string,
 	functionMethod string,
 	param string,
@@ -145,31 +146,32 @@ func generateInferencesRequest(
 	}
 	payload, err := json.Marshal(payloadJson)
 	if err != nil {
-		fmt.Println("Error marshalling outer JSON:", err)
+		ctx.Logger().Warn("Error marshalling outer JSON:", err)
 	}
 	payloadStr := string(payload)
 
-	makeApiCall(payloadStr)
+	ctx.Logger().Debug("Making API call with payload: ", payloadStr)
+	err = makeApiCall(payloadStr)
+	if err != nil {
+		ctx.Logger().Warn("Error making API call:", err)
+	}
 }
 
-func makeApiCall(payload string) {
-	fmt.Println("Making Api Call, Payload: ", payload)
+func makeApiCall(payload string) error {
 	url := os.Getenv("BLOCKLESS_API_URL")
 	method := "POST"
 
 	client := &http.Client{}
 	req, err := http.NewRequest(method, url, strings.NewReader(payload))
 	if err != nil {
-		fmt.Println(err)
-		return
+		return err
 	}
 	req.Header.Add("Accept", "application/json, text/plain, */*")
 	req.Header.Add("Content-Type", "application/json;charset=UTF-8")
 
 	res, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
-		return
+		return err
 	}
 	defer res.Body.Close()
 }

--- a/app/api.go
+++ b/app/api.go
@@ -174,4 +174,6 @@ func makeApiCall(payload string) error {
 		return err
 	}
 	defer res.Body.Close()
+
+	return nil
 }

--- a/test/stress/README.md
+++ b/test/stress/README.md
@@ -9,6 +9,7 @@ bash local_testnet_l1.sh
 To run stress tests, set the STRESS_TEST variable to true
 
 ```
+cd stress
 STRESS_TEST=true go test -v -timeout 0 -test.run TestStressTestSuite .
 ```
 

--- a/x/emissions/keeper/inference_synthesis/forecast_implied_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied_inferences.go
@@ -1,10 +1,8 @@
 package inference_synthesis
 
 import (
-	"fmt"
-
+	errorsmod "cosmossdk.io/errors"
 	alloraMath "github.com/allora-network/allora-chain/math"
-
 	emissions "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
@@ -102,13 +100,11 @@ func CalcForecastImpliedInferences(
 					if inferenceByWorker[inferer] != nil {
 						weightInferenceDotProduct, err = weightInferenceDotProduct.Add(inferenceByWorker[inferer].Value)
 						if err != nil {
-							fmt.Println("Error adding dot product: ", err)
-							return nil, err
+							return nil, errorsmod.Wrapf(err, "error adding dot product")
 						}
 						weightSum, err = weightSum.Add(alloraMath.OneDec())
 						if err != nil {
-							fmt.Println("Error adding weight: ", err)
-							return nil, err
+							return nil, errorsmod.Wrapf(err, "error adding weight")
 						}
 					}
 				}
@@ -130,8 +126,7 @@ func CalcForecastImpliedInferences(
 					// Calculate the approximate forecast regret of the network inference
 					R_ik[j], err = networkCombinedLoss.Sub(forecastElementsByInferer[j].Value)
 					if err != nil {
-						fmt.Println("Error calculating network loss per value: ", err)
-						return nil, err
+						return nil, errorsmod.Wrapf(err, "error calculating network loss per value")
 					}
 					if first {
 						maxjRijk = R_ik[j]
@@ -149,13 +144,11 @@ func CalcForecastImpliedInferences(
 				for _, j := range sortedInferersInForecast {
 					R_ik[j], err = R_ik[j].Quo(maxjRijk.Abs()) // \hatR_ijk = R_ijk / |max_{j'}(R_ijk)|
 					if err != nil {
-						fmt.Println("Error calculating normalized forecasted regrets: ", err)
-						return nil, err
+						return nil, errorsmod.Wrapf(err, "error calculating normalized forecasted regrets")
 					}
 					w_ijk, err := Gradient(pInferenceSynthesis, R_ik[j]) // w_ijk = φ'_p(\hatR_ijk)
 					if err != nil {
-						fmt.Println("Error calculating gradient: ", err)
-						return nil, err
+						return nil, errorsmod.Wrapf(err, "error calculating gradient")
 					}
 					w_ik[j] = w_ijk
 				}
@@ -166,18 +159,15 @@ func CalcForecastImpliedInferences(
 					if inferenceByWorker[j] != nil && !(w_ijk.Equal(alloraMath.ZeroDec())) {
 						thisDotProduct, err := w_ijk.Mul(inferenceByWorker[j].Value)
 						if err != nil {
-							fmt.Println("Error calculating dot product: ", err)
-							return nil, err
+							return nil, errorsmod.Wrapf(err, "error calculating dot product")
 						}
 						weightInferenceDotProduct, err = weightInferenceDotProduct.Add(thisDotProduct)
 						if err != nil {
-							fmt.Println("Error adding dot product: ", err)
-							return nil, err
+							return nil, errorsmod.Wrapf(err, "error adding dot product")
 						}
 						weightSum, err = weightSum.Add(w_ijk)
 						if err != nil {
-							fmt.Println("Error adding weight: ", err)
-							return nil, err
+							return nil, errorsmod.Wrapf(err, "error adding weight")
 						}
 					}
 				}
@@ -185,8 +175,7 @@ func CalcForecastImpliedInferences(
 
 			forecastValue, err := weightInferenceDotProduct.Quo(weightSum)
 			if err != nil {
-				fmt.Println("Error calculating forecast value: ", err)
-				return nil, err
+				return nil, errorsmod.Wrapf(err, "error calculating forecast value")
 			}
 			forecastImpliedInference := emissions.Inference{
 				Inferer: forecast.Forecaster,

--- a/x/emissions/keeper/inference_synthesis/network_losses.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses.go
@@ -1,10 +1,8 @@
 package inference_synthesis
 
 import (
-	"fmt"
-
+	errorsmod "cosmossdk.io/errors"
 	alloraMath "github.com/allora-network/allora-chain/math"
-
 	emissions "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
@@ -51,7 +49,6 @@ func convertMapOfRunningWeightedLossesToWorkerAttributedValue[T emissions.Worker
 		}
 		normalizedWeightedLoss, err := normalizeWeightedLoss(runningLoss, epsilon)
 		if err != nil {
-			fmt.Println("Error normalizing weighted loss: ", err)
 			continue
 		}
 		weightedLosses = append(weightedLosses, &T{
@@ -87,8 +84,7 @@ func CalcNetworkLosses(
 			// Update combined loss with reputer reported loss and stake
 			runningWeightedCombinedLoss, err = RunningWeightedAvgUpdate(&runningWeightedCombinedLoss, stakeAmount, report.ValueBundle.CombinedValue)
 			if err != nil {
-				fmt.Println("Error updating running weighted average for next combined loss: ", err)
-				return emissions.ValueBundle{}, err
+				return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for next combined loss")
 			}
 
 			// Not all reputers may have reported losses on the same set of inferers => important that the code below doesn't assume that!
@@ -103,8 +99,7 @@ func CalcNetworkLosses(
 
 				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedInfererLosses[loss.Worker], stakeAmount, loss.Value)
 				if err != nil {
-					fmt.Println("Error updating running weighted average for inferer: ", err)
-					return emissions.ValueBundle{}, err
+					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for inferer")
 				}
 				runningWeightedInfererLosses[loss.Worker] = &nextAvg
 			}
@@ -120,8 +115,7 @@ func CalcNetworkLosses(
 
 				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedForecasterLosses[loss.Worker], stakeAmount, loss.Value)
 				if err != nil {
-					fmt.Println("Error updating running weighted average for forecaster: ", err)
-					return emissions.ValueBundle{}, err
+					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for forecaster")
 				}
 				runningWeightedForecasterLosses[loss.Worker] = &nextAvg
 			}
@@ -129,8 +123,7 @@ func CalcNetworkLosses(
 			// Update naive loss
 			runningWeightedNaiveLoss, err = RunningWeightedAvgUpdate(&runningWeightedNaiveLoss, stakeAmount, report.ValueBundle.NaiveValue)
 			if err != nil {
-				fmt.Println("Error updating running weighted average for naive loss: ", err)
-				return emissions.ValueBundle{}, err
+				return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for naive loss: ")
 			}
 
 			// Update one-out inferer losses
@@ -143,8 +136,7 @@ func CalcNetworkLosses(
 				}
 				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedOneOutInfererLosses[loss.Worker], stakeAmount, loss.Value)
 				if err != nil {
-					fmt.Println("Error updating running weighted average for one-out inferer: ", err)
-					return emissions.ValueBundle{}, err
+					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for one-out inferer")
 				}
 				runningWeightedOneOutInfererLosses[loss.Worker] = &nextAvg
 			}
@@ -160,8 +152,7 @@ func CalcNetworkLosses(
 
 				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedOneOutForecasterLosses[loss.Worker], stakeAmount, loss.Value)
 				if err != nil {
-					fmt.Println("Error updating running weighted average for one-out forecaster: ", err)
-					return emissions.ValueBundle{}, err
+					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for one-out forecaster")
 				}
 				runningWeightedOneOutForecasterLosses[loss.Worker] = &nextAvg
 			}
@@ -177,8 +168,7 @@ func CalcNetworkLosses(
 
 				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedOneInForecasterLosses[loss.Worker], stakeAmount, loss.Value)
 				if err != nil {
-					fmt.Println("Error updating running weighted average for one-in forecaster: ", err)
-					return emissions.ValueBundle{}, err
+					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for one-in forecaster")
 				}
 				runningWeightedOneInForecasterLosses[loss.Worker] = &nextAvg
 			}
@@ -191,15 +181,13 @@ func CalcNetworkLosses(
 	// Normalize the combined loss
 	combinedValue, err := normalizeWeightedLoss(&runningWeightedCombinedLoss, epsilon)
 	if err != nil {
-		fmt.Println("Error normalizing combined loss: ", err)
-		return emissions.ValueBundle{}, err
+		return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error normalizing combined loss")
 	}
 
 	// Normalize the naive loss
 	naiveValue, err := normalizeWeightedLoss(&runningWeightedNaiveLoss, epsilon)
 	if err != nil {
-		fmt.Println("Error normalizing naive loss: ", err)
-		return emissions.ValueBundle{}, err
+		return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error normalizing naive loss")
 	}
 
 	// Convert the running weighted averages to WorkerAttributedValue/WithheldWorkerAttributedValue for inferers and forecasters
@@ -235,8 +223,7 @@ func CalcCombinedNetworkLoss(
 		if report.ValueBundle != nil {
 			stakeAmount, err := alloraMath.NewDecFromSdkInt(stakesByReputer[report.ValueBundle.Reputer])
 			if err != nil {
-				fmt.Println("Error converting stake to Dec: ", err)
-				return Loss{}, err
+				return Loss{}, errorsmod.Wrapf(err, "Error converting stake to Dec")
 			}
 
 			// Update combined loss with reputer reported loss and stake
@@ -246,8 +233,7 @@ func CalcCombinedNetworkLoss(
 				report.ValueBundle.CombinedValue,
 			)
 			if err != nil {
-				fmt.Println("Error updating running weighted average for combined loss: ", err)
-				return Loss{}, err
+				return Loss{}, errorsmod.Wrapf(err, "Error updating running weighted average for combined loss: ")
 			}
 			runningWeightedCombinedLoss = nextCombinedLoss
 		}
@@ -255,8 +241,7 @@ func CalcCombinedNetworkLoss(
 
 	combinedValue, err := normalizeWeightedLoss(&runningWeightedCombinedLoss, epsilon)
 	if err != nil {
-		fmt.Println("Error normalizing combined loss: ", err)
-		return Loss{}, err
+		return Loss{}, errorsmod.Wrapf(err, "Error normalizing combined loss")
 	}
 
 	return combinedValue, nil
@@ -267,8 +252,7 @@ func normalizeWeightedLoss(
 	epsilon alloraMath.Dec,
 ) (alloraMath.Dec, error) {
 	if runningWeightedLossData.SumWeight.Lt(epsilon) {
-		fmt.Println("Sum weight for combined naive loss is 0")
-		return alloraMath.Dec{}, emissions.ErrFractionDivideByZero
+		return alloraMath.Dec{}, errorsmod.Wrapf(emissions.ErrFractionDivideByZero, "Sum weight for combined naive loss is 0")
 	}
 
 	normalizedWeightedLoss, err := runningWeightedLossData.UnnormalizedWeightedLoss.Quo(runningWeightedLossData.SumWeight)

--- a/x/emissions/keeper/inference_synthesis/network_regrets.go
+++ b/x/emissions/keeper/inference_synthesis/network_regrets.go
@@ -1,9 +1,9 @@
 package inference_synthesis
 
 import (
-	"fmt"
 	"sort"
 
+	errorsmod "cosmossdk.io/errors"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	emissions "github.com/allora-network/allora-chain/x/emissions/types"
@@ -104,8 +104,7 @@ func GetCalcSetNetworkRegrets(
 	for _, infererLoss := range networkLosses.InfererValues {
 		lastRegret, noPriorRegret, err := k.GetInfererNetworkRegret(ctx, topicId, infererLoss.Worker)
 		if err != nil {
-			fmt.Println("Error getting inferer regret: ", err)
-			return err
+			return errorsmod.Wrapf(err, "failed to get inferer regret")
 		}
 		newInfererRegret, err := ComputeAndBuildEMRegret(
 			networkLosses.CombinedValue,
@@ -116,8 +115,7 @@ func GetCalcSetNetworkRegrets(
 			noPriorRegret,
 		)
 		if err != nil {
-			fmt.Println("Error computing and building inferer regret: ", err)
-			return err
+			return errorsmod.Wrapf(err, "Error computing and building inferer regret")
 		}
 		k.SetInfererNetworkRegret(ctx, topicId, infererLoss.Worker, newInfererRegret)
 	}
@@ -129,8 +127,7 @@ func GetCalcSetNetworkRegrets(
 	for _, forecasterLoss := range networkLosses.ForecasterValues {
 		lastRegret, noPriorRegret, err := k.GetForecasterNetworkRegret(ctx, topicId, forecasterLoss.Worker)
 		if err != nil {
-			fmt.Println("Error getting forecaster regret: ", err)
-			return err
+			return errorsmod.Wrapf(err, "Error getting forecaster regret")
 		}
 		newForecasterRegret, err := ComputeAndBuildEMRegret(
 			networkLosses.CombinedValue,
@@ -141,8 +138,7 @@ func GetCalcSetNetworkRegrets(
 			noPriorRegret,
 		)
 		if err != nil {
-			fmt.Println("Error computing and building forecaster regret: ", err)
-			return err
+			return errorsmod.Wrapf(err, "Error computing and building forecaster regret")
 		}
 		k.SetForecasterNetworkRegret(ctx, topicId, forecasterLoss.Worker, newForecasterRegret)
 	}
@@ -159,8 +155,7 @@ func GetCalcSetNetworkRegrets(
 			}
 			lastRegret, noPriorRegret, err := k.GetOneInForecasterNetworkRegret(ctx, topicId, oneInForecasterLoss.Worker, infererLoss.Worker)
 			if err != nil {
-				fmt.Println("Error getting one-in forecaster regret: ", err)
-				return err
+				return errorsmod.Wrapf(err, "Error getting one-in forecaster regret")
 			}
 			newOneInForecasterRegret, err := ComputeAndBuildEMRegret(
 				networkLossesByWorker.OneInForecasterLosses[oneInForecasterLoss.Worker],
@@ -171,16 +166,14 @@ func GetCalcSetNetworkRegrets(
 				noPriorRegret,
 			)
 			if err != nil {
-				fmt.Println("Error computing and building one-in forecaster regret: ", err)
-				return err
+				return errorsmod.Wrapf(err, "Error computing and building one-in forecaster regret")
 			}
 			k.SetOneInForecasterNetworkRegret(ctx, topicId, oneInForecasterLoss.Worker, infererLoss.Worker, newOneInForecasterRegret)
 		}
 		// Self-regret for the forecaster given their own regret
 		lastRegret, noPriorRegret, err := k.GetOneInForecasterNetworkRegret(ctx, topicId, oneInForecasterLoss.Worker, oneInForecasterLoss.Worker)
 		if err != nil {
-			fmt.Println("Error getting one-in forecaster self regret: ", err)
-			return err
+			return errorsmod.Wrapf(err, "Error getting one-in forecaster self regret")
 		}
 		oneInForecasterSelfRegret, err := ComputeAndBuildEMRegret(
 			networkLossesByWorker.OneInForecasterLosses[oneInForecasterLoss.Worker],
@@ -191,8 +184,7 @@ func GetCalcSetNetworkRegrets(
 			noPriorRegret,
 		)
 		if err != nil {
-			fmt.Println("Error computing and building one-in forecaster self regret: ", err)
-			return err
+			return errorsmod.Wrapf(err, "Error computing and building one-in forecaster self regret")
 		}
 		k.SetOneInForecasterNetworkRegret(ctx, topicId, oneInForecasterLoss.Worker, oneInForecasterLoss.Worker, oneInForecasterSelfRegret)
 	}

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -2,7 +2,6 @@ package msgserver
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	"github.com/allora-network/allora-chain/x/emissions/types"
@@ -71,11 +70,6 @@ func (ms msgServer) VerifyAndInsertInferencesFromTopInferers(
 			latestInfererScores[inference.Inferer] = latestScore
 			inferencesByInferer[inference.Inferer] = inference
 		}
-	}
-
-	// iterate errors
-	for worker, err := range errors {
-		fmt.Println("Error for worker:", worker, "Error message:", err)
 	}
 
 	/// If we pseudo-random sample from the non-sybil set of reputers, we would do it here

--- a/x/emissions/keeper/topic_weight.go
+++ b/x/emissions/keeper/topic_weight.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"fmt"
 
 	"cosmossdk.io/errors"
 
@@ -51,9 +50,8 @@ func (k *Keeper) GetCurrentTopicWeight(
 	topicStake, err := k.GetTopicStake(ctx, topicId)
 	if err != nil {
 		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get topic stake")
-	} else {
-		fmt.Println("Topic stake: ", topicStake)
 	}
+
 	topicStakeDec, err := alloraMath.NewDecFromSdkInt(topicStake)
 	if err != nil {
 		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to convert topic stake to dec")
@@ -63,8 +61,6 @@ func (k *Keeper) GetCurrentTopicWeight(
 	topicFeeRevenue, err := k.GetTopicFeeRevenue(ctx, topicId)
 	if err != nil {
 		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get topic fee revenue")
-	} else {
-		fmt.Println("Topic fee revenue: ", topicFeeRevenue)
 	}
 
 	// Calc target weight using fees, epoch length, stake, and params
@@ -72,9 +68,8 @@ func (k *Keeper) GetCurrentTopicWeight(
 	feeRevenue, err := alloraMath.NewDecFromSdkInt(newFeeRevenue)
 	if err != nil {
 		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to convert topic fee revenue to dec")
-	} else {
-		fmt.Println("Fee revenue: ", feeRevenue)
 	}
+
 	if !feeRevenue.Equal(alloraMath.ZeroDec()) {
 		targetWeight, err := k.GetTargetWeight(
 			topicStakeDec,

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -14,27 +14,27 @@ import (
 
 func EndBlocker(ctx context.Context, am AppModule) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	sdkCtx.Logger().Debug("\n ---------------- Emissions EndBlock ------------------- \n")
 	blockHeight := sdkCtx.BlockHeight()
 
 	// Get unnormalized weights of active topics
-	weights, sumWeight, totalRevenue, err := rewards.GetAndOptionallyUpdateActiveTopicWeights(ctx, am.keeper, blockHeight, true)
+	weights, sumWeight, totalRevenue, err := rewards.GetAndOptionallyUpdateActiveTopicWeights(sdkCtx, am.keeper, blockHeight, true)
 	if err != nil {
 		return errors.Wrapf(err, "Weights error")
-	} else {
-		fmt.Println("Weights: Weights: ", weights)
 	}
+	sdkCtx.Logger().Debug(fmt.Sprintf("EndBlocker: Total Revenue: %v, Sum Weight: %v", totalRevenue, sumWeight))
 
 	// REWARDS (will internally filter any non-RewardReady topics)
 	err = rewards.EmitRewards(sdkCtx, am.keeper, blockHeight, weights, sumWeight, totalRevenue)
 	if err != nil {
-		fmt.Println("Error calculating global emission per topic: ", err)
+		sdkCtx.Logger().Error("Error calculating global emission per topic: ", err)
 		return errors.Wrapf(err, "Rewards error")
 	}
 
 	// Reset the churn ready topics
 	err = am.keeper.ResetChurnReadyTopics(ctx)
 	if err != nil {
-		fmt.Println("Error resetting churn ready topics: ", err)
+		sdkCtx.Logger().Error("Error resetting churn ready topics: ", err)
 		return errors.Wrapf(err, "Resetting churn ready topics error")
 	}
 
@@ -49,43 +49,43 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 			// Check the cadence of inferences, and just in case also check multiples of epoch lengths
 			// to avoid potential situations where the block is missed
 			if keeper.CheckCadence(blockHeight, topic) {
-				fmt.Printf("ABCI EndBlocker: Inference cadence met for topic: %v metadata: %s default arg: %s. \n",
+				sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Inference cadence met for topic: %v metadata: %s default arg: %s. \n",
 					topic.Id,
 					topic.Metadata,
-					topic.DefaultArg)
+					topic.DefaultArg))
 
 				// Update the last inference ran
 				err = am.keeper.UpdateTopicEpochLastEnded(sdkCtx, topic.Id, blockHeight)
 				if err != nil {
-					fmt.Println("Error updating last inference ran: ", err)
+					sdkCtx.Logger().Warn("Error updating last inference ran: ", err)
 				}
 				// Add Worker Nonces
 				nextNonce := types.Nonce{BlockHeight: blockHeight + topic.EpochLength}
 				err = am.keeper.AddWorkerNonce(sdkCtx, topic.Id, &nextNonce)
 				if err != nil {
-					fmt.Println("Error adding worker nonce: ", err)
+					sdkCtx.Logger().Warn("Error adding worker nonce: ", err)
 					return
 				}
 				// To notify topic handler that the topic is ready for churn i.e. requests to be sent to workers and reputers
 				err = am.keeper.AddChurnReadyTopic(ctx, topic.Id)
 				if err != nil {
-					fmt.Println("Error setting churn ready topic: ", err)
+					sdkCtx.Logger().Warn("Error setting churn ready topic: ", err)
 					return
 				}
 
 				MaxUnfulfilledReputerRequests, err := am.keeper.GetParamsMaxUnfulfilledReputerRequests(ctx)
 				if err != nil {
 					MaxUnfulfilledReputerRequests = types.DefaultParams().MaxUnfulfilledReputerRequests
-					fmt.Println("Error getting max retries to fulfil nonces for worker requests (using default), err:", err)
+					sdkCtx.Logger().Warn("Error getting max retries to fulfil nonces for worker requests (using default), err:", err)
 				}
 				reputerPruningBlock := blockHeight - (int64(MaxUnfulfilledReputerRequests)*topic.EpochLength + topic.GroundTruthLag)
 				if reputerPruningBlock > 0 {
-					fmt.Println("Pruning reputer nonces before block: ", reputerPruningBlock, " for topic: ", topic.Id, " on block: ", blockHeight)
+					sdkCtx.Logger().Warn("Pruning reputer nonces before block: ", reputerPruningBlock, " for topic: ", topic.Id, " on block: ", blockHeight)
 					am.keeper.PruneReputerNonces(sdkCtx, topic.Id, reputerPruningBlock)
 
 					workerPruningBlock := reputerPruningBlock - topic.EpochLength
 					if workerPruningBlock > 0 {
-						fmt.Println("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
+						sdkCtx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
 						// Prune old worker nonces previous to current blockHeight to avoid inserting inferences after its time has passed
 						// Reputer nonces need to check worker nonces one epoch before the reputer nonces
 						am.keeper.PruneWorkerNonces(sdkCtx, topic.Id, workerPruningBlock)
@@ -103,7 +103,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		weights,
 	)
 	if err != nil {
-		fmt.Println("Error applying function on all reward ready topics: ", err)
+		sdkCtx.Logger().Error("Error applying function on all reward ready topics: ", err)
 		return err
 	}
 	wg.Wait()

--- a/x/emissions/module/module.go
+++ b/x/emissions/module/module.go
@@ -114,6 +114,5 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 
 // EndBlock returns the end blocker for the emissions module.
 func (am AppModule) EndBlock(ctx context.Context) error {
-	fmt.Printf("\n ---------------- Emissions EndBlock ------------------- \n")
 	return EndBlocker(ctx, am)
 }

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -195,9 +195,8 @@ func GenerateRewardsDistributionByTopic(
 					return nil, errors.Wrapf(err, "failed to reset topic fee revenue")
 				}
 			}
-		} else {
-			fmt.Println("Topic ID: ", topicId, " is not in weightsOfActiveTopics")
 		}
+		ctx.Logger().Debug("Topic ID: ", topicId, " is not in weightsOfActiveTopics")
 	}
 
 	sortedTopTopics := alloraMath.GetSortedKeys(weightsOfTopActiveTopics)

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -2,9 +2,8 @@ package rewards
 
 import (
 	"context"
-	"fmt"
-
 	"cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	cosmosMath "cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
@@ -50,7 +49,7 @@ func GetTopicRewardFraction(
 // Active topics have more than a globally-set minimum weight, a function of revenue and stake
 // "Safe" because bounded by max number of pages and apply running, online operations
 func SafeApplyFuncOnAllActiveTopics(
-	ctx context.Context,
+	ctx sdk.Context,
 	k keeper.Keeper,
 	block BlockHeight,
 	fn func(ctx context.Context, topic *types.Topic) error,
@@ -63,14 +62,14 @@ func SafeApplyFuncOnAllActiveTopics(
 		topicPageRequest := &types.SimpleCursorPaginationRequest{Limit: topicPageLimit, Key: topicPageKey}
 		topicsActive, topicPageResponse, err := k.GetIdsOfActiveTopics(ctx, topicPageRequest)
 		if err != nil {
-			fmt.Println("Error getting ids of active topics: ", err)
+			ctx.Logger().Warn("Error getting ids of active topics: ", err)
 			continue
 		}
 
 		for _, topicId := range topicsActive {
 			topic, err := k.GetTopic(ctx, topicId)
 			if err != nil {
-				fmt.Println("Error getting topic: ", err)
+				ctx.Logger().Warn("Error getting topic: ", err)
 				continue
 			}
 
@@ -78,7 +77,7 @@ func SafeApplyFuncOnAllActiveTopics(
 				// All checks passed => Apply function on the topic
 				err = fn(ctx, &topic)
 				if err != nil {
-					fmt.Println("Error applying function on topic: ", err)
+					ctx.Logger().Warn("Error applying function on topic: ", err)
 					continue
 				}
 			}
@@ -98,7 +97,7 @@ func SafeApplyFuncOnAllActiveTopics(
 // We iterate through active topics, fetch their weight, skim the top N by weight (these are the churnable topics)
 // then finally apply a function on each of these churnable topics.
 func IdentifyChurnableAmongActiveTopicsAndApplyFn(
-	ctx context.Context,
+	ctx sdk.Context,
 	k keeper.Keeper,
 	block BlockHeight,
 	fn func(ctx context.Context, topic *types.Topic) error,
@@ -113,19 +112,19 @@ func IdentifyChurnableAmongActiveTopicsAndApplyFn(
 	for _, topicId := range sortedTopActiveTopics {
 		weight := weightsOfTopActiveTopics[topicId]
 		if weight.Equal(alloraMath.ZeroDec()) {
-			fmt.Println("Skipping Topic ID: ", topicId, " Weight: ", weight)
+			ctx.Logger().Debug("Skipping Topic ID: ", topicId, " Weight: ", weight)
 			continue
 		}
 		// Get the topic
 		topic, err := k.GetTopic(ctx, topicId)
 		if err != nil {
-			fmt.Println("Error getting topic: ", err)
+			ctx.Logger().Debug("Error getting topic: ", err)
 			continue
 		}
 		// Execute the function
 		err = fn(ctx, &topic)
 		if err != nil {
-			fmt.Println("Error applying function on topic: ", err)
+			ctx.Logger().Debug("Error applying function on topic: ", err)
 			continue
 		}
 	}
@@ -137,7 +136,7 @@ func IdentifyChurnableAmongActiveTopicsAndApplyFn(
 // Note that the outputted weights are not normalized => not dependent on pan-topic data.
 // updatePrevious is a flag to perform update of previous weight of the topic
 func GetAndOptionallyUpdateActiveTopicWeights(
-	ctx context.Context,
+	ctx sdk.Context,
 	k keeper.Keeper,
 	block BlockHeight,
 	updatePreviousWeights bool,

--- a/x/emissions/types/msg_insert_bulk_reputer_payload.go
+++ b/x/emissions/types/msg_insert_bulk_reputer_payload.go
@@ -15,7 +15,12 @@ func (msg *MsgInsertBulkReputerPayload) ValidateTopLevel() error {
 	if msg.ReputerRequestNonce == nil {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "reputer request nonce cannot be nil")
 	}
-
+	if msg.ReputerRequestNonce.WorkerNonce == nil {
+		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "worker nonce cannot be nil")
+	}
+	if msg.ReputerRequestNonce.ReputerNonce == nil {
+		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "reputer nonce cannot be nil")
+	}
 	if len(msg.ReputerValueBundles) == 0 {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "at least one reputer value bundle needs to be provided")
 	}

--- a/x/mint/keeper/emissions_test.go
+++ b/x/mint/keeper/emissions_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-
 	"cosmossdk.io/math"
 	"github.com/allora-network/allora-chain/x/mint/keeper"
 	"github.com/allora-network/allora-chain/x/mint/types"

--- a/x/mint/keeper/emissions_test.go
+++ b/x/mint/keeper/emissions_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
 
 	"cosmossdk.io/math"
 	"github.com/allora-network/allora-chain/x/mint/keeper"
@@ -112,7 +111,7 @@ func (s *IntegrationTestSuite) TestTargetRewardEmissionPerUnitStakedTokenSimple(
 	// using some random sample values
 	//  ^e_i = ((0.015*2000)/400)*(10000000/12000000)
 
-	result, err := keeper.GetTargetRewardEmissionPerUnitStakedToken(
+	_, err := keeper.GetTargetRewardEmissionPerUnitStakedToken(
 		math.LegacyMustNewDecFromStr("0.015"),
 		math.NewInt(200000),
 		math.NewInt(400),
@@ -120,5 +119,4 @@ func (s *IntegrationTestSuite) TestTargetRewardEmissionPerUnitStakedTokenSimple(
 		math.NewInt(12000000),
 	)
 	s.Require().NoError(err)
-	fmt.Println(result)
 }


### PR DESCRIPTION
• Stop using `fmt.Print` for general logs and use `ctx.Logger` with `Debug` or `Info` depending on the purpose.
• Remove redundant logs and some logs that apparently is not useful anymore.

Adapt the error log pattern:
• For msg-related errors: use `Wrapf ` to return a meaningful message to the user.
• For validator processing errors: use `ctx.Logger` - use `Warn` for non-throwing errors, otherwise use `Error`.

Ticket: https://linear.app/upshot/issue/ORA-1413/println-log