### PR TITLE
Use golines tool to enforce line length of 100 in repo, enforce via Github Action CI

### DIFF
--- a/.github/workflows/format_and_test.yml
+++ b/.github/workflows/format_and_test.yml
@@ -32,6 +32,12 @@ jobs:
           gofmt-path: '.'
           gofmt-flags: '-l -d'
 
+    - name: Install golines tool
+      run: go install github.com/segmentio/golines@latest
+
+    -name: Check code long line formatting using golines
+      run: bash ./scripts/golines.sh
+
     - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.11.0
       with:

--- a/.github/workflows/format_and_test.yml
+++ b/.github/workflows/format_and_test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install golines tool
       run: go install github.com/segmentio/golines@latest
 
-    -name: Check code long line formatting using golines
+    - name: Check code long line formatting using golines
       run: bash ./scripts/golines.sh
 
     - name: Run clang-format style check for C/C++/Protobuf programs.

--- a/app/app.go
+++ b/app/app.go
@@ -140,7 +140,9 @@ type AlloraApp struct {
 }
 
 func init() {
-	sdk.DefaultPowerReduction = math.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+	sdk.DefaultPowerReduction = math.NewIntFromBigInt(
+		new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+	)
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
@@ -156,7 +158,9 @@ func AppConfig() depinject.Config {
 		depinject.Supply(
 			// supply custom module basics
 			map[string]module.AppModuleBasic{
-				genutiltypes.ModuleName: genutil.NewAppModuleBasic(genutiltypes.DefaultMessageValidator),
+				genutiltypes.ModuleName: genutil.NewAppModuleBasic(
+					genutiltypes.DefaultMessageValidator,
+				),
 				govtypes.ModuleName: gov.NewAppModuleBasic(
 					[]govclient.ProposalHandler{
 						paramsclient.ProposalHandler,
@@ -253,7 +257,10 @@ func NewAlloraApp(
 
 	// create the simulation manager and define the order of the modules for deterministic simulations
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing transactions
-	app.sm = module.NewSimulationManagerFromAppModules(app.ModuleManager.Modules, make(map[string]module.AppModuleSimulation, 0))
+	app.sm = module.NewSimulationManagerFromAppModules(
+		app.ModuleManager.Modules,
+		make(map[string]module.AppModuleSimulation, 0),
+	)
 	app.sm.RegisterStoreDecoders()
 
 	topicsHandler := NewTopicsHandler(app.EmissionsKeeper)

--- a/app/export.go
+++ b/app/export.go
@@ -77,22 +77,28 @@ func (app *AlloraApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs
 	/* Handle staking state. */
 
 	// iterate through redelegations, reset creation height
-	app.StakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
-		for i := range red.Entries {
-			red.Entries[i].CreationHeight = 0
-		}
-		app.StakingKeeper.SetRedelegation(ctx, red)
-		return false
-	})
+	app.StakingKeeper.IterateRedelegations(
+		ctx,
+		func(_ int64, red stakingtypes.Redelegation) (stop bool) {
+			for i := range red.Entries {
+				red.Entries[i].CreationHeight = 0
+			}
+			app.StakingKeeper.SetRedelegation(ctx, red)
+			return false
+		},
+	)
 
 	// iterate through unbonding delegations, reset creation height
-	app.StakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
-		for i := range ubd.Entries {
-			ubd.Entries[i].CreationHeight = 0
-		}
-		app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
-		return false
-	})
+	app.StakingKeeper.IterateUnbondingDelegations(
+		ctx,
+		func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
+			for i := range ubd.Entries {
+				ubd.Entries[i].CreationHeight = 0
+			}
+			app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
+			return false
+		},
+	)
 
 	// Iterate through validators by power descending, reset bond heights, and
 	// update bond intra-tx counters.

--- a/app/ibc.go
+++ b/app/ibc.go
@@ -56,8 +56,10 @@ func (app *AlloraApp) registerIBCModules() {
 	keyTable := ibcclienttypes.ParamKeyTable()
 	keyTable.RegisterParamSet(&ibcconnectiontypes.Params{})
 	app.ParamsKeeper.Subspace(ibcexported.ModuleName).WithKeyTable(keyTable)
-	app.ParamsKeeper.Subspace(ibctransfertypes.ModuleName).WithKeyTable(ibctransfertypes.ParamKeyTable())
-	app.ParamsKeeper.Subspace(icacontrollertypes.SubModuleName).WithKeyTable(icacontrollertypes.ParamKeyTable())
+	app.ParamsKeeper.Subspace(ibctransfertypes.ModuleName).
+		WithKeyTable(ibctransfertypes.ParamKeyTable())
+	app.ParamsKeeper.Subspace(icacontrollertypes.SubModuleName).
+		WithKeyTable(icacontrollertypes.ParamKeyTable())
 	app.ParamsKeeper.Subspace(icahosttypes.SubModuleName).WithKeyTable(icahosttypes.ParamKeyTable())
 
 	// add capability keeper and ScopeToModule for ibc module
@@ -70,7 +72,9 @@ func (app *AlloraApp) registerIBCModules() {
 	// add capability keeper and ScopeToModule for ibc module
 	scopedIBCKeeper := app.CapabilityKeeper.ScopeToModule(ibcexported.ModuleName)
 	scopedIBCTransferKeeper := app.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
-	scopedICAControllerKeeper := app.CapabilityKeeper.ScopeToModule(icacontrollertypes.SubModuleName)
+	scopedICAControllerKeeper := app.CapabilityKeeper.ScopeToModule(
+		icacontrollertypes.SubModuleName,
+	)
 	scopedICAHostKeeper := app.CapabilityKeeper.ScopeToModule(icahosttypes.SubModuleName)
 
 	// Create IBC keeper
@@ -151,7 +155,10 @@ func (app *AlloraApp) registerIBCModules() {
 		app.IBCFeeKeeper,
 	)
 
-	icaHostIBCModule := ibcfee.NewIBCMiddleware(icahost.NewIBCModule(app.ICAHostKeeper), app.IBCFeeKeeper)
+	icaHostIBCModule := ibcfee.NewIBCMiddleware(
+		icahost.NewIBCModule(app.ICAHostKeeper),
+		app.IBCFeeKeeper,
+	)
 
 	// Create static IBC router, add transfer route, then set and seal it
 	ibcRouter := porttypes.NewRouter().

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -67,11 +67,20 @@ func SetAddressPrefixes() {
 		}
 
 		if len(bytes) > address.MaxAddrLen {
-			return errors.Wrapf(sdkerrors.ErrUnknownAddress, "address max length is %d, got %d", address.MaxAddrLen, len(bytes))
+			return errors.Wrapf(
+				sdkerrors.ErrUnknownAddress,
+				"address max length is %d, got %d",
+				address.MaxAddrLen,
+				len(bytes),
+			)
 		}
 
 		if len(bytes) != 20 && len(bytes) != 32 {
-			return errors.Wrapf(sdkerrors.ErrUnknownAddress, "address length must be 20 or 32 bytes, got %d", len(bytes))
+			return errors.Wrapf(
+				sdkerrors.ErrUnknownAddress,
+				"address length must be 20 or 32 bytes, got %d",
+				len(bytes),
+			)
 		}
 
 		return nil

--- a/cmd/allorad/cmd/commands.go
+++ b/cmd/allorad/cmd/commands.go
@@ -27,7 +27,11 @@ import (
 	"github.com/allora-network/allora-chain/app"
 )
 
-func initRootCmd(rootCmd *cobra.Command, txConfig client.TxConfig, basicManager module.BasicManager) {
+func initRootCmd(
+	rootCmd *cobra.Command,
+	txConfig client.TxConfig,
+	basicManager module.BasicManager,
+) {
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(basicManager, app.DefaultNodeHome),
 		debug.Cmd(),
@@ -36,7 +40,13 @@ func initRootCmd(rootCmd *cobra.Command, txConfig client.TxConfig, basicManager 
 		snapshot.Cmd(newApp),
 	)
 
-	server.AddCommands(rootCmd, app.DefaultNodeHome, newApp, appExport, func(startCmd *cobra.Command) {})
+	server.AddCommands(
+		rootCmd,
+		app.DefaultNodeHome,
+		newApp,
+		appExport,
+		func(startCmd *cobra.Command) {},
+	)
 
 	// add keybase, auxiliary RPC, query, genesis, and tx child commands
 	rootCmd.AddCommand(
@@ -95,7 +105,12 @@ func txCommand() *cobra.Command {
 }
 
 // newApp is an appCreator
-func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts servertypes.AppOptions) servertypes.Application {
+func newApp(
+	logger log.Logger,
+	db dbm.DB,
+	traceStore io.Writer,
+	appOpts servertypes.AppOptions,
+) servertypes.Application {
 	baseappOptions := server.DefaultBaseappOptions(appOpts)
 	app, err := app.NewAlloraApp(logger, db, traceStore, true, appOpts, baseappOptions...)
 	if err != nil {

--- a/cmd/allorad/cmd/root.go
+++ b/cmd/allorad/cmd/root.go
@@ -80,9 +80,17 @@ func NewRootCmd() *cobra.Command {
 			// sign mode textual is only available in online mode
 			if !clientCtx.Offline {
 				// This needs to go after ReadFromClientConfig, as that function ets the RPC client needed for SIGN_MODE_TEXTUAL.
-				txConfigOpts.EnabledSignModes = append(txConfigOpts.EnabledSignModes, signing.SignMode_SIGN_MODE_TEXTUAL)
-				txConfigOpts.TextualCoinMetadataQueryFn = txmodule.NewGRPCCoinMetadataQueryFn(clientCtx)
-				txConfigWithTextual, err := tx.NewTxConfigWithOptions(codec.NewProtoCodec(clientCtx.InterfaceRegistry), txConfigOpts)
+				txConfigOpts.EnabledSignModes = append(
+					txConfigOpts.EnabledSignModes,
+					signing.SignMode_SIGN_MODE_TEXTUAL,
+				)
+				txConfigOpts.TextualCoinMetadataQueryFn = txmodule.NewGRPCCoinMetadataQueryFn(
+					clientCtx,
+				)
+				txConfigWithTextual, err := tx.NewTxConfigWithOptions(
+					codec.NewProtoCodec(clientCtx.InterfaceRegistry),
+					txConfigOpts,
+				)
 				if err != nil {
 					return err
 				}
@@ -107,7 +115,12 @@ func NewRootCmd() *cobra.Command {
 			cmtCfg.Consensus.TimeoutCommit = 3 * time.Second
 			cmtCfg.LogLevel = "*:error,p2p:info,state:info" // better default logging
 
-			return server.InterceptConfigsPreRunHandler(cmd, serverconfig.DefaultConfigTemplate, srvCfg, cmtCfg)
+			return server.InterceptConfigsPreRunHandler(
+				cmd,
+				serverconfig.DefaultConfigTemplate,
+				srvCfg,
+				cmtCfg,
+			)
 		},
 	}
 
@@ -152,7 +165,10 @@ func ProvideClientContext(
 	return clientCtx
 }
 
-func ProvideKeyring(clientCtx client.Context, addressCodec address.Codec) (clientv2keyring.Keyring, error) {
+func ProvideKeyring(
+	clientCtx client.Context,
+	addressCodec address.Codec,
+) (clientv2keyring.Keyring, error) {
 	kb, err := client.NewKeyringFromBackend(clientCtx, clientCtx.Keyring.Backend())
 	if err != nil {
 		return nil, err

--- a/math/dec_test.go
+++ b/math/dec_test.go
@@ -22,10 +22,22 @@ func TestDec(t *testing.T) {
 
 	// Properties about *FromString functions
 	t.Run("TestInvalidNewDecFromString", rapid.MakeCheck(testInvalidNewDecFromString))
-	t.Run("TestInvalidNewNonNegativeDecFromString", rapid.MakeCheck(testInvalidNewNonNegativeDecFromString))
-	t.Run("TestInvalidNewNonNegativeFixedDecFromString", rapid.MakeCheck(testInvalidNewNonNegativeFixedDecFromString))
-	t.Run("TestInvalidNewPositiveDecFromString", rapid.MakeCheck(testInvalidNewPositiveDecFromString))
-	t.Run("TestInvalidNewPositiveFixedDecFromString", rapid.MakeCheck(testInvalidNewPositiveFixedDecFromString))
+	t.Run(
+		"TestInvalidNewNonNegativeDecFromString",
+		rapid.MakeCheck(testInvalidNewNonNegativeDecFromString),
+	)
+	t.Run(
+		"TestInvalidNewNonNegativeFixedDecFromString",
+		rapid.MakeCheck(testInvalidNewNonNegativeFixedDecFromString),
+	)
+	t.Run(
+		"TestInvalidNewPositiveDecFromString",
+		rapid.MakeCheck(testInvalidNewPositiveDecFromString),
+	)
+	t.Run(
+		"TestInvalidNewPositiveFixedDecFromString",
+		rapid.MakeCheck(testInvalidNewPositiveFixedDecFromString),
+	)
 
 	// Properties about addition
 	t.Run("TestAddLeftIdentity", rapid.MakeCheck(testAddLeftIdentity))
@@ -606,7 +618,9 @@ func testNumDecimalPlaces(t *rapid.T) {
 }
 
 func floatDecimalPlaces(t *rapid.T, f float64) uint32 {
-	reScientific := regexp.MustCompile(`^\-?(?:[[:digit:]]+(?:\.([[:digit:]]+))?|\.([[:digit:]]+))(?:e?(?:\+?([[:digit:]]+)|(-[[:digit:]]+)))?$`)
+	reScientific := regexp.MustCompile(
+		`^\-?(?:[[:digit:]]+(?:\.([[:digit:]]+))?|\.([[:digit:]]+))(?:e?(?:\+?([[:digit:]]+)|(-[[:digit:]]+)))?$`,
+	)
 	fStr := fmt.Sprintf("%g", f)
 	matches := reScientific.FindAllStringSubmatch(fStr, 1)
 	if len(matches) != 1 {
@@ -790,12 +804,42 @@ func TestInDelta(t *testing.T) {
 		epsilon        Dec
 		expectedResult bool
 	}{
-		{NewDecFromInt64(10), NewDecFromInt64(10), NewDecFromInt64(1), true},   // expected == result, within epsilon
-		{NewDecFromInt64(10), NewDecFromInt64(9), NewDecFromInt64(1), true},    // expected != result, but within epsilon
-		{NewDecFromInt64(10), NewDecFromInt64(8), NewDecFromInt64(1), false},   // expected != result, outside epsilon
-		{NewDecFromInt64(10), NewDecFromInt64(10), NewDecFromInt64(0), true},   // expected == result, epsilon is zero
-		{NewDecFromInt64(10), NewDecFromInt64(-10), NewDecFromInt64(1), false}, // expected != result, outside epsilon
-		{NewDecFromInt64(-10), NewDecFromInt64(-10), NewDecFromInt64(0), true}, // expected == result, epsilon is zero
+		{
+			NewDecFromInt64(10),
+			NewDecFromInt64(10),
+			NewDecFromInt64(1),
+			true,
+		}, // expected == result, within epsilon
+		{
+			NewDecFromInt64(10),
+			NewDecFromInt64(9),
+			NewDecFromInt64(1),
+			true,
+		}, // expected != result, but within epsilon
+		{
+			NewDecFromInt64(10),
+			NewDecFromInt64(8),
+			NewDecFromInt64(1),
+			false,
+		}, // expected != result, outside epsilon
+		{
+			NewDecFromInt64(10),
+			NewDecFromInt64(10),
+			NewDecFromInt64(0),
+			true,
+		}, // expected == result, epsilon is zero
+		{
+			NewDecFromInt64(10),
+			NewDecFromInt64(-10),
+			NewDecFromInt64(1),
+			false,
+		}, // expected != result, outside epsilon
+		{
+			NewDecFromInt64(-10),
+			NewDecFromInt64(-10),
+			NewDecFromInt64(0),
+			true,
+		}, // expected == result, epsilon is zero
 	}
 
 	// Run test cases

--- a/math/utils_test.go
+++ b/math/utils_test.go
@@ -62,7 +62,10 @@ func TestStdDev(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := alloraMath.StdDev(tt.data)
 			require.NoError(t, err)
-			require.True(t, alloraMath.InDelta(tt.want, got, alloraMath.MustNewDecFromString("0.0001")))
+			require.True(
+				t,
+				alloraMath.InDelta(tt.want, got, alloraMath.MustNewDecFromString("0.0001")),
+			)
 		})
 	}
 }
@@ -74,7 +77,14 @@ func TestPhiSimple(t *testing.T) {
 	// we expect a value very very close to 64
 	result, err := alloraMath.Phi(p, c, x)
 	require.NoError(t, err)
-	require.False(t, alloraMath.InDelta(alloraMath.NewDecFromInt64(64), result, alloraMath.MustNewDecFromString("0.001")))
+	require.False(
+		t,
+		alloraMath.InDelta(
+			alloraMath.NewDecFromInt64(64),
+			result,
+			alloraMath.MustNewDecFromString("0.001"),
+		),
+	)
 }
 
 // φ'_p(x) = p / (exp(p * (c - x)) + 1)

--- a/scripts/golines.sh
+++ b/scripts/golines.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+
+FILES_NEED_FORMATTING=$(find . -name "*.go" | xargs golines -l)
+if [[ -z $FILES_NEED_FORMATTING ]]
+then
+    exit 0
+else
+    echo "Files are unformatted, need fix"
+    echo
+    echo $FILES_NEED_FORMATTING
+    echo
+    echo "run command to fix: find . -name '*.go' -exec golines -w {} \\;"
+    exit 1
+fi

--- a/test/integration/create_topic_test.go
+++ b/test/integration/create_topic_test.go
@@ -63,7 +63,13 @@ func CreateTopic(m testCommon.TestConfig) (topicId uint64) {
 	require.Equal(m.T, createTopicRequest.GroundTruthLag, storedTopic.GroundTruthLag)
 	require.Equal(m.T, createTopicRequest.DefaultArg, storedTopic.DefaultArg)
 	require.Equal(m.T, createTopicRequest.PNorm, storedTopic.PNorm)
-	require.True(m.T, createTopicRequest.AlphaRegret.Equal(storedTopic.AlphaRegret), "Alpha Regret not equal %s != %s", createTopicRequest.AlphaRegret, storedTopic.AlphaRegret)
+	require.True(
+		m.T,
+		createTopicRequest.AlphaRegret.Equal(storedTopic.AlphaRegret),
+		"Alpha Regret not equal %s != %s",
+		createTopicRequest.AlphaRegret,
+		storedTopic.AlphaRegret,
+	)
 
 	return topicId
 }

--- a/test/integration/distribution_test.go
+++ b/test/integration/distribution_test.go
@@ -168,6 +168,8 @@ func DistributionChecks(m testCommon.TestConfig) {
 	// on the existing tests to do each of the above.
 	m.T.Log("--- Check Validator Balance Goes Up When New Blocks Are Mined  ---")
 	CheckValidatorBalancesIncreaseOnNewBlock(m)
-	m.T.Log("--- Check Allora Rewards Module Account Balance Goes Up When New Blocks Are Mined  ---")
+	m.T.Log(
+		"--- Check Allora Rewards Module Account Balance Goes Up When New Blocks Are Mined  ---",
+	)
 	CheckAlloraRewardsBalanceGoesUpOnNewBlock(m)
 }

--- a/test/integration/staking_test.go
+++ b/test/integration/staking_test.go
@@ -43,7 +43,11 @@ func StakeAliceAsReputerTopic1(m testCommon.TestConfig) {
 		},
 	)
 	require.NoError(m.T, err)
-	require.Equal(m.T, fmt.Sprint(stakeToAdd), aliceStakedAfter.Amount.Sub(aliceStakedBefore.Amount).String())
+	require.Equal(
+		m.T,
+		fmt.Sprint(stakeToAdd),
+		aliceStakedAfter.Amount.Sub(aliceStakedBefore.Amount).String(),
+	)
 }
 
 // func CheckTopic1Activated(m testCommon.TestConfig) {

--- a/test/integration/worker_inference_and_forecast_test.go
+++ b/test/integration/worker_inference_and_forecast_test.go
@@ -18,7 +18,12 @@ const defaultEpochLength = 10
 const approximateBlockLengthSeconds = 5
 const minWaitingNumberofEpochs = 3
 
-func getNonZeroTopicEpochLastRan(ctx context.Context, query types.QueryClient, topicID uint64, maxRetries int) (*types.Topic, error) {
+func getNonZeroTopicEpochLastRan(
+	ctx context.Context,
+	query types.QueryClient,
+	topicID uint64,
+	maxRetries int,
+) (*types.Topic, error) {
 	sleepingTimeBlocks := defaultEpochLength
 	// Retry loop for a maximum of 5 times
 	for retries := 0; retries < maxRetries; retries++ {
@@ -26,7 +31,9 @@ func getNonZeroTopicEpochLastRan(ctx context.Context, query types.QueryClient, t
 		if err == nil {
 			storedTopic := topicResponse.Topic
 			if storedTopic.EpochLastEnded != 0 {
-				sleepingTime := time.Duration(minWaitingNumberofEpochs*storedTopic.EpochLength*approximateBlockLengthSeconds) * time.Second
+				sleepingTime := time.Duration(
+					minWaitingNumberofEpochs*storedTopic.EpochLength*approximateBlockLengthSeconds,
+				) * time.Second
 				fmt.Println(time.Now(), " Topic found, sleeping...", sleepingTime)
 				time.Sleep(sleepingTime)
 				fmt.Println(time.Now(), " Slept.")
@@ -37,7 +44,12 @@ func getNonZeroTopicEpochLastRan(ctx context.Context, query types.QueryClient, t
 			fmt.Println("Error getting topic, retry...", err)
 		}
 		// Sleep for a while before retrying
-		fmt.Println("Retrying sleeping for a default epoch, retry ", retries, " for sleeping time ", sleepingTimeBlocks)
+		fmt.Println(
+			"Retrying sleeping for a default epoch, retry ",
+			retries,
+			" for sleeping time ",
+			sleepingTimeBlocks,
+		)
 		time.Sleep(time.Duration(sleepingTimeBlocks*approximateBlockLengthSeconds) * time.Second)
 	}
 
@@ -86,7 +98,11 @@ func InsertSingleWorkerBulk(m testCommon.TestConfig, topic *types.Topic, blockHe
 	src, err := workerMsg.WorkerDataBundles[0].InferenceForecastsBundle.XXX_Marshal(src, true)
 	require.NoError(m.T, err, "Marshall reputer value bundle should not return an error")
 
-	sig, pubKey, err := m.Client.Context().Keyring.Sign(m.BobAcc.Name, src, signing.SignMode_SIGN_MODE_DIRECT)
+	sig, pubKey, err := m.Client.Context().Keyring.Sign(
+		m.BobAcc.Name,
+		src,
+		signing.SignMode_SIGN_MODE_DIRECT,
+	)
 	require.NoError(m.T, err, "Sign should not return an error")
 	workerPublicKeyBytes := pubKey.Bytes()
 	workerMsg.WorkerDataBundles[0].InferencesForecastsBundleSignature = sig
@@ -107,7 +123,11 @@ func InsertSingleWorkerBulk(m testCommon.TestConfig, topic *types.Topic, blockHe
 		},
 	)
 	require.NoError(m.T, err)
-	require.Equal(m.T, latestInference.LatestInference.Value, alloraMath.MustNewDecFromString("100"))
+	require.Equal(
+		m.T,
+		latestInference.LatestInference.Value,
+		alloraMath.MustNewDecFromString("100"),
+	)
 	require.Equal(m.T, latestInference.LatestInference.BlockHeight, blockHeight)
 	require.Equal(m.T, latestInference.LatestInference.TopicId, topicId)
 	require.Equal(m.T, latestInference.LatestInference.Inferer, InfererAddress1)
@@ -115,7 +135,8 @@ func InsertSingleWorkerBulk(m testCommon.TestConfig, topic *types.Topic, blockHe
 
 // Worker Bob inserts bulk inference and forecast
 func InsertWorkerBulk(m testCommon.TestConfig, topic *types.Topic) (int64, int64) {
-	topicResponse, err := m.Client.QueryEmissions().GetTopic(m.Ctx, &types.QueryTopicRequest{TopicId: topic.Id})
+	topicResponse, err := m.Client.QueryEmissions().
+		GetTopic(m.Ctx, &types.QueryTopicRequest{TopicId: topic.Id})
 	require.NoError(m.T, err)
 	freshTopic := topicResponse.Topic
 
@@ -131,7 +152,11 @@ func InsertWorkerBulk(m testCommon.TestConfig, topic *types.Topic) (int64, int64
 }
 
 // register alice as a reputer in topic 1, then check success
-func InsertReputerBulk(m testCommon.TestConfig, topic *types.Topic, BlockHeightCurrent, BlockHeightEval int64) {
+func InsertReputerBulk(
+	m testCommon.TestConfig,
+	topic *types.Topic,
+	BlockHeightCurrent, BlockHeightEval int64,
+) {
 	// Nonce: calculate from EpochLastRan + EpochLength
 	topicId := topic.Id
 	// Define inferer address as Bob's address, reputer as Alice's
@@ -195,7 +220,11 @@ func InsertReputerBulk(m testCommon.TestConfig, topic *types.Topic, BlockHeightC
 	src, err := reputerValueBundle.XXX_Marshal(src, true)
 	require.NoError(m.T, err, "Marshall reputer value bundle should not return an error")
 
-	valueBundleSignature, pubKey, err := m.Client.Context().Keyring.Sign(m.AliceAcc.Name, src, signing.SignMode_SIGN_MODE_DIRECT)
+	valueBundleSignature, pubKey, err := m.Client.Context().Keyring.Sign(
+		m.AliceAcc.Name,
+		src,
+		signing.SignMode_SIGN_MODE_DIRECT,
+	)
 	require.NoError(m.T, err, "Sign should not return an error")
 	reputerPublicKeyBytes := pubKey.Bytes()
 

--- a/test/stress/concurrency_helpers_test.go
+++ b/test/stress/concurrency_helpers_test.go
@@ -135,9 +135,24 @@ func reportSummaryStatistics(t *testing.T) {
 	percentReputersWithErrors := float64(countReputersWithErrors) / float64(countReputers) * 100
 	percentWorkersWithErrors := float64(countWorkersWithErrors) / float64(countWorkers) * 100
 	t.Logf("\n\nSummary Statistics:")
-	t.Logf("Topics with errors: %d/%d | %.2f%%\n", countTopicErrors, countTopics, percentTopicsWithErrors)
-	t.Logf("Reputers with errors: %d/%d | %.2f%%\n", countReputersWithErrors, countReputers, percentReputersWithErrors)
-	t.Logf("Workers with errors: %d/%d  | %.2f%%\n", countWorkersWithErrors, countWorkers, percentWorkersWithErrors)
+	t.Logf(
+		"Topics with errors: %d/%d | %.2f%%\n",
+		countTopicErrors,
+		countTopics,
+		percentTopicsWithErrors,
+	)
+	t.Logf(
+		"Reputers with errors: %d/%d | %.2f%%\n",
+		countReputersWithErrors,
+		countReputers,
+		percentReputersWithErrors,
+	)
+	t.Logf(
+		"Workers with errors: %d/%d  | %.2f%%\n",
+		countWorkersWithErrors,
+		countWorkers,
+		percentWorkersWithErrors,
+	)
 	mutexCountTopics.Unlock()
 	mutexCountWorkers.Unlock()
 	mutexCountReputers.Unlock()

--- a/test/stress/getters_helpers_test.go
+++ b/test/stress/getters_helpers_test.go
@@ -47,12 +47,24 @@ func getTopicFunderAccountName(seed int, topicFunderIndex int) string {
 
 // return standardized account name for workers
 func getWorkerAccountName(seed int, workerIndex int, topicId uint64) string {
-	return "stress" + strconv.Itoa(seed) + "_topic" + strconv.Itoa(int(topicId)) + "_worker" + strconv.Itoa(workerIndex)
+	return "stress" + strconv.Itoa(
+		seed,
+	) + "_topic" + strconv.Itoa(
+		int(topicId),
+	) + "_worker" + strconv.Itoa(
+		workerIndex,
+	)
 }
 
 // return standardized account name for reputers
 func getReputerAccountName(seed int, reputerIndex int, topicId uint64) string {
-	return "stress" + strconv.Itoa(seed) + "_topic" + strconv.Itoa(int(topicId)) + "_reputer" + strconv.Itoa(reputerIndex)
+	return "stress" + strconv.Itoa(
+		seed,
+	) + "_topic" + strconv.Itoa(
+		int(topicId),
+	) + "_reputer" + strconv.Itoa(
+		reputerIndex,
+	)
 }
 
 // return the approximate block time in seconds
@@ -155,7 +167,16 @@ func getNonZeroTopicEpochLastRan(
 			m.T.Log(topicLog(topicId, "Error getting topic, retry...", err))
 		}
 		// Sleep for a while before retrying
-		m.T.Log(topicLog(topicId, "Retrying sleeping for a default epoch, retry ", retries, " for sleeping time ", sleepingTimeBlocks, " blocks"))
+		m.T.Log(
+			topicLog(
+				topicId,
+				"Retrying sleeping for a default epoch, retry ",
+				retries,
+				" for sleeping time ",
+				sleepingTimeBlocks,
+				" blocks",
+			),
+		)
 		time.Sleep(time.Duration(sleepingTimeBlocks) * approximateSecondsPerBlock * time.Second)
 	}
 

--- a/test/stress/n_workers_reputers_stress_test.go
+++ b/test/stress/n_workers_reputers_stress_test.go
@@ -75,7 +75,11 @@ func workerReputerCoordinationLoop(
 	// every iteration for each worker funding
 	initialFunderAccountAmount := int64(stakeToAdd) +
 		int64(topicsPerTopicIteration)*int64(maxWorkerReputerIterations+1)*topicFunds +
-		int64(maxWorkerReputerIterations+1)*initialWorkerReputerFundAmount*int64(maxReputersPerTopic+maxWorkersPerTopic)
+		int64(
+			maxWorkerReputerIterations+1,
+		)*initialWorkerReputerFundAmount*int64(
+			maxReputersPerTopic+maxWorkersPerTopic,
+		)
 
 	// 1. For every single topic that will be created over the duration of the test
 	//    create a topic funder that will create and fund the topic
@@ -211,7 +215,9 @@ func workerReputerLoop(
 	}
 
 	// Translate the epoch length into time
-	iterationTime := time.Duration(topic.EpochLength) * approximateSecondsBlockTime * iterationsInABatch
+	iterationTime := time.Duration(
+		topic.EpochLength,
+	) * approximateSecondsBlockTime * iterationsInABatch
 
 	countWorkers := 0
 	countReputers := 0
@@ -287,7 +293,18 @@ func workerReputerLoop(
 		// Sleep for an epoch
 		elapsedIteration := time.Since(startIteration)
 		sleepingTime := iterationTime - elapsedIteration
-		m.T.Log(topicLog(topicId, time.Now(), " Sleeping...", sleepingTime, ", elapsed: ", elapsedIteration, " epoch length seconds: ", iterationTime))
+		m.T.Log(
+			topicLog(
+				topicId,
+				time.Now(),
+				" Sleeping...",
+				sleepingTime,
+				", elapsed: ",
+				elapsedIteration,
+				" epoch length seconds: ",
+				iterationTime,
+			),
+		)
 		time.Sleep(sleepingTime)
 		if makeReport {
 			reportShortStatistics(m.T)
@@ -327,8 +344,20 @@ func workerReputerLoop(
 	}
 
 	// Check that only the top workers and reputers are rewarded
-	maxTopInferersCount, maxTopForecastersCount, maxTopReputersCount, _ := getMaxTopWorkersReputersToReward(m)
+	maxTopInferersCount, maxTopForecastersCount, maxTopReputersCount, _ := getMaxTopWorkersReputersToReward(
+		m,
+	)
 	require.Less(m.T, rewardedWorkersCount, maxTopInferersCount, "Only top workers can get reward")
-	require.Less(m.T, rewardedWorkersCount, maxTopForecastersCount, "Only top workers can get reward")
-	require.Less(m.T, rewardedReputersCount, maxTopReputersCount, "Only top reputers can get reward")
+	require.Less(
+		m.T,
+		rewardedWorkersCount,
+		maxTopForecastersCount,
+		"Only top workers can get reward",
+	)
+	require.Less(
+		m.T,
+		rewardedReputersCount,
+		maxTopReputersCount,
+		"Only top reputers can get reward",
+	)
 }

--- a/test/stress/workers_test.go
+++ b/test/stress/workers_test.go
@@ -28,12 +28,16 @@ func createWorkerAddresses(
 		workerAccountName := getWorkerAccountName(m.Seed, workerIndex, topicId)
 		workerAccount, _, err := m.Client.AccountRegistryCreate(workerAccountName)
 		if err != nil {
-			m.T.Log(topicLog(topicId, "Error creating funder address: ", workerAccountName, " - ", err))
+			m.T.Log(
+				topicLog(topicId, "Error creating funder address: ", workerAccountName, " - ", err),
+			)
 			continue
 		}
 		workerAddressToFund, err := workerAccount.Address(params.HumanCoinUnit)
 		if err != nil {
-			m.T.Log(topicLog(topicId, "Error creating funder address: ", workerAccountName, " - ", err))
+			m.T.Log(
+				topicLog(topicId, "Error creating funder address: ", workerAccountName, " - ", err),
+			)
 			continue
 		}
 		workers[workerAccountName] = AccountAndAddress{
@@ -67,7 +71,9 @@ func registerWorkersForIteration(
 			topicId,
 		)
 		if err != nil {
-			m.T.Log(topicLog(topicId, "Error registering worker address: ", worker.addr, " - ", err))
+			m.T.Log(
+				topicLog(topicId, "Error registering worker address: ", worker.addr, " - ", err),
+			)
 			if makeReport {
 				saveWorkerError(topicId, workerName, err)
 				saveTopicError(topicId, err)
@@ -111,7 +117,16 @@ func generateInsertWorkerBundle(
 				topic, err = getLastTopic(m.Ctx, m.Client.QueryEmissions(), topic.Id)
 				if err == nil {
 					blockHeightCurrent = topic.EpochLastEnded + topic.EpochLength
-					m.T.Log(topicLog(topic.Id, "Reset ", leaderWorkerAccountName, "blockHeight to (", blockHeightCurrent, ")"))
+					m.T.Log(
+						topicLog(
+							topic.Id,
+							"Reset ",
+							leaderWorkerAccountName,
+							"blockHeight to (",
+							blockHeightCurrent,
+							")",
+						),
+					)
 				} else {
 					m.T.Log(topicLog(topic.Id, "Error getting topic!"))
 					if makeReport {
@@ -153,7 +168,14 @@ func insertWorkerBulk(
 			generateSingleWorkerBundle(m, topic.Id, blockHeight, key, workers))
 	}
 	leaderWorker := workers[leaderWorkerAccountName]
-	return insertLeaderWorkerBulk(m, topic.Id, blockHeight, leaderWorkerAccountName, leaderWorker.addr, workerDataBundles)
+	return insertLeaderWorkerBulk(
+		m,
+		topic.Id,
+		blockHeight,
+		leaderWorkerAccountName,
+		leaderWorker.addr,
+		workerDataBundles,
+	)
 }
 
 // create inferences and forecasts for a worker
@@ -199,7 +221,11 @@ func generateSingleWorkerBundle(
 	src, err := workerDataBundle.InferenceForecastsBundle.XXX_Marshal(src, true)
 	require.NoError(m.T, err, "Marshall reputer value bundle should not return an error")
 
-	sig, pubKey, err := m.Client.Context().Keyring.Sign(workerAddressName, src, signing.SignMode_SIGN_MODE_DIRECT)
+	sig, pubKey, err := m.Client.Context().Keyring.Sign(
+		workerAddressName,
+		src,
+		signing.SignMode_SIGN_MODE_DIRECT,
+	)
 	require.NoError(m.T, err, "Sign should not return an error")
 	workerPublicKeyBytes := pubKey.Bytes()
 	workerDataBundle.InferencesForecastsBundleSignature = sig
@@ -228,7 +254,15 @@ func insertLeaderWorkerBulk(
 	// serialize workerMsg to json and print
 	LeaderAcc, err := m.Client.AccountRegistryGetByName(leaderWorkerAccountName)
 	if err != nil {
-		m.T.Log(topicLog(topicId, "Error getting leader worker account: ", leaderWorkerAccountName, " - ", err))
+		m.T.Log(
+			topicLog(
+				topicId,
+				"Error getting leader worker account: ",
+				leaderWorkerAccountName,
+				" - ",
+				err,
+			),
+		)
 		return err
 	}
 	txResp, err := m.Client.BroadcastTx(m.Ctx, LeaderAcc, workerMsg)
@@ -265,7 +299,15 @@ func checkWorkersReceivedRewards(
 		if err != nil {
 			m.T.Log(topicLog(topicId, "Error getting worker balance for worker: ", workerName, err))
 			if maxIterations > 20 && workerIndex < 10 {
-				m.T.Log(topicLog(topicId, "ERROR: Worker", workerName, "has insufficient stake:", balance))
+				m.T.Log(
+					topicLog(
+						topicId,
+						"ERROR: Worker",
+						workerName,
+						"has insufficient stake:",
+						balance,
+					),
+				)
 			}
 			if makeReport {
 				saveWorkerError(topicId, workerName, err)

--- a/x/emissions/keeper/expected_keepers.go
+++ b/x/emissions/keeper/expected_keepers.go
@@ -25,9 +25,23 @@ type BankKeeper interface {
 
 	SpendableCoins(ctx context.Context, addr sdk.AccAddress) sdk.Coins
 
-	SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
-	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
-	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToModule(
+		ctx context.Context,
+		senderModule, recipientModule string,
+		amt sdk.Coins,
+	) error
+	SendCoinsFromModuleToAccount(
+		ctx context.Context,
+		senderModule string,
+		recipientAddr sdk.AccAddress,
+		amt sdk.Coins,
+	) error
+	SendCoinsFromAccountToModule(
+		ctx context.Context,
+		senderAddr sdk.AccAddress,
+		recipientModule string,
+		amt sdk.Coins,
+	) error
 
 	BlockedAddr(addr sdk.AccAddress) bool
 }

--- a/x/emissions/keeper/genesis.go
+++ b/x/emissions/keeper/genesis.go
@@ -15,7 +15,10 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 	k.authKeeper.SetModuleAccount(ctx, stakingModuleAccount)
 	alloraRewardsModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraRewardsAccountName)
 	k.authKeeper.SetModuleAccount(ctx, alloraRewardsModuleAccount)
-	alloraPendingRewardsModuleAccount := k.authKeeper.GetModuleAccount(ctx, types.AlloraPendingRewardForDelegatorAccountName)
+	alloraPendingRewardsModuleAccount := k.authKeeper.GetModuleAccount(
+		ctx,
+		types.AlloraPendingRewardForDelegatorAccountName,
+	)
 	k.authKeeper.SetModuleAccount(ctx, alloraPendingRewardsModuleAccount)
 	if err := k.SetTotalStake(ctx, cosmosMath.ZeroInt()); err != nil {
 		return err

--- a/x/emissions/keeper/inference_synthesis/forecast_implied_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied_inferences.go
@@ -61,7 +61,9 @@ func CalcForecastImpliedInferences(
 
 				for _, inferer := range sortedInferersInForecast {
 					if inferenceByWorker[inferer] != nil {
-						weightInferenceDotProduct, err = weightInferenceDotProduct.Add(inferenceByWorker[inferer].Value)
+						weightInferenceDotProduct, err = weightInferenceDotProduct.Add(
+							inferenceByWorker[inferer].Value,
+						)
 						if err != nil {
 							return nil, errorsmod.Wrapf(err, "error adding dot product")
 						}

--- a/x/emissions/keeper/inference_synthesis/forecast_implied_inferences_test.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied_inferences_test.go
@@ -64,9 +64,18 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesRow2() {
 			{
 				Forecaster: "forecaster0",
 				ForecastElements: []*emissions.ForecastElement{
-					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("0.02089366880023640")},
-					{Inferer: "worker1", Value: alloraMath.MustNewDecFromString("0.3342267861383700")},
-					{Inferer: "worker2", Value: alloraMath.MustNewDecFromString("0.0002604615062174660")},
+					{
+						Inferer: "worker0",
+						Value:   alloraMath.MustNewDecFromString("0.02089366880023640"),
+					},
+					{
+						Inferer: "worker1",
+						Value:   alloraMath.MustNewDecFromString("0.3342267861383700"),
+					},
+					{
+						Inferer: "worker2",
+						Value:   alloraMath.MustNewDecFromString("0.0002604615062174660"),
+					},
 				},
 			},
 		},
@@ -116,9 +125,18 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesRow3() {
 			{
 				Forecaster: "forecaster0",
 				ForecastElements: []*emissions.ForecastElement{
-					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("0.00011708024633613200")},
-					{Inferer: "worker1", Value: alloraMath.MustNewDecFromString("0.013382222402411400")},
-					{Inferer: "worker2", Value: alloraMath.MustNewDecFromString("3.82471429104471e-05")},
+					{
+						Inferer: "worker0",
+						Value:   alloraMath.MustNewDecFromString("0.00011708024633613200"),
+					},
+					{
+						Inferer: "worker1",
+						Value:   alloraMath.MustNewDecFromString("0.013382222402411400"),
+					},
+					{
+						Inferer: "worker2",
+						Value:   alloraMath.MustNewDecFromString("3.82471429104471e-05"),
+					},
 				},
 			},
 		},

--- a/x/emissions/keeper/inference_synthesis/inference_synthesis_test.go
+++ b/x/emissions/keeper/inference_synthesis/inference_synthesis_test.go
@@ -54,9 +54,17 @@ type InferenceSynthesisTestSuite struct {
 func (s *InferenceSynthesisTestSuite) SetupTest() {
 	key := storetypes.NewKVStoreKey("emissions")
 	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+	testCtx := testutil.DefaultContextWithDB(
+		s.T(),
+		key,
+		storetypes.NewTransientStoreKey("transient_test"),
+	)
 	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()})
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
+	encCfg := moduletestutil.MakeTestEncodingConfig(
+		auth.AppModuleBasic{},
+		bank.AppModuleBasic{},
+		module.AppModule{},
+	)
 	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
 
 	maccPerms := map[string][]string{
@@ -124,7 +132,11 @@ func (s *InferenceSynthesisTestSuite) SetupTest() {
 	}
 }
 
-func (s *InferenceSynthesisTestSuite) inEpsilon(value alloraMath.Dec, target string, epsilon string) {
+func (s *InferenceSynthesisTestSuite) inEpsilon(
+	value alloraMath.Dec,
+	target string,
+	epsilon string,
+) {
 	require := s.Require()
 	epsilonDec := alloraMath.MustNewDecFromString(epsilon)
 	targetDec := alloraMath.MustNewDecFromString(target)
@@ -141,8 +153,18 @@ func (s *InferenceSynthesisTestSuite) inEpsilon(value alloraMath.Dec, target str
 	require.NoError(err)
 
 	if lowerBound.Lt(upperBound) { // positive values, lower < value < upper
-		require.True(value.Gte(lowerBound), "value: %s, lowerBound: %s", value.String(), lowerBound.String())
-		require.True(value.Lte(upperBound), "value: %s, upperBound: %s", value.String(), upperBound.String())
+		require.True(
+			value.Gte(lowerBound),
+			"value: %s, lowerBound: %s",
+			value.String(),
+			lowerBound.String(),
+		)
+		require.True(
+			value.Lte(upperBound),
+			"value: %s, upperBound: %s",
+			value.String(),
+			upperBound.String(),
+		)
 	} else { // negative values, upper < value < lower
 		require.True(value.Lte(lowerBound), "value: %s, lowerBound: %s", value.String(), lowerBound.String())
 		require.True(value.Gte(upperBound), "value: %s, upperBound: %s", value.String(), upperBound.String())

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -16,7 +16,9 @@ import (
 )
 
 // Create a map from worker address to their inference or forecast-implied inference
-func MakeMapFromWorkerToTheirWork(inferences []*emissions.Inference) map[Worker]*emissions.Inference {
+func MakeMapFromWorkerToTheirWork(
+	inferences []*emissions.Inference,
+) map[Worker]*emissions.Inference {
 	inferencesByWorker := make(map[Worker]*emissions.Inference)
 	for _, inference := range inferences {
 		inferencesByWorker[inference.Inferer] = inference
@@ -89,11 +91,17 @@ func CalcTheStdDevOfRegretsAmongWorkersWithLosses(
 	}
 	stdDevInfererRegrets, err := alloraMath.StdDev(infererRegrets)
 	if err != nil {
-		return StdDevRegrets{}, errorsmod.Wrapf(err, "Error calculating standard deviation of inferer regrets")
+		return StdDevRegrets{}, errorsmod.Wrapf(
+			err,
+			"Error calculating standard deviation of inferer regrets",
+		)
 	}
 	stdDevInfererRegrets, err = stdDevInfererRegrets.Add(epsilon)
 	if err != nil {
-		return StdDevRegrets{}, errorsmod.Wrapf(err, "Error adding epsilon to standard deviation of inferer regrets")
+		return StdDevRegrets{}, errorsmod.Wrapf(
+			err,
+			"Error adding epsilon to standard deviation of inferer regrets",
+		)
 	}
 
 	forecasterRegrets := make([]Regret, 0)
@@ -106,36 +114,61 @@ func CalcTheStdDevOfRegretsAmongWorkersWithLosses(
 	}
 	stdDevForecasterRegrets, err := alloraMath.StdDev(forecasterRegrets)
 	if err != nil {
-		return StdDevRegrets{}, errorsmod.Wrapf(err, "Error calculating standard deviation of forecaster regrets")
+		return StdDevRegrets{}, errorsmod.Wrapf(
+			err,
+			"Error calculating standard deviation of forecaster regrets",
+		)
 	}
 	stdDevForecasterRegrets, err = stdDevForecasterRegrets.Add(epsilon)
 	if err != nil {
-		return StdDevRegrets{}, errorsmod.Wrapf(err, "Error adding epsilon to standard deviation of forecaster regrets")
+		return StdDevRegrets{}, errorsmod.Wrapf(
+			err,
+			"Error adding epsilon to standard deviation of forecaster regrets",
+		)
 	}
 
 	stdDevOneInForecasterRegrets := make(map[Worker]Regret, 0)
 	for _, forecaster := range sortedForecasters {
 		oneInForecasterRegrets := make([]Regret, 0)
 		for _, inferer := range sortedInferers {
-			oneInForecasterRegret, _, err := k.GetOneInForecasterNetworkRegret(ctx, topicId, forecaster, inferer)
+			oneInForecasterRegret, _, err := k.GetOneInForecasterNetworkRegret(
+				ctx,
+				topicId,
+				forecaster,
+				inferer,
+			)
 			if err != nil {
 				return StdDevRegrets{}, errorsmod.Wrapf(err, "Error getting forecaster regret")
 			}
 			oneInForecasterRegrets = append(oneInForecasterRegrets, oneInForecasterRegret.Value)
 		}
-		oneInForecasterSelfRegret, _, err := k.GetOneInForecasterNetworkRegret(ctx, topicId, forecaster, forecaster)
+		oneInForecasterSelfRegret, _, err := k.GetOneInForecasterNetworkRegret(
+			ctx,
+			topicId,
+			forecaster,
+			forecaster,
+		)
 		if err != nil {
-			return StdDevRegrets{}, errorsmod.Wrapf(err, "Error getting one-in forecaster self regret: ")
+			return StdDevRegrets{}, errorsmod.Wrapf(
+				err,
+				"Error getting one-in forecaster self regret: ",
+			)
 		}
 		oneInForecasterRegrets = append(oneInForecasterRegrets, oneInForecasterSelfRegret.Value)
 
 		stdDevOneInForecasterRegret, err := alloraMath.StdDev(oneInForecasterRegrets)
 		if err != nil {
-			return StdDevRegrets{}, errorsmod.Wrapf(err, "Error calculating standard deviation of forecaster regrets")
+			return StdDevRegrets{}, errorsmod.Wrapf(
+				err,
+				"Error calculating standard deviation of forecaster regrets",
+			)
 		}
 		stdDevOneInForecasterRegret, err = stdDevOneInForecasterRegret.Add(epsilon)
 		if err != nil {
-			return StdDevRegrets{}, errorsmod.Wrapf(err, "Error adding epsilon to standard deviation of forecaster regrets")
+			return StdDevRegrets{}, errorsmod.Wrapf(
+				err,
+				"Error adding epsilon to standard deviation of forecaster regrets",
+			)
 		}
 		stdDevOneInForecasterRegrets[forecaster] = stdDevOneInForecasterRegret
 	}
@@ -171,11 +204,17 @@ func accumulateNormalizedI_iAndSumWeights(
 		// If all workers are new, then the weight is 1 for all workers; take regular average of inferences
 		unnormalizedI_i, err = unnormalizedI_i.Add(inference.Value)
 		if err != nil {
-			return alloraMath.ZeroDec(), alloraMath.ZeroDec(), errorsmod.Wrapf(err, "Error adding weight by worker value")
+			return alloraMath.ZeroDec(), alloraMath.ZeroDec(), errorsmod.Wrapf(
+				err,
+				"Error adding weight by worker value",
+			)
 		}
 		sumWeights, err = sumWeights.Add(alloraMath.OneDec())
 		if err != nil {
-			return alloraMath.ZeroDec(), alloraMath.ZeroDec(), errorsmod.Wrapf(err, "Error adding weight")
+			return alloraMath.ZeroDec(), alloraMath.ZeroDec(), errorsmod.Wrapf(
+				err,
+				"Error adding weight",
+			)
 		}
 	} else {
 		// If at least one worker is not new, then we take a weighted average of all workers' inferences
@@ -252,7 +291,10 @@ func CalcWeightedInference(
 			sumWeights,
 		)
 		if err != nil {
-			return InferenceValue{}, errorsmod.Wrapf(err, "Error accumulating i_i and weights for inferer")
+			return InferenceValue{}, errorsmod.Wrapf(
+				err,
+				"Error accumulating i_i and weights for inferer",
+			)
 		}
 	}
 
@@ -274,7 +316,10 @@ func CalcWeightedInference(
 			sumWeights,
 		)
 		if err != nil {
-			return InferenceValue{}, errorsmod.Wrapf(err, "Error accumulating i_i and weights for forecaster")
+			return InferenceValue{}, errorsmod.Wrapf(
+				err,
+				"Error accumulating i_i and weights for forecaster",
+			)
 		}
 	}
 
@@ -284,7 +329,10 @@ func CalcWeightedInference(
 	}
 	ret, err := unnormalizedNetworkInferece.Quo(sumWeights)
 	if err != nil {
-		return InferenceValue{}, errorsmod.Wrapf(err, "Error calculating network combined inference")
+		return InferenceValue{}, errorsmod.Wrapf(
+			err,
+			"Error calculating network combined inference",
+		)
 	}
 	return ret, nil // divide numerator by denominator to get network combined inference
 }
@@ -336,7 +384,10 @@ func CalcOneOutInferences(
 		)
 
 		if err != nil {
-			return nil, nil, errorsmod.Wrapf(err, "Error calculating forecast-implied inferences for held-out inference")
+			return nil, nil, errorsmod.Wrapf(
+				err,
+				"Error calculating forecast-implied inferences for held-out inference",
+			)
 		}
 
 		oneOutNetworkInferenceWithoutInferer, err := CalcWeightedInference(
@@ -393,12 +444,18 @@ func CalcOneOutInferences(
 			cNorm,
 		)
 		if err != nil {
-			return nil, nil, errorsmod.Wrapf(err, "Error calculating one-out inference for forecaster")
+			return nil, nil, errorsmod.Wrapf(
+				err,
+				"Error calculating one-out inference for forecaster",
+			)
 		}
-		oneOutImpliedInferences = append(oneOutImpliedInferences, &emissions.WithheldWorkerAttributedValue{
-			Worker: worker,
-			Value:  oneOutInference,
-		})
+		oneOutImpliedInferences = append(
+			oneOutImpliedInferences,
+			&emissions.WithheldWorkerAttributedValue{
+				Worker: worker,
+				Value:  oneOutInference,
+			},
+		)
 	}
 
 	return oneOutInferences, oneOutImpliedInferences, nil
@@ -428,7 +485,9 @@ func CalcOneInInferences(
 		forecastImpliedInferencesWithForecaster[oneInForecaster] = forecastImpliedInferences[oneInForecaster]
 		// Calculate the network inference without the worker's forecast-implied inference
 
-		sortedForecastersWithForecaster := alloraMath.GetSortedKeys(forecastImpliedInferencesWithForecaster)
+		sortedForecastersWithForecaster := alloraMath.GetSortedKeys(
+			forecastImpliedInferencesWithForecaster,
+		)
 		oneInInference, err := CalcWeightedInference(
 			ctx,
 			k,
@@ -488,7 +547,8 @@ func CalcNetworkInferences(
 		cNorm,
 	)
 	if err != nil {
-		ctx.Logger().Warn(fmt.Sprintf("Error calculating forecast-implied inferences: %s", err.Error()))
+		ctx.Logger().
+			Warn(fmt.Sprintf("Error calculating forecast-implied inferences: %s", err.Error()))
 	}
 	sortedForecasters := alloraMath.GetSortedKeys(forecastImpliedInferenceByWorker)
 
@@ -504,9 +564,13 @@ func CalcNetworkInferences(
 		epsilon,
 	)
 	if err != nil {
-		ctx.Logger().Warn(fmt.Sprintf("Error finding max regret among workers with losses: %s", err.Error()))
+		ctx.Logger().
+			Warn(fmt.Sprintf("Error finding max regret among workers with losses: %s", err.Error()))
 	}
-	maxStdDevCombinedRegret := alloraMath.Max(stdDevRegrets.StdDevInferenceRegret, stdDevRegrets.StdDevForecastRegret)
+	maxStdDevCombinedRegret := alloraMath.Max(
+		stdDevRegrets.StdDevInferenceRegret,
+		stdDevRegrets.StdDevForecastRegret,
+	)
 
 	// Calculate the combined network inference I_i
 	combinedNetworkInference, err := CalcWeightedInference(
@@ -524,7 +588,8 @@ func CalcNetworkInferences(
 		cNorm,
 	)
 	if err != nil {
-		ctx.Logger().Warn(fmt.Sprintf("Error calculating network combined inference: %s", err.Error()))
+		ctx.Logger().
+			Warn(fmt.Sprintf("Error calculating network combined inference: %s", err.Error()))
 	}
 
 	// Calculate the naive inference I^-_i
@@ -633,14 +698,22 @@ func GetNetworkInferencesAtBlock(
 
 	inferences, err := k.GetInferencesAtBlock(ctx, topicId, inferencesNonce)
 	if err != nil {
-		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "no inferences found for topic %v at block %v", topicId, inferencesNonce)
+		return nil, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidRequest,
+			"no inferences found for topic %v at block %v",
+			topicId,
+			inferencesNonce,
+		)
 	}
 	// Add inferences in the bundle -> this bundle will be used as a fallback in case of error
 	for _, infererence := range inferences.Inferences {
-		networkInferences.InfererValues = append(networkInferences.InfererValues, &emissions.WorkerAttributedValue{
-			Worker: infererence.Inferer,
-			Value:  infererence.Value,
-		})
+		networkInferences.InfererValues = append(
+			networkInferences.InfererValues,
+			&emissions.WorkerAttributedValue{
+				Worker: infererence.Inferer,
+				Value:  infererence.Value,
+			},
+		)
 	}
 
 	forecasts, err := k.GetForecastsAtBlock(ctx, topicId, inferencesNonce)
@@ -660,7 +733,11 @@ func GetNetworkInferencesAtBlock(
 			return nil, err
 		}
 
-		reputerReportedLosses, err := k.GetReputerLossBundlesAtBlock(ctx, topicId, previousLossNonce)
+		reputerReportedLosses, err := k.GetReputerLossBundlesAtBlock(
+			ctx,
+			topicId,
+			previousLossNonce,
+		)
 		if err != nil {
 			ctx.Logger().Warn(fmt.Sprintf("Error getting reputer losses: %s", err.Error()))
 			return networkInferences, nil
@@ -683,7 +760,8 @@ func GetNetworkInferencesAtBlock(
 			moduleParams.Epsilon,
 		)
 		if err != nil {
-			ctx.Logger().Warn(fmt.Sprintf("Error calculating network combined loss: %s", err.Error()))
+			ctx.Logger().
+				Warn(fmt.Sprintf("Error calculating network combined loss: %s", err.Error()))
 			return networkInferences, nil
 		}
 		topic, err := k.GetTopic(ctx, topicId)
@@ -691,7 +769,17 @@ func GetNetworkInferencesAtBlock(
 			ctx.Logger().Warn(fmt.Sprintf("Error getting topic: %s", err.Error()))
 			return networkInferences, nil
 		}
-		networkInferences, err = CalcNetworkInferences(ctx, k, topicId, inferences, forecasts, networkCombinedLoss, moduleParams.Epsilon, topic.PNorm, moduleParams.CNorm)
+		networkInferences, err = CalcNetworkInferences(
+			ctx,
+			k,
+			topicId,
+			inferences,
+			forecasts,
+			networkCombinedLoss,
+			moduleParams.Epsilon,
+			topic.PNorm,
+			moduleParams.CNorm,
+		)
 		if err != nil {
 			ctx.Logger().Warn(fmt.Sprintf("Error calculating network inferences: %s", err.Error()))
 			return networkInferences, nil
@@ -722,7 +810,10 @@ func GetNetworkInferencesAtBlock(
 }
 
 // Filter nonces that are within the epoch length of the current block height
-func FilterNoncesWithinEpochLength(n emissions.Nonces, blockHeight, epochLength int64) emissions.Nonces {
+func FilterNoncesWithinEpochLength(
+	n emissions.Nonces,
+	blockHeight, epochLength int64,
+) emissions.Nonces {
 	var filtered emissions.Nonces
 	for _, nonce := range n.Nonces {
 		if blockHeight-nonce.BlockHeight <= epochLength {
@@ -740,7 +831,12 @@ func SortByBlockHeight(r []*emissions.ReputerRequestNonce) {
 }
 
 // Select the top N latest reputer nonces
-func SelectTopNReputerNonces(reputerRequestNonces *emissions.ReputerRequestNonces, N int, currentBlockHeight int64, groundTruthLag int64) []*emissions.ReputerRequestNonce {
+func SelectTopNReputerNonces(
+	reputerRequestNonces *emissions.ReputerRequestNonces,
+	N int,
+	currentBlockHeight int64,
+	groundTruthLag int64,
+) []*emissions.ReputerRequestNonce {
 	topN := make([]*emissions.ReputerRequestNonce, 0)
 	// sort reputerRequestNonces by reputer block height
 

--- a/x/emissions/keeper/inference_synthesis/network_inferences_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences_test.go
@@ -74,7 +74,11 @@ func TestMakeMapFromWorkerToTheirWork(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := inference_synthesis.MakeMapFromWorkerToTheirWork(tc.inferences)
-			assert.True(t, reflect.DeepEqual(result, tc.expected), "Expected and actual maps should be equal")
+			assert.True(
+				t,
+				reflect.DeepEqual(result, tc.expected),
+				"Expected and actual maps should be equal",
+			)
 		})
 	}
 }
@@ -101,27 +105,83 @@ func (s *InferenceSynthesisTestSuite) TestCalcTheStdDevOfRegretsAmongWorkersWith
 
 	epsilon := alloraMath.MustNewDecFromString("0.001")
 
-	err := k.SetInfererNetworkRegret(ctx, topicId, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err := k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetInfererNetworkRegret(ctx, topicId, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
 
-	err = k.SetForecasterNetworkRegret(ctx, topicId, worker3, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
-	err = k.SetForecasterNetworkRegret(ctx, topicId, worker4, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")},
+	)
 	s.Require().NoError(err)
 
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker3, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker3, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker3, worker3, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		worker3,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker4, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker4, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker4, worker4, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		worker4,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")},
+	)
 	s.Require().NoError(err)
 
 	stdDevRegrets, err := inference_synthesis.CalcTheStdDevOfRegretsAmongWorkersWithLosses(
@@ -140,15 +200,21 @@ func (s *InferenceSynthesisTestSuite) TestCalcTheStdDevOfRegretsAmongWorkersWith
 	s.Require().NoError(err)
 	expectedStdDevForecastRegret, err := alloraMath.MustNewDecFromString("0.050").Add(epsilon)
 	s.Require().NoError(err)
-	expectedStdDevOneInForecastRegretWorker3, err := alloraMath.MustNewDecFromString("0.08164965809277260327324280249019638").Add(epsilon)
+	expectedStdDevOneInForecastRegretWorker3, err := alloraMath.MustNewDecFromString("0.08164965809277260327324280249019638").
+		Add(epsilon)
 	s.Require().NoError(err)
-	expectedStdDevOneInForecastRegretWorker4, err := alloraMath.MustNewDecFromString("0.08164965809277260327324280249019638").Add(epsilon)
+	expectedStdDevOneInForecastRegretWorker4, err := alloraMath.MustNewDecFromString("0.08164965809277260327324280249019638").
+		Add(epsilon)
 	s.Require().NoError(err)
 
-	s.Require().True(stdDevRegrets.StdDevInferenceRegret.Equal(expectedStdDevInferenceRegret), "StdDevInferenceRegret mismatch")
-	s.Require().True(stdDevRegrets.StdDevForecastRegret.Equal(expectedStdDevForecastRegret), "StdDevForecastRegret mismatch")
-	s.Require().True(stdDevRegrets.StdDevOneInForecastRegret[worker3].Equal(expectedStdDevOneInForecastRegretWorker3), "StdDevOneInForecastRegret[worker3] mismatch")
-	s.Require().True(stdDevRegrets.StdDevOneInForecastRegret[worker4].Equal(expectedStdDevOneInForecastRegretWorker4), "StdDevOneInForecastRegret[worker4] mismatch")
+	s.Require().
+		True(stdDevRegrets.StdDevInferenceRegret.Equal(expectedStdDevInferenceRegret), "StdDevInferenceRegret mismatch")
+	s.Require().
+		True(stdDevRegrets.StdDevForecastRegret.Equal(expectedStdDevForecastRegret), "StdDevForecastRegret mismatch")
+	s.Require().
+		True(stdDevRegrets.StdDevOneInForecastRegret[worker3].Equal(expectedStdDevOneInForecastRegretWorker3), "StdDevOneInForecastRegret[worker3] mismatch")
+	s.Require().
+		True(stdDevRegrets.StdDevOneInForecastRegret[worker4].Equal(expectedStdDevOneInForecastRegretWorker4), "StdDevOneInForecastRegret[worker4] mismatch")
 }
 
 func (s *InferenceSynthesisTestSuite) TestCalcWeightedInferenceNormalOperation1() {
@@ -319,25 +385,52 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneOutInferencesMultipleWorkers() 
 			{
 				Forecaster: "worker3",
 				ForecastElements: []*emissionstypes.ForecastElement{
-					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("0.00011708024633613200")},
-					{Inferer: "worker1", Value: alloraMath.MustNewDecFromString("0.013382222402411400")},
-					{Inferer: "worker2", Value: alloraMath.MustNewDecFromString("3.82471429104471e-05")},
+					{
+						Inferer: "worker0",
+						Value:   alloraMath.MustNewDecFromString("0.00011708024633613200"),
+					},
+					{
+						Inferer: "worker1",
+						Value:   alloraMath.MustNewDecFromString("0.013382222402411400"),
+					},
+					{
+						Inferer: "worker2",
+						Value:   alloraMath.MustNewDecFromString("3.82471429104471e-05"),
+					},
 				},
 			},
 			{
 				Forecaster: "worker4",
 				ForecastElements: []*emissionstypes.ForecastElement{
-					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("0.00011486217283808300")},
-					{Inferer: "worker1", Value: alloraMath.MustNewDecFromString("0.0060528036329761000")},
-					{Inferer: "worker2", Value: alloraMath.MustNewDecFromString("0.0005337255825785730")},
+					{
+						Inferer: "worker0",
+						Value:   alloraMath.MustNewDecFromString("0.00011486217283808300"),
+					},
+					{
+						Inferer: "worker1",
+						Value:   alloraMath.MustNewDecFromString("0.0060528036329761000"),
+					},
+					{
+						Inferer: "worker2",
+						Value:   alloraMath.MustNewDecFromString("0.0005337255825785730"),
+					},
 				},
 			},
 			{
 				Forecaster: "worker5",
 				ForecastElements: []*emissionstypes.ForecastElement{
-					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("0.001810780808278390")},
-					{Inferer: "worker1", Value: alloraMath.MustNewDecFromString("0.0018544539679880700")},
-					{Inferer: "worker2", Value: alloraMath.MustNewDecFromString("0.001251454152216520")},
+					{
+						Inferer: "worker0",
+						Value:   alloraMath.MustNewDecFromString("0.001810780808278390"),
+					},
+					{
+						Inferer: "worker1",
+						Value:   alloraMath.MustNewDecFromString("0.0018544539679880700"),
+					},
+					{
+						Inferer: "worker2",
+						Value:   alloraMath.MustNewDecFromString("0.001251454152216520"),
+					},
 				},
 			},
 		},
@@ -411,8 +504,10 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneOutInferencesMultipleWorkers() 
 
 	s.Require().NoError(err, "CalcOneOutInferences should not return an error")
 
-	s.Require().Len(oneOutInfererValues, len(expectedOneOutInferences), "Unexpected number of one-out inferences")
-	s.Require().Len(oneOutForecasterValues, len(expectedOneOutImpliedInferences), "Unexpected number of one-out implied inferences")
+	s.Require().
+		Len(oneOutInfererValues, len(expectedOneOutInferences), "Unexpected number of one-out inferences")
+	s.Require().
+		Len(oneOutForecasterValues, len(expectedOneOutImpliedInferences), "Unexpected number of one-out implied inferences")
 
 	for _, expected := range expectedOneOutInferences {
 		found := false
@@ -423,7 +518,11 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneOutInferencesMultipleWorkers() 
 			}
 		}
 		if !found {
-			s.FailNow("Matching worker not found", "Worker %s not found in returned inferences", expected.Worker)
+			s.FailNow(
+				"Matching worker not found",
+				"Worker %s not found in returned inferences",
+				expected.Worker,
+			)
 		}
 	}
 
@@ -436,7 +535,11 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneOutInferencesMultipleWorkers() 
 			}
 		}
 		if !found {
-			s.FailNow("Matching worker not found", "Worker %s not found in returned inferences", expected.Worker)
+			s.FailNow(
+				"Matching worker not found",
+				"Worker %s not found in returned inferences",
+				expected.Worker,
+			)
 		}
 	}
 }
@@ -461,31 +564,76 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneOutInferences5Workers3Forecaste
 			{
 				Forecaster: "forecaster0",
 				ForecastElements: []*emissionstypes.ForecastElement{
-					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("0.003305466418410120")},
-					{Inferer: "worker1", Value: alloraMath.MustNewDecFromString("0.0002788248228566030")},
-					{Inferer: "worker2", Value: alloraMath.MustNewDecFromString(".0000240536828602367")},
-					{Inferer: "worker3", Value: alloraMath.MustNewDecFromString("0.0008240378476798250")},
-					{Inferer: "worker4", Value: alloraMath.MustNewDecFromString("0.0000186192181193532")},
+					{
+						Inferer: "worker0",
+						Value:   alloraMath.MustNewDecFromString("0.003305466418410120"),
+					},
+					{
+						Inferer: "worker1",
+						Value:   alloraMath.MustNewDecFromString("0.0002788248228566030"),
+					},
+					{
+						Inferer: "worker2",
+						Value:   alloraMath.MustNewDecFromString(".0000240536828602367"),
+					},
+					{
+						Inferer: "worker3",
+						Value:   alloraMath.MustNewDecFromString("0.0008240378476798250"),
+					},
+					{
+						Inferer: "worker4",
+						Value:   alloraMath.MustNewDecFromString("0.0000186192181193532"),
+					},
 				},
 			},
 			{
 				Forecaster: "forecaster1",
 				ForecastElements: []*emissionstypes.ForecastElement{
-					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("0.002308441286328890")},
-					{Inferer: "worker1", Value: alloraMath.MustNewDecFromString("0.0000214380788596749")},
-					{Inferer: "worker2", Value: alloraMath.MustNewDecFromString("0.012560171044167200")},
-					{Inferer: "worker3", Value: alloraMath.MustNewDecFromString("0.017998563880697900")},
-					{Inferer: "worker4", Value: alloraMath.MustNewDecFromString("0.00020024906252089700")},
+					{
+						Inferer: "worker0",
+						Value:   alloraMath.MustNewDecFromString("0.002308441286328890"),
+					},
+					{
+						Inferer: "worker1",
+						Value:   alloraMath.MustNewDecFromString("0.0000214380788596749"),
+					},
+					{
+						Inferer: "worker2",
+						Value:   alloraMath.MustNewDecFromString("0.012560171044167200"),
+					},
+					{
+						Inferer: "worker3",
+						Value:   alloraMath.MustNewDecFromString("0.017998563880697900"),
+					},
+					{
+						Inferer: "worker4",
+						Value:   alloraMath.MustNewDecFromString("0.00020024906252089700"),
+					},
 				},
 			},
 			{
 				Forecaster: "forecaster2",
 				ForecastElements: []*emissionstypes.ForecastElement{
-					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("0.005369218152594270")},
-					{Inferer: "worker1", Value: alloraMath.MustNewDecFromString("0.0002578158768320300")},
-					{Inferer: "worker2", Value: alloraMath.MustNewDecFromString("0.0076008583603885900")},
-					{Inferer: "worker3", Value: alloraMath.MustNewDecFromString("0.0076269073955871000")},
-					{Inferer: "worker4", Value: alloraMath.MustNewDecFromString("0.00035670236460009500")},
+					{
+						Inferer: "worker0",
+						Value:   alloraMath.MustNewDecFromString("0.005369218152594270"),
+					},
+					{
+						Inferer: "worker1",
+						Value:   alloraMath.MustNewDecFromString("0.0002578158768320300"),
+					},
+					{
+						Inferer: "worker2",
+						Value:   alloraMath.MustNewDecFromString("0.0076008583603885900"),
+					},
+					{
+						Inferer: "worker3",
+						Value:   alloraMath.MustNewDecFromString("0.0076269073955871000"),
+					},
+					{
+						Inferer: "worker4",
+						Value:   alloraMath.MustNewDecFromString("0.00035670236460009500"),
+					},
 				},
 			},
 		},
@@ -566,8 +714,10 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneOutInferences5Workers3Forecaste
 
 	s.Require().NoError(err, "CalcOneOutInferences should not return an error")
 
-	s.Require().Len(oneOutInfererValues, len(expectedOneOutInferences), "Unexpected number of one-out inferences")
-	s.Require().Len(oneOutForecasterValues, len(expectedOneOutImpliedInferences), "Unexpected number of one-out implied inferences")
+	s.Require().
+		Len(oneOutInfererValues, len(expectedOneOutInferences), "Unexpected number of one-out inferences")
+	s.Require().
+		Len(oneOutForecasterValues, len(expectedOneOutImpliedInferences), "Unexpected number of one-out implied inferences")
 
 	for _, expected := range expectedOneOutInferences {
 		found := false
@@ -578,7 +728,11 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneOutInferences5Workers3Forecaste
 			}
 		}
 		if !found {
-			s.FailNow("Matching worker not found", "Worker %s not found in returned inferences", expected.Worker)
+			s.FailNow(
+				"Matching worker not found",
+				"Worker %s not found in returned inferences",
+				expected.Worker,
+			)
 		}
 	}
 
@@ -591,7 +745,11 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneOutInferences5Workers3Forecaste
 			}
 		}
 		if !found {
-			s.FailNow("Matching worker not found", "Worker %s not found in returned inferences", expected.Worker)
+			s.FailNow(
+				"Matching worker not found",
+				"Worker %s not found in returned inferences",
+				expected.Worker,
+			)
 		}
 	}
 }
@@ -761,29 +919,83 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferences() {
 	cNorm := alloraMath.MustNewDecFromString("0.75")
 
 	// Set inferer network regrets
-	err := k.SetInfererNetworkRegret(ctx, topicId, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err := k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetInfererNetworkRegret(ctx, topicId, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
 
 	// Set forecaster network regrets
-	err = k.SetForecasterNetworkRegret(ctx, topicId, worker3, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
-	err = k.SetForecasterNetworkRegret(ctx, topicId, worker4, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")},
+	)
 	s.Require().NoError(err)
 
 	// Set one-in forecaster network regrets
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker3, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker3, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker4, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker4, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
 
 	// Call the function
-	valueBundle, err := inference_synthesis.CalcNetworkInferences(ctx, k, topicId, inferences, forecasts, networkCombinedLoss, epsilon, pNorm, cNorm)
+	valueBundle, err := inference_synthesis.CalcNetworkInferences(
+		ctx,
+		k,
+		topicId,
+		inferences,
+		forecasts,
+		networkCombinedLoss,
+		epsilon,
+		pNorm,
+		cNorm,
+	)
 	s.Require().NoError(err)
 
 	// Check the results
@@ -808,8 +1020,18 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesSameInfererForeca
 	// Set up input data
 	inferences := &emissionstypes.Inferences{
 		Inferences: []*emissionstypes.Inference{
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.52")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.71")},
+			{
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+				Inferer:     worker1,
+				Value:       alloraMath.MustNewDecFromString("0.52"),
+			},
+			{
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+				Inferer:     worker2,
+				Value:       alloraMath.MustNewDecFromString("0.71"),
+			},
 		},
 	}
 
@@ -842,7 +1064,17 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesSameInfererForeca
 	cNorm := alloraMath.MustNewDecFromString("0.75")
 
 	// Call the function
-	valueBundle, err := inference_synthesis.CalcNetworkInferences(ctx, k, topicId, inferences, forecasts, networkCombinedLoss, epsilon, pNorm, cNorm)
+	valueBundle, err := inference_synthesis.CalcNetworkInferences(
+		ctx,
+		k,
+		topicId,
+		inferences,
+		forecasts,
+		networkCombinedLoss,
+		epsilon,
+		pNorm,
+		cNorm,
+	)
 	s.Require().NoError(err)
 	s.Require().NotNil(valueBundle)
 	s.Require().NotNil(valueBundle.CombinedValue)
@@ -852,29 +1084,83 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesSameInfererForeca
 	// s.Require().NotEmpty(valueBundle.OneInForecasterValues)
 
 	// Set inferer network regrets
-	err = k.SetInfererNetworkRegret(ctx, topicId, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err = k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetInfererNetworkRegret(ctx, topicId, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
 
 	// Set forecaster network regrets
-	err = k.SetForecasterNetworkRegret(ctx, topicId, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
-	err = k.SetForecasterNetworkRegret(ctx, topicId, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")},
+	)
 	s.Require().NoError(err)
 
 	// Set one-in forecaster network regrets
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker1, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker1,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker1, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker1,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker2, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker2,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker2, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker2,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
 
 	// Call the function
-	valueBundle, err = inference_synthesis.CalcNetworkInferences(ctx, k, topicId, inferences, forecasts, networkCombinedLoss, epsilon, pNorm, cNorm)
+	valueBundle, err = inference_synthesis.CalcNetworkInferences(
+		ctx,
+		k,
+		topicId,
+		inferences,
+		forecasts,
+		networkCombinedLoss,
+		epsilon,
+		pNorm,
+		cNorm,
+	)
 	s.Require().NoError(err)
 
 	// Check the results
@@ -899,8 +1185,18 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesIncompleteData() 
 	// Set up input data
 	inferences := &emissionstypes.Inferences{
 		Inferences: []*emissionstypes.Inference{
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.52")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.71")},
+			{
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+				Inferer:     worker1,
+				Value:       alloraMath.MustNewDecFromString("0.52"),
+			},
+			{
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+				Inferer:     worker2,
+				Value:       alloraMath.MustNewDecFromString("0.71"),
+			},
 		},
 	}
 
@@ -933,7 +1229,17 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesIncompleteData() 
 	cNorm := alloraMath.MustNewDecFromString("0.75")
 
 	// Call the function without setting regrets
-	valueBundle, err := inference_synthesis.CalcNetworkInferences(ctx, k, topicId, inferences, forecasts, networkCombinedLoss, epsilon, pNorm, cNorm)
+	valueBundle, err := inference_synthesis.CalcNetworkInferences(
+		ctx,
+		k,
+		topicId,
+		inferences,
+		forecasts,
+		networkCombinedLoss,
+		epsilon,
+		pNorm,
+		cNorm,
+	)
 	s.Require().NoError(err)
 	s.Require().NotNil(valueBundle)
 	s.Require().NotNil(valueBundle.CombinedValue)
@@ -1395,7 +1701,11 @@ func (s *InferenceSynthesisTestSuite) TestFilterNoncesWithinEpochLength() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			actual := inference_synthesis.FilterNoncesWithinEpochLength(tc.nonces, tc.blockHeight, tc.epochLength)
+			actual := inference_synthesis.FilterNoncesWithinEpochLength(
+				tc.nonces,
+				tc.blockHeight,
+				tc.epochLength,
+			)
 			s.Require().Equal(tc.expectedNonce, actual, "Filter nonces do not match")
 		})
 	}
@@ -1415,14 +1725,26 @@ func (s *InferenceSynthesisTestSuite) TestSelectTopNReputerNonces() {
 			name: "N greater than length of nonces, zero lag",
 			reputerRequestNonces: &emissionstypes.ReputerRequestNonces{
 				Nonces: []*emissionstypes.ReputerRequestNonce{
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 1}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 2}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 3}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 4}},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 1},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 2},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 3},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 4},
+					},
 				},
 			},
 			N: 5,
 			expectedTopNReputerNonce: []*emissionstypes.ReputerRequestNonce{
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 3}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 4}},
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 1}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 2}},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 3},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 4},
+				},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 1},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 2},
+				},
 			},
 			currentBlockHeight: 10,
 			groundTruthLag:     0,
@@ -1431,15 +1753,30 @@ func (s *InferenceSynthesisTestSuite) TestSelectTopNReputerNonces() {
 			name: "N less than length of nonces, zero lag",
 			reputerRequestNonces: &emissionstypes.ReputerRequestNonces{
 				Nonces: []*emissionstypes.ReputerRequestNonce{
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 1}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 2}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 3}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 4}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 6}},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 1},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 2},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 3},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 4},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 6},
+					},
 				},
 			},
 			N: 2,
 			expectedTopNReputerNonce: []*emissionstypes.ReputerRequestNonce{
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 6}},
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 3}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 4}},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 6},
+				},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 3},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 4},
+				},
 			},
 			currentBlockHeight: 10,
 			groundTruthLag:     0,
@@ -1448,15 +1785,30 @@ func (s *InferenceSynthesisTestSuite) TestSelectTopNReputerNonces() {
 			name: "Ground truth lag cutting selection midway",
 			reputerRequestNonces: &emissionstypes.ReputerRequestNonces{
 				Nonces: []*emissionstypes.ReputerRequestNonce{
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 2}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 1}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 5}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 3}},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 2},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 1},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 5},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 3},
+					},
 				},
 			},
 			N: 3,
 			expectedTopNReputerNonce: []*emissionstypes.ReputerRequestNonce{
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 3}},
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 2}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 1}},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 3},
+				},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 2},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 1},
+				},
 			},
 			currentBlockHeight: 10,
 			groundTruthLag:     6,
@@ -1465,9 +1817,18 @@ func (s *InferenceSynthesisTestSuite) TestSelectTopNReputerNonces() {
 			name: "Big Ground truth lag, not selecting any nonces",
 			reputerRequestNonces: &emissionstypes.ReputerRequestNonces{
 				Nonces: []*emissionstypes.ReputerRequestNonce{
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 2}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 1}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 5}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 3}},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 2},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 1},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 5},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 3},
+					},
 				},
 			},
 			N:                        3,
@@ -1479,16 +1840,34 @@ func (s *InferenceSynthesisTestSuite) TestSelectTopNReputerNonces() {
 			name: "Small ground truth lag, selecting all nonces",
 			reputerRequestNonces: &emissionstypes.ReputerRequestNonces{
 				Nonces: []*emissionstypes.ReputerRequestNonce{
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 5}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 4}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 3}},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 5},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 4},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 3},
+					},
 				},
 			},
 			N: 3,
 			expectedTopNReputerNonce: []*emissionstypes.ReputerRequestNonce{
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 5}},
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 4}},
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 3}},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 5},
+				},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 4},
+				},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 3},
+				},
 			},
 			currentBlockHeight: 10,
 			groundTruthLag:     2,
@@ -1497,15 +1876,30 @@ func (s *InferenceSynthesisTestSuite) TestSelectTopNReputerNonces() {
 			name: "Mid ground truth lag, selecting some nonces",
 			reputerRequestNonces: &emissionstypes.ReputerRequestNonces{
 				Nonces: []*emissionstypes.ReputerRequestNonce{
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 5}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 4}},
-					{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 3}},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 6},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 5},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 4},
+					},
+					{
+						ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4},
+						WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 3},
+					},
 				},
 			},
 			N: 3,
 			expectedTopNReputerNonce: []*emissionstypes.ReputerRequestNonce{
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 4}},
-				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 3}},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 5},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 4},
+				},
+				{
+					ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4},
+					WorkerNonce:  &emissionstypes.Nonce{BlockHeight: 3},
+				},
 			},
 			currentBlockHeight: 10,
 			groundTruthLag:     5,
@@ -1515,7 +1909,12 @@ func (s *InferenceSynthesisTestSuite) TestSelectTopNReputerNonces() {
 	// Run test cases
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			actual := inference_synthesis.SelectTopNReputerNonces(tc.reputerRequestNonces, tc.N, tc.currentBlockHeight, tc.groundTruthLag)
+			actual := inference_synthesis.SelectTopNReputerNonces(
+				tc.reputerRequestNonces,
+				tc.N,
+				tc.currentBlockHeight,
+				tc.groundTruthLag,
+			)
 			s.Require().Equal(tc.expectedTopNReputerNonce, actual, "Reputer nonces do not match")
 		})
 	}
@@ -1612,29 +2011,83 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesTwoWorkerTwoForec
 	cNorm := alloraMath.MustNewDecFromString("0.75")
 
 	// Set inferer network regrets
-	err := k.SetInfererNetworkRegret(ctx, topicId, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err := k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetInfererNetworkRegret(ctx, topicId, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
 
 	// Set forecaster network regrets
-	err = k.SetForecasterNetworkRegret(ctx, topicId, worker3, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
-	err = k.SetForecasterNetworkRegret(ctx, topicId, worker4, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")},
+	)
 	s.Require().NoError(err)
 
 	// Set one-in forecaster network regrets
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker3, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker3, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker4, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, worker4, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		worker4,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
 
 	// Call the function
-	valueBundle, err := inference_synthesis.CalcNetworkInferences(ctx, k, topicId, inferences, forecasts, networkCombinedLoss, epsilon, pNorm, cNorm)
+	valueBundle, err := inference_synthesis.CalcNetworkInferences(
+		ctx,
+		k,
+		topicId,
+		inferences,
+		forecasts,
+		networkCombinedLoss,
+		epsilon,
+		pNorm,
+		cNorm,
+	)
 	s.Require().NoError(err)
 
 	// Check the results
@@ -1704,45 +2157,139 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesThreeWorkerThreeF
 	cNorm := alloraMath.MustNewDecFromString("0.75")
 
 	// Set inferer network regrets
-	err := k.SetInfererNetworkRegret(ctx, topicId, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.1")})
+	err := k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.1")},
+	)
 	s.Require().NoError(err)
-	err = k.SetInfererNetworkRegret(ctx, topicId, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err = k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetInfererNetworkRegret(ctx, topicId, worker3, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetInfererNetworkRegret(
+		ctx,
+		topicId,
+		worker3,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
 
 	// Set forecaster network regrets
-	err = k.SetForecasterNetworkRegret(ctx, topicId, forecaster1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
-	err = k.SetForecasterNetworkRegret(ctx, topicId, forecaster2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")},
+	)
 	s.Require().NoError(err)
-	err = k.SetForecasterNetworkRegret(ctx, topicId, forecaster3, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")})
+	err = k.SetForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster3,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")},
+	)
 	s.Require().NoError(err)
 
 	// Set one-in forecaster network regrets
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster1, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.7")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster1,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.7")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster1, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.8")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster1,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.8")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster1, worker3, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.9")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster1,
+		worker3,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.9")},
+	)
 	s.Require().NoError(err)
 
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster2, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.1")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster2,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.1")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster2, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster2,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.2")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster2, worker3, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster2,
+		worker3,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.3")},
+	)
 	s.Require().NoError(err)
 
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster3, worker1, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster3,
+		worker1,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.4")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster3, worker2, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster3,
+		worker2,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.5")},
+	)
 	s.Require().NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster3, worker3, emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")})
+	err = k.SetOneInForecasterNetworkRegret(
+		ctx,
+		topicId,
+		forecaster3,
+		worker3,
+		emissionstypes.TimestampedValue{Value: alloraMath.MustNewDecFromString("0.6")},
+	)
 	s.Require().NoError(err)
 
 	// Call the function
-	valueBundle, err := inference_synthesis.CalcNetworkInferences(ctx, k, topicId, inferences, forecasts, networkCombinedLoss, epsilon, pNorm, cNorm)
+	valueBundle, err := inference_synthesis.CalcNetworkInferences(
+		ctx,
+		k,
+		topicId,
+		inferences,
+		forecasts,
+		networkCombinedLoss,
+		epsilon,
+		pNorm,
+		cNorm,
+	)
 	s.Require().NoError(err)
 
 	// Check the results
@@ -1826,7 +2373,8 @@ func (s *InferenceSynthesisTestSuite) TestSortByBlockHeight() {
 			inference_synthesis.SortByBlockHeight(test.input.Nonces)
 
 			// Compare the sorted input with the expected output
-			s.Require().Equal(test.input.Nonces, test.output.Nonces, "Sorting result mismatch.\nExpected: %v\nGot: %v")
+			s.Require().
+				Equal(test.input.Nonces, test.output.Nonces, "Sorting result mismatch.\nExpected: %v\nGot: %v")
 		})
 	}
 }

--- a/x/emissions/keeper/inference_synthesis/network_losses.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses.go
@@ -21,7 +21,9 @@ func RunningWeightedAvgUpdate(
 	if err != nil {
 		return RunningWeightedLoss{}, err
 	}
-	newUnnormalizedWeightedLoss, err := runningWeightedAvg.UnnormalizedWeightedLoss.Add(nextValTimesWeight)
+	newUnnormalizedWeightedLoss, err := runningWeightedAvg.UnnormalizedWeightedLoss.Add(
+		nextValTimesWeight,
+	)
 	if err != nil {
 		return RunningWeightedLoss{}, err
 	}
@@ -70,21 +72,32 @@ func CalcNetworkLosses(
 	runningWeightedInfererLosses := make(map[Worker]*RunningWeightedLoss)
 	runningWeightedForecasterLosses := make(map[Worker]*RunningWeightedLoss)
 	runningWeightedNaiveLoss := RunningWeightedLoss{alloraMath.ZeroDec(), alloraMath.ZeroDec()}
-	runningWeightedOneOutInfererLosses := make(map[Worker]*RunningWeightedLoss) // Withheld worker -> Forecaster -> Loss
+	runningWeightedOneOutInfererLosses := make(
+		map[Worker]*RunningWeightedLoss,
+	) // Withheld worker -> Forecaster -> Loss
 	runningWeightedOneOutForecasterLosses := make(map[Worker]*RunningWeightedLoss)
 	runningWeightedOneInForecasterLosses := make(map[Worker]*RunningWeightedLoss)
 
 	for _, report := range reputerReportedLosses.ReputerValueBundles {
 		if report.ValueBundle != nil {
-			stakeAmount, err := alloraMath.NewDecFromSdkInt(stakesByReputer[report.ValueBundle.Reputer])
+			stakeAmount, err := alloraMath.NewDecFromSdkInt(
+				stakesByReputer[report.ValueBundle.Reputer],
+			)
 			if err != nil {
 				return emissions.ValueBundle{}, err
 			}
 
 			// Update combined loss with reputer reported loss and stake
-			runningWeightedCombinedLoss, err = RunningWeightedAvgUpdate(&runningWeightedCombinedLoss, stakeAmount, report.ValueBundle.CombinedValue)
+			runningWeightedCombinedLoss, err = RunningWeightedAvgUpdate(
+				&runningWeightedCombinedLoss,
+				stakeAmount,
+				report.ValueBundle.CombinedValue,
+			)
 			if err != nil {
-				return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for next combined loss")
+				return emissions.ValueBundle{}, errorsmod.Wrapf(
+					err,
+					"Error updating running weighted average for next combined loss",
+				)
 			}
 
 			// Not all reputers may have reported losses on the same set of inferers => important that the code below doesn't assume that!
@@ -97,9 +110,16 @@ func CalcNetworkLosses(
 					}
 				}
 
-				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedInfererLosses[loss.Worker], stakeAmount, loss.Value)
+				nextAvg, err := RunningWeightedAvgUpdate(
+					runningWeightedInfererLosses[loss.Worker],
+					stakeAmount,
+					loss.Value,
+				)
 				if err != nil {
-					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for inferer")
+					return emissions.ValueBundle{}, errorsmod.Wrapf(
+						err,
+						"Error updating running weighted average for inferer",
+					)
 				}
 				runningWeightedInfererLosses[loss.Worker] = &nextAvg
 			}
@@ -113,17 +133,31 @@ func CalcNetworkLosses(
 					}
 				}
 
-				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedForecasterLosses[loss.Worker], stakeAmount, loss.Value)
+				nextAvg, err := RunningWeightedAvgUpdate(
+					runningWeightedForecasterLosses[loss.Worker],
+					stakeAmount,
+					loss.Value,
+				)
 				if err != nil {
-					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for forecaster")
+					return emissions.ValueBundle{}, errorsmod.Wrapf(
+						err,
+						"Error updating running weighted average for forecaster",
+					)
 				}
 				runningWeightedForecasterLosses[loss.Worker] = &nextAvg
 			}
 
 			// Update naive loss
-			runningWeightedNaiveLoss, err = RunningWeightedAvgUpdate(&runningWeightedNaiveLoss, stakeAmount, report.ValueBundle.NaiveValue)
+			runningWeightedNaiveLoss, err = RunningWeightedAvgUpdate(
+				&runningWeightedNaiveLoss,
+				stakeAmount,
+				report.ValueBundle.NaiveValue,
+			)
 			if err != nil {
-				return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for naive loss: ")
+				return emissions.ValueBundle{}, errorsmod.Wrapf(
+					err,
+					"Error updating running weighted average for naive loss: ",
+				)
 			}
 
 			// Update one-out inferer losses
@@ -134,9 +168,16 @@ func CalcNetworkLosses(
 						SumWeight:                alloraMath.ZeroDec(),
 					}
 				}
-				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedOneOutInfererLosses[loss.Worker], stakeAmount, loss.Value)
+				nextAvg, err := RunningWeightedAvgUpdate(
+					runningWeightedOneOutInfererLosses[loss.Worker],
+					stakeAmount,
+					loss.Value,
+				)
 				if err != nil {
-					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for one-out inferer")
+					return emissions.ValueBundle{}, errorsmod.Wrapf(
+						err,
+						"Error updating running weighted average for one-out inferer",
+					)
 				}
 				runningWeightedOneOutInfererLosses[loss.Worker] = &nextAvg
 			}
@@ -150,9 +191,16 @@ func CalcNetworkLosses(
 					}
 				}
 
-				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedOneOutForecasterLosses[loss.Worker], stakeAmount, loss.Value)
+				nextAvg, err := RunningWeightedAvgUpdate(
+					runningWeightedOneOutForecasterLosses[loss.Worker],
+					stakeAmount,
+					loss.Value,
+				)
 				if err != nil {
-					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for one-out forecaster")
+					return emissions.ValueBundle{}, errorsmod.Wrapf(
+						err,
+						"Error updating running weighted average for one-out forecaster",
+					)
 				}
 				runningWeightedOneOutForecasterLosses[loss.Worker] = &nextAvg
 			}
@@ -166,9 +214,16 @@ func CalcNetworkLosses(
 					}
 				}
 
-				nextAvg, err := RunningWeightedAvgUpdate(runningWeightedOneInForecasterLosses[loss.Worker], stakeAmount, loss.Value)
+				nextAvg, err := RunningWeightedAvgUpdate(
+					runningWeightedOneInForecasterLosses[loss.Worker],
+					stakeAmount,
+					loss.Value,
+				)
 				if err != nil {
-					return emissions.ValueBundle{}, errorsmod.Wrapf(err, "Error updating running weighted average for one-in forecaster")
+					return emissions.ValueBundle{}, errorsmod.Wrapf(
+						err,
+						"Error updating running weighted average for one-in forecaster",
+					)
 				}
 				runningWeightedOneInForecasterLosses[loss.Worker] = &nextAvg
 			}
@@ -191,11 +246,31 @@ func CalcNetworkLosses(
 	}
 
 	// Convert the running weighted averages to WorkerAttributedValue/WithheldWorkerAttributedValue for inferers and forecasters
-	infererLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WorkerAttributedValue](runningWeightedInfererLosses, sortedInferers, epsilon)
-	forecasterLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WorkerAttributedValue](runningWeightedForecasterLosses, sortedForecasters, epsilon)
-	oneOutInfererLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WithheldWorkerAttributedValue](runningWeightedOneOutInfererLosses, sortedInferers, epsilon)
-	oneOutForecasterLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WithheldWorkerAttributedValue](runningWeightedOneOutForecasterLosses, sortedForecasters, epsilon)
-	oneInForecasterLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WorkerAttributedValue](runningWeightedOneInForecasterLosses, sortedForecasters, epsilon)
+	infererLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WorkerAttributedValue](
+		runningWeightedInfererLosses,
+		sortedInferers,
+		epsilon,
+	)
+	forecasterLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WorkerAttributedValue](
+		runningWeightedForecasterLosses,
+		sortedForecasters,
+		epsilon,
+	)
+	oneOutInfererLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WithheldWorkerAttributedValue](
+		runningWeightedOneOutInfererLosses,
+		sortedInferers,
+		epsilon,
+	)
+	oneOutForecasterLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WithheldWorkerAttributedValue](
+		runningWeightedOneOutForecasterLosses,
+		sortedForecasters,
+		epsilon,
+	)
+	oneInForecasterLosses := convertMapOfRunningWeightedLossesToWorkerAttributedValue[emissions.WorkerAttributedValue](
+		runningWeightedOneInForecasterLosses,
+		sortedForecasters,
+		epsilon,
+	)
 
 	output := emissions.ValueBundle{
 		CombinedValue:          combinedValue,
@@ -221,7 +296,9 @@ func CalcCombinedNetworkLoss(
 
 	for _, report := range reputerReportedLosses.ReputerValueBundles {
 		if report.ValueBundle != nil {
-			stakeAmount, err := alloraMath.NewDecFromSdkInt(stakesByReputer[report.ValueBundle.Reputer])
+			stakeAmount, err := alloraMath.NewDecFromSdkInt(
+				stakesByReputer[report.ValueBundle.Reputer],
+			)
 			if err != nil {
 				return Loss{}, errorsmod.Wrapf(err, "Error converting stake to Dec")
 			}
@@ -233,7 +310,10 @@ func CalcCombinedNetworkLoss(
 				report.ValueBundle.CombinedValue,
 			)
 			if err != nil {
-				return Loss{}, errorsmod.Wrapf(err, "Error updating running weighted average for combined loss: ")
+				return Loss{}, errorsmod.Wrapf(
+					err,
+					"Error updating running weighted average for combined loss: ",
+				)
 			}
 			runningWeightedCombinedLoss = nextCombinedLoss
 		}
@@ -252,10 +332,15 @@ func normalizeWeightedLoss(
 	epsilon alloraMath.Dec,
 ) (alloraMath.Dec, error) {
 	if runningWeightedLossData.SumWeight.Lt(epsilon) {
-		return alloraMath.Dec{}, errorsmod.Wrapf(emissions.ErrFractionDivideByZero, "Sum weight for combined naive loss is 0")
+		return alloraMath.Dec{}, errorsmod.Wrapf(
+			emissions.ErrFractionDivideByZero,
+			"Sum weight for combined naive loss is 0",
+		)
 	}
 
-	normalizedWeightedLoss, err := runningWeightedLossData.UnnormalizedWeightedLoss.Quo(runningWeightedLossData.SumWeight)
+	normalizedWeightedLoss, err := runningWeightedLossData.UnnormalizedWeightedLoss.Quo(
+		runningWeightedLossData.SumWeight,
+	)
 	if err != nil {
 		return alloraMath.Dec{}, err
 	}

--- a/x/emissions/keeper/inference_synthesis/network_losses_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses_test.go
@@ -18,28 +18,46 @@ func (s *InferenceSynthesisTestSuite) TestRunningWeightedAvgUpdate() {
 		expectedErr         error
 	}{
 		{
-			name:                "normal operation",
-			initialWeightedLoss: inference_synthesis.RunningWeightedLoss{UnnormalizedWeightedLoss: alloraMath.MustNewDecFromString("0.5"), SumWeight: alloraMath.MustNewDecFromString("1.0")},
-			nextWeight:          alloraMath.MustNewDecFromString("1.0"),
-			nextValue:           alloraMath.MustNewDecFromString("2.0"),
-			expectedLoss:        inference_synthesis.RunningWeightedLoss{UnnormalizedWeightedLoss: alloraMath.MustNewDecFromString("2.5"), SumWeight: alloraMath.MustNewDecFromString("2.0")},
-			expectedErr:         nil,
+			name: "normal operation",
+			initialWeightedLoss: inference_synthesis.RunningWeightedLoss{
+				UnnormalizedWeightedLoss: alloraMath.MustNewDecFromString("0.5"),
+				SumWeight:                alloraMath.MustNewDecFromString("1.0"),
+			},
+			nextWeight: alloraMath.MustNewDecFromString("1.0"),
+			nextValue:  alloraMath.MustNewDecFromString("2.0"),
+			expectedLoss: inference_synthesis.RunningWeightedLoss{
+				UnnormalizedWeightedLoss: alloraMath.MustNewDecFromString("2.5"),
+				SumWeight:                alloraMath.MustNewDecFromString("2.0"),
+			},
+			expectedErr: nil,
 		},
 		{
-			name:                "simple example",
-			initialWeightedLoss: inference_synthesis.RunningWeightedLoss{UnnormalizedWeightedLoss: alloraMath.ZeroDec(), SumWeight: alloraMath.ZeroDec()},
-			nextWeight:          alloraMath.MustNewDecFromString("1.0"),
-			nextValue:           alloraMath.MustNewDecFromString("0.1"),
-			expectedLoss:        inference_synthesis.RunningWeightedLoss{UnnormalizedWeightedLoss: alloraMath.MustNewDecFromString("0.1"), SumWeight: alloraMath.MustNewDecFromString("1.0")},
-			expectedErr:         nil,
+			name: "simple example",
+			initialWeightedLoss: inference_synthesis.RunningWeightedLoss{
+				UnnormalizedWeightedLoss: alloraMath.ZeroDec(),
+				SumWeight:                alloraMath.ZeroDec(),
+			},
+			nextWeight: alloraMath.MustNewDecFromString("1.0"),
+			nextValue:  alloraMath.MustNewDecFromString("0.1"),
+			expectedLoss: inference_synthesis.RunningWeightedLoss{
+				UnnormalizedWeightedLoss: alloraMath.MustNewDecFromString("0.1"),
+				SumWeight:                alloraMath.MustNewDecFromString("1.0"),
+			},
+			expectedErr: nil,
 		},
 		{
-			name:                "simple example2",
-			initialWeightedLoss: inference_synthesis.RunningWeightedLoss{UnnormalizedWeightedLoss: alloraMath.ZeroDec(), SumWeight: alloraMath.ZeroDec()},
-			nextWeight:          alloraMath.MustNewDecFromString("1.0"),
-			nextValue:           alloraMath.MustNewDecFromString("0.2"),
-			expectedLoss:        inference_synthesis.RunningWeightedLoss{UnnormalizedWeightedLoss: alloraMath.MustNewDecFromString("0.2"), SumWeight: alloraMath.MustNewDecFromString("1.0")},
-			expectedErr:         nil,
+			name: "simple example2",
+			initialWeightedLoss: inference_synthesis.RunningWeightedLoss{
+				UnnormalizedWeightedLoss: alloraMath.ZeroDec(),
+				SumWeight:                alloraMath.ZeroDec(),
+			},
+			nextWeight: alloraMath.MustNewDecFromString("1.0"),
+			nextValue:  alloraMath.MustNewDecFromString("0.2"),
+			expectedLoss: inference_synthesis.RunningWeightedLoss{
+				UnnormalizedWeightedLoss: alloraMath.MustNewDecFromString("0.2"),
+				SumWeight:                alloraMath.MustNewDecFromString("1.0"),
+			},
+			expectedErr: nil,
 		},
 	}
 
@@ -78,9 +96,14 @@ func (s *InferenceSynthesisTestSuite) TestCalcCombinedNetworkLossSimpleCaseWithO
 	expectedLoss := alloraMath.MustNewDecFromString("0.1") // exp(0.1) ≈ 1.258925
 	epsilon := alloraMath.MustNewDecFromString("1e-4")
 
-	loss, err := inference_synthesis.CalcCombinedNetworkLoss(stakesByReputer, reportedLosses, epsilon)
+	loss, err := inference_synthesis.CalcCombinedNetworkLoss(
+		stakesByReputer,
+		reportedLosses,
+		epsilon,
+	)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(expectedLoss, loss, alloraMath.MustNewDecFromString("0.00001")), "Loss should match expected value within a small epsilon")
+	s.Require().
+		True(alloraMath.InDelta(expectedLoss, loss, alloraMath.MustNewDecFromString("0.00001")), "Loss should match expected value within a small epsilon")
 }
 
 func (s *InferenceSynthesisTestSuite) TestCalcCombinedNetworkLossTwoReputers() {
@@ -110,9 +133,14 @@ func (s *InferenceSynthesisTestSuite) TestCalcCombinedNetworkLossTwoReputers() {
 		alloraMath.MustNewDecFromString("1e-4")
 	expectedLoss :=
 		alloraMath.MustNewDecFromString("0.16666666666")
-	loss, err := inference_synthesis.CalcCombinedNetworkLoss(stakesByReputer, reportedLosses, epsilon)
+	loss, err := inference_synthesis.CalcCombinedNetworkLoss(
+		stakesByReputer,
+		reportedLosses,
+		epsilon,
+	)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(expectedLoss, loss, alloraMath.MustNewDecFromString("0.00001")), "Loss should match expected value within a small epsilon")
+	s.Require().
+		True(alloraMath.InDelta(expectedLoss, loss, alloraMath.MustNewDecFromString("0.00001")), "Loss should match expected value within a small epsilon")
 }
 
 func (s *InferenceSynthesisTestSuite) TestCalcCombinedNetworkLossEpoch3() {
@@ -170,10 +198,15 @@ func (s *InferenceSynthesisTestSuite) TestCalcCombinedNetworkLossEpoch3() {
 	}
 	epsilon := alloraMath.MustNewDecFromString("1e-4")
 	expectedLoss := alloraMath.MustNewDecFromString(".000015456633")
-	loss, err := inference_synthesis.CalcCombinedNetworkLoss(stakesByReputer, reportedLosses, epsilon)
+	loss, err := inference_synthesis.CalcCombinedNetworkLoss(
+		stakesByReputer,
+		reportedLosses,
+		epsilon,
+	)
 
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(expectedLoss, loss, alloraMath.MustNewDecFromString("0.00001")), "Loss should match expected value within a small epsilon")
+	s.Require().
+		True(alloraMath.InDelta(expectedLoss, loss, alloraMath.MustNewDecFromString("0.00001")), "Loss should match expected value within a small epsilon")
 }
 
 func (s *InferenceSynthesisTestSuite) TestCalcCombinedNetworkLossOneReporterZeroCombinedLoss() {
@@ -193,10 +226,17 @@ func (s *InferenceSynthesisTestSuite) TestCalcCombinedNetworkLossOneReporterZero
 			},
 		}
 	epsilon := alloraMath.MustNewDecFromString("1e-4")
-	expectedLoss := alloraMath.MustNewDecFromString("1e-4") // Should be equal to zero, since the combined loss is allowed to be zero
-	loss, err := inference_synthesis.CalcCombinedNetworkLoss(stakesByReputer, reportedLosses, epsilon)
+	expectedLoss := alloraMath.MustNewDecFromString(
+		"1e-4",
+	) // Should be equal to zero, since the combined loss is allowed to be zero
+	loss, err := inference_synthesis.CalcCombinedNetworkLoss(
+		stakesByReputer,
+		reportedLosses,
+		epsilon,
+	)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(expectedLoss, loss, alloraMath.MustNewDecFromString("0.00001")), "Loss should match expected value within a small epsilon")
+	s.Require().
+		True(alloraMath.InDelta(expectedLoss, loss, alloraMath.MustNewDecFromString("0.00001")), "Loss should match expected value within a small epsilon")
 }
 
 func getTestCasesOneWorker() []struct {
@@ -508,7 +548,11 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkLosses() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			output, err := inference_synthesis.CalcNetworkLosses(tc.stakesByReputer, tc.reportedLosses, tc.epsilon)
+			output, err := inference_synthesis.CalcNetworkLosses(
+				tc.stakesByReputer,
+				tc.reportedLosses,
+				tc.epsilon,
+			)
 			if tc.expectedError != nil {
 				require.Error(err)
 				require.EqualError(err, tc.expectedError.Error())
@@ -559,7 +603,11 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkLossesCombined() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			output, err := inference_synthesis.CalcNetworkLosses(tc.stakesByReputer, tc.reportedLosses, tc.epsilon)
+			output, err := inference_synthesis.CalcNetworkLosses(
+				tc.stakesByReputer,
+				tc.reportedLosses,
+				tc.epsilon,
+			)
 			if tc.expectedError != nil {
 				require.Error(err)
 				require.EqualError(err, tc.expectedError.Error())

--- a/x/emissions/keeper/inference_synthesis/network_regrets.go
+++ b/x/emissions/keeper/inference_synthesis/network_regrets.go
@@ -102,7 +102,11 @@ func GetCalcSetNetworkRegrets(
 		return networkLosses.InfererValues[i].Worker < networkLosses.InfererValues[j].Worker
 	})
 	for _, infererLoss := range networkLosses.InfererValues {
-		lastRegret, noPriorRegret, err := k.GetInfererNetworkRegret(ctx, topicId, infererLoss.Worker)
+		lastRegret, noPriorRegret, err := k.GetInfererNetworkRegret(
+			ctx,
+			topicId,
+			infererLoss.Worker,
+		)
 		if err != nil {
 			return errorsmod.Wrapf(err, "failed to get inferer regret")
 		}
@@ -125,7 +129,11 @@ func GetCalcSetNetworkRegrets(
 		return networkLosses.ForecasterValues[i].Worker < networkLosses.ForecasterValues[j].Worker
 	})
 	for _, forecasterLoss := range networkLosses.ForecasterValues {
-		lastRegret, noPriorRegret, err := k.GetForecasterNetworkRegret(ctx, topicId, forecasterLoss.Worker)
+		lastRegret, noPriorRegret, err := k.GetForecasterNetworkRegret(
+			ctx,
+			topicId,
+			forecasterLoss.Worker,
+		)
 		if err != nil {
 			return errorsmod.Wrapf(err, "Error getting forecaster regret")
 		}
@@ -153,7 +161,12 @@ func GetCalcSetNetworkRegrets(
 			if infererLoss.Worker == oneInForecasterLoss.Worker {
 				continue
 			}
-			lastRegret, noPriorRegret, err := k.GetOneInForecasterNetworkRegret(ctx, topicId, oneInForecasterLoss.Worker, infererLoss.Worker)
+			lastRegret, noPriorRegret, err := k.GetOneInForecasterNetworkRegret(
+				ctx,
+				topicId,
+				oneInForecasterLoss.Worker,
+				infererLoss.Worker,
+			)
 			if err != nil {
 				return errorsmod.Wrapf(err, "Error getting one-in forecaster regret")
 			}
@@ -168,10 +181,21 @@ func GetCalcSetNetworkRegrets(
 			if err != nil {
 				return errorsmod.Wrapf(err, "Error computing and building one-in forecaster regret")
 			}
-			k.SetOneInForecasterNetworkRegret(ctx, topicId, oneInForecasterLoss.Worker, infererLoss.Worker, newOneInForecasterRegret)
+			k.SetOneInForecasterNetworkRegret(
+				ctx,
+				topicId,
+				oneInForecasterLoss.Worker,
+				infererLoss.Worker,
+				newOneInForecasterRegret,
+			)
 		}
 		// Self-regret for the forecaster given their own regret
-		lastRegret, noPriorRegret, err := k.GetOneInForecasterNetworkRegret(ctx, topicId, oneInForecasterLoss.Worker, oneInForecasterLoss.Worker)
+		lastRegret, noPriorRegret, err := k.GetOneInForecasterNetworkRegret(
+			ctx,
+			topicId,
+			oneInForecasterLoss.Worker,
+			oneInForecasterLoss.Worker,
+		)
 		if err != nil {
 			return errorsmod.Wrapf(err, "Error getting one-in forecaster self regret")
 		}
@@ -184,9 +208,18 @@ func GetCalcSetNetworkRegrets(
 			noPriorRegret,
 		)
 		if err != nil {
-			return errorsmod.Wrapf(err, "Error computing and building one-in forecaster self regret")
+			return errorsmod.Wrapf(
+				err,
+				"Error computing and building one-in forecaster self regret",
+			)
 		}
-		k.SetOneInForecasterNetworkRegret(ctx, topicId, oneInForecasterLoss.Worker, oneInForecasterLoss.Worker, oneInForecasterSelfRegret)
+		k.SetOneInForecasterNetworkRegret(
+			ctx,
+			topicId,
+			oneInForecasterLoss.Worker,
+			oneInForecasterLoss.Worker,
+			oneInForecasterSelfRegret,
+		)
 	}
 
 	return nil

--- a/x/emissions/keeper/inference_synthesis/network_regrets_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_regrets_test.go
@@ -64,13 +64,22 @@ func (s *InferenceSynthesisTestSuite) TestComputeAndBuildEMRegret() {
 
 	blockHeight := int64(123)
 
-	result, err := inference_synthesis.ComputeAndBuildEMRegret(lossA, lossB, previous, alpha, blockHeight, false)
+	result, err := inference_synthesis.ComputeAndBuildEMRegret(
+		lossA,
+		lossB,
+		previous,
+		alpha,
+		blockHeight,
+		false,
+	)
 	require.NoError(err)
 
 	expected, err := alloraMath.NewDecFromString("210")
 	require.NoError(err)
 
-	require.True(alloraMath.InDelta(expected, result.Value, alloraMath.MustNewDecFromString("0.0001")))
+	require.True(
+		alloraMath.InDelta(expected, result.Value, alloraMath.MustNewDecFromString("0.0001")),
+	)
 	require.Equal(blockHeight, result.BlockHeight)
 }
 
@@ -131,27 +140,50 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsTwoWorkers() {
 	expected := alloraMath.MustNewDecFromString("210")
 	expectedOneIn := alloraMath.MustNewDecFromString("180")
 
-	worker3LastRegret, worker3NoPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, worker3)
+	worker3LastRegret, worker3NoPriorRegret, err := k.GetInfererNetworkRegret(
+		s.ctx,
+		topicId,
+		worker3,
+	)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetForecasterNetworkRegret(s.ctx, topicId, worker3)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetForecasterNetworkRegret(
+		s.ctx,
+		topicId,
+		worker3,
+	)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker1)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(
+		s.ctx,
+		topicId,
+		worker3,
+		worker1,
+	)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker2)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(
+		s.ctx,
+		topicId,
+		worker3,
+		worker2,
+	)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker3)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(
+		s.ctx,
+		topicId,
+		worker3,
+		worker3,
+	)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
@@ -159,18 +191,41 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsTwoWorkers() {
 	for _, acc := range bothAccs {
 		lastRegret, noPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, acc)
 		require.NoError(err)
-		require.True(alloraMath.InDelta(expected, lastRegret.Value, alloraMath.MustNewDecFromString("0.0001")))
+		require.True(
+			alloraMath.InDelta(
+				expected,
+				lastRegret.Value,
+				alloraMath.MustNewDecFromString("0.0001"),
+			),
+		)
 		require.False(noPriorRegret)
 
 		lastRegret, noPriorRegret, err = k.GetForecasterNetworkRegret(s.ctx, topicId, acc)
 		require.NoError(err)
-		require.True(alloraMath.InDelta(expected, lastRegret.Value, alloraMath.MustNewDecFromString("0.0001")))
+		require.True(
+			alloraMath.InDelta(
+				expected,
+				lastRegret.Value,
+				alloraMath.MustNewDecFromString("0.0001"),
+			),
+		)
 		require.False(noPriorRegret)
 
 		for _, accInner := range bothAccs {
-			lastRegret, noPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, acc, accInner)
+			lastRegret, noPriorRegret, err = k.GetOneInForecasterNetworkRegret(
+				s.ctx,
+				topicId,
+				acc,
+				accInner,
+			)
 			require.NoError(err)
-			require.True(alloraMath.InDelta(expectedOneIn, lastRegret.Value, alloraMath.MustNewDecFromString("0.0001")))
+			require.True(
+				alloraMath.InDelta(
+					expectedOneIn,
+					lastRegret.Value,
+					alloraMath.MustNewDecFromString("0.0001"),
+				),
+			)
 			require.False(noPriorRegret)
 		}
 	}
@@ -250,7 +305,13 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsThreeWorkers()
 	for _, workerAcc := range allWorkerAccs {
 		lastRegret, noPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, workerAcc)
 		require.NoError(err)
-		require.True(alloraMath.InDelta(expected, lastRegret.Value, alloraMath.MustNewDecFromString("0.0001")))
+		require.True(
+			alloraMath.InDelta(
+				expected,
+				lastRegret.Value,
+				alloraMath.MustNewDecFromString("0.0001"),
+			),
+		)
 		require.False(noPriorRegret)
 
 		lastRegret, noPriorRegret, err = k.GetForecasterNetworkRegret(s.ctx, topicId, workerAcc)
@@ -258,7 +319,12 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsThreeWorkers()
 		require.False(noPriorRegret)
 
 		for _, innerWorkerAcc := range allWorkerAccs {
-			lastRegret, noPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, workerAcc, innerWorkerAcc)
+			lastRegret, noPriorRegret, err = k.GetOneInForecasterNetworkRegret(
+				s.ctx,
+				topicId,
+				workerAcc,
+				innerWorkerAcc,
+			)
 			require.NoError(err)
 			require.False(noPriorRegret)
 		}

--- a/x/emissions/keeper/msgserver/msg_server_common_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_common_test.go
@@ -27,11 +27,36 @@ func TestFindTopNByScoreDesc(t *testing.T) {
 	worker5Addr := sdk.AccAddress(worker5PrivateKey.PubKey().Address())
 
 	latestReputerScores := make(map[string]types.Score)
-	latestReputerScores[worker1Addr.String()] = types.Score{TopicId: topicId, BlockNumber: 1, Address: worker1Addr.String(), Score: alloraMath.NewDecFromInt64(90)}
-	latestReputerScores[worker2Addr.String()] = types.Score{TopicId: topicId, BlockNumber: 1, Address: worker2Addr.String(), Score: alloraMath.NewDecFromInt64(40)}
-	latestReputerScores[worker3Addr.String()] = types.Score{TopicId: topicId, BlockNumber: 1, Address: worker3Addr.String(), Score: alloraMath.NewDecFromInt64(80)}
-	latestReputerScores[worker4Addr.String()] = types.Score{TopicId: topicId, BlockNumber: 1, Address: worker4Addr.String(), Score: alloraMath.NewDecFromInt64(20)}
-	latestReputerScores[worker5Addr.String()] = types.Score{TopicId: topicId, BlockNumber: 1, Address: worker5Addr.String(), Score: alloraMath.NewDecFromInt64(100)}
+	latestReputerScores[worker1Addr.String()] = types.Score{
+		TopicId:     topicId,
+		BlockNumber: 1,
+		Address:     worker1Addr.String(),
+		Score:       alloraMath.NewDecFromInt64(90),
+	}
+	latestReputerScores[worker2Addr.String()] = types.Score{
+		TopicId:     topicId,
+		BlockNumber: 1,
+		Address:     worker2Addr.String(),
+		Score:       alloraMath.NewDecFromInt64(40),
+	}
+	latestReputerScores[worker3Addr.String()] = types.Score{
+		TopicId:     topicId,
+		BlockNumber: 1,
+		Address:     worker3Addr.String(),
+		Score:       alloraMath.NewDecFromInt64(80),
+	}
+	latestReputerScores[worker4Addr.String()] = types.Score{
+		TopicId:     topicId,
+		BlockNumber: 1,
+		Address:     worker4Addr.String(),
+		Score:       alloraMath.NewDecFromInt64(20),
+	}
+	latestReputerScores[worker5Addr.String()] = types.Score{
+		TopicId:     topicId,
+		BlockNumber: 1,
+		Address:     worker5Addr.String(),
+		Score:       alloraMath.NewDecFromInt64(100),
+	}
 
 	topActors := FindTopNByScoreDesc(3, latestReputerScores, 1)
 	require.Equal(t, worker5Addr.String(), topActors[0])

--- a/x/emissions/keeper/msgserver/msg_server_demand.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand.go
@@ -10,7 +10,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (ms msgServer) FundTopic(ctx context.Context, msg *types.MsgFundTopic) (*types.MsgFundTopicResponse, error) {
+func (ms msgServer) FundTopic(
+	ctx context.Context,
+	msg *types.MsgFundTopic,
+) (*types.MsgFundTopicResponse, error) {
 	// Check the topic is valid
 	topicExists, err := ms.k.TopicExists(ctx, msg.TopicId)
 	if err != nil {

--- a/x/emissions/keeper/msgserver/msg_server_demand_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand_test.go
@@ -12,13 +12,25 @@ func (s *KeeperTestSuite) TestFundTopicSimple() {
 	sender := senderAddr.String()
 	topicId := s.CreateOneTopic()
 	// put some stake in the topic
-	err := s.emissionsKeeper.AddStake(s.ctx, topicId, PKS[1].Address().String(), cosmosMath.NewInt(500000))
+	err := s.emissionsKeeper.AddStake(
+		s.ctx,
+		topicId,
+		PKS[1].Address().String(),
+		cosmosMath.NewInt(500000),
+	)
 	s.Require().NoError(err)
 	s.emissionsKeeper.InactivateTopic(s.ctx, topicId)
 	var initialStake int64 = 1000
-	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake)))
+	initialStakeCoins := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake)),
+	)
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, senderAddr, initialStakeCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		s.ctx,
+		types.AlloraStakingAccountName,
+		senderAddr,
+		initialStakeCoins,
+	)
 	r := types.MsgFundTopic{
 		Sender:  sender,
 		TopicId: topicId,
@@ -55,8 +67,10 @@ func (s *KeeperTestSuite) TestFundTopicSimple() {
 		r.Amount,
 	)
 	s.Require().NoError(err)
-	s.Require().True(feeRevAfter.GT(feeRevBefore), "Topic fee revenue should be greater after funding the topic")
-	s.Require().True(topicWeightAfter.Gt(topicWeightBefore), "Topic weight should be greater after funding the topic")
+	s.Require().
+		True(feeRevAfter.GT(feeRevBefore), "Topic fee revenue should be greater after funding the topic")
+	s.Require().
+		True(topicWeightAfter.Gt(topicWeightBefore), "Topic weight should be greater after funding the topic")
 }
 
 func (s *KeeperTestSuite) TestHighWeightForHighFundedTopic() {
@@ -65,17 +79,34 @@ func (s *KeeperTestSuite) TestHighWeightForHighFundedTopic() {
 	topicId := s.CreateOneTopic()
 	topicId2 := s.CreateOneTopic()
 	// put some stake in the topic
-	err := s.emissionsKeeper.AddStake(s.ctx, topicId, PKS[1].Address().String(), cosmosMath.NewInt(500000))
+	err := s.emissionsKeeper.AddStake(
+		s.ctx,
+		topicId,
+		PKS[1].Address().String(),
+		cosmosMath.NewInt(500000),
+	)
 	s.Require().NoError(err)
 	s.emissionsKeeper.InactivateTopic(s.ctx, topicId)
-	err = s.emissionsKeeper.AddStake(s.ctx, topicId2, PKS[1].Address().String(), cosmosMath.NewInt(500000))
+	err = s.emissionsKeeper.AddStake(
+		s.ctx,
+		topicId2,
+		PKS[1].Address().String(),
+		cosmosMath.NewInt(500000),
+	)
 	s.Require().NoError(err)
 	s.emissionsKeeper.InactivateTopic(s.ctx, topicId2)
 	var initialStake int64 = 1000
 	var initialStake2 int64 = 10000
-	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake+initialStake2)))
+	initialStakeCoins := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake+initialStake2)),
+	)
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, senderAddr, initialStakeCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		s.ctx,
+		types.AlloraStakingAccountName,
+		senderAddr,
+		initialStakeCoins,
+	)
 	r := types.MsgFundTopic{
 		Sender:  sender,
 		TopicId: topicId,
@@ -124,7 +155,8 @@ func (s *KeeperTestSuite) TestHighWeightForHighFundedTopic() {
 	)
 	s.Require().NoError(err)
 
-	s.Require().Equal(topic2Weight.Gt(topicWeight), true, "Topic1 weight should be greater than Topic2 weight")
+	s.Require().
+		Equal(topic2Weight.Gt(topicWeight), true, "Topic1 weight should be greater than Topic2 weight")
 }
 
 /*

--- a/x/emissions/keeper/msgserver/msg_server_losses_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses_test.go
@@ -30,7 +30,10 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayload() {
 	minStakeScaled := params.RequiredMinimumStake.Mul(inference_synthesis.CosmosIntOneE18())
 
 	topicId := s.commonStakingSetup(ctx, reputerAddr.String(), workerAddr.String(), minStakeScaled)
-	s.MintTokensToAddress(reputerAddr, cosmosMath.NewIntFromBigInt(params.RequiredMinimumStake.BigInt()))
+	s.MintTokensToAddress(
+		reputerAddr,
+		cosmosMath.NewIntFromBigInt(params.RequiredMinimumStake.BigInt()),
+	)
 
 	addStakeMsg := &types.MsgAddStake{
 		Sender:  reputerAddr.String(),
@@ -57,7 +60,9 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayload() {
 	expectedInferences := types.Inferences{
 		Inferences: []*types.Inference{
 			{
-				Value:   alloraMath.NewDecFromInt64(1), // Assuming NewDecFromInt64 exists and is appropriate
+				Value: alloraMath.NewDecFromInt64(
+					1,
+				), // Assuming NewDecFromInt64 exists and is appropriate
 				Inferer: workerAddr.String(),
 			},
 		},
@@ -163,7 +168,10 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayloadInvalid() {
 
 	topicId := s.commonStakingSetup(ctx, reputerAddr.String(), workerAddr.String(), minStakeScaled)
 
-	s.MintTokensToAddress(reputerAddr, cosmosMath.NewIntFromBigInt(params.RequiredMinimumStake.BigInt()))
+	s.MintTokensToAddress(
+		reputerAddr,
+		cosmosMath.NewIntFromBigInt(params.RequiredMinimumStake.BigInt()),
+	)
 
 	addStakeMsg := &types.MsgAddStake{
 		Sender:  reputerAddr.String(),
@@ -190,7 +198,9 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayloadInvalid() {
 	expectedInferences := types.Inferences{
 		Inferences: []*types.Inference{
 			{
-				Value:   alloraMath.NewDecFromInt64(1), // Assuming NewDecFromInt64 exists and is appropriate
+				Value: alloraMath.NewDecFromInt64(
+					1,
+				), // Assuming NewDecFromInt64 exists and is appropriate
 				Inferer: workerAddr.String(),
 			},
 		},
@@ -311,7 +321,10 @@ func (s *KeeperTestSuite) TestMsgInsertHugeBulkReputerPayloadFails() {
 
 	topicId := s.commonStakingSetup(ctx, reputerAddr.String(), workerAddr.String(), minStakeScaled)
 
-	s.MintTokensToAddress(reputerAddr, cosmosMath.NewIntFromBigInt(params.RequiredMinimumStake.BigInt()))
+	s.MintTokensToAddress(
+		reputerAddr,
+		cosmosMath.NewIntFromBigInt(params.RequiredMinimumStake.BigInt()),
+	)
 
 	addStakeMsg := &types.MsgAddStake{
 		Sender:  reputerAddr.String(),
@@ -338,7 +351,9 @@ func (s *KeeperTestSuite) TestMsgInsertHugeBulkReputerPayloadFails() {
 	expectedInferences := types.Inferences{
 		Inferences: []*types.Inference{
 			{
-				Value:   alloraMath.NewDecFromInt64(1), // Assuming NewDecFromInt64 exists and is appropriate
+				Value: alloraMath.NewDecFromInt64(
+					1,
+				), // Assuming NewDecFromInt64 exists and is appropriate
 				Inferer: workerAddr.String(),
 			},
 		},

--- a/x/emissions/keeper/msgserver/msg_server_params.go
+++ b/x/emissions/keeper/msgserver/msg_server_params.go
@@ -6,7 +6,10 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (ms msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
+func (ms msgServer) UpdateParams(
+	ctx context.Context,
+	msg *types.MsgUpdateParams,
+) (*types.MsgUpdateParamsResponse, error) {
 	if err := ms.k.ValidateStringIsBech32(msg.Sender); err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/msgserver/msg_server_params_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_params_test.go
@@ -118,21 +118,39 @@ func (s *KeeperTestSuite) TestUpdateAllParams() {
 	require.Equal(newParams.MaxGradientThreshold[0], updatedParams.MaxGradientThreshold)
 	require.Equal(newParams.MinStakeFraction[0], updatedParams.MinStakeFraction)
 	require.Equal(newParams.Epsilon[0], updatedParams.Epsilon)
-	require.Equal(newParams.MaxUnfulfilledWorkerRequests[0], updatedParams.MaxUnfulfilledWorkerRequests)
-	require.Equal(newParams.MaxUnfulfilledReputerRequests[0], updatedParams.MaxUnfulfilledReputerRequests)
+	require.Equal(
+		newParams.MaxUnfulfilledWorkerRequests[0],
+		updatedParams.MaxUnfulfilledWorkerRequests,
+	)
+	require.Equal(
+		newParams.MaxUnfulfilledReputerRequests[0],
+		updatedParams.MaxUnfulfilledReputerRequests,
+	)
 	require.Equal(newParams.TopicRewardStakeImportance[0], updatedParams.TopicRewardStakeImportance)
-	require.Equal(newParams.TopicRewardFeeRevenueImportance[0], updatedParams.TopicRewardFeeRevenueImportance)
+	require.Equal(
+		newParams.TopicRewardFeeRevenueImportance[0],
+		updatedParams.TopicRewardFeeRevenueImportance,
+	)
 	require.Equal(newParams.TopicRewardAlpha[0], updatedParams.TopicRewardAlpha)
 	require.Equal(newParams.TaskRewardAlpha[0], updatedParams.TaskRewardAlpha)
-	require.Equal(newParams.ValidatorsVsAlloraPercentReward[0], updatedParams.ValidatorsVsAlloraPercentReward)
+	require.Equal(
+		newParams.ValidatorsVsAlloraPercentReward[0],
+		updatedParams.ValidatorsVsAlloraPercentReward,
+	)
 	require.Equal(newParams.MaxSamplesToScaleScores[0], updatedParams.MaxSamplesToScaleScores)
 	require.Equal(newParams.MaxTopInferersToReward[0], updatedParams.MaxTopInferersToReward)
 	require.Equal(newParams.MaxTopForecastersToReward[0], updatedParams.MaxTopForecastersToReward)
 	require.Equal(newParams.MaxTopReputersToReward[0], updatedParams.MaxTopReputersToReward)
 	require.Equal(newParams.CreateTopicFee[0], updatedParams.CreateTopicFee)
 	require.Equal(newParams.GradientDescentMaxIters[0], updatedParams.GradientDescentMaxIters)
-	require.Equal(newParams.MaxRetriesToFulfilNoncesWorker[0], updatedParams.MaxRetriesToFulfilNoncesWorker)
-	require.Equal(newParams.MaxRetriesToFulfilNoncesReputer[0], updatedParams.MaxRetriesToFulfilNoncesReputer)
+	require.Equal(
+		newParams.MaxRetriesToFulfilNoncesWorker[0],
+		updatedParams.MaxRetriesToFulfilNoncesWorker,
+	)
+	require.Equal(
+		newParams.MaxRetriesToFulfilNoncesReputer[0],
+		updatedParams.MaxRetriesToFulfilNoncesReputer,
+	)
 	require.Equal(newParams.RegistrationFee[0], updatedParams.RegistrationFee)
 	require.Equal(newParams.DefaultPageLimit[0], updatedParams.DefaultPageLimit)
 	require.Equal(newParams.MaxPageLimit[0], updatedParams.MaxPageLimit)

--- a/x/emissions/keeper/msgserver/msg_server_registrations.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations.go
@@ -11,7 +11,10 @@ import (
 )
 
 // Registers a new network participant to the network for the first time for worker or reputer
-func (ms msgServer) Register(ctx context.Context, msg *types.MsgRegister) (*types.MsgRegisterResponse, error) {
+func (ms msgServer) Register(
+	ctx context.Context,
+	msg *types.MsgRegister,
+) (*types.MsgRegisterResponse, error) {
 	if err := msg.Validate(); err != nil {
 		return nil, err
 	}
@@ -30,7 +33,12 @@ func (ms msgServer) Register(ctx context.Context, msg *types.MsgRegister) (*type
 	}
 
 	// Before creating topic, transfer fee amount from creator to ecosystem bucket
-	err = ms.k.SendCoinsFromAccountToModule(ctx, msg.Sender, mintTypes.EcosystemModuleName, sdk.NewCoins(fee))
+	err = ms.k.SendCoinsFromAccountToModule(
+		ctx,
+		msg.Sender,
+		mintTypes.EcosystemModuleName,
+		sdk.NewCoins(fee),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +70,10 @@ func (ms msgServer) Register(ctx context.Context, msg *types.MsgRegister) (*type
 }
 
 // Remove registration from a topic for worker or reputer
-func (ms msgServer) RemoveRegistration(ctx context.Context, msg *types.MsgRemoveRegistration) (*types.MsgRemoveRegistrationResponse, error) {
+func (ms msgServer) RemoveRegistration(
+	ctx context.Context,
+	msg *types.MsgRemoveRegistration,
+) (*types.MsgRemoveRegistrationResponse, error) {
 	// Check if topic exists
 	topicExists, err := ms.k.TopicExists(ctx, msg.TopicId)
 	if err != nil {
@@ -113,7 +124,10 @@ func (ms msgServer) RemoveRegistration(ctx context.Context, msg *types.MsgRemove
 	}, nil
 }
 
-func (ms msgServer) CheckBalanceForRegistration(ctx context.Context, address string) (bool, sdk.Coin, error) {
+func (ms msgServer) CheckBalanceForRegistration(
+	ctx context.Context,
+	address string,
+) (bool, sdk.Coin, error) {
 	moduleParams, err := ms.k.GetParams(ctx)
 	if err != nil {
 		return false, sdk.Coin{}, err

--- a/x/emissions/keeper/msgserver/msg_server_registrations_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations_test.go
@@ -47,14 +47,22 @@ func (s *KeeperTestSuite) TestMsgRegisterReputer() {
 	)
 	require.NoError(err, "SendCoinsFromModuleToAccount should not return an error")
 
-	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topicId, reputerAddr.String())
+	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.False(isReputerRegistered, "Reputer should not be registered in topic")
 
 	_, err = msgServer.Register(ctx, registerMsg)
 	require.NoError(err, "Registering reputer should not return an error")
 
-	isReputerRegistered, err = s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topicId, reputerAddr.String())
+	isReputerRegistered, err = s.emissionsKeeper.IsReputerRegisteredInTopic(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.True(isReputerRegistered, "Reputer should be registered in topic")
 }
@@ -95,7 +103,11 @@ func (s *KeeperTestSuite) TestMsgRemoveRegistration() {
 	_, err = msgServer.Register(ctx, registerMsg)
 	require.NoError(err, "Registering reputer should not return an error")
 
-	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topicId, reputerAddr.String())
+	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.True(isReputerRegistered, "Reputer should be registered in topic")
 
@@ -108,7 +120,11 @@ func (s *KeeperTestSuite) TestMsgRemoveRegistration() {
 	_, err = msgServer.RemoveRegistration(ctx, unregisterMsg)
 	require.NoError(err, "Registering reputer should not return an error")
 
-	isReputerRegistered, err = s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topicId, reputerAddr.String())
+	isReputerRegistered, err = s.emissionsKeeper.IsReputerRegisteredInTopic(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.False(isReputerRegistered, "Reputer should be registered in topic")
 }
@@ -146,18 +162,30 @@ func (s *KeeperTestSuite) TestMsgRegisterWorker() {
 	)
 	require.NoError(err, "SendCoinsFromModuleToAccount should not return an error")
 
-	isWorkerRegistered, err := s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topicId, workerAddr.String())
+	isWorkerRegistered, err := s.emissionsKeeper.IsWorkerRegisteredInTopic(
+		ctx,
+		topicId,
+		workerAddr.String(),
+	)
 	require.NoError(err)
 	require.False(isWorkerRegistered, "Worker should not be registered in topic")
 
-	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topicId, workerAddr.String())
+	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(
+		ctx,
+		topicId,
+		workerAddr.String(),
+	)
 	require.NoError(err)
 	require.False(isReputerRegistered, "Reputer should not be registered in topic")
 
 	_, err = msgServer.Register(ctx, registerMsg)
 	require.NoError(err, "Registering worker should not return an error")
 
-	isWorkerRegistered, err = s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topicId, workerAddr.String())
+	isWorkerRegistered, err = s.emissionsKeeper.IsWorkerRegisteredInTopic(
+		ctx,
+		topicId,
+		workerAddr.String(),
+	)
 	require.NoError(err)
 	require.True(isWorkerRegistered, "Worker should be registered in topic")
 }
@@ -198,7 +226,11 @@ func (s *KeeperTestSuite) TestMsgRemoveRegistrationWorker() {
 	_, err = msgServer.Register(ctx, registerMsg)
 	require.NoError(err, "Registering worker should not return an error")
 
-	isWorkerRegistered, err := s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topicId, workerAddr.String())
+	isWorkerRegistered, err := s.emissionsKeeper.IsWorkerRegisteredInTopic(
+		ctx,
+		topicId,
+		workerAddr.String(),
+	)
 	require.NoError(err)
 	require.True(isWorkerRegistered, "Worker should be registered in topic")
 
@@ -211,7 +243,11 @@ func (s *KeeperTestSuite) TestMsgRemoveRegistrationWorker() {
 	_, err = msgServer.RemoveRegistration(ctx, unregisterMsg)
 	require.NoError(err, "Unregistering worker should not return an error")
 
-	isWorkerRegistered, err = s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topicId, workerAddr.String())
+	isWorkerRegistered, err = s.emissionsKeeper.IsWorkerRegisteredInTopic(
+		ctx,
+		topicId,
+		workerAddr.String(),
+	)
 	require.NoError(err)
 	require.False(isWorkerRegistered, "Worker should be registered in topic")
 }
@@ -282,7 +318,12 @@ func (s *KeeperTestSuite) TestMsgRegisterReputerInsufficientDenom() {
 		Owner:        reputerAddr.String(),
 	}
 
-	s.emissionsKeeper.AddStake(ctx, topicId, reputerAddr.String(), registrationInitialStake.QuoRaw(2))
+	s.emissionsKeeper.AddStake(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+		registrationInitialStake.QuoRaw(2),
+	)
 
 	// Try to register without any funds to pay fees
 	_, err := msgServer.Register(ctx, reputerRegMsg)
@@ -360,7 +401,8 @@ func (s *KeeperTestSuite) TestBlocklistedAddressUnableToRegister() {
 		Owner:        reputer.String(),
 	}
 	_, err = s.msgServer.Register(s.ctx, reputerRegMsg)
-	s.Require().ErrorIs(err, types.ErrTopicRegistrantNotEnoughDenom, "Register should return an error")
+	s.Require().
+		ErrorIs(err, types.ErrTopicRegistrantNotEnoughDenom, "Register should return an error")
 }
 
 func (s *KeeperTestSuite) TestMsgRegisterReputerInvalidTopicNotExist() {

--- a/x/emissions/keeper/msgserver/msg_server_stake.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake.go
@@ -13,7 +13,10 @@ import (
 )
 
 // Function for reputers to call to add stake to an existing stake position.
-func (ms msgServer) AddStake(ctx context.Context, msg *types.MsgAddStake) (*types.MsgAddStakeResponse, error) {
+func (ms msgServer) AddStake(
+	ctx context.Context,
+	msg *types.MsgAddStake,
+) (*types.MsgAddStakeResponse, error) {
 	if msg.Amount.IsZero() {
 		return nil, types.ErrReceivedZeroAmount
 	}
@@ -60,7 +63,10 @@ func (ms msgServer) AddStake(ctx context.Context, msg *types.MsgAddStake) (*type
 // once the withdrawal delay has passed then ConfirmRemoveStake can be called to remove the stake.
 // if a stake removal is not confirmed within a certain time period, the stake removal becomes invalid
 // and one must start the stake removal process again and wait the delay again.
-func (ms msgServer) StartRemoveStake(ctx context.Context, msg *types.MsgStartRemoveStake) (*types.MsgStartRemoveStakeResponse, error) {
+func (ms msgServer) StartRemoveStake(
+	ctx context.Context,
+	msg *types.MsgStartRemoveStake,
+) (*types.MsgStartRemoveStakeResponse, error) {
 	if msg.Amount.IsZero() {
 		return nil, types.ErrReceivedZeroAmount
 	}
@@ -71,7 +77,11 @@ func (ms msgServer) StartRemoveStake(ctx context.Context, msg *types.MsgStartRem
 		return nil, err
 	}
 
-	delegateStakeUponReputerInTopic, err := ms.k.GetDelegateStakeUponReputer(ctx, msg.TopicId, msg.Sender)
+	delegateStakeUponReputerInTopic, err := ms.k.GetDelegateStakeUponReputer(
+		ctx,
+		msg.TopicId,
+		msg.Sender,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +109,10 @@ func (ms msgServer) StartRemoveStake(ctx context.Context, msg *types.MsgStartRem
 }
 
 // Function for reputers or workers to call to remove stake from an existing stake position.
-func (ms msgServer) ConfirmRemoveStake(ctx context.Context, msg *types.MsgConfirmRemoveStake) (*types.MsgConfirmRemoveStakeResponse, error) {
+func (ms msgServer) ConfirmRemoveStake(
+	ctx context.Context,
+	msg *types.MsgConfirmRemoveStake,
+) (*types.MsgConfirmRemoveStakeResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	// Pull the stake removal from the delayed queue
 	stakeRemoval, err := ms.k.GetStakeRemovalByTopicAndAddress(ctx, msg.TopicId, msg.Sender)
@@ -129,7 +142,12 @@ func (ms msgServer) ConfirmRemoveStake(ctx context.Context, msg *types.MsgConfir
 	}
 
 	// Update the stake data structures
-	err = ms.k.RemoveStake(ctx, stakeRemoval.Placement.TopicId, msg.Sender, stakeRemoval.Placement.Amount)
+	err = ms.k.RemoveStake(
+		ctx,
+		stakeRemoval.Placement.TopicId,
+		msg.Sender,
+		stakeRemoval.Placement.Amount,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +155,10 @@ func (ms msgServer) ConfirmRemoveStake(ctx context.Context, msg *types.MsgConfir
 }
 
 // Delegates a stake to a reputer. Sender need not be registered to delegate stake.
-func (ms msgServer) DelegateStake(ctx context.Context, msg *types.MsgDelegateStake) (*types.MsgDelegateStakeResponse, error) {
+func (ms msgServer) DelegateStake(
+	ctx context.Context,
+	msg *types.MsgDelegateStake,
+) (*types.MsgDelegateStakeResponse, error) {
 	if msg.Amount.IsZero() {
 		return nil, types.ErrReceivedZeroAmount
 	}
@@ -183,7 +204,10 @@ func (ms msgServer) DelegateStake(ctx context.Context, msg *types.MsgDelegateSta
 // once the withdrawal delay has passed then ConfirmRemoveStake can be called to remove the stake.
 // if a stake removal is not confirmed within a certain time period, the stake removal becomes invalid
 // and one must start the stake removal process again and wait the delay again.
-func (ms msgServer) StartRemoveDelegateStake(ctx context.Context, msg *types.MsgStartRemoveDelegateStake) (*types.MsgStartRemoveDelegateStakeResponse, error) {
+func (ms msgServer) StartRemoveDelegateStake(
+	ctx context.Context,
+	msg *types.MsgStartRemoveDelegateStake,
+) (*types.MsgStartRemoveDelegateStakeResponse, error) {
 	if msg.Amount.IsZero() {
 		return nil, types.ErrReceivedZeroAmount
 	}
@@ -198,7 +222,12 @@ func (ms msgServer) StartRemoveDelegateStake(ctx context.Context, msg *types.Msg
 	}
 
 	// Check the reputer has enough stake already placed on the topic to remove the stake
-	delegateStakePlaced, err := ms.k.GetDelegateStakePlacement(ctx, msg.TopicId, msg.Sender, msg.Reputer)
+	delegateStakePlaced, err := ms.k.GetDelegateStakePlacement(
+		ctx,
+		msg.TopicId,
+		msg.Sender,
+		msg.Reputer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -230,10 +259,18 @@ func (ms msgServer) StartRemoveDelegateStake(ctx context.Context, msg *types.Msg
 }
 
 // Function for delegators to call to remove stake from an existing delegate stake position.
-func (ms msgServer) ConfirmRemoveDelegateStake(ctx context.Context, msg *types.MsgConfirmDelegateRemoveStake) (*types.MsgConfirmRemoveDelegateStakeResponse, error) {
+func (ms msgServer) ConfirmRemoveDelegateStake(
+	ctx context.Context,
+	msg *types.MsgConfirmDelegateRemoveStake,
+) (*types.MsgConfirmRemoveDelegateStakeResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	// Pull the stake removal from the delayed queue
-	stakeRemoval, err := ms.k.GetDelegateStakeRemovalByTopicAndAddress(ctx, msg.TopicId, msg.Reputer, msg.Sender)
+	stakeRemoval, err := ms.k.GetDelegateStakeRemovalByTopicAndAddress(
+		ctx,
+		msg.TopicId,
+		msg.Reputer,
+		msg.Sender,
+	)
 	if err != nil {
 		if errors.Is(err, collections.ErrNotFound) {
 			return nil, types.ErrConfirmRemoveStakeNoRemovalStarted
@@ -261,7 +298,13 @@ func (ms msgServer) ConfirmRemoveDelegateStake(ctx context.Context, msg *types.M
 	}
 
 	// Update the stake data structures
-	err = ms.k.RemoveDelegateStake(ctx, stakeRemoval.Placement.TopicId, msg.Sender, msg.Reputer, stakeRemoval.Placement.Amount)
+	err = ms.k.RemoveDelegateStake(
+		ctx,
+		stakeRemoval.Placement.TopicId,
+		msg.Sender,
+		msg.Reputer,
+		stakeRemoval.Placement.Amount,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +312,10 @@ func (ms msgServer) ConfirmRemoveDelegateStake(ctx context.Context, msg *types.M
 	return &types.MsgConfirmRemoveDelegateStakeResponse{}, nil
 }
 
-func (ms msgServer) RewardDelegateStake(ctx context.Context, msg *types.MsgRewardDelegateStake) (*types.MsgRewardDelegateStakeResponse, error) {
+func (ms msgServer) RewardDelegateStake(
+	ctx context.Context,
+	msg *types.MsgRewardDelegateStake,
+) (*types.MsgRewardDelegateStakeResponse, error) {
 	// Check the target reputer exists and is registered
 	isRegistered, err := ms.k.IsReputerRegisteredInTopic(ctx, msg.TopicId, msg.Reputer)
 	if err != nil {
@@ -297,7 +343,12 @@ func (ms msgServer) RewardDelegateStake(ctx context.Context, msg *types.MsgRewar
 	}
 	if pendingReward.Gt(alloraMath.NewDecFromInt64(0)) {
 		coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, pendingReward.SdkIntTrim()))
-		err = ms.k.SendCoinsFromModuleToAccount(ctx, types.AlloraPendingRewardForDelegatorAccountName, msg.Sender, coins)
+		err = ms.k.SendCoinsFromModuleToAccount(
+			ctx,
+			types.AlloraPendingRewardForDelegatorAccountName,
+			msg.Sender,
+			coins,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -36,12 +36,21 @@ func (s *KeeperTestSuite) commonStakingSetup(
 		PNorm:           alloraMath.NewDecFromInt64(3),
 	}
 
-	reputerInitialBalance := types.DefaultParams().CreateTopicFee.Add(cosmosMath.Int(reputerInitialBalanceUint))
+	reputerInitialBalance := types.DefaultParams().CreateTopicFee.Add(
+		cosmosMath.Int(reputerInitialBalanceUint),
+	)
 
-	reputerInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, reputerInitialBalance))
+	reputerInitialBalanceCoins := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, reputerInitialBalance),
+	)
 
 	s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, reputerInitialBalanceCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, reputerAddr, reputerInitialBalanceCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		ctx,
+		types.AlloraStakingAccountName,
+		reputerAddr,
+		reputerInitialBalanceCoins,
+	)
 
 	response, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
 	require.NoError(err, "CreateTopic fails on creation")
@@ -59,11 +68,18 @@ func (s *KeeperTestSuite) commonStakingSetup(
 	_, err = msgServer.Register(ctx, reputerRegMsg)
 	require.NoError(err, "Registering reputer should not return an error")
 
-	workerInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(1000)))
+	workerInitialBalanceCoins := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(1000)),
+	)
 
 	s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, workerInitialBalanceCoins)
 	s.bankKeeper.MintCoins(ctx, types.AlloraRewardsAccountName, workerInitialBalanceCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, workerAddr, workerInitialBalanceCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		ctx,
+		types.AlloraStakingAccountName,
+		workerAddr,
+		workerInitialBalanceCoins,
+	)
 
 	// Register Worker
 	workerRegMsg := &types.MsgRegister{
@@ -145,9 +161,12 @@ func (s *KeeperTestSuite) TestStartRemoveStake() {
 	retrievedInfo, err := keeper.GetStakeRemovalByTopicAndAddress(ctx, topicId, senderAddr.String())
 	require.NoError(err)
 	require.NotNil(retrievedInfo)
-	s.Require().Equal(msg.TopicId, retrievedInfo.Placement.TopicId, "Topic IDs should match for all placements")
-	s.Require().Equal(msg.Sender, retrievedInfo.Placement.Reputer, "Reputer addresses should match for all placements")
-	s.Require().Equal(msg.Amount, retrievedInfo.Placement.Amount, "Amounts should match for all placements")
+	s.Require().
+		Equal(msg.TopicId, retrievedInfo.Placement.TopicId, "Topic IDs should match for all placements")
+	s.Require().
+		Equal(msg.Sender, retrievedInfo.Placement.Reputer, "Reputer addresses should match for all placements")
+	s.Require().
+		Equal(msg.Amount, retrievedInfo.Placement.Amount, "Amounts should match for all placements")
 }
 
 func (s *KeeperTestSuite) TestStartRemoveStakeInsufficientStake() {
@@ -199,7 +218,11 @@ func (s *KeeperTestSuite) TestConfirmRemoveStake() {
 	}
 
 	// Manually setting the removal in state (this part would normally involve interacting with the keeper to set up state).
-	keeper.SetStakeRemoval(ctx, senderAddr.String(), stakeRemoval) // This assumes such a method exists.
+	keeper.SetStakeRemoval(
+		ctx,
+		senderAddr.String(),
+		stakeRemoval,
+	) // This assumes such a method exists.
 
 	msg := &types.MsgConfirmRemoveStake{
 		Sender:  senderAddr.String(),
@@ -286,7 +309,11 @@ func (s *KeeperTestSuite) TestConfirmRemoveStakeTooEarly() {
 	}
 
 	// Manually setting the removal in state (this part would normally involve interacting with the keeper to set up state).
-	keeper.SetStakeRemoval(ctx, senderAddr.String(), stakeRemoval) // This assumes such a method exists.
+	keeper.SetStakeRemoval(
+		ctx,
+		senderAddr.String(),
+		stakeRemoval,
+	) // This assumes such a method exists.
 
 	msg := &types.MsgConfirmRemoveStake{
 		Sender:  senderAddr.String(),
@@ -294,18 +321,27 @@ func (s *KeeperTestSuite) TestConfirmRemoveStakeTooEarly() {
 	}
 
 	// Set the current block height to simulate an attempt to confirm removal too early, before the delay has fully passed.
-	ctx = ctx.WithBlockHeight(startBlock + removalDelay - 1) // Attempting to confirm just before the delay period ends
+	ctx = ctx.WithBlockHeight(
+		startBlock + removalDelay - 1,
+	) // Attempting to confirm just before the delay period ends
 
 	// Perform the stake confirmation
 	response, err := s.msgServer.ConfirmRemoveStake(ctx, msg)
 	require.Error(err, "Should error because the stake removal is being confirmed too early")
 	require.Nil(response, "Response should be nil when confirming too early")
-	require.ErrorIs(types.ErrConfirmRemoveStakeTooEarly, err, "Error should be ErrConfirmRemoveStakeTooEarly")
+	require.ErrorIs(
+		types.ErrConfirmRemoveStakeTooEarly,
+		err,
+		"Error should be ErrConfirmRemoveStakeTooEarly",
+	)
 
 	// Verify the stake has not been removed
 	finalStake, err := keeper.GetStakeOnReputerInTopic(ctx, topicId, senderAddr.String())
 	require.NoError(err)
-	require.False(finalStake.IsZero(), "Stake amount should not be zero since removal is not confirmed")
+	require.False(
+		finalStake.IsZero(),
+		"Stake amount should not be zero since removal is not confirmed",
+	)
 }
 
 func (s *KeeperTestSuite) TestDelegateStake() {
@@ -336,11 +372,20 @@ func (s *KeeperTestSuite) TestDelegateStake() {
 		Amount:  stakeAmount,
 	}
 
-	reputerStake, err := s.emissionsKeeper.GetStakeOnReputerInTopic(ctx, topicId, reputerAddr.String())
+	reputerStake, err := s.emissionsKeeper.GetStakeOnReputerInTopic(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.Equal(cosmosMath.ZeroInt(), reputerStake, "Stake amount mismatch")
 
-	amount0, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegatorAddr.String(), reputerAddr.String())
+	amount0, err := keeper.GetDelegateStakePlacement(
+		ctx,
+		topicId,
+		delegatorAddr.String(),
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.Equal(alloraMath.NewDecFromInt64(0), amount0.Amount)
 
@@ -349,11 +394,20 @@ func (s *KeeperTestSuite) TestDelegateStake() {
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil after successful delegation")
 
-	reputerStake, err = s.emissionsKeeper.GetStakeOnReputerInTopic(ctx, topicId, reputerAddr.String())
+	reputerStake, err = s.emissionsKeeper.GetStakeOnReputerInTopic(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
 
-	amount1, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegatorAddr.String(), reputerAddr.String())
+	amount1, err := keeper.GetDelegateStakePlacement(
+		ctx,
+		topicId,
+		delegatorAddr.String(),
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.Equal(stakeAmount, amount1.Amount.SdkIntTrim())
 }
@@ -423,11 +477,20 @@ func (s *KeeperTestSuite) TestDelegateeCantWithdrawDelegatedStake() {
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil after successful delegation")
 
-	reputerStake, err := s.emissionsKeeper.GetStakeOnReputerInTopic(ctx, topicId, reputerAddr.String())
+	reputerStake, err := s.emissionsKeeper.GetStakeOnReputerInTopic(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
 
-	amount1, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegatorAddr.String(), reputerAddr.String())
+	amount1, err := keeper.GetDelegateStakePlacement(
+		ctx,
+		topicId,
+		delegatorAddr.String(),
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.Equal(stakeAmount, amount1.Amount.SdkIntTrim())
 
@@ -463,8 +526,14 @@ func (s *KeeperTestSuite) TestDelegateStakeUnregisteredReputer() {
 	// Attempt to perform the stake delegation
 	response, err := s.msgServer.DelegateStake(ctx, msg)
 	require.Error(err)
-	require.Nil(response, "Response should be nil when delegation fails due to unregistered reputer")
-	require.True(errors.Is(err, types.ErrAddressIsNotRegisteredInThisTopic), "Error should indicate that the reputer is not registered in the topic")
+	require.Nil(
+		response,
+		"Response should be nil when delegation fails due to unregistered reputer",
+	)
+	require.True(
+		errors.Is(err, types.ErrAddressIsNotRegisteredInThisTopic),
+		"Error should indicate that the reputer is not registered in the topic",
+	)
 }
 
 func (s *KeeperTestSuite) TestStartRemoveDelegateStake() {
@@ -508,16 +577,29 @@ func (s *KeeperTestSuite) TestStartRemoveDelegateStake() {
 		Amount:  stakeAmount,
 	}
 
-	_, err = keeper.GetDelegateStakeRemovalByTopicAndAddress(ctx, topicId, reputerAddr.String(), delegatorAddr.String())
+	_, err = keeper.GetDelegateStakeRemovalByTopicAndAddress(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+		delegatorAddr.String(),
+	)
 	require.Error(err)
 
 	// Perform the stake removal initiation
 	response2, err := s.msgServer.StartRemoveDelegateStake(ctx, msg2)
 	require.NoError(err)
-	require.NotNil(response2, "Response should not be nil after successful stake removal initiation")
+	require.NotNil(
+		response2,
+		"Response should not be nil after successful stake removal initiation",
+	)
 
 	// Verification: Check if the removal has been queued
-	removalInfo, err := keeper.GetDelegateStakeRemovalByTopicAndAddress(ctx, topicId, reputerAddr.String(), delegatorAddr.String())
+	removalInfo, err := keeper.GetDelegateStakeRemovalByTopicAndAddress(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+		delegatorAddr.String(),
+	)
 	require.NoError(err)
 	require.NotNil(removalInfo, "Stake removal should be recorded in the state")
 }
@@ -618,18 +700,32 @@ func (s *KeeperTestSuite) TestConfirmRemoveDelegateStake() {
 	ctx = ctx.WithBlockHeight(startBlock + removalDelay + 1)
 
 	// Try to confirm removal after delay window
-	response, err := s.msgServer.ConfirmRemoveDelegateStake(ctx, &types.MsgConfirmDelegateRemoveStake{
-		Sender:  delegatorAddr.String(),
-		Reputer: reputerAddr.String(),
-		TopicId: topicId,
-	})
+	response, err := s.msgServer.ConfirmRemoveDelegateStake(
+		ctx,
+		&types.MsgConfirmDelegateRemoveStake{
+			Sender:  delegatorAddr.String(),
+			Reputer: reputerAddr.String(),
+			TopicId: topicId,
+		},
+	)
 	require.NoError(err)
-	require.NotNil(response, "Response should not be nil after successful confirmation of stake removal")
+	require.NotNil(
+		response,
+		"Response should not be nil after successful confirmation of stake removal",
+	)
 
 	// Check that the stake was actually removed
-	delegateStakePlaced, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegatorAddr.String(), reputerAddr.String())
+	delegateStakePlaced, err := keeper.GetDelegateStakePlacement(
+		ctx,
+		topicId,
+		delegatorAddr.String(),
+		reputerAddr.String(),
+	)
 	require.NoError(err)
-	require.True(delegateStakePlaced.Amount.IsZero(), "Delegate stake should be zero after successful removal")
+	require.True(
+		delegateStakePlaced.Amount.IsZero(),
+		"Delegate stake should be zero after successful removal",
+	)
 }
 
 func (s *KeeperTestSuite) TestRewardDelegateStake() {
@@ -650,7 +746,12 @@ func (s *KeeperTestSuite) TestRewardDelegateStake() {
 	delegatorStakeAmount2 := cosmosMath.NewInt(500)
 	delegator2StakeAmount := cosmosMath.NewInt(5000)
 
-	topicId := s.commonStakingSetup(ctx, reputerAddr.String(), workerAddr.String(), registrationInitialBalance)
+	topicId := s.commonStakingSetup(
+		ctx,
+		reputerAddr.String(),
+		workerAddr.String(),
+		registrationInitialBalance,
+	)
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegator2Addr, cosmosMath.NewInt(1000000))
@@ -679,11 +780,20 @@ func (s *KeeperTestSuite) TestRewardDelegateStake() {
 		Amount:  delegator2StakeAmount,
 	}
 
-	reputerStake, err := s.emissionsKeeper.GetStakeOnReputerInTopic(ctx, topicId, reputerAddr.String())
+	reputerStake, err := s.emissionsKeeper.GetStakeOnReputerInTopic(
+		ctx,
+		topicId,
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
 
-	amount0, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegatorAddr.String(), reputerAddr.String())
+	amount0, err := keeper.GetDelegateStakePlacement(
+		ctx,
+		topicId,
+		delegatorAddr.String(),
+		reputerAddr.String(),
+	)
 	require.NoError(err)
 	require.Equal(alloraMath.NewDecFromInt64(0), amount0.Amount)
 
@@ -714,11 +824,25 @@ func (s *KeeperTestSuite) TestRewardDelegateStake() {
 			NaiveValue:    alloraMath.MustNewDecFromString("1500.0"),
 		},
 	}
-	reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, reputerValueBundle)
-	_ = s.emissionsKeeper.InsertReputerLossBundlesAtBlock(s.ctx, topicId, block, reputerValueBundles)
+	reputerValueBundles.ReputerValueBundles = append(
+		reputerValueBundles.ReputerValueBundles,
+		reputerValueBundle,
+	)
+	_ = s.emissionsKeeper.InsertReputerLossBundlesAtBlock(
+		s.ctx,
+		topicId,
+		block,
+		reputerValueBundles,
+	)
 
 	// Calculate and Set the reputer scores
-	scores, err := rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err := rewards.GenerateReputerScores(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		block,
+		reputerValueBundles,
+	)
 	s.Require().NoError(err)
 
 	// Generate rewards
@@ -770,11 +894,25 @@ func (s *KeeperTestSuite) TestRewardDelegateStake() {
 			NaiveValue:    alloraMath.MustNewDecFromString("1500.0"),
 		},
 	}
-	newReputerValueBundles.ReputerValueBundles = append(newReputerValueBundles.ReputerValueBundles, newReputerValueBundle)
-	_ = s.emissionsKeeper.InsertReputerLossBundlesAtBlock(s.ctx, topicId, newBlock, newReputerValueBundles)
+	newReputerValueBundles.ReputerValueBundles = append(
+		newReputerValueBundles.ReputerValueBundles,
+		newReputerValueBundle,
+	)
+	_ = s.emissionsKeeper.InsertReputerLossBundlesAtBlock(
+		s.ctx,
+		topicId,
+		newBlock,
+		newReputerValueBundles,
+	)
 
 	// Calculate and Set the reputer scores
-	scores, err = rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err = rewards.GenerateReputerScores(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		block,
+		reputerValueBundles,
+	)
 	s.Require().NoError(err)
 
 	// Generate new rewards
@@ -806,7 +944,8 @@ func (s *KeeperTestSuite) TestRewardDelegateStake() {
 	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
 	afterBalance := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	s.Require().NoError(err)
-	s.Require().Greater(afterBalance.Amount.Uint64(), beforeBalance.Amount.Uint64(), "Balance must be increased")
+	s.Require().
+		Greater(afterBalance.Amount.Uint64(), beforeBalance.Amount.Uint64(), "Balance must be increased")
 
 	beforeBalance2 := s.bankKeeper.GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
 	rewardMsg2 := &types.MsgRewardDelegateStake{
@@ -817,5 +956,6 @@ func (s *KeeperTestSuite) TestRewardDelegateStake() {
 	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg2)
 	afterBalance2 := s.bankKeeper.GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
 	s.Require().NoError(err)
-	s.Require().Greater(afterBalance2.Amount.Uint64(), beforeBalance2.Amount.Uint64(), "Balance must be increased")
+	s.Require().
+		Greater(afterBalance2.Amount.Uint64(), beforeBalance2.Amount.Uint64(), "Balance must be increased")
 }

--- a/x/emissions/keeper/msgserver/msg_server_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_test.go
@@ -79,9 +79,17 @@ func (s *KeeperTestSuite) SetupTest() {
 	key := storetypes.NewKVStoreKey("emissions")
 	storeService := runtime.NewKVStoreService(key)
 	s.storeService = storeService
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+	testCtx := testutil.DefaultContextWithDB(
+		s.T(),
+		key,
+		storetypes.NewTransientStoreKey("transient_test"),
+	)
 	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()})
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
+	encCfg := moduletestutil.MakeTestEncodingConfig(
+		auth.AppModuleBasic{},
+		bank.AppModuleBasic{},
+		module.AppModule{},
+	)
 	s.codec = encCfg.Codec
 	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
 	s.addressCodec = addressCodec
@@ -169,7 +177,12 @@ func (s *KeeperTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cos
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
 
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		s.ctx,
+		types.AlloraStakingAccountName,
+		address,
+		creatorInitialBalanceCoins,
+	)
 }
 
 func (s *KeeperTestSuite) MintTokensToModule(moduleName string, amount cosmosMath.Int) {
@@ -231,10 +244,17 @@ func (s *KeeperTestSuite) TestCreateSeveralTopics() {
 	}
 
 	creatorInitialBalance := types.DefaultParams().CreateTopicFee.Mul(cosmosMath.NewInt(3))
-	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, creatorInitialBalance))
+	creatorInitialBalanceCoins := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, creatorInitialBalance),
+	)
 
 	s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, creator, creatorInitialBalanceCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		ctx,
+		types.AlloraStakingAccountName,
+		creator,
+		creatorInitialBalanceCoins,
+	)
 
 	initialTopicId, err := s.emissionsKeeper.GetNextTopicId(s.ctx)
 	s.Require().NoError(err)

--- a/x/emissions/keeper/msgserver/msg_server_topics.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics.go
@@ -11,14 +11,20 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.MsgCreateNewTopic) (*types.MsgCreateNewTopicResponse, error) {
+func (ms msgServer) CreateNewTopic(
+	ctx context.Context,
+	msg *types.MsgCreateNewTopic,
+) (*types.MsgCreateNewTopicResponse, error) {
 	if err := msg.Validate(); err != nil {
 		return nil, err
 	}
 
 	hasEnoughBal, fee, _ := ms.CheckAddressHasBalanceForTopicCreationFee(ctx, msg.Creator)
 	if !hasEnoughBal {
-		return nil, errors.Wrapf(sdkerrors.ErrInsufficientFunds, "sender has insufficient balance to cover topic creation fee")
+		return nil, errors.Wrapf(
+			sdkerrors.ErrInsufficientFunds,
+			"sender has insufficient balance to cover topic creation fee",
+		)
 	}
 
 	id, err := ms.k.GetNextTopicId(ctx)
@@ -35,7 +41,12 @@ func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.MsgCreateNewT
 	}
 
 	// Before creating topic, transfer fee amount from creator to ecosystem bucket
-	err = ms.k.SendCoinsFromAccountToModule(ctx, msg.Creator, mintTypes.EcosystemModuleName, sdk.NewCoins(fee))
+	err = ms.k.SendCoinsFromAccountToModule(
+		ctx,
+		msg.Creator,
+		mintTypes.EcosystemModuleName,
+		sdk.NewCoins(fee),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +80,10 @@ func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.MsgCreateNewT
 	return &types.MsgCreateNewTopicResponse{TopicId: id}, nil
 }
 
-func (ms msgServer) CheckAddressHasBalanceForTopicCreationFee(ctx context.Context, address string) (bool, sdk.Coin, error) {
+func (ms msgServer) CheckAddressHasBalanceForTopicCreationFee(
+	ctx context.Context,
+	address string,
+) (bool, sdk.Coin, error) {
 	moduleParams, err := ms.k.GetParams(ctx)
 	if err != nil {
 		return false, sdk.Coin{}, err

--- a/x/emissions/keeper/msgserver/msg_server_util_topic_activation.go
+++ b/x/emissions/keeper/msgserver/msg_server_util_topic_activation.go
@@ -10,7 +10,11 @@ import (
 type TopicId = uint64
 type Allo = cosmosMath.Int
 
-func (ms *msgServer) ActivateTopicIfWeightAtLeastGlobalMin(ctx context.Context, topicId TopicId, amount Allo) error {
+func (ms *msgServer) ActivateTopicIfWeightAtLeastGlobalMin(
+	ctx context.Context,
+	topicId TopicId,
+	amount Allo,
+) error {
 	isActivated, err := ms.k.IsTopicActive(ctx, topicId)
 	if err != nil {
 		return errors.Wrapf(err, "error getting topic activation status")

--- a/x/emissions/keeper/msgserver/msg_server_whitelist.go
+++ b/x/emissions/keeper/msgserver/msg_server_whitelist.go
@@ -6,7 +6,10 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (ms msgServer) AddToWhitelistAdmin(ctx context.Context, msg *types.MsgAddToWhitelistAdmin) (*types.MsgAddToWhitelistAdminResponse, error) {
+func (ms msgServer) AddToWhitelistAdmin(
+	ctx context.Context,
+	msg *types.MsgAddToWhitelistAdmin,
+) (*types.MsgAddToWhitelistAdminResponse, error) {
 	// Check that sender is also a whitelist admin
 	isAdmin, err := ms.k.IsWhitelistAdmin(ctx, msg.Sender)
 	if err != nil {
@@ -27,7 +30,10 @@ func (ms msgServer) AddToWhitelistAdmin(ctx context.Context, msg *types.MsgAddTo
 	return &types.MsgAddToWhitelistAdminResponse{}, nil
 }
 
-func (ms msgServer) RemoveFromWhitelistAdmin(ctx context.Context, msg *types.MsgRemoveFromWhitelistAdmin) (*types.MsgRemoveFromWhitelistAdminResponse, error) {
+func (ms msgServer) RemoveFromWhitelistAdmin(
+	ctx context.Context,
+	msg *types.MsgRemoveFromWhitelistAdmin,
+) (*types.MsgRemoveFromWhitelistAdminResponse, error) {
 	// Check that sender is also a whitelist admin
 	isAdmin, err := ms.k.IsWhitelistAdmin(ctx, msg.Sender)
 	if err != nil {

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -52,7 +52,11 @@ func (ms msgServer) VerifyAndInsertInferencesFromTopInferers(
 		// Ensure that we only have one inference per inferer. If not, we just take the first one
 		if _, ok := inferencesByInferer[inference.Inferer]; !ok {
 			// Check if the inferer is registered
-			isInfererRegistered, err := ms.k.IsWorkerRegisteredInTopic(ctx, topicId, inference.Inferer)
+			isInfererRegistered, err := ms.k.IsWorkerRegisteredInTopic(
+				ctx,
+				topicId,
+				inference.Inferer,
+			)
 			if err != nil {
 				errors[workerDataBundle.Worker] = "Err to check if worker is registered in topic"
 				continue
@@ -75,7 +79,11 @@ func (ms msgServer) VerifyAndInsertInferencesFromTopInferers(
 	}
 
 	/// If we pseudo-random sample from the non-sybil set of reputers, we would do it here
-	topInferers := FindTopNByScoreDesc(maxTopWorkersToReward, latestInfererScores, nonce.BlockHeight)
+	topInferers := FindTopNByScoreDesc(
+		maxTopWorkersToReward,
+		latestInfererScores,
+		nonce.BlockHeight,
+	)
 
 	// Build list of inferences that pass all filters
 	// AND are from top performing inferers among those who have submitted inferences in this batch
@@ -146,7 +154,11 @@ func (ms msgServer) VerifyAndInsertForecastsFromTopForecasters(
 		// Ensure that we only have one forecast per forecaster. If not, we just take the first one
 		if _, ok := forecastsByForecaster[forecast.Forecaster]; !ok {
 			// Check if the forecaster is registered
-			isForecasterRegistered, err := ms.k.IsWorkerRegisteredInTopic(ctx, topicId, forecast.Forecaster)
+			isForecasterRegistered, err := ms.k.IsWorkerRegisteredInTopic(
+				ctx,
+				topicId,
+				forecast.Forecaster,
+			)
 			if err != nil {
 				continue
 			}
@@ -183,13 +195,20 @@ func (ms msgServer) VerifyAndInsertForecastsFromTopForecasters(
 	}
 
 	/// If we pseudo-random sample from the non-sybil set of reputers, we would do it here
-	topForecasters := FindTopNByScoreDesc(maxTopWorkersToReward, latestForecasterScores, nonce.BlockHeight)
+	topForecasters := FindTopNByScoreDesc(
+		maxTopWorkersToReward,
+		latestForecasterScores,
+		nonce.BlockHeight,
+	)
 
 	// Build list of forecasts that pass all filters
 	// AND are from top performing forecasters among those who have submitted forecasts in this batch
 	forecastsFromTopForecasters := make([]*types.Forecast, 0)
 	for _, worker := range topForecasters {
-		forecastsFromTopForecasters = append(forecastsFromTopForecasters, forecastsByForecaster[worker])
+		forecastsFromTopForecasters = append(
+			forecastsFromTopForecasters,
+			forecastsByForecaster[worker],
+		)
 	}
 
 	// Though less than ideal because it produces less-acurate network inferences,
@@ -214,7 +233,10 @@ func (ms msgServer) VerifyAndInsertForecastsFromTopForecasters(
 
 // A tx function that accepts a list of forecasts and possibly returns an error
 // Need to call this once per forecaster per topic inference solicitation round because protobuf does not nested repeated fields
-func (ms msgServer) InsertBulkWorkerPayload(ctx context.Context, msg *types.MsgInsertBulkWorkerPayload) (*types.MsgInsertBulkWorkerPayloadResponse, error) {
+func (ms msgServer) InsertBulkWorkerPayload(
+	ctx context.Context,
+	msg *types.MsgInsertBulkWorkerPayload,
+) (*types.MsgInsertBulkWorkerPayloadResponse, error) {
 	err := ms.CheckInputLength(ctx, msg)
 	if err != nil {
 		return nil, err
@@ -285,7 +307,8 @@ func (ms msgServer) InsertBulkWorkerPayload(ctx context.Context, msg *types.MsgI
 		BlockHeight: msg.Nonce.BlockHeight - topic.EpochLength,
 	}
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.Logger().Debug(fmt.Sprintf("InsertBulkWorkerPayload workerNonce %d", workerNonce.BlockHeight))
+	sdkCtx.Logger().
+		Debug(fmt.Sprintf("InsertBulkWorkerPayload workerNonce %d", workerNonce.BlockHeight))
 
 	err = ms.k.AddReputerNonce(ctx, topic.Id, msg.Nonce, workerNonce)
 	if err != nil {

--- a/x/emissions/keeper/queryserver/query_server_forecasts.go
+++ b/x/emissions/keeper/queryserver/query_server_forecasts.go
@@ -6,7 +6,10 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (qs queryServer) GetForecastsAtBlock(ctx context.Context, req *types.QueryForecastsAtBlockRequest) (*types.QueryForecastsAtBlockResponse, error) {
+func (qs queryServer) GetForecastsAtBlock(
+	ctx context.Context,
+	req *types.QueryForecastsAtBlockRequest,
+) (*types.QueryForecastsAtBlockResponse, error) {
 	forecasts, err := qs.k.GetForecastsAtBlock(ctx, req.TopicId, req.BlockHeight)
 	if err != nil {
 		return nil, err

--- a/x/emissions/keeper/queryserver/query_server_inferences.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences.go
@@ -12,7 +12,10 @@ import (
 )
 
 // GetWorkerLatestInferenceByTopicId handles the query for the latest inference by a specific worker for a given topic.
-func (qs queryServer) GetWorkerLatestInferenceByTopicId(ctx context.Context, req *types.QueryWorkerLatestInferenceRequest) (*types.QueryWorkerLatestInferenceResponse, error) {
+func (qs queryServer) GetWorkerLatestInferenceByTopicId(
+	ctx context.Context,
+	req *types.QueryWorkerLatestInferenceRequest,
+) (*types.QueryWorkerLatestInferenceResponse, error) {
 	topicExists, err := qs.k.TopicExists(ctx, req.TopicId)
 	if !topicExists {
 		return nil, status.Errorf(codes.NotFound, "topic %v not found", req.TopicId)
@@ -28,7 +31,10 @@ func (qs queryServer) GetWorkerLatestInferenceByTopicId(ctx context.Context, req
 	return &types.QueryWorkerLatestInferenceResponse{LatestInference: &inference}, nil
 }
 
-func (qs queryServer) GetInferencesAtBlock(ctx context.Context, req *types.QueryInferencesAtBlockRequest) (*types.QueryInferencesAtBlockResponse, error) {
+func (qs queryServer) GetInferencesAtBlock(
+	ctx context.Context,
+	req *types.QueryInferencesAtBlockRequest,
+) (*types.QueryInferencesAtBlockResponse, error) {
 
 	inferences, err := qs.k.GetInferencesAtBlock(ctx, req.TopicId, req.BlockHeight)
 	if err != nil {
@@ -39,7 +45,10 @@ func (qs queryServer) GetInferencesAtBlock(ctx context.Context, req *types.Query
 }
 
 // Return full set of inferences in I_i from the chain
-func (qs queryServer) GetNetworkInferencesAtBlock(ctx context.Context, req *types.QueryNetworkInferencesAtBlockRequest) (*types.QueryNetworkInferencesAtBlockResponse, error) {
+func (qs queryServer) GetNetworkInferencesAtBlock(
+	ctx context.Context,
+	req *types.QueryNetworkInferencesAtBlockRequest,
+) (*types.QueryNetworkInferencesAtBlockResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	topic, err := qs.k.GetTopic(ctx, req.TopicId)
@@ -47,10 +56,18 @@ func (qs queryServer) GetNetworkInferencesAtBlock(ctx context.Context, req *type
 		return nil, status.Errorf(codes.NotFound, "topic %v not found", req.TopicId)
 	}
 	if topic.EpochLastEnded == 0 {
-		return nil, status.Errorf(codes.NotFound, "network inference not available for topic %v", req.TopicId)
+		return nil, status.Errorf(
+			codes.NotFound,
+			"network inference not available for topic %v",
+			req.TopicId,
+		)
 	}
 	if req.BlockHeightLastInference > sdkCtx.BlockHeight() {
-		return nil, status.Errorf(codes.InvalidArgument, "block height cannot be greater than current block height %v", sdkCtx.BlockHeight())
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"block height cannot be greater than current block height %v",
+			sdkCtx.BlockHeight(),
+		)
 	}
 
 	networkInferences, err := synth.GetNetworkInferencesAtBlock(

--- a/x/emissions/keeper/queryserver/query_server_inferences_test.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences_test.go
@@ -103,7 +103,8 @@ func (s *KeeperTestSuite) TestGetWorkerLatestInferenceByTopicId() {
 	)
 	s.Require().NoError(err, "Retrieving latest inference should succeed")
 	s.Require().NotNil(response.LatestInference, "Response should contain a latest inference")
-	s.Require().Equal(&inference, response.LatestInference, "The latest inference should match the expected data")
+	s.Require().
+		Equal(&inference, response.LatestInference, "The latest inference should match the expected data")
 }
 
 func (s *KeeperTestSuite) TestGetNetworkInferencesAtBlock() {

--- a/x/emissions/keeper/queryserver/query_server_losses.go
+++ b/x/emissions/keeper/queryserver/query_server_losses.go
@@ -6,7 +6,10 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (qs queryServer) GetNetworkLossBundleAtBlock(ctx context.Context, req *types.QueryNetworkLossBundleAtBlockRequest) (*types.QueryNetworkLossBundleAtBlockResponse, error) {
+func (qs queryServer) GetNetworkLossBundleAtBlock(
+	ctx context.Context,
+	req *types.QueryNetworkLossBundleAtBlockRequest,
+) (*types.QueryNetworkLossBundleAtBlockResponse, error) {
 	networkLoss, err := qs.k.GetNetworkLossBundleAtBlock(ctx, req.TopicId, req.BlockHeight)
 	if err != nil {
 		return nil, err

--- a/x/emissions/keeper/queryserver/query_server_losses_test.go
+++ b/x/emissions/keeper/queryserver/query_server_losses_test.go
@@ -29,5 +29,6 @@ func (s *KeeperTestSuite) TestGetNetworkLossBundleAtBlock() {
 
 	s.Require().NoError(err)
 	s.Require().NotNil(response.LossBundle)
-	s.Require().Equal(expectedBundle, response.LossBundle, "Retrieved loss bundle should match the expected bundle")
+	s.Require().
+		Equal(expectedBundle, response.LossBundle, "Retrieved loss bundle should match the expected bundle")
 }

--- a/x/emissions/keeper/queryserver/query_server_params.go
+++ b/x/emissions/keeper/queryserver/query_server_params.go
@@ -10,7 +10,10 @@ import (
 )
 
 // Params defines the handler for the Query/Params RPC method.
-func (qs queryServer) Params(ctx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+func (qs queryServer) Params(
+	ctx context.Context,
+	req *types.QueryParamsRequest,
+) (*types.QueryParamsResponse, error) {
 	params, err := qs.k.GetParams(ctx)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/x/emissions/keeper/queryserver/query_server_registrations.go
+++ b/x/emissions/keeper/queryserver/query_server_registrations.go
@@ -7,7 +7,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (qs queryServer) GetWorkerNodeInfo(ctx context.Context, req *types.QueryWorkerNodeInfoRequest) (*types.QueryWorkerNodeInfoResponse, error) {
+func (qs queryServer) GetWorkerNodeInfo(
+	ctx context.Context,
+	req *types.QueryWorkerNodeInfoRequest,
+) (*types.QueryWorkerNodeInfoResponse, error) {
 	node, err := qs.k.GetWorkerByLibp2pKey(sdk.UnwrapSDKContext(ctx), req.Libp2PKey)
 	if err != nil {
 		return nil, err
@@ -16,7 +19,10 @@ func (qs queryServer) GetWorkerNodeInfo(ctx context.Context, req *types.QueryWor
 	return &types.QueryWorkerNodeInfoResponse{NodeInfo: &node}, nil
 }
 
-func (qs queryServer) GetReputerNodeInfo(ctx context.Context, req *types.QueryReputerNodeInfoRequest) (*types.QueryReputerNodeInfoResponse, error) {
+func (qs queryServer) GetReputerNodeInfo(
+	ctx context.Context,
+	req *types.QueryReputerNodeInfoRequest,
+) (*types.QueryReputerNodeInfoResponse, error) {
 	node, err := qs.k.GetReputerByLibp2pKey(sdk.UnwrapSDKContext(ctx), req.Libp2PKey)
 	if err != nil {
 		return nil, err
@@ -25,7 +31,10 @@ func (qs queryServer) GetReputerNodeInfo(ctx context.Context, req *types.QueryRe
 	return &types.QueryReputerNodeInfoResponse{NodeInfo: &node}, nil
 }
 
-func (qs queryServer) GetWorkerAddressByP2PKey(ctx context.Context, req *types.QueryWorkerAddressByP2PKeyRequest) (*types.QueryWorkerAddressByP2PKeyResponse, error) {
+func (qs queryServer) GetWorkerAddressByP2PKey(
+	ctx context.Context,
+	req *types.QueryWorkerAddressByP2PKeyRequest,
+) (*types.QueryWorkerAddressByP2PKeyResponse, error) {
 	workerAddr, err := qs.k.GetWorkerAddressByP2PKey(sdk.UnwrapSDKContext(ctx), req.Libp2PKey)
 	if err != nil {
 		return nil, err
@@ -34,7 +43,10 @@ func (qs queryServer) GetWorkerAddressByP2PKey(ctx context.Context, req *types.Q
 	return &types.QueryWorkerAddressByP2PKeyResponse{Address: workerAddr.String()}, nil
 }
 
-func (qs queryServer) GetReputerAddressByP2PKey(ctx context.Context, req *types.QueryReputerAddressByP2PKeyRequest) (*types.QueryReputerAddressByP2PKeyResponse, error) {
+func (qs queryServer) GetReputerAddressByP2PKey(
+	ctx context.Context,
+	req *types.QueryReputerAddressByP2PKeyRequest,
+) (*types.QueryReputerAddressByP2PKeyResponse, error) {
 	address, err := qs.k.GetReputerAddressByP2PKey(sdk.UnwrapSDKContext(ctx), req.Libp2PKey)
 	if err != nil {
 		return nil, err
@@ -43,11 +55,18 @@ func (qs queryServer) GetReputerAddressByP2PKey(ctx context.Context, req *types.
 	return &types.QueryReputerAddressByP2PKeyResponse{Address: address.String()}, nil
 }
 
-func (qs queryServer) IsWorkerRegisteredInTopicId(ctx context.Context, req *types.QueryIsWorkerRegisteredInTopicIdRequest) (*types.QueryIsWorkerRegisteredInTopicIdResponse, error) {
+func (qs queryServer) IsWorkerRegisteredInTopicId(
+	ctx context.Context,
+	req *types.QueryIsWorkerRegisteredInTopicIdRequest,
+) (*types.QueryIsWorkerRegisteredInTopicIdResponse, error) {
 	if err := qs.k.ValidateStringIsBech32(req.Address); err != nil {
 		return nil, err
 	}
-	isRegistered, err := qs.k.IsWorkerRegisteredInTopic(sdk.UnwrapSDKContext(ctx), req.TopicId, req.Address)
+	isRegistered, err := qs.k.IsWorkerRegisteredInTopic(
+		sdk.UnwrapSDKContext(ctx),
+		req.TopicId,
+		req.Address,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -55,11 +74,18 @@ func (qs queryServer) IsWorkerRegisteredInTopicId(ctx context.Context, req *type
 	return &types.QueryIsWorkerRegisteredInTopicIdResponse{IsRegistered: isRegistered}, nil
 }
 
-func (qs queryServer) IsReputerRegisteredInTopicId(ctx context.Context, req *types.QueryIsReputerRegisteredInTopicIdRequest) (*types.QueryIsReputerRegisteredInTopicIdResponse, error) {
+func (qs queryServer) IsReputerRegisteredInTopicId(
+	ctx context.Context,
+	req *types.QueryIsReputerRegisteredInTopicIdRequest,
+) (*types.QueryIsReputerRegisteredInTopicIdResponse, error) {
 	if err := qs.k.ValidateStringIsBech32(req.Address); err != nil {
 		return nil, err
 	}
-	isRegistered, err := qs.k.IsReputerRegisteredInTopic(sdk.UnwrapSDKContext(ctx), req.TopicId, req.Address)
+	isRegistered, err := qs.k.IsReputerRegisteredInTopic(
+		sdk.UnwrapSDKContext(ctx),
+		req.TopicId,
+		req.Address,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/queryserver/query_server_registrations_test.go
+++ b/x/emissions/keeper/queryserver/query_server_registrations_test.go
@@ -36,7 +36,8 @@ func (s *KeeperTestSuite) TestGetWorkerNodeInfo() {
 	s.Require().NoError(err, "GetWorkerNodeInfo should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
 	s.Require().NotNil(response.NodeInfo, "The response NodeInfo should not be nil")
-	s.Require().Equal(&expectedNode, response.NodeInfo, "The retrieved node information should match the expected node information")
+	s.Require().
+		Equal(&expectedNode, response.NodeInfo, "The retrieved node information should match the expected node information")
 
 	invalidReq := &types.QueryWorkerNodeInfoRequest{
 		Libp2PKey: "nonexistent-libp2p-key",
@@ -73,7 +74,8 @@ func (s *KeeperTestSuite) TestGetReputerNodeInfo() {
 	s.Require().NoError(err, "GetReputerNodeInfo should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
 	s.Require().NotNil(response.NodeInfo, "The response NodeInfo should not be nil")
-	s.Require().Equal(&expectedReputer, response.NodeInfo, "The retrieved node information should match the expected node information")
+	s.Require().
+		Equal(&expectedReputer, response.NodeInfo, "The retrieved node information should match the expected node information")
 
 	invalidReq := &types.QueryReputerNodeInfoRequest{
 		Libp2PKey: "nonExistentKey123",
@@ -112,7 +114,8 @@ func (s *KeeperTestSuite) TestGetWorkerAddressByP2PKey() {
 
 	s.Require().NoError(err, "GetWorkerAddressByP2PKey should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
-	s.Require().Equal(worker, response.Address, "The retrieved worker address should match the expected worker address")
+	s.Require().
+		Equal(worker, response.Address, "The retrieved worker address should match the expected worker address")
 
 	invalidReq := &types.QueryWorkerAddressByP2PKeyRequest{
 		Libp2PKey: nonexistentWorkerP2pKey,
@@ -152,7 +155,8 @@ func (s *KeeperTestSuite) TestGetReputerAddressByP2PKey() {
 
 	s.Require().NoError(err, "GetReputerAddressByP2PKey should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
-	s.Require().Equal(reputer, response.Address, "The retrieved reputer address should match the expected reputer address")
+	s.Require().
+		Equal(reputer, response.Address, "The retrieved reputer address should match the expected reputer address")
 
 	// Test invalid request
 	invalidReq := &types.QueryReputerAddressByP2PKeyRequest{
@@ -174,9 +178,11 @@ func (s *KeeperTestSuite) TestUnregisteredWorkerIsUnregisteredInTopicId() {
 		Address: notRegisteredWorkerAddr,
 	}
 	invalidResponse, err := queryServer.IsWorkerRegisteredInTopicId(ctx, notRegisteredRequest)
-	s.Require().NoError(err, "IsWorkerRegisteredInTopicId should handle non-registered addresses without error")
+	s.Require().
+		NoError(err, "IsWorkerRegisteredInTopicId should handle non-registered addresses without error")
 	s.Require().NotNil(invalidResponse, "The response for non-registered worker should not be nil")
-	s.Require().False(invalidResponse.IsRegistered, "The worker should not be registered for the topic")
+	s.Require().
+		False(invalidResponse.IsRegistered, "The worker should not be registered for the topic")
 }
 
 func (s *KeeperTestSuite) TestRegisteredWorkerIsRegisteredInTopicId() {
@@ -256,7 +262,12 @@ func (s *KeeperTestSuite) TestRegisteredReputerIsRegisteredInTopicId() {
 	mintAmount := sdk.NewCoins(sdk.NewInt64Coin(params.DefaultBondDenom, 100))
 	err := s.bankKeeper.MintCoins(ctx, minttypes.ModuleName, mintAmount)
 	require.NoError(err, "MintCoins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, reputerAddr, mintAmount)
+	err = s.bankKeeper.SendCoinsFromModuleToAccount(
+		ctx,
+		minttypes.ModuleName,
+		reputerAddr,
+		mintAmount,
+	)
 	require.NoError(err, "SendCoinsFromModuleToAccount should not return an error")
 
 	queryReq := &types.QueryIsReputerRegisteredInTopicIdRequest{

--- a/x/emissions/keeper/queryserver/query_server_stake.go
+++ b/x/emissions/keeper/queryserver/query_server_stake.go
@@ -13,7 +13,10 @@ import (
 )
 
 // TotalStake defines the handler for the Query/TotalStake RPC method.
-func (qs queryServer) GetTotalStake(ctx context.Context, req *types.QueryTotalStakeRequest) (*types.QueryTotalStakeResponse, error) {
+func (qs queryServer) GetTotalStake(
+	ctx context.Context,
+	req *types.QueryTotalStakeRequest,
+) (*types.QueryTotalStakeResponse, error) {
 	totalStake, err := qs.k.GetTotalStake(ctx)
 	if err != nil {
 		return nil, err
@@ -24,7 +27,10 @@ func (qs queryServer) GetTotalStake(ctx context.Context, req *types.QueryTotalSt
 // Retrieves all stake in a topic for a given reputer address,
 // including reputer's stake in themselves and stake delegated to them.
 // Also includes stake that is queued for removal.
-func (qs queryServer) GetReputerStakeInTopic(ctx context.Context, req *types.QueryReputerStakeInTopicRequest) (*types.QueryReputerStakeInTopicResponse, error) {
+func (qs queryServer) GetReputerStakeInTopic(
+	ctx context.Context,
+	req *types.QueryReputerStakeInTopicRequest,
+) (*types.QueryReputerStakeInTopicResponse, error) {
 	if err := qs.k.ValidateStringIsBech32(req.Address); err != nil {
 		return nil, err
 	}
@@ -39,7 +45,10 @@ func (qs queryServer) GetReputerStakeInTopic(ctx context.Context, req *types.Que
 // Retrieves all stake in a topic for a given set of reputer addresses,
 // including their stake in themselves and stake delegated to them.
 // Also includes stake that is queued for removal.
-func (qs queryServer) GetMultiReputerStakeInTopic(ctx context.Context, req *types.QueryMultiReputerStakeInTopicRequest) (*types.QueryMultiReputerStakeInTopicResponse, error) {
+func (qs queryServer) GetMultiReputerStakeInTopic(
+	ctx context.Context,
+	req *types.QueryMultiReputerStakeInTopicRequest,
+) (*types.QueryMultiReputerStakeInTopicResponse, error) {
 	maxLimit := types.DefaultParams().MaxPageLimit
 	moduleParams, err := qs.k.GetParams(ctx)
 	if err == nil {
@@ -47,7 +56,10 @@ func (qs queryServer) GetMultiReputerStakeInTopic(ctx context.Context, req *type
 	}
 
 	if uint64(len(req.Addresses)) > maxLimit {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("cannot query more than %d addresses at once", maxLimit))
+		return nil, status.Error(
+			codes.InvalidArgument,
+			fmt.Sprintf("cannot query more than %d addresses at once", maxLimit),
+		)
 	}
 
 	stakes := make([]*types.StakePlacement, len(req.Addresses))
@@ -66,7 +78,10 @@ func (qs queryServer) GetMultiReputerStakeInTopic(ctx context.Context, req *type
 }
 
 // Retrieves total delegate stake on a given reputer address in a given topic
-func (qs queryServer) GetDelegateStakeInTopicInReputer(ctx context.Context, req *types.QueryDelegateStakeInTopicInReputerRequest) (*types.QueryDelegateStakeInTopicInReputerResponse, error) {
+func (qs queryServer) GetDelegateStakeInTopicInReputer(
+	ctx context.Context,
+	req *types.QueryDelegateStakeInTopicInReputerRequest,
+) (*types.QueryDelegateStakeInTopicInReputerResponse, error) {
 	if err := qs.k.ValidateStringIsBech32(req.ReputerAddress); err != nil {
 		return nil, err
 	}
@@ -78,22 +93,35 @@ func (qs queryServer) GetDelegateStakeInTopicInReputer(ctx context.Context, req 
 	return &types.QueryDelegateStakeInTopicInReputerResponse{Amount: stake}, nil
 }
 
-func (qs queryServer) GetStakeFromDelegatorInTopicInReputer(ctx context.Context, req *types.QueryStakeFromDelegatorInTopicInReputerRequest) (*types.QueryStakeFromDelegatorInTopicInReputerResponse, error) {
+func (qs queryServer) GetStakeFromDelegatorInTopicInReputer(
+	ctx context.Context,
+	req *types.QueryStakeFromDelegatorInTopicInReputerRequest,
+) (*types.QueryStakeFromDelegatorInTopicInReputerResponse, error) {
 	if err := qs.k.ValidateStringIsBech32(req.ReputerAddress); err != nil {
 		return nil, errors.Wrapf(err, "reputer address")
 	}
 	if err := qs.k.ValidateStringIsBech32(req.DelegatorAddress); err != nil {
 		return nil, errors.Wrapf(err, "delegator address")
 	}
-	stake, err := qs.k.GetDelegateStakePlacement(ctx, req.TopicId, req.DelegatorAddress, req.ReputerAddress)
+	stake, err := qs.k.GetDelegateStakePlacement(
+		ctx,
+		req.TopicId,
+		req.DelegatorAddress,
+		req.ReputerAddress,
+	)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	return &types.QueryStakeFromDelegatorInTopicInReputerResponse{Amount: stake.Amount.SdkIntTrim()}, nil
+	return &types.QueryStakeFromDelegatorInTopicInReputerResponse{
+		Amount: stake.Amount.SdkIntTrim(),
+	}, nil
 }
 
-func (qs queryServer) GetStakeFromDelegatorInTopic(ctx context.Context, req *types.QueryStakeFromDelegatorInTopicRequest) (*types.QueryStakeFromDelegatorInTopicResponse, error) {
+func (qs queryServer) GetStakeFromDelegatorInTopic(
+	ctx context.Context,
+	req *types.QueryStakeFromDelegatorInTopicRequest,
+) (*types.QueryStakeFromDelegatorInTopicResponse, error) {
 	if err := qs.k.ValidateStringIsBech32(req.DelegatorAddress); err != nil {
 		return nil, err
 	}
@@ -106,7 +134,10 @@ func (qs queryServer) GetStakeFromDelegatorInTopic(ctx context.Context, req *typ
 }
 
 // Retrieves total stake in a given topic
-func (qs queryServer) GetTopicStake(ctx context.Context, req *types.QueryTopicStakeRequest) (*types.QueryTopicStakeResponse, error) {
+func (qs queryServer) GetTopicStake(
+	ctx context.Context,
+	req *types.QueryTopicStakeRequest,
+) (*types.QueryTopicStakeResponse, error) {
 	stake, err := qs.k.GetTopicStake(ctx, req.TopicId)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/x/emissions/keeper/queryserver/query_server_stake_test.go
+++ b/x/emissions/keeper/queryserver/query_server_stake_test.go
@@ -19,7 +19,8 @@ func (s *KeeperTestSuite) TestGetTotalStake() {
 	response, err := queryServer.GetTotalStake(ctx, req)
 	s.Require().NoError(err, "GetTotalStake should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
-	s.Require().Equal(expectedTotalStake, response.Amount, "The retrieved total stake should match the expected value")
+	s.Require().
+		Equal(expectedTotalStake, response.Amount, "The retrieved total stake should match the expected value")
 }
 
 func (s *KeeperTestSuite) TestGetReputerStakeInTopic() {
@@ -43,7 +44,8 @@ func (s *KeeperTestSuite) TestGetReputerStakeInTopic() {
 	response, err := queryServer.GetReputerStakeInTopic(ctx, req)
 	s.Require().NoError(err, "GetReputerStakeInTopic should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
-	s.Require().Equal(initialStake, response.Amount, "The retrieved stake should match the initial stake set for the reputer in the topic")
+	s.Require().
+		Equal(initialStake, response.Amount, "The retrieved stake should match the initial stake set for the reputer in the topic")
 }
 
 func (s *KeeperTestSuite) TestGetMultiReputerStakeInTopic() {
@@ -72,9 +74,12 @@ func (s *KeeperTestSuite) TestGetMultiReputerStakeInTopic() {
 	response, err := queryServer.GetMultiReputerStakeInTopic(ctx, req)
 	s.Require().NoError(err, "GetReputerStakeInTopic should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
-	s.Require().Len(response.Amounts, 2, "The retrieved set of stakes should have length equal to the number of reputers queried")
-	s.Require().Equal(initialStake1, response.Amounts[0].Amount, "The retrieved stake should match the initial stake set for the first reputer in the topic")
-	s.Require().Equal(initialStake2, response.Amounts[1].Amount, "The retrieved stake should match the initial stake set for the second reputer in the topic")
+	s.Require().
+		Len(response.Amounts, 2, "The retrieved set of stakes should have length equal to the number of reputers queried")
+	s.Require().
+		Equal(initialStake1, response.Amounts[0].Amount, "The retrieved stake should match the initial stake set for the first reputer in the topic")
+	s.Require().
+		Equal(initialStake2, response.Amounts[1].Amount, "The retrieved stake should match the initial stake set for the second reputer in the topic")
 }
 
 func (s *KeeperTestSuite) TestGetDelegateStakeInTopicInReputer() {
@@ -101,7 +106,8 @@ func (s *KeeperTestSuite) TestGetDelegateStakeInTopicInReputer() {
 	response, err := queryServer.GetDelegateStakeInTopicInReputer(ctx, req)
 	s.Require().NoError(err, "GetDelegateStakeInTopicInReputer should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
-	s.Require().Equal(initialStakeAmount, response.Amount, "The retrieved delegate stake should match the initial stake set for the reputer in the topic")
+	s.Require().
+		Equal(initialStakeAmount, response.Amount, "The retrieved delegate stake should match the initial stake set for the reputer in the topic")
 }
 
 func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopicInReputer() {
@@ -130,7 +136,8 @@ func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopicInReputer() {
 	response, err := queryServer.GetStakeFromDelegatorInTopicInReputer(ctx, req)
 	s.Require().NoError(err, "GetStakeFromDelegatorInTopicInReputer should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
-	s.Require().Equal(stakeAmount, response.Amount, "The retrieved stake amount should match the delegated stake")
+	s.Require().
+		Equal(stakeAmount, response.Amount, "The retrieved stake amount should match the delegated stake")
 }
 
 func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopic() {
@@ -145,10 +152,22 @@ func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopic() {
 	initialStakeAmount := cosmosMath.NewInt(500)
 	additionalStakeAmount := cosmosMath.NewInt(300)
 
-	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, PKS[1].Address().String(), initialStakeAmount)
+	err = keeper.AddDelegateStake(
+		ctx,
+		topicId,
+		delegatorAddr,
+		PKS[1].Address().String(),
+		initialStakeAmount,
+	)
 	s.Require().NoError(err)
 
-	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, PKS[1].Address().String(), additionalStakeAmount)
+	err = keeper.AddDelegateStake(
+		ctx,
+		topicId,
+		delegatorAddr,
+		PKS[1].Address().String(),
+		additionalStakeAmount,
+	)
 	s.Require().NoError(err)
 
 	req := &types.QueryStakeFromDelegatorInTopicRequest{
@@ -160,7 +179,8 @@ func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopic() {
 	s.Require().NoError(err, "GetStakeFromDelegatorInTopic should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
 	expectedTotalStake := initialStakeAmount.Add(additionalStakeAmount)
-	s.Require().Equal(expectedTotalStake, response.Amount, "The retrieved stake amount should match the total delegated stake")
+	s.Require().
+		Equal(expectedTotalStake, response.Amount, "The retrieved stake amount should match the total delegated stake")
 }
 
 func (s *KeeperTestSuite) TestGetTopicStake() {
@@ -182,5 +202,6 @@ func (s *KeeperTestSuite) TestGetTopicStake() {
 	response, err := queryServer.GetTopicStake(ctx, req)
 	s.Require().NoError(err, "GetTopicStake should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
-	s.Require().Equal(stakeAmount, response.Amount, "The retrieved topic stake should match the stake amount added")
+	s.Require().
+		Equal(stakeAmount, response.Amount, "The retrieved topic stake should match the stake amount added")
 }

--- a/x/emissions/keeper/queryserver/query_server_test.go
+++ b/x/emissions/keeper/queryserver/query_server_test.go
@@ -74,9 +74,17 @@ func TestKeeperTestSuite(t *testing.T) {
 func (s *KeeperTestSuite) SetupTest() {
 	key := storetypes.NewKVStoreKey("emissions")
 	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+	testCtx := testutil.DefaultContextWithDB(
+		s.T(),
+		key,
+		storetypes.NewTransientStoreKey("transient_test"),
+	)
 	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()})
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
+	encCfg := moduletestutil.MakeTestEncodingConfig(
+		auth.AppModuleBasic{},
+		bank.AppModuleBasic{},
+		module.AppModule{},
+	)
 	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
 
 	maccPerms := map[string][]string{
@@ -163,7 +171,12 @@ func (s *KeeperTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cos
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
 
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		s.ctx,
+		types.AlloraStakingAccountName,
+		address,
+		creatorInitialBalanceCoins,
+	)
 }
 
 func (s *KeeperTestSuite) CreateOneTopic() uint64 {
@@ -220,10 +233,17 @@ func (s *KeeperTestSuite) TestCreateSeveralTopics() {
 	}
 
 	creatorInitialBalance := types.DefaultParams().CreateTopicFee.Mul(cosmosMath.NewInt(3))
-	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, creatorInitialBalance))
+	creatorInitialBalanceCoins := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, creatorInitialBalance),
+	)
 
 	s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, creator, creatorInitialBalanceCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		ctx,
+		types.AlloraStakingAccountName,
+		creator,
+		creatorInitialBalanceCoins,
+	)
 
 	initialTopicId, err := s.emissionsKeeper.GetNextTopicId(s.ctx)
 	s.Require().NoError(err)

--- a/x/emissions/keeper/queryserver/query_server_topics.go
+++ b/x/emissions/keeper/queryserver/query_server_topics.go
@@ -10,7 +10,10 @@ import (
 )
 
 // NextTopicId is a monotonically increasing counter that is used to assign unique IDs to topics.
-func (qs queryServer) GetNextTopicId(ctx context.Context, req *types.QueryNextTopicIdRequest) (*types.QueryNextTopicIdResponse, error) {
+func (qs queryServer) GetNextTopicId(
+	ctx context.Context,
+	req *types.QueryNextTopicIdRequest,
+) (*types.QueryNextTopicIdResponse, error) {
 	nextTopicId, err := qs.k.GetNextTopicId(ctx)
 	if err != nil {
 		return nil, err
@@ -19,14 +22,20 @@ func (qs queryServer) GetNextTopicId(ctx context.Context, req *types.QueryNextTo
 }
 
 // Topics defines the handler for the Query/Topics RPC method.
-func (qs queryServer) GetTopic(ctx context.Context, req *types.QueryTopicRequest) (*types.QueryTopicResponse, error) {
+func (qs queryServer) GetTopic(
+	ctx context.Context,
+	req *types.QueryTopicRequest,
+) (*types.QueryTopicResponse, error) {
 	topic, err := qs.k.GetTopic(ctx, req.TopicId)
 
 	return &types.QueryTopicResponse{Topic: &topic}, err
 }
 
 // Retrieves a list of active topics. Paginated.
-func (qs queryServer) GetActiveTopics(ctx context.Context, req *types.QueryActiveTopicsRequest) (*types.QueryActiveTopicsResponse, error) {
+func (qs queryServer) GetActiveTopics(
+	ctx context.Context,
+	req *types.QueryActiveTopicsRequest,
+) (*types.QueryActiveTopicsResponse, error) {
 	activeTopics, pageRes, err := qs.k.GetIdsOfActiveTopics(ctx, req.Pagination)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/x/emissions/keeper/queryserver/query_server_topics_test.go
+++ b/x/emissions/keeper/queryserver/query_server_topics_test.go
@@ -29,7 +29,8 @@ func (s *KeeperTestSuite) TestGetNextTopicId() {
 	s.Require().NoError(err, "GetNextTopicId should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
 	expectedNextTopicId := initialNextTopicId + uint64(topicsToCreate)
-	s.Require().Equal(expectedNextTopicId, response.NextTopicId, "The next topic ID should match the expected value after topic creation")
+	s.Require().
+		Equal(expectedNextTopicId, response.NextTopicId, "The next topic ID should match the expected value after topic creation")
 }
 
 func (s *KeeperTestSuite) TestGetTopic() {
@@ -46,7 +47,8 @@ func (s *KeeperTestSuite) TestGetTopic() {
 	s.Require().NotNil(response, "Response should not be nil even if the topic does not exist")
 	s.Require().NotNil(response.Topic, "Topic should be nil for a non-existent topic")
 	s.Require().Equal(response.Topic.Id, uint64(0), "Topic should be nil for a non-existent topic")
-	s.Require().Error(err, "No error should be returned; the response should gracefully handle not found")
+	s.Require().
+		Error(err, "No error should be returned; the response should gracefully handle not found")
 
 	// Setting up a new topic
 	newTopic := types.Topic{Id: topicId, Metadata: metadata}
@@ -59,7 +61,8 @@ func (s *KeeperTestSuite) TestGetTopic() {
 	s.Require().NotNil(response, "The response should not be nil")
 	s.Require().NotNil(response.Topic, "The response's Topic should not be nil")
 	s.Require().Equal(newTopic, *response.Topic, "Retrieved topic should match the set topic")
-	s.Require().Equal(metadata, response.Topic.Metadata, "The metadata of the retrieved topic should match")
+	s.Require().
+		Equal(metadata, response.Topic.Metadata, "The metadata of the retrieved topic should match")
 }
 
 func (s *KeeperTestSuite) TestGetActiveTopics() {
@@ -90,7 +93,8 @@ func (s *KeeperTestSuite) TestGetActiveTopics() {
 	s.Require().Equal(len(response.Topics), 2, "Should retrieve exactly two active topics")
 
 	for _, topic := range response.Topics {
-		s.Require().True(topic.Id == 1 || topic.Id == 3, "Only active topic IDs (1 or 3) should be returned")
+		s.Require().
+			True(topic.Id == 1 || topic.Id == 3, "Only active topic IDs (1 or 3) should be returned")
 		isActive, err := keeper.IsTopicActive(ctx, topic.Id)
 		s.Require().NoError(err, "Checking topic activity should not fail")
 		s.Require().True(isActive, "Only active topics should be returned")

--- a/x/emissions/keeper/queryserver/query_server_whitelist.go
+++ b/x/emissions/keeper/queryserver/query_server_whitelist.go
@@ -10,7 +10,10 @@ import (
 )
 
 // Params defines the handler for the Query/Params RPC method.
-func (qs queryServer) IsWhitelistAdmin(ctx context.Context, req *types.QueryIsWhitelistAdminRequest) (*types.QueryIsWhitelistAdminResponse, error) {
+func (qs queryServer) IsWhitelistAdmin(
+	ctx context.Context,
+	req *types.QueryIsWhitelistAdminRequest,
+) (*types.QueryIsWhitelistAdminResponse, error) {
 	if err := qs.k.ValidateStringIsBech32(req.Address); err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/queryserver/query_server_whitelist_test.go
+++ b/x/emissions/keeper/queryserver/query_server_whitelist_test.go
@@ -31,5 +31,6 @@ func (s *KeeperTestSuite) TestIsWhitelistAdmin() {
 	response, err = queryServer.IsWhitelistAdmin(ctx, req)
 	s.Require().NoError(err, "IsWhitelistAdmin should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")
-	s.Require().False(response.IsAdmin, "The IsAdmin field should be false for the anti test address")
+	s.Require().
+		False(response.IsAdmin, "The IsAdmin field should be false for the anti test address")
 }

--- a/x/emissions/keeper/topic_weight.go
+++ b/x/emissions/keeper/topic_weight.go
@@ -54,20 +54,30 @@ func (k *Keeper) GetCurrentTopicWeight(
 
 	topicStakeDec, err := alloraMath.NewDecFromSdkInt(topicStake)
 	if err != nil {
-		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to convert topic stake to dec")
+		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(
+			err,
+			"failed to convert topic stake to dec",
+		)
 	}
 
 	// Get and total topic fee revenue
 	topicFeeRevenue, err := k.GetTopicFeeRevenue(ctx, topicId)
 	if err != nil {
-		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get topic fee revenue")
+		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(
+			err,
+			"failed to get topic fee revenue",
+		)
 	}
 
 	// Calc target weight using fees, epoch length, stake, and params
-	newFeeRevenue := cosmosMath.NewIntFromBigInt(additionalRevenue.BigInt()).Add(topicFeeRevenue.Revenue)
+	newFeeRevenue := cosmosMath.NewIntFromBigInt(additionalRevenue.BigInt()).
+		Add(topicFeeRevenue.Revenue)
 	feeRevenue, err := alloraMath.NewDecFromSdkInt(newFeeRevenue)
 	if err != nil {
-		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to convert topic fee revenue to dec")
+		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(
+			err,
+			"failed to convert topic fee revenue to dec",
+		)
 	}
 
 	if !feeRevenue.Equal(alloraMath.ZeroDec()) {
@@ -79,15 +89,26 @@ func (k *Keeper) GetCurrentTopicWeight(
 			feeImportance,
 		)
 		if err != nil {
-			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get target weight")
+			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(
+				err,
+				"failed to get target weight",
+			)
 		}
 
 		// Take EMA of target weight with previous weight
 		previousTopicWeight, noPrior, err := k.GetPreviousTopicWeight(ctx, topicId)
 		if err != nil {
-			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get previous topic weight")
+			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(
+				err,
+				"failed to get previous topic weight",
+			)
 		}
-		weight, err = alloraMath.CalcEma(topicRewardAlpha, targetWeight, previousTopicWeight, noPrior)
+		weight, err = alloraMath.CalcEma(
+			topicRewardAlpha,
+			targetWeight,
+			previousTopicWeight,
+			noPrior,
+		)
 		if err != nil {
 			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to calculate EMA")
 		}

--- a/x/emissions/module/module.go
+++ b/x/emissions/module/module.go
@@ -81,7 +81,11 @@ func (AppModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 }
 
 // ValidateGenesis performs genesis state validation for the circuit module.
-func (AppModule) ValidateGenesis(cdc codec.JSONCodec, _ client.TxEncodingConfig, bz json.RawMessage) error {
+func (AppModule) ValidateGenesis(
+	cdc codec.JSONCodec,
+	_ client.TxEncodingConfig,
+	bz json.RawMessage,
+) error {
 	var data types.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &data); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)

--- a/x/emissions/module/rewards/reputer_rewards.go
+++ b/x/emissions/module/rewards/reputer_rewards.go
@@ -27,17 +27,28 @@ func GetReputersRewardFractions(
 		reputers[i] = scorePtr.Address
 		stake, err := k.GetStakeOnReputerInTopic(ctx, topicId, scorePtr.Address)
 		if err != nil {
-			return []string{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to get reputer stake on topic %d", topicId)
+			return []string{}, []alloraMath.Dec{}, errors.Wrapf(
+				err,
+				"failed to get reputer stake on topic %d",
+				topicId,
+			)
 		}
 		stakes[i], err = alloraMath.NewDecFromSdkInt(stake)
 		if err != nil {
-			return []string{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to convert reputer stake %d", stake)
+			return []string{}, []alloraMath.Dec{}, errors.Wrapf(
+				err,
+				"failed to convert reputer stake %d",
+				stake,
+			)
 		}
 	}
 
 	rewardFractions, err := CalculateReputerRewardFractions(stakes, scores, pReward)
 	if err != nil {
-		return []string{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to get reputer reward fractions")
+		return []string{}, []alloraMath.Dec{}, errors.Wrapf(
+			err,
+			"failed to get reputer reward fractions",
+		)
 	}
 
 	return reputers, rewardFractions, nil
@@ -58,9 +69,16 @@ func GetReputerTaskEntropy(
 	numReputers := len(reputers)
 	emaReputerRewards := make([]alloraMath.Dec, numReputers)
 	for i, reputer := range reputers {
-		previousReputerRewardFraction, noPriorRegret, err := k.GetPreviousReputerRewardFraction(ctx, topicId, reputer)
+		previousReputerRewardFraction, noPriorRegret, err := k.GetPreviousReputerRewardFraction(
+			ctx,
+			topicId,
+			reputer,
+		)
 		if err != nil {
-			return alloraMath.Dec{}, errors.Wrapf(err, "failed to get previous reputer reward fraction")
+			return alloraMath.Dec{}, errors.Wrapf(
+				err,
+				"failed to get previous reputer reward fraction",
+			)
 		}
 		emaReputerRewards[i], err = alloraMath.CalcEma(
 			emaAlpha,
@@ -85,7 +103,10 @@ func GetReputerTaskEntropy(
 	for i, reputer := range reputers {
 		err := k.SetPreviousReputerRewardFraction(ctx, topicId, reputer, modifiedRewardFractions[i])
 		if err != nil {
-			return alloraMath.Dec{}, errors.Wrapf(err, "failed to set previous reputer reward fraction")
+			return alloraMath.Dec{}, errors.Wrapf(
+				err,
+				"failed to set previous reputer reward fraction",
+			)
 		}
 	}
 
@@ -182,7 +203,9 @@ func GetRewardForReputerFromTotalReward(
 		if delegatorReward.Gt(alloraMath.NewDecFromInt64(0)) {
 			// update reward share
 			// new_share = current_share + (reward / total_stake)
-			totalDelegatorStakeAmountDec, err := alloraMath.NewDecFromSdkInt(totalDelegatorStakeAmount)
+			totalDelegatorStakeAmountDec, err := alloraMath.NewDecFromSdkInt(
+				totalDelegatorStakeAmount,
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/x/emissions/module/rewards/reputer_rewards_test.go
+++ b/x/emissions/module/rewards/reputer_rewards_test.go
@@ -172,15 +172,25 @@ func (s *RewardsTestSuite) TestGetReputersRewardsShouldGenerateRewardsForDelegat
 	s.Require().NoError(err)
 
 	// Add balance to the reward account
-	rewardToDistribute := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(100000000)))
+	rewardToDistribute := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(100000000)),
+	)
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraRewardsAccountName, rewardToDistribute)
 
 	// Check delegator rewards account balance
-	moduleAccAddr := s.accountKeeper.GetModuleAddress(types.AlloraPendingRewardForDelegatorAccountName)
+	moduleAccAddr := s.accountKeeper.GetModuleAddress(
+		types.AlloraPendingRewardForDelegatorAccountName,
+	)
 	inicialBalance := s.bankKeeper.GetBalance(s.ctx, moduleAccAddr, params.DefaultBondDenom)
 
 	// Add delegator for the reputer 1
-	err = s.emissionsKeeper.AddDelegateStake(s.ctx, topicId, s.addrs[5].String(), reputerAddrs[0], cosmosMath.NewInt(10000000000))
+	err = s.emissionsKeeper.AddDelegateStake(
+		s.ctx,
+		topicId,
+		s.addrs[5].String(),
+		reputerAddrs[0],
+		cosmosMath.NewInt(10000000000),
+	)
 	s.Require().NoError(err)
 
 	// Reputers fractions of total reward
@@ -357,7 +367,13 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldIncreaseFractionO
 	s.Require().NoError(err)
 
 	// Calculate and Set the reputer scores
-	scores, err := rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err := rewards.GenerateReputerScores(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		block,
+		reputerValueBundles,
+	)
 	s.Require().NoError(err)
 
 	// Get reputer rewards
@@ -420,7 +436,13 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldOutputZeroForRepu
 	)
 
 	// Calculate and Set the reputer scores
-	scores, err := rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err := rewards.GenerateReputerScores(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		block,
+		reputerValueBundles,
+	)
 	s.Require().NoError(err)
 
 	// Get reputer rewards
@@ -440,7 +462,12 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldOutputZeroForRepu
 }
 
 // mockReputersData generates reputer scores, stakes and losses
-func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64, reputerAddrs []string) (types.ReputerValueBundles, error) {
+func mockReputersData(
+	s *RewardsTestSuite,
+	topicId uint64,
+	block int64,
+	reputerAddrs []string,
+) (types.ReputerValueBundles, error) {
 	var scores = []alloraMath.Dec{
 		alloraMath.MustNewDecFromString("17.53436"),
 		alloraMath.MustNewDecFromString("20.29489"),
@@ -482,10 +509,18 @@ func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64, reputerA
 				NaiveValue:    alloraMath.MustNewDecFromString("1500.0"),
 			},
 		}
-		reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, reputerValueBundle)
+		reputerValueBundles.ReputerValueBundles = append(
+			reputerValueBundles.ReputerValueBundles,
+			reputerValueBundle,
+		)
 	}
 
-	err := s.emissionsKeeper.InsertReputerLossBundlesAtBlock(s.ctx, topicId, block, reputerValueBundles)
+	err := s.emissionsKeeper.InsertReputerLossBundlesAtBlock(
+		s.ctx,
+		topicId,
+		block,
+		reputerValueBundles,
+	)
 	if err != nil {
 		return types.ReputerValueBundles{}, err
 	}

--- a/x/emissions/module/rewards/rewards_internal.go
+++ b/x/emissions/module/rewards/rewards_internal.go
@@ -29,7 +29,13 @@ func GetScoreFractions(
 	cReward alloraMath.Dec,
 	epsilon alloraMath.Dec,
 ) ([]alloraMath.Dec, error) {
-	mappedValues, err := GetMappingFunctionValues(latestWorkerScores, latestTimeStepsScores, pReward, cReward, epsilon)
+	mappedValues, err := GetMappingFunctionValues(
+		latestWorkerScores,
+		latestTimeStepsScores,
+		pReward,
+		cReward,
+		epsilon,
+	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error in GetMappingFunctionValue")
 	}
@@ -183,7 +189,9 @@ func GetFinalWorkerScoreForecastTask(
 // Consider the losses and the stake of each reputer to calculate the stake-weighted loss.
 // The stake weighted loss is used to calculate the network-wide losses.
 // L_i / L_ij / L_ik / L^-_i / L^-_il / L^+_ik
-func GetStakeWeightedLoss(reputersStakes, reputersReportedLosses []alloraMath.Dec) (alloraMath.Dec, error) {
+func GetStakeWeightedLoss(
+	reputersStakes, reputersReportedLosses []alloraMath.Dec,
+) (alloraMath.Dec, error) {
 	if len(reputersStakes) != len(reputersReportedLosses) {
 		return alloraMath.ZeroDec(), types.ErrInvalidSliceLength
 	}
@@ -269,7 +277,9 @@ func GetStakeWeightedLossMatrix(
 		stakeWeightedLoss[j] = sum
 
 		// Find most distant value from consensus value
-		maxDistance, err := alloraMath.OneDec().Mul(alloraMath.MustNewDecFromString("-1")) // Initialize with an impossible value
+		maxDistance, err := alloraMath.OneDec().
+			Mul(alloraMath.MustNewDecFromString("-1"))
+			// Initialize with an impossible value
 		if err != nil {
 			return nil, nil, err
 		}
@@ -339,7 +349,9 @@ func GetConsensusScore(
 		if err != nil {
 			return alloraMath.ZeroDec(), err
 		}
-		rLossOverCLossSquared, err := rLossOverConsensusLoss.Mul(rLossOverConsensusLoss) // == Pow(x,2)
+		rLossOverCLossSquared, err := rLossOverConsensusLoss.Mul(
+			rLossOverConsensusLoss,
+		) // == Pow(x,2)
 		if err != nil {
 			return alloraMath.ZeroDec(), err
 		}
@@ -406,7 +418,13 @@ func GetAllConsensusScores(
 	scores := make([]alloraMath.Dec, numReputers)
 	for i := int64(0); i < numReputers; i++ {
 		losses := allLosses[i]
-		scores[i], err = GetConsensusScore(losses, consensus, mostDistantValues, fTolerance, epsilon)
+		scores[i], err = GetConsensusScore(
+			losses,
+			consensus,
+			mostDistantValues,
+			fTolerance,
+			epsilon,
+		)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error in GetConsensusScore")
 		}
@@ -454,7 +472,14 @@ func GetAllReputersOutput(
 			coeffs := make([]alloraMath.Dec, len(coefficients))
 			copy(coeffs, coefficients)
 
-			scores, err := GetAllConsensusScores(allLosses, stakes, coeffs, numReputers, fTolerance, epsilon)
+			scores, err := GetAllConsensusScores(
+				allLosses,
+				stakes,
+				coeffs,
+				numReputers,
+				fTolerance,
+				epsilon,
+			)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "error in GetAllConsensusScores")
 			}
@@ -465,7 +490,14 @@ func GetAllReputersOutput(
 				return nil, nil, err
 			}
 
-			scores2, err := GetAllConsensusScores(allLosses, stakes, coeffs2, numReputers, fTolerance, epsilon)
+			scores2, err := GetAllConsensusScores(
+				allLosses,
+				stakes,
+				coeffs2,
+				numReputers,
+				fTolerance,
+				epsilon,
+			)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "error in GetAllConsensusScores")
 			}
@@ -498,7 +530,9 @@ func GetAllReputersOutput(
 			if err != nil {
 				return nil, nil, err
 			}
-			coefficientsPlusLearningRateTimesGradient, err := coefficients[j].Add(learningRateTimesGradient)
+			coefficientsPlusLearningRateTimesGradient, err := coefficients[j].Add(
+				learningRateTimesGradient,
+			)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -549,11 +583,15 @@ func GetAllReputersOutput(
 				if err != nil {
 					return nil, nil, err
 				}
-				coefDiffTimesListenedDiffOverStakedFracDiff, err := coeffDiffTimesListenedDiff.Quo(stakedFracDiff)
+				coefDiffTimesListenedDiffOverStakedFracDiff, err := coeffDiffTimesListenedDiff.Quo(
+					stakedFracDiff,
+				)
 				if err != nil {
 					return nil, nil, err
 				}
-				coefficients[l], err = oldCoefficients[l].Add(coefDiffTimesListenedDiffOverStakedFracDiff)
+				coefficients[l], err = oldCoefficients[l].Add(
+					coefDiffTimesListenedDiffOverStakedFracDiff,
+				)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/x/emissions/module/rewards/rewards_internal_test.go
+++ b/x/emissions/module/rewards/rewards_internal_test.go
@@ -28,7 +28,11 @@ func (s *MathTestSuite) TestAdjustedStakeSimple() {
 	// and we calculate the adjusted stake for reputer 2 (the 100_000)
 
 	stake := alloraMath.NewDecFromInt64(100000)
-	allStakes := []alloraMath.Dec{alloraMath.NewDecFromInt64(50000), stake, alloraMath.NewDecFromInt64(150000)}
+	allStakes := []alloraMath.Dec{
+		alloraMath.NewDecFromInt64(50000),
+		stake,
+		alloraMath.NewDecFromInt64(150000),
+	}
 	listeningCoefficient := alloraMath.MustNewDecFromString("0.18")
 	allListeningCoefficients := []alloraMath.Dec{
 		alloraMath.MustNewDecFromString("0.25"),
@@ -39,7 +43,9 @@ func (s *MathTestSuite) TestAdjustedStakeSimple() {
 
 	// use wolfram alpha to calculate the expected result
 	// https://www.wolframalpha.com/input?i2d=true&i=1-%5C%2840%29%5C%2840%29Power%5B%5C%2840%29Power%5B%5C%2840%29ln%5C%2840%291%2BPower%5Be%2C20%5D%5C%2841%29%5C%2841%29%2C1%5D%5C%2841%29%2C-1%5D%5C%2841%29*Power%5B%5C%2840%29ln%5C%2840%291%2BPower%5Be%2C%5C%2840%29-20%5C%2840%29Divide%5B3*0.18*100%5C%2844%29000%2C0.18*100%5C%2844%29000+%2B+0.25*50%5C%2844%29000+%2B+0.63*150%5C%2844%29000%5D+-+1%5C%2841%29%5C%2841%29%5D%5C%2841%29%5C%2841%29%2C1%5D%5C%2841%29
-	expected := alloraMath.MustNewDecFromString("0.4319994174428689223916439092220111693737492607160554179509")
+	expected := alloraMath.MustNewDecFromString(
+		"0.4319994174428689223916439092220111693737492607160554179509",
+	)
 
 	result, err := rewards.GetAdjustedStake(
 		stake,
@@ -49,7 +55,8 @@ func (s *MathTestSuite) TestAdjustedStakeSimple() {
 		numReputers,
 	)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(expected, result, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(expected, result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
 func (s *MathTestSuite) TestNormalizeAgainstSlice() {
@@ -68,7 +75,8 @@ func (s *MathTestSuite) TestNormalizeAgainstSlice() {
 
 	s.Require().NoError(err)
 	for i := range expected {
-		s.Require().True(alloraMath.InDelta(expected[i], result[i], alloraMath.MustNewDecFromString("0.0001")))
+		s.Require().
+			True(alloraMath.InDelta(expected[i], result[i], alloraMath.MustNewDecFromString("0.0001")))
 	}
 }
 
@@ -84,10 +92,13 @@ func (s *MathTestSuite) TestEntropySimple() {
 
 	// using wolfram alpha to get a sample result
 	// https://www.wolframalpha.com/input?i2d=true&i=-Power%5B%5C%2840%29Divide%5B0.75%2C3%5D%5C%2841%29%2C0.25%5D*%5C%2840%290.2*ln%5C%2840%290.2%5C%2841%29+%2B+0.3*ln%5C%2840%290.3%5C%2841%29+%2B+0.5*ln%5C%2840%290.5%5C%2841%29%5C%2841%29
-	expected := alloraMath.MustNewDecFromString("0.7280746285142275338742683350155248011115920866691059016669")
+	expected := alloraMath.MustNewDecFromString(
+		"0.7280746285142275338742683350155248011115920866691059016669",
+	)
 	result, err := rewards.Entropy(f_ij, N_i_eff, N_i, beta)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(expected, result, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(expected, result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
 func (s *MathTestSuite) TestNumberRatio() {
@@ -103,11 +114,14 @@ func (s *MathTestSuite) TestNumberRatio() {
 	// 1 / (0.2 *0.2 + 0.3*0.3 + 0.4*0.4 + 0.5*0.5 + 0.6*0.6 + 0.7*0.7)
 	// 1 / (0.04 + 0.09 + 0.16 + 0.25 + 0.36 + 0.49)
 	// 1 / 1.39 = 0.719424460431654676259005145797598627787307032590051458
-	expected := alloraMath.MustNewDecFromString("0.719424460431654676259005145797598627787307032590051458")
+	expected := alloraMath.MustNewDecFromString(
+		"0.719424460431654676259005145797598627787307032590051458",
+	)
 
 	result, err := rewards.NumberRatio(rewardFractions)
 	s.Require().NoError(err, "Error calculating number ratio")
-	s.Require().True(alloraMath.InDelta(expected, result, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(expected, result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
 func (s *MathTestSuite) TestNumberRatioZeroFractions() {
@@ -165,7 +179,8 @@ func (s *MathTestSuite) TestInferenceRewardsZero() {
 		&totalReward,                           // E_i
 	)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(alloraMath.ZeroDec(), result, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(alloraMath.ZeroDec(), result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
 func (s *MathTestSuite) TestForecastRewardsSimple() {
@@ -268,7 +283,8 @@ func (s *MathTestSuite) TestReputerRewardSimple() {
 		&totalReward,
 	)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.5"), result, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.5"), result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
 func (s *MathTestSuite) TestReputerRewardZero() {
@@ -280,22 +296,28 @@ func (s *MathTestSuite) TestReputerRewardZero() {
 		&totalReward,
 	)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(alloraMath.ZeroDec(), result, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(alloraMath.ZeroDec(), result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
 func (s *MathTestSuite) TestForecastingPerformanceScoreSimple() {
 	networkInferenceLoss := alloraMath.MustNewDecFromString("100.0")
 	naiveNetworkInferenceLoss := alloraMath.MustNewDecFromString("1000.0")
-	score, err := rewards.ForecastingPerformanceScore(naiveNetworkInferenceLoss, networkInferenceLoss)
+	score, err := rewards.ForecastingPerformanceScore(
+		naiveNetworkInferenceLoss,
+		networkInferenceLoss,
+	)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(alloraMath.MustNewDecFromString("900.0"), score, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(alloraMath.MustNewDecFromString("900.0"), score, alloraMath.MustNewDecFromString("0.0001")))
 }
 
 func (s *MathTestSuite) TestSigmoidSimple() {
 	x := alloraMath.MustNewDecFromString("-4")
 	result, err := rewards.Sigmoid(x)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.01798621"), result, alloraMath.MustNewDecFromString("0.00000001")))
+	s.Require().
+		True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.01798621"), result, alloraMath.MustNewDecFromString("0.00000001")))
 }
 
 func (s *MathTestSuite) TestForecastingUtilitySimple() {
@@ -303,13 +325,15 @@ func (s *MathTestSuite) TestForecastingUtilitySimple() {
 	negativeScore := alloraMath.MustNewDecFromString("-0.1")
 	ret, err := rewards.ForecastingUtility(negativeScore)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.1"), ret, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.1"), ret, alloraMath.MustNewDecFromString("0.0001")))
 
 	// Test case where score > 1
 	highScore := alloraMath.MustNewDecFromString("1.1")
 	ret, err = rewards.ForecastingUtility(highScore)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.5"), ret, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.5"), ret, alloraMath.MustNewDecFromString("0.0001")))
 
 	// Test case where 0 <= score <= 1
 	forecastingPerformanceScore := alloraMath.MustNewDecFromString("0.125")
@@ -318,7 +342,8 @@ func (s *MathTestSuite) TestForecastingUtilitySimple() {
 
 	ret, err = rewards.ForecastingUtility(forecastingPerformanceScore)
 	s.Require().NoError(err)
-	s.Require().True(alloraMath.InDelta(expectedResult, ret, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(expectedResult, ret, alloraMath.MustNewDecFromString("0.0001")))
 }
 
 func (s *MathTestSuite) TestNormalizationFactorSimple() {
@@ -334,20 +359,33 @@ func (s *MathTestSuite) TestNormalizationFactorSimple() {
 	result, err := rewards.NormalizationFactor(entropyInference, entropyForecasting, chi)
 	s.Require().NoError(err)
 
-	s.Require().True(alloraMath.InDelta(alloraMath.NewDecFromInt64(2), result, alloraMath.MustNewDecFromString("0.0001")))
+	s.Require().
+		True(alloraMath.InDelta(alloraMath.NewDecFromInt64(2), result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
 func TestGetScoreFractions(t *testing.T) {
 
 	latestWorkerScores := []alloraMath.Dec{
-		alloraMath.MustNewDecFromString("-0.00388"), alloraMath.MustNewDecFromString("-0.01554"), alloraMath.MustNewDecFromString("0.00545"), alloraMath.MustNewDecFromString("0.03906"), alloraMath.MustNewDecFromString("0.09418"),
+		alloraMath.MustNewDecFromString(
+			"-0.00388",
+		), alloraMath.MustNewDecFromString("-0.01554"), alloraMath.MustNewDecFromString("0.00545"), alloraMath.MustNewDecFromString("0.03906"), alloraMath.MustNewDecFromString("0.09418"),
 	}
 	latestTimeStepsScores := []alloraMath.Dec{
-		alloraMath.MustNewDecFromString("-0.00675"), alloraMath.MustNewDecFromString("-0.00622"), alloraMath.MustNewDecFromString("-0.00388"),
-		alloraMath.MustNewDecFromString("-0.01502"), alloraMath.MustNewDecFromString("-0.01214"), alloraMath.MustNewDecFromString("-0.01554"),
-		alloraMath.MustNewDecFromString("0.00392"), alloraMath.MustNewDecFromString("0.00559"), alloraMath.MustNewDecFromString("0.00545"),
-		alloraMath.MustNewDecFromString("0.0438"), alloraMath.MustNewDecFromString("0.04304"), alloraMath.MustNewDecFromString("0.03906"),
-		alloraMath.MustNewDecFromString("0.09719"), alloraMath.MustNewDecFromString("0.09675"), alloraMath.MustNewDecFromString("0.09418"),
+		alloraMath.MustNewDecFromString(
+			"-0.00675",
+		), alloraMath.MustNewDecFromString("-0.00622"), alloraMath.MustNewDecFromString("-0.00388"),
+		alloraMath.MustNewDecFromString(
+			"-0.01502",
+		), alloraMath.MustNewDecFromString("-0.01214"), alloraMath.MustNewDecFromString("-0.01554"),
+		alloraMath.MustNewDecFromString(
+			"0.00392",
+		), alloraMath.MustNewDecFromString("0.00559"), alloraMath.MustNewDecFromString("0.00545"),
+		alloraMath.MustNewDecFromString(
+			"0.0438",
+		), alloraMath.MustNewDecFromString("0.04304"), alloraMath.MustNewDecFromString("0.03906"),
+		alloraMath.MustNewDecFromString(
+			"0.09719",
+		), alloraMath.MustNewDecFromString("0.09675"), alloraMath.MustNewDecFromString("0.09418"),
 	}
 	pReward := alloraMath.MustNewDecFromString("1.5")
 	cReward := alloraMath.MustNewDecFromString("0.75")
@@ -360,7 +398,13 @@ func TestGetScoreFractions(t *testing.T) {
 		alloraMath.MustNewDecFromString("0.60248987755351395"),
 	}
 
-	got, err := rewards.GetScoreFractions(latestWorkerScores, latestTimeStepsScores, pReward, cReward, epsilon)
+	got, err := rewards.GetScoreFractions(
+		latestWorkerScores,
+		latestTimeStepsScores,
+		pReward,
+		cReward,
+		epsilon,
+	)
 	require.NoError(t, err)
 
 	for i := range want {
@@ -385,11 +429,29 @@ func TestCalculateReputerRewardFractions(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "basic",
-			stakes:  []alloraMath.Dec{alloraMath.MustNewDecFromString("1178377.89152"), alloraMath.MustNewDecFromString("385287.87376"), alloraMath.MustNewDecFromString("395488.13091"), alloraMath.MustNewDecFromString("208201.11762"), alloraMath.MustNewDecFromString("369044.55988")},
-			scores:  []alloraMath.Dec{alloraMath.MustNewDecFromString("17.53839"), alloraMath.MustNewDecFromString("22.63517"), alloraMath.MustNewDecFromString("26.28035"), alloraMath.MustNewDecFromString("13.51383"), alloraMath.MustNewDecFromString("15.08629")},
+			name: "basic",
+			stakes: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("1178377.89152"),
+				alloraMath.MustNewDecFromString("385287.87376"),
+				alloraMath.MustNewDecFromString("395488.13091"),
+				alloraMath.MustNewDecFromString("208201.11762"),
+				alloraMath.MustNewDecFromString("369044.55988"),
+			},
+			scores: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("17.53839"),
+				alloraMath.MustNewDecFromString("22.63517"),
+				alloraMath.MustNewDecFromString("26.28035"),
+				alloraMath.MustNewDecFromString("13.51383"),
+				alloraMath.MustNewDecFromString("15.08629"),
+			},
 			preward: alloraMath.OneDec(),
-			want:    []alloraMath.Dec{alloraMath.MustNewDecFromString("0.42911"), alloraMath.MustNewDecFromString("0.18108"), alloraMath.MustNewDecFromString("0.2158"), alloraMath.MustNewDecFromString("0.05842"), alloraMath.MustNewDecFromString("0.1156")},
+			want: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("0.42911"),
+				alloraMath.MustNewDecFromString("0.18108"),
+				alloraMath.MustNewDecFromString("0.2158"),
+				alloraMath.MustNewDecFromString("0.05842"),
+				alloraMath.MustNewDecFromString("0.1156"),
+			},
 			wantErr: false,
 		},
 	}
@@ -426,20 +488,324 @@ func TestGetStakeWeightedLossMatrix(t *testing.T) {
 				alloraMath.MustNewDecFromString("0.71687"),
 			},
 			reputersReportedLosses: [][]alloraMath.Dec{
-				{alloraMath.MustNewDecFromString("0.0112"), alloraMath.MustNewDecFromString("0.00231"), alloraMath.MustNewDecFromString("0.02274"), alloraMath.MustNewDecFromString("0.01299"), alloraMath.MustNewDecFromString("0.02515"), alloraMath.MustNewDecFromString("0.0185"), alloraMath.MustNewDecFromString("0.01018"), alloraMath.MustNewDecFromString("0.02105"), alloraMath.MustNewDecFromString("0.01041"), alloraMath.MustNewDecFromString("0.0183"), alloraMath.MustNewDecFromString("0.01022"), alloraMath.MustNewDecFromString("0.01333"), alloraMath.MustNewDecFromString("0.01298"), alloraMath.MustNewDecFromString("0.01023"), alloraMath.MustNewDecFromString("0.01268"), alloraMath.MustNewDecFromString("0.01381"), alloraMath.MustNewDecFromString("0.01731"), alloraMath.MustNewDecFromString("0.01238"), alloraMath.MustNewDecFromString("0.01168"), alloraMath.MustNewDecFromString("0.00929"), alloraMath.MustNewDecFromString("0.01212"), alloraMath.MustNewDecFromString("0.01806"), alloraMath.MustNewDecFromString("0.01901"), alloraMath.MustNewDecFromString("0.01828"), alloraMath.MustNewDecFromString("0.01522"), alloraMath.MustNewDecFromString("0.01833"), alloraMath.MustNewDecFromString("0.0101"), alloraMath.MustNewDecFromString("0.01224"), alloraMath.MustNewDecFromString("0.01226"), alloraMath.MustNewDecFromString("0.01474"), alloraMath.MustNewDecFromString("0.01218"), alloraMath.MustNewDecFromString("0.01604"), alloraMath.MustNewDecFromString("0.01149"), alloraMath.MustNewDecFromString("0.02075"), alloraMath.MustNewDecFromString("0.00818"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01127"), alloraMath.MustNewDecFromString("0.01495"), alloraMath.MustNewDecFromString("0.00689"), alloraMath.MustNewDecFromString("0.0108"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.0124"), alloraMath.MustNewDecFromString("0.01588"), alloraMath.MustNewDecFromString("0.01012"), alloraMath.MustNewDecFromString("0.01467"), alloraMath.MustNewDecFromString("0.0128"), alloraMath.MustNewDecFromString("0.01234"), alloraMath.MustNewDecFromString("0.0148"), alloraMath.MustNewDecFromString("0.01046"), alloraMath.MustNewDecFromString("0.01192"), alloraMath.MustNewDecFromString("0.01381"), alloraMath.MustNewDecFromString("0.01687"), alloraMath.MustNewDecFromString("0.01136"), alloraMath.MustNewDecFromString("0.01185"), alloraMath.MustNewDecFromString("0.01568"), alloraMath.MustNewDecFromString("0.00949"), alloraMath.MustNewDecFromString("0.01339")},
-				{alloraMath.MustNewDecFromString("0.01635"), alloraMath.MustNewDecFromString("0.00179"), alloraMath.MustNewDecFromString("0.03396"), alloraMath.MustNewDecFromString("0.0153"), alloraMath.MustNewDecFromString("0.01988"), alloraMath.MustNewDecFromString("0.00962"), alloraMath.MustNewDecFromString("0.01191"), alloraMath.MustNewDecFromString("0.01616"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.01216"), alloraMath.MustNewDecFromString("0.01292"), alloraMath.MustNewDecFromString("0.01564"), alloraMath.MustNewDecFromString("0.01323"), alloraMath.MustNewDecFromString("0.01261"), alloraMath.MustNewDecFromString("0.01145"), alloraMath.MustNewDecFromString("0.0163"), alloraMath.MustNewDecFromString("0.014"), alloraMath.MustNewDecFromString("0.01373"), alloraMath.MustNewDecFromString("0.01453"), alloraMath.MustNewDecFromString("0.01207"), alloraMath.MustNewDecFromString("0.01641"), alloraMath.MustNewDecFromString("0.01601"), alloraMath.MustNewDecFromString("0.01114"), alloraMath.MustNewDecFromString("0.01259"), alloraMath.MustNewDecFromString("0.01589"), alloraMath.MustNewDecFromString("0.01229"), alloraMath.MustNewDecFromString("0.01309"), alloraMath.MustNewDecFromString("0.0138"), alloraMath.MustNewDecFromString("0.01162"), alloraMath.MustNewDecFromString("0.01145"), alloraMath.MustNewDecFromString("0.01013"), alloraMath.MustNewDecFromString("0.01208"), alloraMath.MustNewDecFromString("0.0111"), alloraMath.MustNewDecFromString("0.0118"), alloraMath.MustNewDecFromString("0.01374"), alloraMath.MustNewDecFromString("0.01428"), alloraMath.MustNewDecFromString("0.01791"), alloraMath.MustNewDecFromString("0.01288"), alloraMath.MustNewDecFromString("0.01161"), alloraMath.MustNewDecFromString("0.01151"), alloraMath.MustNewDecFromString("0.01148"), alloraMath.MustNewDecFromString("0.01284"), alloraMath.MustNewDecFromString("0.01239"), alloraMath.MustNewDecFromString("0.01023"), alloraMath.MustNewDecFromString("0.01712"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01639"), alloraMath.MustNewDecFromString("0.01043"), alloraMath.MustNewDecFromString("0.01308"), alloraMath.MustNewDecFromString("0.01455"), alloraMath.MustNewDecFromString("0.01607"), alloraMath.MustNewDecFromString("0.01205"), alloraMath.MustNewDecFromString("0.01357"), alloraMath.MustNewDecFromString("0.01108"), alloraMath.MustNewDecFromString("0.01633"), alloraMath.MustNewDecFromString("0.01208"), alloraMath.MustNewDecFromString("0.01278")},
-				{alloraMath.MustNewDecFromString("0.01345"), alloraMath.MustNewDecFromString("0.00209"), alloraMath.MustNewDecFromString("0.03249"), alloraMath.MustNewDecFromString("0.01688"), alloraMath.MustNewDecFromString("0.02126"), alloraMath.MustNewDecFromString("0.01338"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01605"), alloraMath.MustNewDecFromString("0.0133"), alloraMath.MustNewDecFromString("0.01407"), alloraMath.MustNewDecFromString("0.01367"), alloraMath.MustNewDecFromString("0.01244"), alloraMath.MustNewDecFromString("0.0145"), alloraMath.MustNewDecFromString("0.01262"), alloraMath.MustNewDecFromString("0.01348"), alloraMath.MustNewDecFromString("0.01684"), alloraMath.MustNewDecFromString("0.01148"), alloraMath.MustNewDecFromString("0.01705"), alloraMath.MustNewDecFromString("0.01714"), alloraMath.MustNewDecFromString("0.0124"), alloraMath.MustNewDecFromString("0.0125"), alloraMath.MustNewDecFromString("0.01462"), alloraMath.MustNewDecFromString("0.01274"), alloraMath.MustNewDecFromString("0.01407"), alloraMath.MustNewDecFromString("0.01667"), alloraMath.MustNewDecFromString("0.01316"), alloraMath.MustNewDecFromString("0.01628"), alloraMath.MustNewDecFromString("0.01373"), alloraMath.MustNewDecFromString("0.01409"), alloraMath.MustNewDecFromString("0.01603"), alloraMath.MustNewDecFromString("0.01378"), alloraMath.MustNewDecFromString("0.01143"), alloraMath.MustNewDecFromString("0.013"), alloraMath.MustNewDecFromString("0.01644"), alloraMath.MustNewDecFromString("0.01528"), alloraMath.MustNewDecFromString("0.01441"), alloraMath.MustNewDecFromString("0.01404"), alloraMath.MustNewDecFromString("0.01402"), alloraMath.MustNewDecFromString("0.01479"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.01244"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01419"), alloraMath.MustNewDecFromString("0.01497"), alloraMath.MustNewDecFromString("0.01629"), alloraMath.MustNewDecFromString("0.01514"), alloraMath.MustNewDecFromString("0.01133"), alloraMath.MustNewDecFromString("0.01339"), alloraMath.MustNewDecFromString("0.01053"), alloraMath.MustNewDecFromString("0.01424"), alloraMath.MustNewDecFromString("0.01428"), alloraMath.MustNewDecFromString("0.01446"), alloraMath.MustNewDecFromString("0.01805"), alloraMath.MustNewDecFromString("0.01229"), alloraMath.MustNewDecFromString("0.01586"), alloraMath.MustNewDecFromString("0.01234"), alloraMath.MustNewDecFromString("0.01513")},
-				{alloraMath.MustNewDecFromString("0.01675"), alloraMath.MustNewDecFromString("0.00318"), alloraMath.MustNewDecFromString("0.02623"), alloraMath.MustNewDecFromString("0.02734"), alloraMath.MustNewDecFromString("0.03526"), alloraMath.MustNewDecFromString("0.02733"), alloraMath.MustNewDecFromString("0.01697"), alloraMath.MustNewDecFromString("0.01619"), alloraMath.MustNewDecFromString("0.01925"), alloraMath.MustNewDecFromString("0.02018"), alloraMath.MustNewDecFromString("0.01735"), alloraMath.MustNewDecFromString("0.01922"), alloraMath.MustNewDecFromString("0.02225"), alloraMath.MustNewDecFromString("0.0189"), alloraMath.MustNewDecFromString("0.01923"), alloraMath.MustNewDecFromString("0.03193"), alloraMath.MustNewDecFromString("0.01956"), alloraMath.MustNewDecFromString("0.01763"), alloraMath.MustNewDecFromString("0.01975"), alloraMath.MustNewDecFromString("0.01466"), alloraMath.MustNewDecFromString("0.02021"), alloraMath.MustNewDecFromString("0.01803"), alloraMath.MustNewDecFromString("0.01438"), alloraMath.MustNewDecFromString("0.01929"), alloraMath.MustNewDecFromString("0.02305"), alloraMath.MustNewDecFromString("0.02223"), alloraMath.MustNewDecFromString("0.02445"), alloraMath.MustNewDecFromString("0.01967"), alloraMath.MustNewDecFromString("0.02292"), alloraMath.MustNewDecFromString("0.01878"), alloraMath.MustNewDecFromString("0.01751"), alloraMath.MustNewDecFromString("0.02695"), alloraMath.MustNewDecFromString("0.01849"), alloraMath.MustNewDecFromString("0.01658"), alloraMath.MustNewDecFromString("0.01948"), alloraMath.MustNewDecFromString("0.01594"), alloraMath.MustNewDecFromString("0.02318"), alloraMath.MustNewDecFromString("0.01906"), alloraMath.MustNewDecFromString("0.01607"), alloraMath.MustNewDecFromString("0.01369"), alloraMath.MustNewDecFromString("0.01686"), alloraMath.MustNewDecFromString("0.01314"), alloraMath.MustNewDecFromString("0.01936"), alloraMath.MustNewDecFromString("0.01518"), alloraMath.MustNewDecFromString("0.018"), alloraMath.MustNewDecFromString("0.02212"), alloraMath.MustNewDecFromString("0.02259"), alloraMath.MustNewDecFromString("0.01674"), alloraMath.MustNewDecFromString("0.02944"), alloraMath.MustNewDecFromString("0.01796"), alloraMath.MustNewDecFromString("0.02187"), alloraMath.MustNewDecFromString("0.01895"), alloraMath.MustNewDecFromString("0.01637"), alloraMath.MustNewDecFromString("0.01594"), alloraMath.MustNewDecFromString("0.01608"), alloraMath.MustNewDecFromString("0.02203"), alloraMath.MustNewDecFromString("0.01486")},
-				{alloraMath.MustNewDecFromString("0.02093"), alloraMath.MustNewDecFromString("0.00213"), alloraMath.MustNewDecFromString("0.02462"), alloraMath.MustNewDecFromString("0.0203"), alloraMath.MustNewDecFromString("0.03115"), alloraMath.MustNewDecFromString("0.01"), alloraMath.MustNewDecFromString("0.01545"), alloraMath.MustNewDecFromString("0.01785"), alloraMath.MustNewDecFromString("0.01662"), alloraMath.MustNewDecFromString("0.01156"), alloraMath.MustNewDecFromString("0.02284"), alloraMath.MustNewDecFromString("0.01475"), alloraMath.MustNewDecFromString("0.01331"), alloraMath.MustNewDecFromString("0.01592"), alloraMath.MustNewDecFromString("0.01462"), alloraMath.MustNewDecFromString("0.02333"), alloraMath.MustNewDecFromString("0.01836"), alloraMath.MustNewDecFromString("0.01465"), alloraMath.MustNewDecFromString("0.0186"), alloraMath.MustNewDecFromString("0.01566"), alloraMath.MustNewDecFromString("0.01506"), alloraMath.MustNewDecFromString("0.01678"), alloraMath.MustNewDecFromString("0.01423"), alloraMath.MustNewDecFromString("0.01658"), alloraMath.MustNewDecFromString("0.01741"), alloraMath.MustNewDecFromString("0.03491"), alloraMath.MustNewDecFromString("0.01408"), alloraMath.MustNewDecFromString("0.01191"), alloraMath.MustNewDecFromString("0.01572"), alloraMath.MustNewDecFromString("0.01355"), alloraMath.MustNewDecFromString("0.01477"), alloraMath.MustNewDecFromString("0.01662"), alloraMath.MustNewDecFromString("0.01128"), alloraMath.MustNewDecFromString("0.02581"), alloraMath.MustNewDecFromString("0.01718"), alloraMath.MustNewDecFromString("0.01705"), alloraMath.MustNewDecFromString("0.01251"), alloraMath.MustNewDecFromString("0.02158"), alloraMath.MustNewDecFromString("0.01187"), alloraMath.MustNewDecFromString("0.01504"), alloraMath.MustNewDecFromString("0.0135"), alloraMath.MustNewDecFromString("0.02432"), alloraMath.MustNewDecFromString("0.01602"), alloraMath.MustNewDecFromString("0.01194"), alloraMath.MustNewDecFromString("0.0153"), alloraMath.MustNewDecFromString("0.0199"), alloraMath.MustNewDecFromString("0.01673"), alloraMath.MustNewDecFromString("0.01049"), alloraMath.MustNewDecFromString("0.02068"), alloraMath.MustNewDecFromString("0.01573"), alloraMath.MustNewDecFromString("0.01487"), alloraMath.MustNewDecFromString("0.02639"), alloraMath.MustNewDecFromString("0.01981"), alloraMath.MustNewDecFromString("0.02123"), alloraMath.MustNewDecFromString("0.02134"), alloraMath.MustNewDecFromString("0.0217"), alloraMath.MustNewDecFromString("0.01177")},
+				{
+					alloraMath.MustNewDecFromString("0.0112"),
+					alloraMath.MustNewDecFromString("0.00231"),
+					alloraMath.MustNewDecFromString("0.02274"),
+					alloraMath.MustNewDecFromString("0.01299"),
+					alloraMath.MustNewDecFromString("0.02515"),
+					alloraMath.MustNewDecFromString("0.0185"),
+					alloraMath.MustNewDecFromString("0.01018"),
+					alloraMath.MustNewDecFromString("0.02105"),
+					alloraMath.MustNewDecFromString("0.01041"),
+					alloraMath.MustNewDecFromString("0.0183"),
+					alloraMath.MustNewDecFromString("0.01022"),
+					alloraMath.MustNewDecFromString("0.01333"),
+					alloraMath.MustNewDecFromString("0.01298"),
+					alloraMath.MustNewDecFromString("0.01023"),
+					alloraMath.MustNewDecFromString("0.01268"),
+					alloraMath.MustNewDecFromString("0.01381"),
+					alloraMath.MustNewDecFromString("0.01731"),
+					alloraMath.MustNewDecFromString("0.01238"),
+					alloraMath.MustNewDecFromString("0.01168"),
+					alloraMath.MustNewDecFromString("0.00929"),
+					alloraMath.MustNewDecFromString("0.01212"),
+					alloraMath.MustNewDecFromString("0.01806"),
+					alloraMath.MustNewDecFromString("0.01901"),
+					alloraMath.MustNewDecFromString("0.01828"),
+					alloraMath.MustNewDecFromString("0.01522"),
+					alloraMath.MustNewDecFromString("0.01833"),
+					alloraMath.MustNewDecFromString("0.0101"),
+					alloraMath.MustNewDecFromString("0.01224"),
+					alloraMath.MustNewDecFromString("0.01226"),
+					alloraMath.MustNewDecFromString("0.01474"),
+					alloraMath.MustNewDecFromString("0.01218"),
+					alloraMath.MustNewDecFromString("0.01604"),
+					alloraMath.MustNewDecFromString("0.01149"),
+					alloraMath.MustNewDecFromString("0.02075"),
+					alloraMath.MustNewDecFromString("0.00818"),
+					alloraMath.MustNewDecFromString("0.0116"),
+					alloraMath.MustNewDecFromString("0.01127"),
+					alloraMath.MustNewDecFromString("0.01495"),
+					alloraMath.MustNewDecFromString("0.00689"),
+					alloraMath.MustNewDecFromString("0.0108"),
+					alloraMath.MustNewDecFromString("0.01417"),
+					alloraMath.MustNewDecFromString("0.0124"),
+					alloraMath.MustNewDecFromString("0.01588"),
+					alloraMath.MustNewDecFromString("0.01012"),
+					alloraMath.MustNewDecFromString("0.01467"),
+					alloraMath.MustNewDecFromString("0.0128"),
+					alloraMath.MustNewDecFromString("0.01234"),
+					alloraMath.MustNewDecFromString("0.0148"),
+					alloraMath.MustNewDecFromString("0.01046"),
+					alloraMath.MustNewDecFromString("0.01192"),
+					alloraMath.MustNewDecFromString("0.01381"),
+					alloraMath.MustNewDecFromString("0.01687"),
+					alloraMath.MustNewDecFromString("0.01136"),
+					alloraMath.MustNewDecFromString("0.01185"),
+					alloraMath.MustNewDecFromString("0.01568"),
+					alloraMath.MustNewDecFromString("0.00949"),
+					alloraMath.MustNewDecFromString("0.01339"),
+				},
+				{
+					alloraMath.MustNewDecFromString("0.01635"),
+					alloraMath.MustNewDecFromString("0.00179"),
+					alloraMath.MustNewDecFromString("0.03396"),
+					alloraMath.MustNewDecFromString("0.0153"),
+					alloraMath.MustNewDecFromString("0.01988"),
+					alloraMath.MustNewDecFromString("0.00962"),
+					alloraMath.MustNewDecFromString("0.01191"),
+					alloraMath.MustNewDecFromString("0.01616"),
+					alloraMath.MustNewDecFromString("0.01417"),
+					alloraMath.MustNewDecFromString("0.01216"),
+					alloraMath.MustNewDecFromString("0.01292"),
+					alloraMath.MustNewDecFromString("0.01564"),
+					alloraMath.MustNewDecFromString("0.01323"),
+					alloraMath.MustNewDecFromString("0.01261"),
+					alloraMath.MustNewDecFromString("0.01145"),
+					alloraMath.MustNewDecFromString("0.0163"),
+					alloraMath.MustNewDecFromString("0.014"),
+					alloraMath.MustNewDecFromString("0.01373"),
+					alloraMath.MustNewDecFromString("0.01453"),
+					alloraMath.MustNewDecFromString("0.01207"),
+					alloraMath.MustNewDecFromString("0.01641"),
+					alloraMath.MustNewDecFromString("0.01601"),
+					alloraMath.MustNewDecFromString("0.01114"),
+					alloraMath.MustNewDecFromString("0.01259"),
+					alloraMath.MustNewDecFromString("0.01589"),
+					alloraMath.MustNewDecFromString("0.01229"),
+					alloraMath.MustNewDecFromString("0.01309"),
+					alloraMath.MustNewDecFromString("0.0138"),
+					alloraMath.MustNewDecFromString("0.01162"),
+					alloraMath.MustNewDecFromString("0.01145"),
+					alloraMath.MustNewDecFromString("0.01013"),
+					alloraMath.MustNewDecFromString("0.01208"),
+					alloraMath.MustNewDecFromString("0.0111"),
+					alloraMath.MustNewDecFromString("0.0118"),
+					alloraMath.MustNewDecFromString("0.01374"),
+					alloraMath.MustNewDecFromString("0.01428"),
+					alloraMath.MustNewDecFromString("0.01791"),
+					alloraMath.MustNewDecFromString("0.01288"),
+					alloraMath.MustNewDecFromString("0.01161"),
+					alloraMath.MustNewDecFromString("0.01151"),
+					alloraMath.MustNewDecFromString("0.01148"),
+					alloraMath.MustNewDecFromString("0.01284"),
+					alloraMath.MustNewDecFromString("0.01239"),
+					alloraMath.MustNewDecFromString("0.01023"),
+					alloraMath.MustNewDecFromString("0.01712"),
+					alloraMath.MustNewDecFromString("0.0116"),
+					alloraMath.MustNewDecFromString("0.01639"),
+					alloraMath.MustNewDecFromString("0.01043"),
+					alloraMath.MustNewDecFromString("0.01308"),
+					alloraMath.MustNewDecFromString("0.01455"),
+					alloraMath.MustNewDecFromString("0.01607"),
+					alloraMath.MustNewDecFromString("0.01205"),
+					alloraMath.MustNewDecFromString("0.01357"),
+					alloraMath.MustNewDecFromString("0.01108"),
+					alloraMath.MustNewDecFromString("0.01633"),
+					alloraMath.MustNewDecFromString("0.01208"),
+					alloraMath.MustNewDecFromString("0.01278"),
+				},
+				{
+					alloraMath.MustNewDecFromString("0.01345"),
+					alloraMath.MustNewDecFromString("0.00209"),
+					alloraMath.MustNewDecFromString("0.03249"),
+					alloraMath.MustNewDecFromString("0.01688"),
+					alloraMath.MustNewDecFromString("0.02126"),
+					alloraMath.MustNewDecFromString("0.01338"),
+					alloraMath.MustNewDecFromString("0.0116"),
+					alloraMath.MustNewDecFromString("0.01605"),
+					alloraMath.MustNewDecFromString("0.0133"),
+					alloraMath.MustNewDecFromString("0.01407"),
+					alloraMath.MustNewDecFromString("0.01367"),
+					alloraMath.MustNewDecFromString("0.01244"),
+					alloraMath.MustNewDecFromString("0.0145"),
+					alloraMath.MustNewDecFromString("0.01262"),
+					alloraMath.MustNewDecFromString("0.01348"),
+					alloraMath.MustNewDecFromString("0.01684"),
+					alloraMath.MustNewDecFromString("0.01148"),
+					alloraMath.MustNewDecFromString("0.01705"),
+					alloraMath.MustNewDecFromString("0.01714"),
+					alloraMath.MustNewDecFromString("0.0124"),
+					alloraMath.MustNewDecFromString("0.0125"),
+					alloraMath.MustNewDecFromString("0.01462"),
+					alloraMath.MustNewDecFromString("0.01274"),
+					alloraMath.MustNewDecFromString("0.01407"),
+					alloraMath.MustNewDecFromString("0.01667"),
+					alloraMath.MustNewDecFromString("0.01316"),
+					alloraMath.MustNewDecFromString("0.01628"),
+					alloraMath.MustNewDecFromString("0.01373"),
+					alloraMath.MustNewDecFromString("0.01409"),
+					alloraMath.MustNewDecFromString("0.01603"),
+					alloraMath.MustNewDecFromString("0.01378"),
+					alloraMath.MustNewDecFromString("0.01143"),
+					alloraMath.MustNewDecFromString("0.013"),
+					alloraMath.MustNewDecFromString("0.01644"),
+					alloraMath.MustNewDecFromString("0.01528"),
+					alloraMath.MustNewDecFromString("0.01441"),
+					alloraMath.MustNewDecFromString("0.01404"),
+					alloraMath.MustNewDecFromString("0.01402"),
+					alloraMath.MustNewDecFromString("0.01479"),
+					alloraMath.MustNewDecFromString("0.01417"),
+					alloraMath.MustNewDecFromString("0.01244"),
+					alloraMath.MustNewDecFromString("0.0116"),
+					alloraMath.MustNewDecFromString("0.01419"),
+					alloraMath.MustNewDecFromString("0.01497"),
+					alloraMath.MustNewDecFromString("0.01629"),
+					alloraMath.MustNewDecFromString("0.01514"),
+					alloraMath.MustNewDecFromString("0.01133"),
+					alloraMath.MustNewDecFromString("0.01339"),
+					alloraMath.MustNewDecFromString("0.01053"),
+					alloraMath.MustNewDecFromString("0.01424"),
+					alloraMath.MustNewDecFromString("0.01428"),
+					alloraMath.MustNewDecFromString("0.01446"),
+					alloraMath.MustNewDecFromString("0.01805"),
+					alloraMath.MustNewDecFromString("0.01229"),
+					alloraMath.MustNewDecFromString("0.01586"),
+					alloraMath.MustNewDecFromString("0.01234"),
+					alloraMath.MustNewDecFromString("0.01513"),
+				},
+				{
+					alloraMath.MustNewDecFromString("0.01675"),
+					alloraMath.MustNewDecFromString("0.00318"),
+					alloraMath.MustNewDecFromString("0.02623"),
+					alloraMath.MustNewDecFromString("0.02734"),
+					alloraMath.MustNewDecFromString("0.03526"),
+					alloraMath.MustNewDecFromString("0.02733"),
+					alloraMath.MustNewDecFromString("0.01697"),
+					alloraMath.MustNewDecFromString("0.01619"),
+					alloraMath.MustNewDecFromString("0.01925"),
+					alloraMath.MustNewDecFromString("0.02018"),
+					alloraMath.MustNewDecFromString("0.01735"),
+					alloraMath.MustNewDecFromString("0.01922"),
+					alloraMath.MustNewDecFromString("0.02225"),
+					alloraMath.MustNewDecFromString("0.0189"),
+					alloraMath.MustNewDecFromString("0.01923"),
+					alloraMath.MustNewDecFromString("0.03193"),
+					alloraMath.MustNewDecFromString("0.01956"),
+					alloraMath.MustNewDecFromString("0.01763"),
+					alloraMath.MustNewDecFromString("0.01975"),
+					alloraMath.MustNewDecFromString("0.01466"),
+					alloraMath.MustNewDecFromString("0.02021"),
+					alloraMath.MustNewDecFromString("0.01803"),
+					alloraMath.MustNewDecFromString("0.01438"),
+					alloraMath.MustNewDecFromString("0.01929"),
+					alloraMath.MustNewDecFromString("0.02305"),
+					alloraMath.MustNewDecFromString("0.02223"),
+					alloraMath.MustNewDecFromString("0.02445"),
+					alloraMath.MustNewDecFromString("0.01967"),
+					alloraMath.MustNewDecFromString("0.02292"),
+					alloraMath.MustNewDecFromString("0.01878"),
+					alloraMath.MustNewDecFromString("0.01751"),
+					alloraMath.MustNewDecFromString("0.02695"),
+					alloraMath.MustNewDecFromString("0.01849"),
+					alloraMath.MustNewDecFromString("0.01658"),
+					alloraMath.MustNewDecFromString("0.01948"),
+					alloraMath.MustNewDecFromString("0.01594"),
+					alloraMath.MustNewDecFromString("0.02318"),
+					alloraMath.MustNewDecFromString("0.01906"),
+					alloraMath.MustNewDecFromString("0.01607"),
+					alloraMath.MustNewDecFromString("0.01369"),
+					alloraMath.MustNewDecFromString("0.01686"),
+					alloraMath.MustNewDecFromString("0.01314"),
+					alloraMath.MustNewDecFromString("0.01936"),
+					alloraMath.MustNewDecFromString("0.01518"),
+					alloraMath.MustNewDecFromString("0.018"),
+					alloraMath.MustNewDecFromString("0.02212"),
+					alloraMath.MustNewDecFromString("0.02259"),
+					alloraMath.MustNewDecFromString("0.01674"),
+					alloraMath.MustNewDecFromString("0.02944"),
+					alloraMath.MustNewDecFromString("0.01796"),
+					alloraMath.MustNewDecFromString("0.02187"),
+					alloraMath.MustNewDecFromString("0.01895"),
+					alloraMath.MustNewDecFromString("0.01637"),
+					alloraMath.MustNewDecFromString("0.01594"),
+					alloraMath.MustNewDecFromString("0.01608"),
+					alloraMath.MustNewDecFromString("0.02203"),
+					alloraMath.MustNewDecFromString("0.01486"),
+				},
+				{
+					alloraMath.MustNewDecFromString("0.02093"),
+					alloraMath.MustNewDecFromString("0.00213"),
+					alloraMath.MustNewDecFromString("0.02462"),
+					alloraMath.MustNewDecFromString("0.0203"),
+					alloraMath.MustNewDecFromString("0.03115"),
+					alloraMath.MustNewDecFromString("0.01"),
+					alloraMath.MustNewDecFromString("0.01545"),
+					alloraMath.MustNewDecFromString("0.01785"),
+					alloraMath.MustNewDecFromString("0.01662"),
+					alloraMath.MustNewDecFromString("0.01156"),
+					alloraMath.MustNewDecFromString("0.02284"),
+					alloraMath.MustNewDecFromString("0.01475"),
+					alloraMath.MustNewDecFromString("0.01331"),
+					alloraMath.MustNewDecFromString("0.01592"),
+					alloraMath.MustNewDecFromString("0.01462"),
+					alloraMath.MustNewDecFromString("0.02333"),
+					alloraMath.MustNewDecFromString("0.01836"),
+					alloraMath.MustNewDecFromString("0.01465"),
+					alloraMath.MustNewDecFromString("0.0186"),
+					alloraMath.MustNewDecFromString("0.01566"),
+					alloraMath.MustNewDecFromString("0.01506"),
+					alloraMath.MustNewDecFromString("0.01678"),
+					alloraMath.MustNewDecFromString("0.01423"),
+					alloraMath.MustNewDecFromString("0.01658"),
+					alloraMath.MustNewDecFromString("0.01741"),
+					alloraMath.MustNewDecFromString("0.03491"),
+					alloraMath.MustNewDecFromString("0.01408"),
+					alloraMath.MustNewDecFromString("0.01191"),
+					alloraMath.MustNewDecFromString("0.01572"),
+					alloraMath.MustNewDecFromString("0.01355"),
+					alloraMath.MustNewDecFromString("0.01477"),
+					alloraMath.MustNewDecFromString("0.01662"),
+					alloraMath.MustNewDecFromString("0.01128"),
+					alloraMath.MustNewDecFromString("0.02581"),
+					alloraMath.MustNewDecFromString("0.01718"),
+					alloraMath.MustNewDecFromString("0.01705"),
+					alloraMath.MustNewDecFromString("0.01251"),
+					alloraMath.MustNewDecFromString("0.02158"),
+					alloraMath.MustNewDecFromString("0.01187"),
+					alloraMath.MustNewDecFromString("0.01504"),
+					alloraMath.MustNewDecFromString("0.0135"),
+					alloraMath.MustNewDecFromString("0.02432"),
+					alloraMath.MustNewDecFromString("0.01602"),
+					alloraMath.MustNewDecFromString("0.01194"),
+					alloraMath.MustNewDecFromString("0.0153"),
+					alloraMath.MustNewDecFromString("0.0199"),
+					alloraMath.MustNewDecFromString("0.01673"),
+					alloraMath.MustNewDecFromString("0.01049"),
+					alloraMath.MustNewDecFromString("0.02068"),
+					alloraMath.MustNewDecFromString("0.01573"),
+					alloraMath.MustNewDecFromString("0.01487"),
+					alloraMath.MustNewDecFromString("0.02639"),
+					alloraMath.MustNewDecFromString("0.01981"),
+					alloraMath.MustNewDecFromString("0.02123"),
+					alloraMath.MustNewDecFromString("0.02134"),
+					alloraMath.MustNewDecFromString("0.0217"),
+					alloraMath.MustNewDecFromString("0.01177"),
+				},
 			},
 			want: []alloraMath.Dec{
-				alloraMath.MustNewDecFromString("0.0152671"), alloraMath.MustNewDecFromString("0.002216"), alloraMath.MustNewDecFromString("0.02790"), alloraMath.MustNewDecFromString("0.017319"), alloraMath.MustNewDecFromString("0.025520"), alloraMath.MustNewDecFromString("0.0148812"), alloraMath.MustNewDecFromString("0.012625"), alloraMath.MustNewDecFromString("0.01780378"), alloraMath.MustNewDecFromString("0.0140014"),
-				alloraMath.MustNewDecFromString("0.015013"), alloraMath.MustNewDecFromString("0.014774"), alloraMath.MustNewDecFromString("0.014550"), alloraMath.MustNewDecFromString("0.0144484"), alloraMath.MustNewDecFromString("0.0133076"), alloraMath.MustNewDecFromString("0.0137"), alloraMath.MustNewDecFromString("0.018843"), alloraMath.MustNewDecFromString("0.0158344"), alloraMath.MustNewDecFromString("0.014681"),
-				alloraMath.MustNewDecFromString("0.015683"), alloraMath.MustNewDecFromString("0.012371"), alloraMath.MustNewDecFromString("0.014564"), alloraMath.MustNewDecFromString("0.0166473"), alloraMath.MustNewDecFromString("0.0145905"), alloraMath.MustNewDecFromString("0.01598"), alloraMath.MustNewDecFromString("0.01696"), alloraMath.MustNewDecFromString("0.01964"), alloraMath.MustNewDecFromString("0.0144"),
-				alloraMath.MustNewDecFromString("0.0136411"), alloraMath.MustNewDecFromString("0.014375"), alloraMath.MustNewDecFromString("0.0145467"), alloraMath.MustNewDecFromString("0.01319248"), alloraMath.MustNewDecFromString("0.01555"), alloraMath.MustNewDecFromString("0.01246"), alloraMath.MustNewDecFromString("0.01849"), alloraMath.MustNewDecFromString("0.01386"), alloraMath.MustNewDecFromString("0.01430"),
-				alloraMath.MustNewDecFromString("0.0148031"), alloraMath.MustNewDecFromString("0.016073"), alloraMath.MustNewDecFromString("0.01154604"), alloraMath.MustNewDecFromString("0.01281518"), alloraMath.MustNewDecFromString("0.01340968"), alloraMath.MustNewDecFromString("0.014733235"), alloraMath.MustNewDecFromString("0.01520795"), alloraMath.MustNewDecFromString("0.012093517"), alloraMath.MustNewDecFromString("0.0160167"),
-				alloraMath.MustNewDecFromString("0.01547095"), alloraMath.MustNewDecFromString("0.01496103"), alloraMath.MustNewDecFromString("0.01296408"), alloraMath.MustNewDecFromString("0.0151219369"), alloraMath.MustNewDecFromString("0.014375538"), alloraMath.MustNewDecFromString("0.01548074"), alloraMath.MustNewDecFromString("0.017446629"), alloraMath.MustNewDecFromString("0.015452587"), alloraMath.MustNewDecFromString("0.01407107"),
-				alloraMath.MustNewDecFromString("0.01700426"), alloraMath.MustNewDecFromString("0.014413132"), alloraMath.MustNewDecFromString("0.013480447"),
+				alloraMath.MustNewDecFromString(
+					"0.0152671",
+				), alloraMath.MustNewDecFromString("0.002216"), alloraMath.MustNewDecFromString("0.02790"), alloraMath.MustNewDecFromString("0.017319"), alloraMath.MustNewDecFromString("0.025520"), alloraMath.MustNewDecFromString("0.0148812"), alloraMath.MustNewDecFromString("0.012625"), alloraMath.MustNewDecFromString("0.01780378"), alloraMath.MustNewDecFromString("0.0140014"),
+				alloraMath.MustNewDecFromString(
+					"0.015013",
+				), alloraMath.MustNewDecFromString("0.014774"), alloraMath.MustNewDecFromString("0.014550"), alloraMath.MustNewDecFromString("0.0144484"), alloraMath.MustNewDecFromString("0.0133076"), alloraMath.MustNewDecFromString("0.0137"), alloraMath.MustNewDecFromString("0.018843"), alloraMath.MustNewDecFromString("0.0158344"), alloraMath.MustNewDecFromString("0.014681"),
+				alloraMath.MustNewDecFromString(
+					"0.015683",
+				), alloraMath.MustNewDecFromString("0.012371"), alloraMath.MustNewDecFromString("0.014564"), alloraMath.MustNewDecFromString("0.0166473"), alloraMath.MustNewDecFromString("0.0145905"), alloraMath.MustNewDecFromString("0.01598"), alloraMath.MustNewDecFromString("0.01696"), alloraMath.MustNewDecFromString("0.01964"), alloraMath.MustNewDecFromString("0.0144"),
+				alloraMath.MustNewDecFromString(
+					"0.0136411",
+				), alloraMath.MustNewDecFromString("0.014375"), alloraMath.MustNewDecFromString("0.0145467"), alloraMath.MustNewDecFromString("0.01319248"), alloraMath.MustNewDecFromString("0.01555"), alloraMath.MustNewDecFromString("0.01246"), alloraMath.MustNewDecFromString("0.01849"), alloraMath.MustNewDecFromString("0.01386"), alloraMath.MustNewDecFromString("0.01430"),
+				alloraMath.MustNewDecFromString(
+					"0.0148031",
+				), alloraMath.MustNewDecFromString("0.016073"), alloraMath.MustNewDecFromString("0.01154604"), alloraMath.MustNewDecFromString("0.01281518"), alloraMath.MustNewDecFromString("0.01340968"), alloraMath.MustNewDecFromString("0.014733235"), alloraMath.MustNewDecFromString("0.01520795"), alloraMath.MustNewDecFromString("0.012093517"), alloraMath.MustNewDecFromString("0.0160167"),
+				alloraMath.MustNewDecFromString(
+					"0.01547095",
+				), alloraMath.MustNewDecFromString("0.01496103"), alloraMath.MustNewDecFromString("0.01296408"), alloraMath.MustNewDecFromString("0.0151219369"), alloraMath.MustNewDecFromString("0.014375538"), alloraMath.MustNewDecFromString("0.01548074"), alloraMath.MustNewDecFromString("0.017446629"), alloraMath.MustNewDecFromString("0.015452587"), alloraMath.MustNewDecFromString("0.01407107"),
+				alloraMath.MustNewDecFromString(
+					"0.01700426",
+				), alloraMath.MustNewDecFromString("0.014413132"), alloraMath.MustNewDecFromString("0.013480447"),
 			},
 			wantErr: false,
 		},
@@ -447,7 +813,10 @@ func TestGetStakeWeightedLossMatrix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := rewards.GetStakeWeightedLossMatrix(tt.reputersAdjustedStakes, tt.reputersReportedLosses)
+			got, _, err := rewards.GetStakeWeightedLossMatrix(
+				tt.reputersAdjustedStakes,
+				tt.reputersReportedLosses,
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetStakeWeightedLossMatrix() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -475,12 +844,29 @@ func TestGetStakeWeightedLossMatrixWithMissingLosses(t *testing.T) {
 				alloraMath.MustNewDecFromString("1.0"),
 			},
 			reputersReportedLosses: [][]alloraMath.Dec{
-				{alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("2.0"), alloraMath.MustNewDecFromString("3.0"), alloraMath.MustNewDecFromString("4.0")},
-				{alloraMath.MustNewDecFromString("2.0"), alloraMath.NewNaN(), alloraMath.MustNewDecFromString("5.0"), alloraMath.MustNewDecFromString("3.0")},
-				{alloraMath.NewNaN(), alloraMath.NewNaN(), alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("2.0")},
+				{
+					alloraMath.MustNewDecFromString("1.0"),
+					alloraMath.MustNewDecFromString("2.0"),
+					alloraMath.MustNewDecFromString("3.0"),
+					alloraMath.MustNewDecFromString("4.0"),
+				},
+				{
+					alloraMath.MustNewDecFromString("2.0"),
+					alloraMath.NewNaN(),
+					alloraMath.MustNewDecFromString("5.0"),
+					alloraMath.MustNewDecFromString("3.0"),
+				},
+				{
+					alloraMath.NewNaN(),
+					alloraMath.NewNaN(),
+					alloraMath.MustNewDecFromString("1.0"),
+					alloraMath.MustNewDecFromString("2.0"),
+				},
 			},
 			want: []alloraMath.Dec{
-				alloraMath.MustNewDecFromString("1.5"), alloraMath.MustNewDecFromString("2.00000"), alloraMath.MustNewDecFromString("3.0"), alloraMath.MustNewDecFromString("2.999999"),
+				alloraMath.MustNewDecFromString(
+					"1.5",
+				), alloraMath.MustNewDecFromString("2.00000"), alloraMath.MustNewDecFromString("3.0"), alloraMath.MustNewDecFromString("2.999999"),
 			},
 			wantErr: false,
 		},
@@ -488,7 +874,10 @@ func TestGetStakeWeightedLossMatrixWithMissingLosses(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := rewards.GetStakeWeightedLossMatrix(tt.reputersAdjustedStakes, tt.reputersReportedLosses)
+			got, _, err := rewards.GetStakeWeightedLossMatrix(
+				tt.reputersAdjustedStakes,
+				tt.reputersReportedLosses,
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetStakeWeightedLossMatrix() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -509,11 +898,23 @@ func TestGetStakeWeightedLoss(t *testing.T) {
 		wantErr                bool
 	}{
 		{
-			name:                   "simple average",
-			reputersStakes:         []alloraMath.Dec{alloraMath.MustNewDecFromString("1176644.37627"), alloraMath.MustNewDecFromString("384623.3607"), alloraMath.MustNewDecFromString("394676.13226"), alloraMath.MustNewDecFromString("207999.66194"), alloraMath.MustNewDecFromString("368582.76542")},
-			reputersReportedLosses: []alloraMath.Dec{alloraMath.MustNewDecFromString("0.0112"), alloraMath.MustNewDecFromString("0.01635"), alloraMath.MustNewDecFromString("0.01345"), alloraMath.MustNewDecFromString("0.01675"), alloraMath.MustNewDecFromString("0.02093")},
-			want:                   alloraMath.MustNewDecFromString("0.0142047230098813"),
-			wantErr:                false,
+			name: "simple average",
+			reputersStakes: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("1176644.37627"),
+				alloraMath.MustNewDecFromString("384623.3607"),
+				alloraMath.MustNewDecFromString("394676.13226"),
+				alloraMath.MustNewDecFromString("207999.66194"),
+				alloraMath.MustNewDecFromString("368582.76542"),
+			},
+			reputersReportedLosses: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("0.0112"),
+				alloraMath.MustNewDecFromString("0.01635"),
+				alloraMath.MustNewDecFromString("0.01345"),
+				alloraMath.MustNewDecFromString("0.01675"),
+				alloraMath.MustNewDecFromString("0.02093"),
+			},
+			want:    alloraMath.MustNewDecFromString("0.0142047230098813"),
+			wantErr: false,
 		},
 	}
 
@@ -551,7 +952,11 @@ func TestGetFinalWorkerScoreForecastTask(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := rewards.GetFinalWorkerScoreForecastTask(tt.scoreOneIn, tt.scoreOneOut, tt.fUniqueAgg)
+			got, err := rewards.GetFinalWorkerScoreForecastTask(
+				tt.scoreOneIn,
+				tt.scoreOneOut,
+				tt.fUniqueAgg,
+			)
 			require.NoError(t, err)
 			if !alloraMath.InDelta(tt.want, got, alloraMath.MustNewDecFromString("0.00001")) {
 				t.Errorf("GetFinalWorkerScoreForecastTask() got = %v, want %v", got, tt.want)
@@ -562,21 +967,336 @@ func TestGetFinalWorkerScoreForecastTask(t *testing.T) {
 
 func TestGetAllConsensusScores(t *testing.T) {
 	allLosses := [][]alloraMath.Dec{
-		{alloraMath.MustNewDecFromString("0.0112"), alloraMath.MustNewDecFromString("0.00231"), alloraMath.MustNewDecFromString("0.02274"), alloraMath.MustNewDecFromString("0.01299"), alloraMath.MustNewDecFromString("0.02515"), alloraMath.MustNewDecFromString("0.0185"), alloraMath.MustNewDecFromString("0.01018"), alloraMath.MustNewDecFromString("0.02105"), alloraMath.MustNewDecFromString("0.01041"), alloraMath.MustNewDecFromString("0.0183"), alloraMath.MustNewDecFromString("0.01022"), alloraMath.MustNewDecFromString("0.01333"), alloraMath.MustNewDecFromString("0.01298"), alloraMath.MustNewDecFromString("0.01023"), alloraMath.MustNewDecFromString("0.01268"), alloraMath.MustNewDecFromString("0.01381"), alloraMath.MustNewDecFromString("0.01731"), alloraMath.MustNewDecFromString("0.01238"), alloraMath.MustNewDecFromString("0.01168"), alloraMath.MustNewDecFromString("0.00929"), alloraMath.MustNewDecFromString("0.01212"), alloraMath.MustNewDecFromString("0.01806"), alloraMath.MustNewDecFromString("0.01901"), alloraMath.MustNewDecFromString("0.01828"), alloraMath.MustNewDecFromString("0.01522"), alloraMath.MustNewDecFromString("0.01833"), alloraMath.MustNewDecFromString("0.0101"), alloraMath.MustNewDecFromString("0.01224"), alloraMath.MustNewDecFromString("0.01226"), alloraMath.MustNewDecFromString("0.01474"), alloraMath.MustNewDecFromString("0.01218"), alloraMath.MustNewDecFromString("0.01604"), alloraMath.MustNewDecFromString("0.01149"), alloraMath.MustNewDecFromString("0.02075"), alloraMath.MustNewDecFromString("0.00818"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01127"), alloraMath.MustNewDecFromString("0.01495"), alloraMath.MustNewDecFromString("0.00689"), alloraMath.MustNewDecFromString("0.0108"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.0124"), alloraMath.MustNewDecFromString("0.01588"), alloraMath.MustNewDecFromString("0.01012"), alloraMath.MustNewDecFromString("0.01467"), alloraMath.MustNewDecFromString("0.0128"), alloraMath.MustNewDecFromString("0.01234"), alloraMath.MustNewDecFromString("0.0148"), alloraMath.MustNewDecFromString("0.01046"), alloraMath.MustNewDecFromString("0.01192"), alloraMath.MustNewDecFromString("0.01381"), alloraMath.MustNewDecFromString("0.01687"), alloraMath.MustNewDecFromString("0.01136"), alloraMath.MustNewDecFromString("0.01185"), alloraMath.MustNewDecFromString("0.01568"), alloraMath.MustNewDecFromString("0.00949"), alloraMath.MustNewDecFromString("0.01339")},
-		{alloraMath.MustNewDecFromString("0.01635"), alloraMath.MustNewDecFromString("0.00179"), alloraMath.MustNewDecFromString("0.03396"), alloraMath.MustNewDecFromString("0.0153"), alloraMath.MustNewDecFromString("0.01988"), alloraMath.MustNewDecFromString("0.00962"), alloraMath.MustNewDecFromString("0.01191"), alloraMath.MustNewDecFromString("0.01616"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.01216"), alloraMath.MustNewDecFromString("0.01292"), alloraMath.MustNewDecFromString("0.01564"), alloraMath.MustNewDecFromString("0.01323"), alloraMath.MustNewDecFromString("0.01261"), alloraMath.MustNewDecFromString("0.01145"), alloraMath.MustNewDecFromString("0.0163"), alloraMath.MustNewDecFromString("0.014"), alloraMath.MustNewDecFromString("0.01373"), alloraMath.MustNewDecFromString("0.01453"), alloraMath.MustNewDecFromString("0.01207"), alloraMath.MustNewDecFromString("0.01641"), alloraMath.MustNewDecFromString("0.01601"), alloraMath.MustNewDecFromString("0.01114"), alloraMath.MustNewDecFromString("0.01259"), alloraMath.MustNewDecFromString("0.01589"), alloraMath.MustNewDecFromString("0.01229"), alloraMath.MustNewDecFromString("0.01309"), alloraMath.MustNewDecFromString("0.0138"), alloraMath.MustNewDecFromString("0.01162"), alloraMath.MustNewDecFromString("0.01145"), alloraMath.MustNewDecFromString("0.01013"), alloraMath.MustNewDecFromString("0.01208"), alloraMath.MustNewDecFromString("0.0111"), alloraMath.MustNewDecFromString("0.0118"), alloraMath.MustNewDecFromString("0.01374"), alloraMath.MustNewDecFromString("0.01428"), alloraMath.MustNewDecFromString("0.01791"), alloraMath.MustNewDecFromString("0.01288"), alloraMath.MustNewDecFromString("0.01161"), alloraMath.MustNewDecFromString("0.01151"), alloraMath.MustNewDecFromString("0.01148"), alloraMath.MustNewDecFromString("0.01284"), alloraMath.MustNewDecFromString("0.01239"), alloraMath.MustNewDecFromString("0.01023"), alloraMath.MustNewDecFromString("0.01712"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01639"), alloraMath.MustNewDecFromString("0.01043"), alloraMath.MustNewDecFromString("0.01308"), alloraMath.MustNewDecFromString("0.01455"), alloraMath.MustNewDecFromString("0.01607"), alloraMath.MustNewDecFromString("0.01205"), alloraMath.MustNewDecFromString("0.01357"), alloraMath.MustNewDecFromString("0.01108"), alloraMath.MustNewDecFromString("0.01633"), alloraMath.MustNewDecFromString("0.01208"), alloraMath.MustNewDecFromString("0.01278")},
-		{alloraMath.MustNewDecFromString("0.01345"), alloraMath.MustNewDecFromString("0.00209"), alloraMath.MustNewDecFromString("0.03249"), alloraMath.MustNewDecFromString("0.01688"), alloraMath.MustNewDecFromString("0.02126"), alloraMath.MustNewDecFromString("0.01338"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01605"), alloraMath.MustNewDecFromString("0.0133"), alloraMath.MustNewDecFromString("0.01407"), alloraMath.MustNewDecFromString("0.01367"), alloraMath.MustNewDecFromString("0.01244"), alloraMath.MustNewDecFromString("0.0145"), alloraMath.MustNewDecFromString("0.01262"), alloraMath.MustNewDecFromString("0.01348"), alloraMath.MustNewDecFromString("0.01684"), alloraMath.MustNewDecFromString("0.01148"), alloraMath.MustNewDecFromString("0.01705"), alloraMath.MustNewDecFromString("0.01714"), alloraMath.MustNewDecFromString("0.0124"), alloraMath.MustNewDecFromString("0.0125"), alloraMath.MustNewDecFromString("0.01462"), alloraMath.MustNewDecFromString("0.01274"), alloraMath.MustNewDecFromString("0.01407"), alloraMath.MustNewDecFromString("0.01667"), alloraMath.MustNewDecFromString("0.01316"), alloraMath.MustNewDecFromString("0.01628"), alloraMath.MustNewDecFromString("0.01373"), alloraMath.MustNewDecFromString("0.01409"), alloraMath.MustNewDecFromString("0.01603"), alloraMath.MustNewDecFromString("0.01378"), alloraMath.MustNewDecFromString("0.01143"), alloraMath.MustNewDecFromString("0.013"), alloraMath.MustNewDecFromString("0.01644"), alloraMath.MustNewDecFromString("0.01528"), alloraMath.MustNewDecFromString("0.01441"), alloraMath.MustNewDecFromString("0.01404"), alloraMath.MustNewDecFromString("0.01402"), alloraMath.MustNewDecFromString("0.01479"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.01244"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01419"), alloraMath.MustNewDecFromString("0.01497"), alloraMath.MustNewDecFromString("0.01629"), alloraMath.MustNewDecFromString("0.01514"), alloraMath.MustNewDecFromString("0.01133"), alloraMath.MustNewDecFromString("0.01339"), alloraMath.MustNewDecFromString("0.01053"), alloraMath.MustNewDecFromString("0.01424"), alloraMath.MustNewDecFromString("0.01428"), alloraMath.MustNewDecFromString("0.01446"), alloraMath.MustNewDecFromString("0.01805"), alloraMath.MustNewDecFromString("0.01229"), alloraMath.MustNewDecFromString("0.01586"), alloraMath.MustNewDecFromString("0.01234"), alloraMath.MustNewDecFromString("0.01513")},
-		{alloraMath.MustNewDecFromString("0.01675"), alloraMath.MustNewDecFromString("0.00318"), alloraMath.MustNewDecFromString("0.02623"), alloraMath.MustNewDecFromString("0.02734"), alloraMath.MustNewDecFromString("0.03526"), alloraMath.MustNewDecFromString("0.02733"), alloraMath.MustNewDecFromString("0.01697"), alloraMath.MustNewDecFromString("0.01619"), alloraMath.MustNewDecFromString("0.01925"), alloraMath.MustNewDecFromString("0.02018"), alloraMath.MustNewDecFromString("0.01735"), alloraMath.MustNewDecFromString("0.01922"), alloraMath.MustNewDecFromString("0.02225"), alloraMath.MustNewDecFromString("0.0189"), alloraMath.MustNewDecFromString("0.01923"), alloraMath.MustNewDecFromString("0.03193"), alloraMath.MustNewDecFromString("0.01956"), alloraMath.MustNewDecFromString("0.01763"), alloraMath.MustNewDecFromString("0.01975"), alloraMath.MustNewDecFromString("0.01466"), alloraMath.MustNewDecFromString("0.02021"), alloraMath.MustNewDecFromString("0.01803"), alloraMath.MustNewDecFromString("0.01438"), alloraMath.MustNewDecFromString("0.01929"), alloraMath.MustNewDecFromString("0.02305"), alloraMath.MustNewDecFromString("0.02223"), alloraMath.MustNewDecFromString("0.02445"), alloraMath.MustNewDecFromString("0.01967"), alloraMath.MustNewDecFromString("0.02292"), alloraMath.MustNewDecFromString("0.01878"), alloraMath.MustNewDecFromString("0.01751"), alloraMath.MustNewDecFromString("0.02695"), alloraMath.MustNewDecFromString("0.01849"), alloraMath.MustNewDecFromString("0.01658"), alloraMath.MustNewDecFromString("0.01948"), alloraMath.MustNewDecFromString("0.01594"), alloraMath.MustNewDecFromString("0.02318"), alloraMath.MustNewDecFromString("0.01906"), alloraMath.MustNewDecFromString("0.01607"), alloraMath.MustNewDecFromString("0.01369"), alloraMath.MustNewDecFromString("0.01686"), alloraMath.MustNewDecFromString("0.01314"), alloraMath.MustNewDecFromString("0.01936"), alloraMath.MustNewDecFromString("0.01518"), alloraMath.MustNewDecFromString("0.018"), alloraMath.MustNewDecFromString("0.02212"), alloraMath.MustNewDecFromString("0.02259"), alloraMath.MustNewDecFromString("0.01674"), alloraMath.MustNewDecFromString("0.02944"), alloraMath.MustNewDecFromString("0.01796"), alloraMath.MustNewDecFromString("0.02187"), alloraMath.MustNewDecFromString("0.01895"), alloraMath.MustNewDecFromString("0.01637"), alloraMath.MustNewDecFromString("0.01594"), alloraMath.MustNewDecFromString("0.01608"), alloraMath.MustNewDecFromString("0.02203"), alloraMath.MustNewDecFromString("0.01486")},
-		{alloraMath.MustNewDecFromString("0.02093"), alloraMath.MustNewDecFromString("0.00213"), alloraMath.MustNewDecFromString("0.02462"), alloraMath.MustNewDecFromString("0.0203"), alloraMath.MustNewDecFromString("0.03115"), alloraMath.MustNewDecFromString("0.01"), alloraMath.MustNewDecFromString("0.01545"), alloraMath.MustNewDecFromString("0.01785"), alloraMath.MustNewDecFromString("0.01662"), alloraMath.MustNewDecFromString("0.01156"), alloraMath.MustNewDecFromString("0.02284"), alloraMath.MustNewDecFromString("0.01475"), alloraMath.MustNewDecFromString("0.01331"), alloraMath.MustNewDecFromString("0.01592"), alloraMath.MustNewDecFromString("0.01462"), alloraMath.MustNewDecFromString("0.02333"), alloraMath.MustNewDecFromString("0.01836"), alloraMath.MustNewDecFromString("0.01465"), alloraMath.MustNewDecFromString("0.0186"), alloraMath.MustNewDecFromString("0.01566"), alloraMath.MustNewDecFromString("0.01506"), alloraMath.MustNewDecFromString("0.01678"), alloraMath.MustNewDecFromString("0.01423"), alloraMath.MustNewDecFromString("0.01658"), alloraMath.MustNewDecFromString("0.01741"), alloraMath.MustNewDecFromString("0.03491"), alloraMath.MustNewDecFromString("0.01408"), alloraMath.MustNewDecFromString("0.01191"), alloraMath.MustNewDecFromString("0.01572"), alloraMath.MustNewDecFromString("0.01355"), alloraMath.MustNewDecFromString("0.01477"), alloraMath.MustNewDecFromString("0.01662"), alloraMath.MustNewDecFromString("0.01128"), alloraMath.MustNewDecFromString("0.02581"), alloraMath.MustNewDecFromString("0.01718"), alloraMath.MustNewDecFromString("0.01705"), alloraMath.MustNewDecFromString("0.01251"), alloraMath.MustNewDecFromString("0.02158"), alloraMath.MustNewDecFromString("0.01187"), alloraMath.MustNewDecFromString("0.01504"), alloraMath.MustNewDecFromString("0.0135"), alloraMath.MustNewDecFromString("0.02432"), alloraMath.MustNewDecFromString("0.01602"), alloraMath.MustNewDecFromString("0.01194"), alloraMath.MustNewDecFromString("0.0153"), alloraMath.MustNewDecFromString("0.0199"), alloraMath.MustNewDecFromString("0.01673"), alloraMath.MustNewDecFromString("0.01049"), alloraMath.MustNewDecFromString("0.02068"), alloraMath.MustNewDecFromString("0.01573"), alloraMath.MustNewDecFromString("0.01487"), alloraMath.MustNewDecFromString("0.02639"), alloraMath.MustNewDecFromString("0.01981"), alloraMath.MustNewDecFromString("0.02123"), alloraMath.MustNewDecFromString("0.02134"), alloraMath.MustNewDecFromString("0.0217"), alloraMath.MustNewDecFromString("0.01177")},
+		{
+			alloraMath.MustNewDecFromString("0.0112"),
+			alloraMath.MustNewDecFromString("0.00231"),
+			alloraMath.MustNewDecFromString("0.02274"),
+			alloraMath.MustNewDecFromString("0.01299"),
+			alloraMath.MustNewDecFromString("0.02515"),
+			alloraMath.MustNewDecFromString("0.0185"),
+			alloraMath.MustNewDecFromString("0.01018"),
+			alloraMath.MustNewDecFromString("0.02105"),
+			alloraMath.MustNewDecFromString("0.01041"),
+			alloraMath.MustNewDecFromString("0.0183"),
+			alloraMath.MustNewDecFromString("0.01022"),
+			alloraMath.MustNewDecFromString("0.01333"),
+			alloraMath.MustNewDecFromString("0.01298"),
+			alloraMath.MustNewDecFromString("0.01023"),
+			alloraMath.MustNewDecFromString("0.01268"),
+			alloraMath.MustNewDecFromString("0.01381"),
+			alloraMath.MustNewDecFromString("0.01731"),
+			alloraMath.MustNewDecFromString("0.01238"),
+			alloraMath.MustNewDecFromString("0.01168"),
+			alloraMath.MustNewDecFromString("0.00929"),
+			alloraMath.MustNewDecFromString("0.01212"),
+			alloraMath.MustNewDecFromString("0.01806"),
+			alloraMath.MustNewDecFromString("0.01901"),
+			alloraMath.MustNewDecFromString("0.01828"),
+			alloraMath.MustNewDecFromString("0.01522"),
+			alloraMath.MustNewDecFromString("0.01833"),
+			alloraMath.MustNewDecFromString("0.0101"),
+			alloraMath.MustNewDecFromString("0.01224"),
+			alloraMath.MustNewDecFromString("0.01226"),
+			alloraMath.MustNewDecFromString("0.01474"),
+			alloraMath.MustNewDecFromString("0.01218"),
+			alloraMath.MustNewDecFromString("0.01604"),
+			alloraMath.MustNewDecFromString("0.01149"),
+			alloraMath.MustNewDecFromString("0.02075"),
+			alloraMath.MustNewDecFromString("0.00818"),
+			alloraMath.MustNewDecFromString("0.0116"),
+			alloraMath.MustNewDecFromString("0.01127"),
+			alloraMath.MustNewDecFromString("0.01495"),
+			alloraMath.MustNewDecFromString("0.00689"),
+			alloraMath.MustNewDecFromString("0.0108"),
+			alloraMath.MustNewDecFromString("0.01417"),
+			alloraMath.MustNewDecFromString("0.0124"),
+			alloraMath.MustNewDecFromString("0.01588"),
+			alloraMath.MustNewDecFromString("0.01012"),
+			alloraMath.MustNewDecFromString("0.01467"),
+			alloraMath.MustNewDecFromString("0.0128"),
+			alloraMath.MustNewDecFromString("0.01234"),
+			alloraMath.MustNewDecFromString("0.0148"),
+			alloraMath.MustNewDecFromString("0.01046"),
+			alloraMath.MustNewDecFromString("0.01192"),
+			alloraMath.MustNewDecFromString("0.01381"),
+			alloraMath.MustNewDecFromString("0.01687"),
+			alloraMath.MustNewDecFromString("0.01136"),
+			alloraMath.MustNewDecFromString("0.01185"),
+			alloraMath.MustNewDecFromString("0.01568"),
+			alloraMath.MustNewDecFromString("0.00949"),
+			alloraMath.MustNewDecFromString("0.01339"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.01635"),
+			alloraMath.MustNewDecFromString("0.00179"),
+			alloraMath.MustNewDecFromString("0.03396"),
+			alloraMath.MustNewDecFromString("0.0153"),
+			alloraMath.MustNewDecFromString("0.01988"),
+			alloraMath.MustNewDecFromString("0.00962"),
+			alloraMath.MustNewDecFromString("0.01191"),
+			alloraMath.MustNewDecFromString("0.01616"),
+			alloraMath.MustNewDecFromString("0.01417"),
+			alloraMath.MustNewDecFromString("0.01216"),
+			alloraMath.MustNewDecFromString("0.01292"),
+			alloraMath.MustNewDecFromString("0.01564"),
+			alloraMath.MustNewDecFromString("0.01323"),
+			alloraMath.MustNewDecFromString("0.01261"),
+			alloraMath.MustNewDecFromString("0.01145"),
+			alloraMath.MustNewDecFromString("0.0163"),
+			alloraMath.MustNewDecFromString("0.014"),
+			alloraMath.MustNewDecFromString("0.01373"),
+			alloraMath.MustNewDecFromString("0.01453"),
+			alloraMath.MustNewDecFromString("0.01207"),
+			alloraMath.MustNewDecFromString("0.01641"),
+			alloraMath.MustNewDecFromString("0.01601"),
+			alloraMath.MustNewDecFromString("0.01114"),
+			alloraMath.MustNewDecFromString("0.01259"),
+			alloraMath.MustNewDecFromString("0.01589"),
+			alloraMath.MustNewDecFromString("0.01229"),
+			alloraMath.MustNewDecFromString("0.01309"),
+			alloraMath.MustNewDecFromString("0.0138"),
+			alloraMath.MustNewDecFromString("0.01162"),
+			alloraMath.MustNewDecFromString("0.01145"),
+			alloraMath.MustNewDecFromString("0.01013"),
+			alloraMath.MustNewDecFromString("0.01208"),
+			alloraMath.MustNewDecFromString("0.0111"),
+			alloraMath.MustNewDecFromString("0.0118"),
+			alloraMath.MustNewDecFromString("0.01374"),
+			alloraMath.MustNewDecFromString("0.01428"),
+			alloraMath.MustNewDecFromString("0.01791"),
+			alloraMath.MustNewDecFromString("0.01288"),
+			alloraMath.MustNewDecFromString("0.01161"),
+			alloraMath.MustNewDecFromString("0.01151"),
+			alloraMath.MustNewDecFromString("0.01148"),
+			alloraMath.MustNewDecFromString("0.01284"),
+			alloraMath.MustNewDecFromString("0.01239"),
+			alloraMath.MustNewDecFromString("0.01023"),
+			alloraMath.MustNewDecFromString("0.01712"),
+			alloraMath.MustNewDecFromString("0.0116"),
+			alloraMath.MustNewDecFromString("0.01639"),
+			alloraMath.MustNewDecFromString("0.01043"),
+			alloraMath.MustNewDecFromString("0.01308"),
+			alloraMath.MustNewDecFromString("0.01455"),
+			alloraMath.MustNewDecFromString("0.01607"),
+			alloraMath.MustNewDecFromString("0.01205"),
+			alloraMath.MustNewDecFromString("0.01357"),
+			alloraMath.MustNewDecFromString("0.01108"),
+			alloraMath.MustNewDecFromString("0.01633"),
+			alloraMath.MustNewDecFromString("0.01208"),
+			alloraMath.MustNewDecFromString("0.01278"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.01345"),
+			alloraMath.MustNewDecFromString("0.00209"),
+			alloraMath.MustNewDecFromString("0.03249"),
+			alloraMath.MustNewDecFromString("0.01688"),
+			alloraMath.MustNewDecFromString("0.02126"),
+			alloraMath.MustNewDecFromString("0.01338"),
+			alloraMath.MustNewDecFromString("0.0116"),
+			alloraMath.MustNewDecFromString("0.01605"),
+			alloraMath.MustNewDecFromString("0.0133"),
+			alloraMath.MustNewDecFromString("0.01407"),
+			alloraMath.MustNewDecFromString("0.01367"),
+			alloraMath.MustNewDecFromString("0.01244"),
+			alloraMath.MustNewDecFromString("0.0145"),
+			alloraMath.MustNewDecFromString("0.01262"),
+			alloraMath.MustNewDecFromString("0.01348"),
+			alloraMath.MustNewDecFromString("0.01684"),
+			alloraMath.MustNewDecFromString("0.01148"),
+			alloraMath.MustNewDecFromString("0.01705"),
+			alloraMath.MustNewDecFromString("0.01714"),
+			alloraMath.MustNewDecFromString("0.0124"),
+			alloraMath.MustNewDecFromString("0.0125"),
+			alloraMath.MustNewDecFromString("0.01462"),
+			alloraMath.MustNewDecFromString("0.01274"),
+			alloraMath.MustNewDecFromString("0.01407"),
+			alloraMath.MustNewDecFromString("0.01667"),
+			alloraMath.MustNewDecFromString("0.01316"),
+			alloraMath.MustNewDecFromString("0.01628"),
+			alloraMath.MustNewDecFromString("0.01373"),
+			alloraMath.MustNewDecFromString("0.01409"),
+			alloraMath.MustNewDecFromString("0.01603"),
+			alloraMath.MustNewDecFromString("0.01378"),
+			alloraMath.MustNewDecFromString("0.01143"),
+			alloraMath.MustNewDecFromString("0.013"),
+			alloraMath.MustNewDecFromString("0.01644"),
+			alloraMath.MustNewDecFromString("0.01528"),
+			alloraMath.MustNewDecFromString("0.01441"),
+			alloraMath.MustNewDecFromString("0.01404"),
+			alloraMath.MustNewDecFromString("0.01402"),
+			alloraMath.MustNewDecFromString("0.01479"),
+			alloraMath.MustNewDecFromString("0.01417"),
+			alloraMath.MustNewDecFromString("0.01244"),
+			alloraMath.MustNewDecFromString("0.0116"),
+			alloraMath.MustNewDecFromString("0.01419"),
+			alloraMath.MustNewDecFromString("0.01497"),
+			alloraMath.MustNewDecFromString("0.01629"),
+			alloraMath.MustNewDecFromString("0.01514"),
+			alloraMath.MustNewDecFromString("0.01133"),
+			alloraMath.MustNewDecFromString("0.01339"),
+			alloraMath.MustNewDecFromString("0.01053"),
+			alloraMath.MustNewDecFromString("0.01424"),
+			alloraMath.MustNewDecFromString("0.01428"),
+			alloraMath.MustNewDecFromString("0.01446"),
+			alloraMath.MustNewDecFromString("0.01805"),
+			alloraMath.MustNewDecFromString("0.01229"),
+			alloraMath.MustNewDecFromString("0.01586"),
+			alloraMath.MustNewDecFromString("0.01234"),
+			alloraMath.MustNewDecFromString("0.01513"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.01675"),
+			alloraMath.MustNewDecFromString("0.00318"),
+			alloraMath.MustNewDecFromString("0.02623"),
+			alloraMath.MustNewDecFromString("0.02734"),
+			alloraMath.MustNewDecFromString("0.03526"),
+			alloraMath.MustNewDecFromString("0.02733"),
+			alloraMath.MustNewDecFromString("0.01697"),
+			alloraMath.MustNewDecFromString("0.01619"),
+			alloraMath.MustNewDecFromString("0.01925"),
+			alloraMath.MustNewDecFromString("0.02018"),
+			alloraMath.MustNewDecFromString("0.01735"),
+			alloraMath.MustNewDecFromString("0.01922"),
+			alloraMath.MustNewDecFromString("0.02225"),
+			alloraMath.MustNewDecFromString("0.0189"),
+			alloraMath.MustNewDecFromString("0.01923"),
+			alloraMath.MustNewDecFromString("0.03193"),
+			alloraMath.MustNewDecFromString("0.01956"),
+			alloraMath.MustNewDecFromString("0.01763"),
+			alloraMath.MustNewDecFromString("0.01975"),
+			alloraMath.MustNewDecFromString("0.01466"),
+			alloraMath.MustNewDecFromString("0.02021"),
+			alloraMath.MustNewDecFromString("0.01803"),
+			alloraMath.MustNewDecFromString("0.01438"),
+			alloraMath.MustNewDecFromString("0.01929"),
+			alloraMath.MustNewDecFromString("0.02305"),
+			alloraMath.MustNewDecFromString("0.02223"),
+			alloraMath.MustNewDecFromString("0.02445"),
+			alloraMath.MustNewDecFromString("0.01967"),
+			alloraMath.MustNewDecFromString("0.02292"),
+			alloraMath.MustNewDecFromString("0.01878"),
+			alloraMath.MustNewDecFromString("0.01751"),
+			alloraMath.MustNewDecFromString("0.02695"),
+			alloraMath.MustNewDecFromString("0.01849"),
+			alloraMath.MustNewDecFromString("0.01658"),
+			alloraMath.MustNewDecFromString("0.01948"),
+			alloraMath.MustNewDecFromString("0.01594"),
+			alloraMath.MustNewDecFromString("0.02318"),
+			alloraMath.MustNewDecFromString("0.01906"),
+			alloraMath.MustNewDecFromString("0.01607"),
+			alloraMath.MustNewDecFromString("0.01369"),
+			alloraMath.MustNewDecFromString("0.01686"),
+			alloraMath.MustNewDecFromString("0.01314"),
+			alloraMath.MustNewDecFromString("0.01936"),
+			alloraMath.MustNewDecFromString("0.01518"),
+			alloraMath.MustNewDecFromString("0.018"),
+			alloraMath.MustNewDecFromString("0.02212"),
+			alloraMath.MustNewDecFromString("0.02259"),
+			alloraMath.MustNewDecFromString("0.01674"),
+			alloraMath.MustNewDecFromString("0.02944"),
+			alloraMath.MustNewDecFromString("0.01796"),
+			alloraMath.MustNewDecFromString("0.02187"),
+			alloraMath.MustNewDecFromString("0.01895"),
+			alloraMath.MustNewDecFromString("0.01637"),
+			alloraMath.MustNewDecFromString("0.01594"),
+			alloraMath.MustNewDecFromString("0.01608"),
+			alloraMath.MustNewDecFromString("0.02203"),
+			alloraMath.MustNewDecFromString("0.01486"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.02093"),
+			alloraMath.MustNewDecFromString("0.00213"),
+			alloraMath.MustNewDecFromString("0.02462"),
+			alloraMath.MustNewDecFromString("0.0203"),
+			alloraMath.MustNewDecFromString("0.03115"),
+			alloraMath.MustNewDecFromString("0.01"),
+			alloraMath.MustNewDecFromString("0.01545"),
+			alloraMath.MustNewDecFromString("0.01785"),
+			alloraMath.MustNewDecFromString("0.01662"),
+			alloraMath.MustNewDecFromString("0.01156"),
+			alloraMath.MustNewDecFromString("0.02284"),
+			alloraMath.MustNewDecFromString("0.01475"),
+			alloraMath.MustNewDecFromString("0.01331"),
+			alloraMath.MustNewDecFromString("0.01592"),
+			alloraMath.MustNewDecFromString("0.01462"),
+			alloraMath.MustNewDecFromString("0.02333"),
+			alloraMath.MustNewDecFromString("0.01836"),
+			alloraMath.MustNewDecFromString("0.01465"),
+			alloraMath.MustNewDecFromString("0.0186"),
+			alloraMath.MustNewDecFromString("0.01566"),
+			alloraMath.MustNewDecFromString("0.01506"),
+			alloraMath.MustNewDecFromString("0.01678"),
+			alloraMath.MustNewDecFromString("0.01423"),
+			alloraMath.MustNewDecFromString("0.01658"),
+			alloraMath.MustNewDecFromString("0.01741"),
+			alloraMath.MustNewDecFromString("0.03491"),
+			alloraMath.MustNewDecFromString("0.01408"),
+			alloraMath.MustNewDecFromString("0.01191"),
+			alloraMath.MustNewDecFromString("0.01572"),
+			alloraMath.MustNewDecFromString("0.01355"),
+			alloraMath.MustNewDecFromString("0.01477"),
+			alloraMath.MustNewDecFromString("0.01662"),
+			alloraMath.MustNewDecFromString("0.01128"),
+			alloraMath.MustNewDecFromString("0.02581"),
+			alloraMath.MustNewDecFromString("0.01718"),
+			alloraMath.MustNewDecFromString("0.01705"),
+			alloraMath.MustNewDecFromString("0.01251"),
+			alloraMath.MustNewDecFromString("0.02158"),
+			alloraMath.MustNewDecFromString("0.01187"),
+			alloraMath.MustNewDecFromString("0.01504"),
+			alloraMath.MustNewDecFromString("0.0135"),
+			alloraMath.MustNewDecFromString("0.02432"),
+			alloraMath.MustNewDecFromString("0.01602"),
+			alloraMath.MustNewDecFromString("0.01194"),
+			alloraMath.MustNewDecFromString("0.0153"),
+			alloraMath.MustNewDecFromString("0.0199"),
+			alloraMath.MustNewDecFromString("0.01673"),
+			alloraMath.MustNewDecFromString("0.01049"),
+			alloraMath.MustNewDecFromString("0.02068"),
+			alloraMath.MustNewDecFromString("0.01573"),
+			alloraMath.MustNewDecFromString("0.01487"),
+			alloraMath.MustNewDecFromString("0.02639"),
+			alloraMath.MustNewDecFromString("0.01981"),
+			alloraMath.MustNewDecFromString("0.02123"),
+			alloraMath.MustNewDecFromString("0.02134"),
+			alloraMath.MustNewDecFromString("0.0217"),
+			alloraMath.MustNewDecFromString("0.01177"),
+		},
 	}
-	stakes := []alloraMath.Dec{alloraMath.MustNewDecFromString("1176644.37627"), alloraMath.MustNewDecFromString("384623.3607"), alloraMath.MustNewDecFromString("394676.13226"), alloraMath.MustNewDecFromString("207999.66194"), alloraMath.MustNewDecFromString("368582.76542")}
-	allListeningCoefficients := []alloraMath.Dec{alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("1.0"), alloraMath.MustNewDecFromString("1.0")}
+	stakes := []alloraMath.Dec{
+		alloraMath.MustNewDecFromString("1176644.37627"),
+		alloraMath.MustNewDecFromString("384623.3607"),
+		alloraMath.MustNewDecFromString("394676.13226"),
+		alloraMath.MustNewDecFromString("207999.66194"),
+		alloraMath.MustNewDecFromString("368582.76542"),
+	}
+	allListeningCoefficients := []alloraMath.Dec{
+		alloraMath.MustNewDecFromString("1.0"),
+		alloraMath.MustNewDecFromString("1.0"),
+		alloraMath.MustNewDecFromString("1.0"),
+		alloraMath.MustNewDecFromString("1.0"),
+		alloraMath.MustNewDecFromString("1.0"),
+	}
 	var numReputers int64 = 5
 	fTolerance := alloraMath.MustNewDecFromString("0.01")
 	epsilon := alloraMath.MustNewDecFromString("1e-4")
-	want := []alloraMath.Dec{alloraMath.MustNewDecFromString("0.0169833"), alloraMath.MustNewDecFromString("0.01706869"), alloraMath.MustNewDecFromString("0.016047"), alloraMath.MustNewDecFromString("0.01164"), alloraMath.MustNewDecFromString("0.01345")}
+	want := []alloraMath.Dec{
+		alloraMath.MustNewDecFromString("0.0169833"),
+		alloraMath.MustNewDecFromString("0.01706869"),
+		alloraMath.MustNewDecFromString("0.016047"),
+		alloraMath.MustNewDecFromString("0.01164"),
+		alloraMath.MustNewDecFromString("0.01345"),
+	}
 	wantErr := false
 
-	got, err := rewards.GetAllConsensusScores(allLosses, stakes, allListeningCoefficients, numReputers, fTolerance, epsilon)
+	got, err := rewards.GetAllConsensusScores(
+		allLosses,
+		stakes,
+		allListeningCoefficients,
+		numReputers,
+		fTolerance,
+		epsilon,
+	)
 	if (err != nil) != wantErr {
 		t.Errorf("GetAllConsensusScores() error = %v, wantErr %v", err, wantErr)
 		return
@@ -596,11 +1316,301 @@ func (s *RewardsTestSuite) TestGetAllReputersOutput() {
 	fTolerance := alloraMath.MustNewDecFromString("0.01")
 
 	allLosses := [][]alloraMath.Dec{
-		{alloraMath.MustNewDecFromString("0.0112"), alloraMath.MustNewDecFromString("0.00231"), alloraMath.MustNewDecFromString("0.02274"), alloraMath.MustNewDecFromString("0.01299"), alloraMath.MustNewDecFromString("0.02515"), alloraMath.MustNewDecFromString("0.0185"), alloraMath.MustNewDecFromString("0.01018"), alloraMath.MustNewDecFromString("0.02105"), alloraMath.MustNewDecFromString("0.01041"), alloraMath.MustNewDecFromString("0.0183"), alloraMath.MustNewDecFromString("0.01022"), alloraMath.MustNewDecFromString("0.01333"), alloraMath.MustNewDecFromString("0.01298"), alloraMath.MustNewDecFromString("0.01023"), alloraMath.MustNewDecFromString("0.01268"), alloraMath.MustNewDecFromString("0.01381"), alloraMath.MustNewDecFromString("0.01731"), alloraMath.MustNewDecFromString("0.01238"), alloraMath.MustNewDecFromString("0.01168"), alloraMath.MustNewDecFromString("0.00929"), alloraMath.MustNewDecFromString("0.01212"), alloraMath.MustNewDecFromString("0.01806"), alloraMath.MustNewDecFromString("0.01901"), alloraMath.MustNewDecFromString("0.01828"), alloraMath.MustNewDecFromString("0.01522"), alloraMath.MustNewDecFromString("0.01833"), alloraMath.MustNewDecFromString("0.0101"), alloraMath.MustNewDecFromString("0.01224"), alloraMath.MustNewDecFromString("0.01226"), alloraMath.MustNewDecFromString("0.01474"), alloraMath.MustNewDecFromString("0.01218"), alloraMath.MustNewDecFromString("0.01604"), alloraMath.MustNewDecFromString("0.01149"), alloraMath.MustNewDecFromString("0.02075"), alloraMath.MustNewDecFromString("0.00818"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01127"), alloraMath.MustNewDecFromString("0.01495"), alloraMath.MustNewDecFromString("0.00689"), alloraMath.MustNewDecFromString("0.0108"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.0124"), alloraMath.MustNewDecFromString("0.01588"), alloraMath.MustNewDecFromString("0.01012"), alloraMath.MustNewDecFromString("0.01467"), alloraMath.MustNewDecFromString("0.0128"), alloraMath.MustNewDecFromString("0.01234"), alloraMath.MustNewDecFromString("0.0148"), alloraMath.MustNewDecFromString("0.01046"), alloraMath.MustNewDecFromString("0.01192"), alloraMath.MustNewDecFromString("0.01381"), alloraMath.MustNewDecFromString("0.01687"), alloraMath.MustNewDecFromString("0.01136"), alloraMath.MustNewDecFromString("0.01185"), alloraMath.MustNewDecFromString("0.01568"), alloraMath.MustNewDecFromString("0.00949"), alloraMath.MustNewDecFromString("0.01339")},
-		{alloraMath.MustNewDecFromString("0.01635"), alloraMath.MustNewDecFromString("0.00179"), alloraMath.MustNewDecFromString("0.03396"), alloraMath.MustNewDecFromString("0.0153"), alloraMath.MustNewDecFromString("0.01988"), alloraMath.MustNewDecFromString("0.00962"), alloraMath.MustNewDecFromString("0.01191"), alloraMath.MustNewDecFromString("0.01616"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.01216"), alloraMath.MustNewDecFromString("0.01292"), alloraMath.MustNewDecFromString("0.01564"), alloraMath.MustNewDecFromString("0.01323"), alloraMath.MustNewDecFromString("0.01261"), alloraMath.MustNewDecFromString("0.01145"), alloraMath.MustNewDecFromString("0.0163"), alloraMath.MustNewDecFromString("0.014"), alloraMath.MustNewDecFromString("0.01373"), alloraMath.MustNewDecFromString("0.01453"), alloraMath.MustNewDecFromString("0.01207"), alloraMath.MustNewDecFromString("0.01641"), alloraMath.MustNewDecFromString("0.01601"), alloraMath.MustNewDecFromString("0.01114"), alloraMath.MustNewDecFromString("0.01259"), alloraMath.MustNewDecFromString("0.01589"), alloraMath.MustNewDecFromString("0.01229"), alloraMath.MustNewDecFromString("0.01309"), alloraMath.MustNewDecFromString("0.0138"), alloraMath.MustNewDecFromString("0.01162"), alloraMath.MustNewDecFromString("0.01145"), alloraMath.MustNewDecFromString("0.01013"), alloraMath.MustNewDecFromString("0.01208"), alloraMath.MustNewDecFromString("0.0111"), alloraMath.MustNewDecFromString("0.0118"), alloraMath.MustNewDecFromString("0.01374"), alloraMath.MustNewDecFromString("0.01428"), alloraMath.MustNewDecFromString("0.01791"), alloraMath.MustNewDecFromString("0.01288"), alloraMath.MustNewDecFromString("0.01161"), alloraMath.MustNewDecFromString("0.01151"), alloraMath.MustNewDecFromString("0.01148"), alloraMath.MustNewDecFromString("0.01284"), alloraMath.MustNewDecFromString("0.01239"), alloraMath.MustNewDecFromString("0.01023"), alloraMath.MustNewDecFromString("0.01712"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01639"), alloraMath.MustNewDecFromString("0.01043"), alloraMath.MustNewDecFromString("0.01308"), alloraMath.MustNewDecFromString("0.01455"), alloraMath.MustNewDecFromString("0.01607"), alloraMath.MustNewDecFromString("0.01205"), alloraMath.MustNewDecFromString("0.01357"), alloraMath.MustNewDecFromString("0.01108"), alloraMath.MustNewDecFromString("0.01633"), alloraMath.MustNewDecFromString("0.01208"), alloraMath.MustNewDecFromString("0.01278")},
-		{alloraMath.MustNewDecFromString("0.01345"), alloraMath.MustNewDecFromString("0.00209"), alloraMath.MustNewDecFromString("0.03249"), alloraMath.MustNewDecFromString("0.01688"), alloraMath.MustNewDecFromString("0.02126"), alloraMath.MustNewDecFromString("0.01338"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01605"), alloraMath.MustNewDecFromString("0.0133"), alloraMath.MustNewDecFromString("0.01407"), alloraMath.MustNewDecFromString("0.01367"), alloraMath.MustNewDecFromString("0.01244"), alloraMath.MustNewDecFromString("0.0145"), alloraMath.MustNewDecFromString("0.01262"), alloraMath.MustNewDecFromString("0.01348"), alloraMath.MustNewDecFromString("0.01684"), alloraMath.MustNewDecFromString("0.01148"), alloraMath.MustNewDecFromString("0.01705"), alloraMath.MustNewDecFromString("0.01714"), alloraMath.MustNewDecFromString("0.0124"), alloraMath.MustNewDecFromString("0.0125"), alloraMath.MustNewDecFromString("0.01462"), alloraMath.MustNewDecFromString("0.01274"), alloraMath.MustNewDecFromString("0.01407"), alloraMath.MustNewDecFromString("0.01667"), alloraMath.MustNewDecFromString("0.01316"), alloraMath.MustNewDecFromString("0.01628"), alloraMath.MustNewDecFromString("0.01373"), alloraMath.MustNewDecFromString("0.01409"), alloraMath.MustNewDecFromString("0.01603"), alloraMath.MustNewDecFromString("0.01378"), alloraMath.MustNewDecFromString("0.01143"), alloraMath.MustNewDecFromString("0.013"), alloraMath.MustNewDecFromString("0.01644"), alloraMath.MustNewDecFromString("0.01528"), alloraMath.MustNewDecFromString("0.01441"), alloraMath.MustNewDecFromString("0.01404"), alloraMath.MustNewDecFromString("0.01402"), alloraMath.MustNewDecFromString("0.01479"), alloraMath.MustNewDecFromString("0.01417"), alloraMath.MustNewDecFromString("0.01244"), alloraMath.MustNewDecFromString("0.0116"), alloraMath.MustNewDecFromString("0.01419"), alloraMath.MustNewDecFromString("0.01497"), alloraMath.MustNewDecFromString("0.01629"), alloraMath.MustNewDecFromString("0.01514"), alloraMath.MustNewDecFromString("0.01133"), alloraMath.MustNewDecFromString("0.01339"), alloraMath.MustNewDecFromString("0.01053"), alloraMath.MustNewDecFromString("0.01424"), alloraMath.MustNewDecFromString("0.01428"), alloraMath.MustNewDecFromString("0.01446"), alloraMath.MustNewDecFromString("0.01805"), alloraMath.MustNewDecFromString("0.01229"), alloraMath.MustNewDecFromString("0.01586"), alloraMath.MustNewDecFromString("0.01234"), alloraMath.MustNewDecFromString("0.01513")},
-		{alloraMath.MustNewDecFromString("0.01675"), alloraMath.MustNewDecFromString("0.00318"), alloraMath.MustNewDecFromString("0.02623"), alloraMath.MustNewDecFromString("0.02734"), alloraMath.MustNewDecFromString("0.03526"), alloraMath.MustNewDecFromString("0.02733"), alloraMath.MustNewDecFromString("0.01697"), alloraMath.MustNewDecFromString("0.01619"), alloraMath.MustNewDecFromString("0.01925"), alloraMath.MustNewDecFromString("0.02018"), alloraMath.MustNewDecFromString("0.01735"), alloraMath.MustNewDecFromString("0.01922"), alloraMath.MustNewDecFromString("0.02225"), alloraMath.MustNewDecFromString("0.0189"), alloraMath.MustNewDecFromString("0.01923"), alloraMath.MustNewDecFromString("0.03193"), alloraMath.MustNewDecFromString("0.01956"), alloraMath.MustNewDecFromString("0.01763"), alloraMath.MustNewDecFromString("0.01975"), alloraMath.MustNewDecFromString("0.01466"), alloraMath.MustNewDecFromString("0.02021"), alloraMath.MustNewDecFromString("0.01803"), alloraMath.MustNewDecFromString("0.01438"), alloraMath.MustNewDecFromString("0.01929"), alloraMath.MustNewDecFromString("0.02305"), alloraMath.MustNewDecFromString("0.02223"), alloraMath.MustNewDecFromString("0.02445"), alloraMath.MustNewDecFromString("0.01967"), alloraMath.MustNewDecFromString("0.02292"), alloraMath.MustNewDecFromString("0.01878"), alloraMath.MustNewDecFromString("0.01751"), alloraMath.MustNewDecFromString("0.02695"), alloraMath.MustNewDecFromString("0.01849"), alloraMath.MustNewDecFromString("0.01658"), alloraMath.MustNewDecFromString("0.01948"), alloraMath.MustNewDecFromString("0.01594"), alloraMath.MustNewDecFromString("0.02318"), alloraMath.MustNewDecFromString("0.01906"), alloraMath.MustNewDecFromString("0.01607"), alloraMath.MustNewDecFromString("0.01369"), alloraMath.MustNewDecFromString("0.01686"), alloraMath.MustNewDecFromString("0.01314"), alloraMath.MustNewDecFromString("0.01936"), alloraMath.MustNewDecFromString("0.01518"), alloraMath.MustNewDecFromString("0.018"), alloraMath.MustNewDecFromString("0.02212"), alloraMath.MustNewDecFromString("0.02259"), alloraMath.MustNewDecFromString("0.01674"), alloraMath.MustNewDecFromString("0.02944"), alloraMath.MustNewDecFromString("0.01796"), alloraMath.MustNewDecFromString("0.02187"), alloraMath.MustNewDecFromString("0.01895"), alloraMath.MustNewDecFromString("0.01637"), alloraMath.MustNewDecFromString("0.01594"), alloraMath.MustNewDecFromString("0.01608"), alloraMath.MustNewDecFromString("0.02203"), alloraMath.MustNewDecFromString("0.01486")},
-		{alloraMath.MustNewDecFromString("0.02093"), alloraMath.MustNewDecFromString("0.00213"), alloraMath.MustNewDecFromString("0.02462"), alloraMath.MustNewDecFromString("0.0203"), alloraMath.MustNewDecFromString("0.03115"), alloraMath.MustNewDecFromString("0.01"), alloraMath.MustNewDecFromString("0.01545"), alloraMath.MustNewDecFromString("0.01785"), alloraMath.MustNewDecFromString("0.01662"), alloraMath.MustNewDecFromString("0.01156"), alloraMath.MustNewDecFromString("0.02284"), alloraMath.MustNewDecFromString("0.01475"), alloraMath.MustNewDecFromString("0.01331"), alloraMath.MustNewDecFromString("0.01592"), alloraMath.MustNewDecFromString("0.01462"), alloraMath.MustNewDecFromString("0.02333"), alloraMath.MustNewDecFromString("0.01836"), alloraMath.MustNewDecFromString("0.01465"), alloraMath.MustNewDecFromString("0.0186"), alloraMath.MustNewDecFromString("0.01566"), alloraMath.MustNewDecFromString("0.01506"), alloraMath.MustNewDecFromString("0.01678"), alloraMath.MustNewDecFromString("0.01423"), alloraMath.MustNewDecFromString("0.01658"), alloraMath.MustNewDecFromString("0.01741"), alloraMath.MustNewDecFromString("0.03491"), alloraMath.MustNewDecFromString("0.01408"), alloraMath.MustNewDecFromString("0.01191"), alloraMath.MustNewDecFromString("0.01572"), alloraMath.MustNewDecFromString("0.01355"), alloraMath.MustNewDecFromString("0.01477"), alloraMath.MustNewDecFromString("0.01662"), alloraMath.MustNewDecFromString("0.01128"), alloraMath.MustNewDecFromString("0.02581"), alloraMath.MustNewDecFromString("0.01718"), alloraMath.MustNewDecFromString("0.01705"), alloraMath.MustNewDecFromString("0.01251"), alloraMath.MustNewDecFromString("0.02158"), alloraMath.MustNewDecFromString("0.01187"), alloraMath.MustNewDecFromString("0.01504"), alloraMath.MustNewDecFromString("0.0135"), alloraMath.MustNewDecFromString("0.02432"), alloraMath.MustNewDecFromString("0.01602"), alloraMath.MustNewDecFromString("0.01194"), alloraMath.MustNewDecFromString("0.0153"), alloraMath.MustNewDecFromString("0.0199"), alloraMath.MustNewDecFromString("0.01673"), alloraMath.MustNewDecFromString("0.01049"), alloraMath.MustNewDecFromString("0.02068"), alloraMath.MustNewDecFromString("0.01573"), alloraMath.MustNewDecFromString("0.01487"), alloraMath.MustNewDecFromString("0.02639"), alloraMath.MustNewDecFromString("0.01981"), alloraMath.MustNewDecFromString("0.02123"), alloraMath.MustNewDecFromString("0.02134"), alloraMath.MustNewDecFromString("0.0217"), alloraMath.MustNewDecFromString("0.01177")},
+		{
+			alloraMath.MustNewDecFromString("0.0112"),
+			alloraMath.MustNewDecFromString("0.00231"),
+			alloraMath.MustNewDecFromString("0.02274"),
+			alloraMath.MustNewDecFromString("0.01299"),
+			alloraMath.MustNewDecFromString("0.02515"),
+			alloraMath.MustNewDecFromString("0.0185"),
+			alloraMath.MustNewDecFromString("0.01018"),
+			alloraMath.MustNewDecFromString("0.02105"),
+			alloraMath.MustNewDecFromString("0.01041"),
+			alloraMath.MustNewDecFromString("0.0183"),
+			alloraMath.MustNewDecFromString("0.01022"),
+			alloraMath.MustNewDecFromString("0.01333"),
+			alloraMath.MustNewDecFromString("0.01298"),
+			alloraMath.MustNewDecFromString("0.01023"),
+			alloraMath.MustNewDecFromString("0.01268"),
+			alloraMath.MustNewDecFromString("0.01381"),
+			alloraMath.MustNewDecFromString("0.01731"),
+			alloraMath.MustNewDecFromString("0.01238"),
+			alloraMath.MustNewDecFromString("0.01168"),
+			alloraMath.MustNewDecFromString("0.00929"),
+			alloraMath.MustNewDecFromString("0.01212"),
+			alloraMath.MustNewDecFromString("0.01806"),
+			alloraMath.MustNewDecFromString("0.01901"),
+			alloraMath.MustNewDecFromString("0.01828"),
+			alloraMath.MustNewDecFromString("0.01522"),
+			alloraMath.MustNewDecFromString("0.01833"),
+			alloraMath.MustNewDecFromString("0.0101"),
+			alloraMath.MustNewDecFromString("0.01224"),
+			alloraMath.MustNewDecFromString("0.01226"),
+			alloraMath.MustNewDecFromString("0.01474"),
+			alloraMath.MustNewDecFromString("0.01218"),
+			alloraMath.MustNewDecFromString("0.01604"),
+			alloraMath.MustNewDecFromString("0.01149"),
+			alloraMath.MustNewDecFromString("0.02075"),
+			alloraMath.MustNewDecFromString("0.00818"),
+			alloraMath.MustNewDecFromString("0.0116"),
+			alloraMath.MustNewDecFromString("0.01127"),
+			alloraMath.MustNewDecFromString("0.01495"),
+			alloraMath.MustNewDecFromString("0.00689"),
+			alloraMath.MustNewDecFromString("0.0108"),
+			alloraMath.MustNewDecFromString("0.01417"),
+			alloraMath.MustNewDecFromString("0.0124"),
+			alloraMath.MustNewDecFromString("0.01588"),
+			alloraMath.MustNewDecFromString("0.01012"),
+			alloraMath.MustNewDecFromString("0.01467"),
+			alloraMath.MustNewDecFromString("0.0128"),
+			alloraMath.MustNewDecFromString("0.01234"),
+			alloraMath.MustNewDecFromString("0.0148"),
+			alloraMath.MustNewDecFromString("0.01046"),
+			alloraMath.MustNewDecFromString("0.01192"),
+			alloraMath.MustNewDecFromString("0.01381"),
+			alloraMath.MustNewDecFromString("0.01687"),
+			alloraMath.MustNewDecFromString("0.01136"),
+			alloraMath.MustNewDecFromString("0.01185"),
+			alloraMath.MustNewDecFromString("0.01568"),
+			alloraMath.MustNewDecFromString("0.00949"),
+			alloraMath.MustNewDecFromString("0.01339"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.01635"),
+			alloraMath.MustNewDecFromString("0.00179"),
+			alloraMath.MustNewDecFromString("0.03396"),
+			alloraMath.MustNewDecFromString("0.0153"),
+			alloraMath.MustNewDecFromString("0.01988"),
+			alloraMath.MustNewDecFromString("0.00962"),
+			alloraMath.MustNewDecFromString("0.01191"),
+			alloraMath.MustNewDecFromString("0.01616"),
+			alloraMath.MustNewDecFromString("0.01417"),
+			alloraMath.MustNewDecFromString("0.01216"),
+			alloraMath.MustNewDecFromString("0.01292"),
+			alloraMath.MustNewDecFromString("0.01564"),
+			alloraMath.MustNewDecFromString("0.01323"),
+			alloraMath.MustNewDecFromString("0.01261"),
+			alloraMath.MustNewDecFromString("0.01145"),
+			alloraMath.MustNewDecFromString("0.0163"),
+			alloraMath.MustNewDecFromString("0.014"),
+			alloraMath.MustNewDecFromString("0.01373"),
+			alloraMath.MustNewDecFromString("0.01453"),
+			alloraMath.MustNewDecFromString("0.01207"),
+			alloraMath.MustNewDecFromString("0.01641"),
+			alloraMath.MustNewDecFromString("0.01601"),
+			alloraMath.MustNewDecFromString("0.01114"),
+			alloraMath.MustNewDecFromString("0.01259"),
+			alloraMath.MustNewDecFromString("0.01589"),
+			alloraMath.MustNewDecFromString("0.01229"),
+			alloraMath.MustNewDecFromString("0.01309"),
+			alloraMath.MustNewDecFromString("0.0138"),
+			alloraMath.MustNewDecFromString("0.01162"),
+			alloraMath.MustNewDecFromString("0.01145"),
+			alloraMath.MustNewDecFromString("0.01013"),
+			alloraMath.MustNewDecFromString("0.01208"),
+			alloraMath.MustNewDecFromString("0.0111"),
+			alloraMath.MustNewDecFromString("0.0118"),
+			alloraMath.MustNewDecFromString("0.01374"),
+			alloraMath.MustNewDecFromString("0.01428"),
+			alloraMath.MustNewDecFromString("0.01791"),
+			alloraMath.MustNewDecFromString("0.01288"),
+			alloraMath.MustNewDecFromString("0.01161"),
+			alloraMath.MustNewDecFromString("0.01151"),
+			alloraMath.MustNewDecFromString("0.01148"),
+			alloraMath.MustNewDecFromString("0.01284"),
+			alloraMath.MustNewDecFromString("0.01239"),
+			alloraMath.MustNewDecFromString("0.01023"),
+			alloraMath.MustNewDecFromString("0.01712"),
+			alloraMath.MustNewDecFromString("0.0116"),
+			alloraMath.MustNewDecFromString("0.01639"),
+			alloraMath.MustNewDecFromString("0.01043"),
+			alloraMath.MustNewDecFromString("0.01308"),
+			alloraMath.MustNewDecFromString("0.01455"),
+			alloraMath.MustNewDecFromString("0.01607"),
+			alloraMath.MustNewDecFromString("0.01205"),
+			alloraMath.MustNewDecFromString("0.01357"),
+			alloraMath.MustNewDecFromString("0.01108"),
+			alloraMath.MustNewDecFromString("0.01633"),
+			alloraMath.MustNewDecFromString("0.01208"),
+			alloraMath.MustNewDecFromString("0.01278"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.01345"),
+			alloraMath.MustNewDecFromString("0.00209"),
+			alloraMath.MustNewDecFromString("0.03249"),
+			alloraMath.MustNewDecFromString("0.01688"),
+			alloraMath.MustNewDecFromString("0.02126"),
+			alloraMath.MustNewDecFromString("0.01338"),
+			alloraMath.MustNewDecFromString("0.0116"),
+			alloraMath.MustNewDecFromString("0.01605"),
+			alloraMath.MustNewDecFromString("0.0133"),
+			alloraMath.MustNewDecFromString("0.01407"),
+			alloraMath.MustNewDecFromString("0.01367"),
+			alloraMath.MustNewDecFromString("0.01244"),
+			alloraMath.MustNewDecFromString("0.0145"),
+			alloraMath.MustNewDecFromString("0.01262"),
+			alloraMath.MustNewDecFromString("0.01348"),
+			alloraMath.MustNewDecFromString("0.01684"),
+			alloraMath.MustNewDecFromString("0.01148"),
+			alloraMath.MustNewDecFromString("0.01705"),
+			alloraMath.MustNewDecFromString("0.01714"),
+			alloraMath.MustNewDecFromString("0.0124"),
+			alloraMath.MustNewDecFromString("0.0125"),
+			alloraMath.MustNewDecFromString("0.01462"),
+			alloraMath.MustNewDecFromString("0.01274"),
+			alloraMath.MustNewDecFromString("0.01407"),
+			alloraMath.MustNewDecFromString("0.01667"),
+			alloraMath.MustNewDecFromString("0.01316"),
+			alloraMath.MustNewDecFromString("0.01628"),
+			alloraMath.MustNewDecFromString("0.01373"),
+			alloraMath.MustNewDecFromString("0.01409"),
+			alloraMath.MustNewDecFromString("0.01603"),
+			alloraMath.MustNewDecFromString("0.01378"),
+			alloraMath.MustNewDecFromString("0.01143"),
+			alloraMath.MustNewDecFromString("0.013"),
+			alloraMath.MustNewDecFromString("0.01644"),
+			alloraMath.MustNewDecFromString("0.01528"),
+			alloraMath.MustNewDecFromString("0.01441"),
+			alloraMath.MustNewDecFromString("0.01404"),
+			alloraMath.MustNewDecFromString("0.01402"),
+			alloraMath.MustNewDecFromString("0.01479"),
+			alloraMath.MustNewDecFromString("0.01417"),
+			alloraMath.MustNewDecFromString("0.01244"),
+			alloraMath.MustNewDecFromString("0.0116"),
+			alloraMath.MustNewDecFromString("0.01419"),
+			alloraMath.MustNewDecFromString("0.01497"),
+			alloraMath.MustNewDecFromString("0.01629"),
+			alloraMath.MustNewDecFromString("0.01514"),
+			alloraMath.MustNewDecFromString("0.01133"),
+			alloraMath.MustNewDecFromString("0.01339"),
+			alloraMath.MustNewDecFromString("0.01053"),
+			alloraMath.MustNewDecFromString("0.01424"),
+			alloraMath.MustNewDecFromString("0.01428"),
+			alloraMath.MustNewDecFromString("0.01446"),
+			alloraMath.MustNewDecFromString("0.01805"),
+			alloraMath.MustNewDecFromString("0.01229"),
+			alloraMath.MustNewDecFromString("0.01586"),
+			alloraMath.MustNewDecFromString("0.01234"),
+			alloraMath.MustNewDecFromString("0.01513"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.01675"),
+			alloraMath.MustNewDecFromString("0.00318"),
+			alloraMath.MustNewDecFromString("0.02623"),
+			alloraMath.MustNewDecFromString("0.02734"),
+			alloraMath.MustNewDecFromString("0.03526"),
+			alloraMath.MustNewDecFromString("0.02733"),
+			alloraMath.MustNewDecFromString("0.01697"),
+			alloraMath.MustNewDecFromString("0.01619"),
+			alloraMath.MustNewDecFromString("0.01925"),
+			alloraMath.MustNewDecFromString("0.02018"),
+			alloraMath.MustNewDecFromString("0.01735"),
+			alloraMath.MustNewDecFromString("0.01922"),
+			alloraMath.MustNewDecFromString("0.02225"),
+			alloraMath.MustNewDecFromString("0.0189"),
+			alloraMath.MustNewDecFromString("0.01923"),
+			alloraMath.MustNewDecFromString("0.03193"),
+			alloraMath.MustNewDecFromString("0.01956"),
+			alloraMath.MustNewDecFromString("0.01763"),
+			alloraMath.MustNewDecFromString("0.01975"),
+			alloraMath.MustNewDecFromString("0.01466"),
+			alloraMath.MustNewDecFromString("0.02021"),
+			alloraMath.MustNewDecFromString("0.01803"),
+			alloraMath.MustNewDecFromString("0.01438"),
+			alloraMath.MustNewDecFromString("0.01929"),
+			alloraMath.MustNewDecFromString("0.02305"),
+			alloraMath.MustNewDecFromString("0.02223"),
+			alloraMath.MustNewDecFromString("0.02445"),
+			alloraMath.MustNewDecFromString("0.01967"),
+			alloraMath.MustNewDecFromString("0.02292"),
+			alloraMath.MustNewDecFromString("0.01878"),
+			alloraMath.MustNewDecFromString("0.01751"),
+			alloraMath.MustNewDecFromString("0.02695"),
+			alloraMath.MustNewDecFromString("0.01849"),
+			alloraMath.MustNewDecFromString("0.01658"),
+			alloraMath.MustNewDecFromString("0.01948"),
+			alloraMath.MustNewDecFromString("0.01594"),
+			alloraMath.MustNewDecFromString("0.02318"),
+			alloraMath.MustNewDecFromString("0.01906"),
+			alloraMath.MustNewDecFromString("0.01607"),
+			alloraMath.MustNewDecFromString("0.01369"),
+			alloraMath.MustNewDecFromString("0.01686"),
+			alloraMath.MustNewDecFromString("0.01314"),
+			alloraMath.MustNewDecFromString("0.01936"),
+			alloraMath.MustNewDecFromString("0.01518"),
+			alloraMath.MustNewDecFromString("0.018"),
+			alloraMath.MustNewDecFromString("0.02212"),
+			alloraMath.MustNewDecFromString("0.02259"),
+			alloraMath.MustNewDecFromString("0.01674"),
+			alloraMath.MustNewDecFromString("0.02944"),
+			alloraMath.MustNewDecFromString("0.01796"),
+			alloraMath.MustNewDecFromString("0.02187"),
+			alloraMath.MustNewDecFromString("0.01895"),
+			alloraMath.MustNewDecFromString("0.01637"),
+			alloraMath.MustNewDecFromString("0.01594"),
+			alloraMath.MustNewDecFromString("0.01608"),
+			alloraMath.MustNewDecFromString("0.02203"),
+			alloraMath.MustNewDecFromString("0.01486"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.02093"),
+			alloraMath.MustNewDecFromString("0.00213"),
+			alloraMath.MustNewDecFromString("0.02462"),
+			alloraMath.MustNewDecFromString("0.0203"),
+			alloraMath.MustNewDecFromString("0.03115"),
+			alloraMath.MustNewDecFromString("0.01"),
+			alloraMath.MustNewDecFromString("0.01545"),
+			alloraMath.MustNewDecFromString("0.01785"),
+			alloraMath.MustNewDecFromString("0.01662"),
+			alloraMath.MustNewDecFromString("0.01156"),
+			alloraMath.MustNewDecFromString("0.02284"),
+			alloraMath.MustNewDecFromString("0.01475"),
+			alloraMath.MustNewDecFromString("0.01331"),
+			alloraMath.MustNewDecFromString("0.01592"),
+			alloraMath.MustNewDecFromString("0.01462"),
+			alloraMath.MustNewDecFromString("0.02333"),
+			alloraMath.MustNewDecFromString("0.01836"),
+			alloraMath.MustNewDecFromString("0.01465"),
+			alloraMath.MustNewDecFromString("0.0186"),
+			alloraMath.MustNewDecFromString("0.01566"),
+			alloraMath.MustNewDecFromString("0.01506"),
+			alloraMath.MustNewDecFromString("0.01678"),
+			alloraMath.MustNewDecFromString("0.01423"),
+			alloraMath.MustNewDecFromString("0.01658"),
+			alloraMath.MustNewDecFromString("0.01741"),
+			alloraMath.MustNewDecFromString("0.03491"),
+			alloraMath.MustNewDecFromString("0.01408"),
+			alloraMath.MustNewDecFromString("0.01191"),
+			alloraMath.MustNewDecFromString("0.01572"),
+			alloraMath.MustNewDecFromString("0.01355"),
+			alloraMath.MustNewDecFromString("0.01477"),
+			alloraMath.MustNewDecFromString("0.01662"),
+			alloraMath.MustNewDecFromString("0.01128"),
+			alloraMath.MustNewDecFromString("0.02581"),
+			alloraMath.MustNewDecFromString("0.01718"),
+			alloraMath.MustNewDecFromString("0.01705"),
+			alloraMath.MustNewDecFromString("0.01251"),
+			alloraMath.MustNewDecFromString("0.02158"),
+			alloraMath.MustNewDecFromString("0.01187"),
+			alloraMath.MustNewDecFromString("0.01504"),
+			alloraMath.MustNewDecFromString("0.0135"),
+			alloraMath.MustNewDecFromString("0.02432"),
+			alloraMath.MustNewDecFromString("0.01602"),
+			alloraMath.MustNewDecFromString("0.01194"),
+			alloraMath.MustNewDecFromString("0.0153"),
+			alloraMath.MustNewDecFromString("0.0199"),
+			alloraMath.MustNewDecFromString("0.01673"),
+			alloraMath.MustNewDecFromString("0.01049"),
+			alloraMath.MustNewDecFromString("0.02068"),
+			alloraMath.MustNewDecFromString("0.01573"),
+			alloraMath.MustNewDecFromString("0.01487"),
+			alloraMath.MustNewDecFromString("0.02639"),
+			alloraMath.MustNewDecFromString("0.01981"),
+			alloraMath.MustNewDecFromString("0.02123"),
+			alloraMath.MustNewDecFromString("0.02134"),
+			alloraMath.MustNewDecFromString("0.0217"),
+			alloraMath.MustNewDecFromString("0.01177"),
+		},
 	}
 	stakes := []alloraMath.Dec{
 		alloraMath.MustNewDecFromString("1176644.37627"),

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -61,9 +61,17 @@ type RewardsTestSuite struct {
 func (s *RewardsTestSuite) SetupTest() {
 	key := storetypes.NewKVStoreKey("emissions")
 	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+	testCtx := testutil.DefaultContextWithDB(
+		s.T(),
+		key,
+		storetypes.NewTransientStoreKey("transient_test"),
+	)
 	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()})
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
+	encCfg := moduletestutil.MakeTestEncodingConfig(
+		auth.AppModuleBasic{},
+		bank.AppModuleBasic{},
+		module.AppModule{},
+	)
 
 	maccPerms := map[string][]string{
 		"fee_collector":                {"minter"},
@@ -162,9 +170,16 @@ func (s *RewardsTestSuite) SetupTest() {
 }
 
 func (s *RewardsTestSuite) FundAccount(amount int64, accAddress sdk.AccAddress) {
-	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(amount)))
+	initialStakeCoins := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(amount)),
+	)
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, accAddress, initialStakeCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		s.ctx,
+		types.AlloraStakingAccountName,
+		accAddress,
+		initialStakeCoins,
+	)
 }
 
 func TestModuleTestSuite(t *testing.T) {
@@ -175,7 +190,12 @@ func (s *RewardsTestSuite) MintTokensToAddress(address sdk.AccAddress, amount co
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
 
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		s.ctx,
+		types.AlloraStakingAccountName,
+		address,
+		creatorInitialBalanceCoins,
+	)
 }
 
 func (s *RewardsTestSuite) MintTokensToModule(moduleName string, amount cosmosMath.Int) {
@@ -714,7 +734,13 @@ func (s *RewardsTestSuite) getRewardsDistribution(
 	reputerAddrs := getAddrsFromValues(reputerValues)
 
 	// Insert inference from workers
-	inferenceBundles := GenerateSimpleWorkerDataBundles(s, topicId, blockHeight, workerValues, reputerAddrs)
+	inferenceBundles := GenerateSimpleWorkerDataBundles(
+		s,
+		topicId,
+		blockHeight,
+		workerValues,
+		reputerAddrs,
+	)
 
 	_, err = s.msgServer.InsertBulkWorkerPayload(s.ctx, &types.MsgInsertBulkWorkerPayload{
 		Sender:            workerAddrs[0].String(),
@@ -762,7 +788,11 @@ func (s *RewardsTestSuite) getRewardsDistribution(
 	return rewardsDistributionByTopicParticipant
 }
 
-func areTaskRewardsEqualIgnoringTopicId(s *RewardsTestSuite, A []rewards.TaskRewards, B []rewards.TaskRewards) bool {
+func areTaskRewardsEqualIgnoringTopicId(
+	s *RewardsTestSuite,
+	A []rewards.TaskRewards,
+	B []rewards.TaskRewards,
+) bool {
 	if len(A) != len(B) {
 		s.Fail("Lengths are different")
 	}
@@ -775,7 +805,11 @@ func areTaskRewardsEqualIgnoringTopicId(s *RewardsTestSuite, A []rewards.TaskRew
 					s.Fail("Worker %v found twice", taskRewardA.Address)
 				}
 				found = true
-				if !alloraMath.InDelta(taskRewardA.Reward, taskRewardB.Reward, alloraMath.MustNewDecFromString("0.00001")) {
+				if !alloraMath.InDelta(
+					taskRewardA.Reward,
+					taskRewardB.Reward,
+					alloraMath.MustNewDecFromString("0.00001"),
+				) {
 					return false
 				}
 				if taskRewardA.Type != taskRewardB.Type {
@@ -900,8 +934,12 @@ func (s *RewardsTestSuite) TestFixingTaskRewardAlphaDoesNotChangePerformanceImpo
 		"0.1",
 	)
 
-	require.True(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_0, rewardsDistribution1_0))
-	require.True(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_1, rewardsDistribution1_1))
+	require.True(
+		areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_0, rewardsDistribution1_0),
+	)
+	require.True(
+		areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_1, rewardsDistribution1_1),
+	)
 }
 
 // We have 2 trials with 2 epochs each, and the first worker does better in the 2nd epoch in both trials,
@@ -1017,8 +1055,12 @@ func (s *RewardsTestSuite) TestIncreasingTaskRewardAlphaIncreasesImportanceOfPre
 		"0.1",
 	)
 
-	require.True(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_0, rewardsDistribution1_0))
-	require.False(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_1, rewardsDistribution1_1))
+	require.True(
+		areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_0, rewardsDistribution1_0),
+	)
+	require.False(
+		areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_1, rewardsDistribution1_1),
+	)
 
 	var workerReward_0_0_1_Reward alloraMath.Dec
 	found := false
@@ -1206,8 +1248,20 @@ func (s *RewardsTestSuite) TestIncreasingAlphaRegretIncreasesPresentEffectOnRegr
 	require.False(notFound)
 
 	require.True(worker0_0.Value.Gt(worker0_1.Value))
-	require.True(alloraMath.InDelta(worker1_0.Value, worker1_1.Value, alloraMath.MustNewDecFromString("0.00001")))
-	require.True(alloraMath.InDelta(worker2_0.Value, worker2_1.Value, alloraMath.MustNewDecFromString("0.00001")))
+	require.True(
+		alloraMath.InDelta(
+			worker1_0.Value,
+			worker1_1.Value,
+			alloraMath.MustNewDecFromString("0.00001"),
+		),
+	)
+	require.True(
+		alloraMath.InDelta(
+			worker2_0.Value,
+			worker2_1.Value,
+			alloraMath.MustNewDecFromString("0.00001"),
+		),
+	)
 }
 
 func (s *RewardsTestSuite) TestGenerateTasksRewardsShouldIncreaseRewardShareIfMoreParticipants() {
@@ -1345,7 +1399,14 @@ func (s *RewardsTestSuite) TestGenerateTasksRewardsShouldIncreaseRewardShareIfMo
 	params, err := s.emissionsKeeper.GetParams(s.ctx)
 	s.Require().NoError(err)
 
-	firstRewardsDistribution, firstTotalReputerReward, err := rewards.GenerateRewardsDistributionByTopicParticipant(s.ctx, s.emissionsKeeper, topicId, &topicTotalRewards, block, params)
+	firstRewardsDistribution, firstTotalReputerReward, err := rewards.GenerateRewardsDistributionByTopicParticipant(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		&topicTotalRewards,
+		block,
+		params,
+	)
 	s.Require().NoError(err)
 
 	calcFirstTotalReputerReward := alloraMath.ZeroDec()
@@ -1488,7 +1549,14 @@ func (s *RewardsTestSuite) TestGenerateTasksRewardsShouldIncreaseRewardShareIfMo
 	})
 	s.Require().NoError(err)
 
-	secondRewardsDistribution, secondTotalReputerReward, err := rewards.GenerateRewardsDistributionByTopicParticipant(s.ctx, s.emissionsKeeper, topicId, &topicTotalRewards, block, params)
+	secondRewardsDistribution, secondTotalReputerReward, err := rewards.GenerateRewardsDistributionByTopicParticipant(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		&topicTotalRewards,
+		block,
+		params,
+	)
 	s.Require().NoError(err)
 
 	calcSecondTotalReputerReward := alloraMath.ZeroDec()
@@ -1630,7 +1698,11 @@ func (s *RewardsTestSuite) TestRewardsIncreasesBalance() {
 	reputerStake := make([]cosmosMath.Int, 5)
 	for i, addr := range reputerAddrs {
 		reputerBalances[i] = s.bankKeeper.GetBalance(s.ctx, addr, params.DefaultBondDenom)
-		reputerStake[i], err = s.emissionsKeeper.GetStakeOnReputerInTopic(s.ctx, topicId, addr.String())
+		reputerStake[i], err = s.emissionsKeeper.GetStakeOnReputerInTopic(
+			s.ctx,
+			topicId,
+			addr.String(),
+		)
 		s.Require().NoError(err)
 	}
 
@@ -1677,7 +1749,11 @@ func (s *RewardsTestSuite) TestRewardsIncreasesBalance() {
 	s.Require().NoError(err)
 
 	for i, addr := range reputerAddrs {
-		reputerStakeCurrent, err := s.emissionsKeeper.GetStakeOnReputerInTopic(s.ctx, topicId, addr.String())
+		reputerStakeCurrent, err := s.emissionsKeeper.GetStakeOnReputerInTopic(
+			s.ctx,
+			topicId,
+			addr.String(),
+		)
 		s.Require().NoError(err)
 		s.Require().True(
 			reputerStakeCurrent.GT(reputerStake[i]),
@@ -1692,7 +1768,8 @@ func (s *RewardsTestSuite) TestRewardsIncreasesBalance() {
 	}
 
 	for i, addr := range workerAddrs {
-		s.Require().True(s.bankKeeper.GetBalance(s.ctx, addr, params.DefaultBondDenom).Amount.GT(workerBalances[i].Amount))
+		s.Require().
+			True(s.bankKeeper.GetBalance(s.ctx, addr, params.DefaultBondDenom).Amount.GT(workerBalances[i].Amount))
 	}
 }
 
@@ -1802,9 +1879,16 @@ func (s *RewardsTestSuite) TestRewardsHandleStandardDeviationOfZero() {
 
 	// fund topic 1
 	var initialStake int64 = 1000
-	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake)))
+	initialStakeCoins := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake)),
+	)
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, reputerAddrs[0], initialStakeCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		s.ctx,
+		types.AlloraStakingAccountName,
+		reputerAddrs[0],
+		initialStakeCoins,
+	)
 	fundTopicMessage := types.MsgFundTopic{
 		Sender:  reputerAddrs[0].String(),
 		TopicId: topicId1,
@@ -1815,7 +1899,12 @@ func (s *RewardsTestSuite) TestRewardsHandleStandardDeviationOfZero() {
 
 	// fund topic 2
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, reputerAddrs[0], initialStakeCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		s.ctx,
+		types.AlloraStakingAccountName,
+		reputerAddrs[0],
+		initialStakeCoins,
+	)
 	fundTopicMessage.TopicId = topicId2
 	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
 	s.Require().NoError(err)
@@ -1847,7 +1936,11 @@ func (s *RewardsTestSuite) TestRewardsHandleStandardDeviationOfZero() {
 	for i, addr := range reputerAddrs {
 		reputerBalances[i] = s.bankKeeper.GetBalance(s.ctx, addr, params.DefaultBondDenom)
 		if i > 2 {
-			reputerStake[i], err = s.emissionsKeeper.GetStakeOnReputerInTopic(s.ctx, topicId2, addr.String())
+			reputerStake[i], err = s.emissionsKeeper.GetStakeOnReputerInTopic(
+				s.ctx,
+				topicId2,
+				addr.String(),
+			)
 			s.Require().NoError(err)
 		} else {
 			reputerStake[i], err = s.emissionsKeeper.GetStakeOnReputerInTopic(s.ctx, topicId1, addr.String())
@@ -1975,7 +2068,10 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionWithOneInfererAndOneReputer
 
 	cosmosOneE18 := inference_synthesis.CosmosIntOneE18()
 
-	s.MintTokensToAddress(reputer, cosmosMath.NewInt(1176644).Mul(cosmosMath.NewIntFromBigInt(cosmosOneE18.BigInt())))
+	s.MintTokensToAddress(
+		reputer,
+		cosmosMath.NewInt(1176644).Mul(cosmosMath.NewIntFromBigInt(cosmosOneE18.BigInt())),
+	)
 	// Add Stake for reputer
 	_, err = s.msgServer.AddStake(s.ctx, &types.MsgAddStake{
 		Sender:  reputer.String(),
@@ -1985,9 +2081,16 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionWithOneInfererAndOneReputer
 	s.Require().NoError(err)
 
 	var initialStake int64 = 1000
-	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake)))
+	initialStakeCoins := sdk.NewCoins(
+		sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake)),
+	)
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, reputer, initialStakeCoins)
+	s.bankKeeper.SendCoinsFromModuleToAccount(
+		s.ctx,
+		types.AlloraStakingAccountName,
+		reputer,
+		initialStakeCoins,
+	)
 	fundTopicMessage := types.MsgFundTopic{
 		Sender:  reputer.String(),
 		TopicId: topicId,
@@ -2043,10 +2146,12 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionWithOneInfererAndOneReputer
 				BlockHeight: blockHeight,
 			},
 		},
-		Reputer:                reputer.String(),
-		CombinedValue:          alloraMath.MustNewDecFromString("0.01127"),
-		NaiveValue:             alloraMath.MustNewDecFromString("0.0116"),
-		InfererValues:          []*types.WorkerAttributedValue{{Worker: worker.String(), Value: alloraMath.MustNewDecFromString("0.0112")}},
+		Reputer:       reputer.String(),
+		CombinedValue: alloraMath.MustNewDecFromString("0.01127"),
+		NaiveValue:    alloraMath.MustNewDecFromString("0.0116"),
+		InfererValues: []*types.WorkerAttributedValue{
+			{Worker: worker.String(), Value: alloraMath.MustNewDecFromString("0.0112")},
+		},
 		ForecasterValues:       []*types.WorkerAttributedValue{},
 		OneOutInfererValues:    []*types.WithheldWorkerAttributedValue{},
 		OneOutForecasterValues: []*types.WithheldWorkerAttributedValue{},
@@ -2234,8 +2339,10 @@ func (s *RewardsTestSuite) TestOnlyFewTopActorsGetReward() {
 		*networkLossBundles)
 	s.Require().NoError(err)
 
-	s.Require().Equal(len(infererScores), int(params.GetMaxTopInferersToReward()), "Only few Top inferers can get reward")
-	s.Require().Equal(len(forecasterScores), int(params.GetMaxTopForecastersToReward()), "Only few Top forecasters can get reward")
+	s.Require().
+		Equal(len(infererScores), int(params.GetMaxTopInferersToReward()), "Only few Top inferers can get reward")
+	s.Require().
+		Equal(len(forecasterScores), int(params.GetMaxTopForecastersToReward()), "Only few Top forecasters can get reward")
 }
 
 func (s *RewardsTestSuite) TestGenerateRewardsDistributionByTopic() {
@@ -2752,5 +2859,6 @@ func (s *RewardsTestSuite) TestTotalInferersRewardFractionGrowsWithMoreInferers(
 	}
 	thirdForecasterFraction, err := totalForecastersReward.Quo(totalReward)
 	s.Require().NoError(err)
-	s.Require().True(firstForecasterFraction.Lt(thirdForecasterFraction), "Third forecaster fraction must be bigger than first fraction")
+	s.Require().
+		True(firstForecasterFraction.Lt(thirdForecasterFraction), "Third forecaster fraction must be bigger than first fraction")
 }

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -37,7 +37,11 @@ func GenerateReputerScores(
 		reputers = append(reputers, reportedLoss.ValueBundle.Reputer)
 
 		// Get reputer topic stake
-		reputerStake, err := keeper.GetStakeOnReputerInTopic(ctx, topicId, reportedLoss.ValueBundle.Reputer)
+		reputerStake, err := keeper.GetStakeOnReputerInTopic(
+			ctx,
+			topicId,
+			reportedLoss.ValueBundle.Reputer,
+		)
 		if err != nil {
 			return []types.Score{}, errors.Wrapf(err, "Error getting GetStakeOnReputerInTopic")
 		}
@@ -115,7 +119,13 @@ func GenerateReputerScores(
 }
 
 // GenerateInferenceScores calculates and persists scores for workers based on their inference task performance.
-func GenerateInferenceScores(ctx sdk.Context, keeper keeper.Keeper, topicId uint64, block int64, networkLosses types.ValueBundle) ([]types.Score, error) {
+func GenerateInferenceScores(
+	ctx sdk.Context,
+	keeper keeper.Keeper,
+	topicId uint64,
+	block int64,
+	networkLosses types.ValueBundle,
+) ([]types.Score, error) {
 	var newScores []types.Score
 
 	// If there is only one inferer, set score to 0
@@ -212,9 +222,16 @@ func GenerateForecastScores(
 		}
 
 		// Calculate forecast score
-		workerFinalScore, err := GetFinalWorkerScoreForecastTask(workerScoreOneIn, workersScoresOneOut[i], fUniqueAgg)
+		workerFinalScore, err := GetFinalWorkerScoreForecastTask(
+			workerScoreOneIn,
+			workersScoresOneOut[i],
+			fUniqueAgg,
+		)
 		if err != nil {
-			return []types.Score{}, errors.Wrapf(err, "Error getting final worker score forecast task")
+			return []types.Score{}, errors.Wrapf(
+				err,
+				"Error getting final worker score forecast task",
+			)
 		}
 
 		newScore := types.Score{
@@ -259,9 +276,18 @@ func ensureWorkerPresence(reportedLosses types.ReputerValueBundles) types.Repute
 
 	// Ensure each set has all workers, add NaN value for missing workers
 	for _, bundle := range reportedLosses.ReputerValueBundles {
-		bundle.ValueBundle.OneOutInfererValues = EnsureAllWorkersPresentWithheld(bundle.ValueBundle.OneOutInfererValues, allWorkersOneOutInferer)
-		bundle.ValueBundle.OneOutForecasterValues = EnsureAllWorkersPresentWithheld(bundle.ValueBundle.OneOutForecasterValues, allWorkersOneOutForecaster)
-		bundle.ValueBundle.OneInForecasterValues = EnsureAllWorkersPresent(bundle.ValueBundle.OneInForecasterValues, allWorkersOneInForecaster)
+		bundle.ValueBundle.OneOutInfererValues = EnsureAllWorkersPresentWithheld(
+			bundle.ValueBundle.OneOutInfererValues,
+			allWorkersOneOutInferer,
+		)
+		bundle.ValueBundle.OneOutForecasterValues = EnsureAllWorkersPresentWithheld(
+			bundle.ValueBundle.OneOutForecasterValues,
+			allWorkersOneOutForecaster,
+		)
+		bundle.ValueBundle.OneInForecasterValues = EnsureAllWorkersPresent(
+			bundle.ValueBundle.OneInForecasterValues,
+			allWorkersOneInForecaster,
+		)
 	}
 
 	return reportedLosses

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -285,7 +285,12 @@ func (s *RewardsTestSuite) TestEnsureAllWorkersPresentWithheld() {
 	}
 }
 
-func GenerateReputerLatestScores(s *RewardsTestSuite, reputers []sdk.AccAddress, blockHeight int64, topicId uint64) error {
+func GenerateReputerLatestScores(
+	s *RewardsTestSuite,
+	reputers []sdk.AccAddress,
+	blockHeight int64,
+	topicId uint64,
+) error {
 	var scores = []alloraMath.Dec{
 		alloraMath.MustNewDecFromString("17.53436"),
 		alloraMath.MustNewDecFromString("20.29489"),
@@ -320,24 +325,62 @@ func PrepareMockLosses(reputersCount int, workersCount int) (
 ) {
 	rnd := rand.New(rand.NewSource(20))
 	for i := 0; i < reputersCount; i++ {
-		reputersLosses = append(reputersLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-		reputersNaiveLosses = append(reputersNaiveLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
+		reputersLosses = append(
+			reputersLosses,
+			alloraMath.MustNewDecFromString(
+				strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64),
+			),
+		)
+		reputersNaiveLosses = append(
+			reputersNaiveLosses,
+			alloraMath.MustNewDecFromString(
+				strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64),
+			),
+		)
 		var infererLosses = make([]alloraMath.Dec, 0)
 		var forecasterLosses = make([]alloraMath.Dec, 0)
 		var infererOneOutLosses = make([]alloraMath.Dec, 0)
 		var forecasterOneOutLosses = make([]alloraMath.Dec, 0)
 		var oneInNaiveLosses = make([]alloraMath.Dec, 0)
 		for j := 0; j < workersCount; j++ {
-			infererLosses = append(infererLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-			forecasterLosses = append(forecasterLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-			infererOneOutLosses = append(infererOneOutLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-			forecasterOneOutLosses = append(forecasterOneOutLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-			oneInNaiveLosses = append(oneInNaiveLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
+			infererLosses = append(
+				infererLosses,
+				alloraMath.MustNewDecFromString(
+					strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64),
+				),
+			)
+			forecasterLosses = append(
+				forecasterLosses,
+				alloraMath.MustNewDecFromString(
+					strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64),
+				),
+			)
+			infererOneOutLosses = append(
+				infererOneOutLosses,
+				alloraMath.MustNewDecFromString(
+					strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64),
+				),
+			)
+			forecasterOneOutLosses = append(
+				forecasterOneOutLosses,
+				alloraMath.MustNewDecFromString(
+					strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64),
+				),
+			)
+			oneInNaiveLosses = append(
+				oneInNaiveLosses,
+				alloraMath.MustNewDecFromString(
+					strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64),
+				),
+			)
 		}
 		reputersInfererLosses = append(reputersInfererLosses, infererLosses)
 		reputersForecasterLosses = append(reputersForecasterLosses, forecasterLosses)
 		reputersInfererOneOutLosses = append(reputersInfererOneOutLosses, infererOneOutLosses)
-		reputersForecasterOneOutLosses = append(reputersForecasterOneOutLosses, forecasterOneOutLosses)
+		reputersForecasterOneOutLosses = append(
+			reputersForecasterOneOutLosses,
+			forecasterOneOutLosses,
+		)
 		reputersOneInNaiveLosses = append(reputersOneInNaiveLosses, oneInNaiveLosses)
 	}
 	return reputersLosses,
@@ -348,7 +391,13 @@ func PrepareMockLosses(reputersCount int, workersCount int) (
 		reputersForecasterOneOutLosses,
 		reputersOneInNaiveLosses
 }
-func GenerateLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64, reputers []sdk.AccAddress) types.ReputerValueBundles {
+
+func GenerateLossBundles(
+	s *RewardsTestSuite,
+	blockHeight int64,
+	topicId uint64,
+	reputers []sdk.AccAddress,
+) types.ReputerValueBundles {
 	workers := []sdk.AccAddress{
 		s.addrs[5],
 		s.addrs[6],
@@ -579,11 +628,26 @@ func GenerateLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64,
 		}
 
 		for j, worker := range workers {
-			valueBundle.InfererValues[j] = &types.WorkerAttributedValue{Worker: worker.String(), Value: reputersInfererLosses[i][j]}
-			valueBundle.ForecasterValues[j] = &types.WorkerAttributedValue{Worker: worker.String(), Value: reputersForecasterLosses[i][j]}
-			valueBundle.OneOutInfererValues[j] = &types.WithheldWorkerAttributedValue{Worker: worker.String(), Value: reputersInfererOneOutLosses[i][j]}
-			valueBundle.OneOutForecasterValues[j] = &types.WithheldWorkerAttributedValue{Worker: worker.String(), Value: reputersForecasterOneOutLosses[i][j]}
-			valueBundle.OneInForecasterValues[j] = &types.WorkerAttributedValue{Worker: worker.String(), Value: reputersOneInNaiveLosses[i][j]}
+			valueBundle.InfererValues[j] = &types.WorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersInfererLosses[i][j],
+			}
+			valueBundle.ForecasterValues[j] = &types.WorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersForecasterLosses[i][j],
+			}
+			valueBundle.OneOutInfererValues[j] = &types.WithheldWorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersInfererOneOutLosses[i][j],
+			}
+			valueBundle.OneOutForecasterValues[j] = &types.WithheldWorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersForecasterOneOutLosses[i][j],
+			}
+			valueBundle.OneInForecasterValues[j] = &types.WorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersOneInNaiveLosses[i][j],
+			}
 		}
 
 		sig, err := GenerateReputerSignature(s, valueBundle, reputer)
@@ -594,13 +658,22 @@ func GenerateLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64,
 			Signature:   sig,
 			ValueBundle: valueBundle,
 		}
-		reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, bundle)
+		reputerValueBundles.ReputerValueBundles = append(
+			reputerValueBundles.ReputerValueBundles,
+			bundle,
+		)
 	}
 
 	return reputerValueBundles
 }
 
-func GenerateHugeLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64, reputers []sdk.AccAddress, workers []sdk.AccAddress) types.ReputerValueBundles {
+func GenerateHugeLossBundles(
+	s *RewardsTestSuite,
+	blockHeight int64,
+	topicId uint64,
+	reputers []sdk.AccAddress,
+	workers []sdk.AccAddress,
+) types.ReputerValueBundles {
 
 	var (
 		reputersLosses,
@@ -635,11 +708,26 @@ func GenerateHugeLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uin
 		}
 
 		for j, worker := range workers {
-			valueBundle.InfererValues[j] = &types.WorkerAttributedValue{Worker: worker.String(), Value: reputersInfererLosses[i][j]}
-			valueBundle.ForecasterValues[j] = &types.WorkerAttributedValue{Worker: worker.String(), Value: reputersForecasterLosses[i][j]}
-			valueBundle.OneOutInfererValues[j] = &types.WithheldWorkerAttributedValue{Worker: worker.String(), Value: reputersInfererOneOutLosses[i][j]}
-			valueBundle.OneOutForecasterValues[j] = &types.WithheldWorkerAttributedValue{Worker: worker.String(), Value: reputersForecasterOneOutLosses[i][j]}
-			valueBundle.OneInForecasterValues[j] = &types.WorkerAttributedValue{Worker: worker.String(), Value: reputersOneInNaiveLosses[i][j]}
+			valueBundle.InfererValues[j] = &types.WorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersInfererLosses[i][j],
+			}
+			valueBundle.ForecasterValues[j] = &types.WorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersForecasterLosses[i][j],
+			}
+			valueBundle.OneOutInfererValues[j] = &types.WithheldWorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersInfererOneOutLosses[i][j],
+			}
+			valueBundle.OneOutForecasterValues[j] = &types.WithheldWorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersForecasterOneOutLosses[i][j],
+			}
+			valueBundle.OneInForecasterValues[j] = &types.WorkerAttributedValue{
+				Worker: worker.String(),
+				Value:  reputersOneInNaiveLosses[i][j],
+			}
 		}
 
 		sig, err := GenerateReputerSignature(s, valueBundle, reputer)
@@ -650,13 +738,21 @@ func GenerateHugeLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uin
 			Signature:   sig,
 			ValueBundle: valueBundle,
 		}
-		reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, bundle)
+		reputerValueBundles.ReputerValueBundles = append(
+			reputerValueBundles.ReputerValueBundles,
+			bundle,
+		)
 	}
 
 	return reputerValueBundles
 }
 
-func GenerateHugeWorkerDataBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64, workers []sdk.AccAddress) []*types.WorkerDataBundle {
+func GenerateHugeWorkerDataBundles(
+	s *RewardsTestSuite,
+	blockHeight int64,
+	topicId uint64,
+	workers []sdk.AccAddress,
+) []*types.WorkerDataBundle {
 	var inferences []*types.WorkerDataBundle
 	for _, worker := range workers {
 		workerInferenceForecastBundle := &types.InferenceForecastBundle{
@@ -664,7 +760,9 @@ func GenerateHugeWorkerDataBundles(s *RewardsTestSuite, blockHeight int64, topic
 				TopicId:     topicId,
 				BlockHeight: blockHeight,
 				Inferer:     worker.String(),
-				Value:       alloraMath.MustNewDecFromString(strconv.FormatInt(int64(rand.Intn(1000)+1), 10)),
+				Value: alloraMath.MustNewDecFromString(
+					strconv.FormatInt(int64(rand.Intn(1000)+1), 10),
+				),
 			},
 			Forecast: &types.Forecast{
 				TopicId:     topicId,
@@ -673,11 +771,15 @@ func GenerateHugeWorkerDataBundles(s *RewardsTestSuite, blockHeight int64, topic
 				ForecastElements: []*types.ForecastElement{
 					{
 						Inferer: s.addrs[26].String(),
-						Value:   alloraMath.MustNewDecFromString(strconv.FormatInt(int64(rand.Intn(1000)+1), 10)),
+						Value: alloraMath.MustNewDecFromString(
+							strconv.FormatInt(int64(rand.Intn(1000)+1), 10),
+						),
 					},
 					{
 						Inferer: s.addrs[27].String(),
-						Value:   alloraMath.MustNewDecFromString(strconv.FormatInt(int64(rand.Intn(1000)+1), 10)),
+						Value: alloraMath.MustNewDecFromString(
+							strconv.FormatInt(int64(rand.Intn(1000)+1), 10),
+						),
 					},
 				},
 			},
@@ -694,7 +796,12 @@ func GenerateHugeWorkerDataBundles(s *RewardsTestSuite, blockHeight int64, topic
 	}
 	return inferences
 }
-func GenerateReputerSignature(s *RewardsTestSuite, valueBundle *types.ValueBundle, account sdk.AccAddress) ([]byte, error) {
+
+func GenerateReputerSignature(
+	s *RewardsTestSuite,
+	valueBundle *types.ValueBundle,
+	account sdk.AccAddress,
+) ([]byte, error) {
 	protoBytesIn := make([]byte, 0)
 	protoBytesIn, err := valueBundle.XXX_Marshal(protoBytesIn, true)
 	if err != nil {
@@ -710,7 +817,11 @@ func GenerateReputerSignature(s *RewardsTestSuite, valueBundle *types.ValueBundl
 	return sig, nil
 }
 
-func GenerateWorkerSignature(s *RewardsTestSuite, valueBundle *types.InferenceForecastBundle, account sdk.AccAddress) ([]byte, error) {
+func GenerateWorkerSignature(
+	s *RewardsTestSuite,
+	valueBundle *types.InferenceForecastBundle,
+	account sdk.AccAddress,
+) ([]byte, error) {
 	protoBytesIn := make([]byte, 0)
 	protoBytesIn, err := valueBundle.XXX_Marshal(protoBytesIn, true)
 	if err != nil {
@@ -731,7 +842,11 @@ func GetAccPubKey(s *RewardsTestSuite, address sdk.AccAddress) string {
 	return hex.EncodeToString(pk)
 }
 
-func GenerateWorkerDataBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64) []*types.WorkerDataBundle {
+func GenerateWorkerDataBundles(
+	s *RewardsTestSuite,
+	blockHeight int64,
+	topicId uint64,
+) []*types.WorkerDataBundle {
 	var inferences []*types.WorkerDataBundle
 	worker1Addr := s.addrs[5]
 	worker2Addr := s.addrs[6]
@@ -908,7 +1023,11 @@ func GenerateWorkerDataBundles(s *RewardsTestSuite, blockHeight int64, topicId u
 	return inferences
 }
 
-func GenerateMoreInferencesDataBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64) []*types.WorkerDataBundle {
+func GenerateMoreInferencesDataBundles(
+	s *RewardsTestSuite,
+	blockHeight int64,
+	topicId uint64,
+) []*types.WorkerDataBundle {
 	var newInferences []*types.WorkerDataBundle
 	oldForecaster := s.addrs[5]
 	worker1Addr := s.addrs[10]
@@ -983,7 +1102,11 @@ func GenerateMoreInferencesDataBundles(s *RewardsTestSuite, blockHeight int64, t
 	return newInferences
 }
 
-func GenerateMoreForecastersDataBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64) []*types.WorkerDataBundle {
+func GenerateMoreForecastersDataBundles(
+	s *RewardsTestSuite,
+	blockHeight int64,
+	topicId uint64,
+) []*types.WorkerDataBundle {
 	var newForecasts []*types.WorkerDataBundle
 	oldInferencer1 := s.addrs[5]
 	oldInferencer2 := s.addrs[6]
@@ -1116,7 +1239,11 @@ func GenerateSimpleWorkerDataBundles(
 				},
 			},
 		}
-		workerSig, err := GenerateWorkerSignature(s, newWorkerInferenceForecastBundle, workerValue.Address)
+		workerSig, err := GenerateWorkerSignature(
+			s,
+			newWorkerInferenceForecastBundle,
+			workerValue.Address,
+		)
 		s.Require().NoError(err)
 		workerBundle := &types.WorkerDataBundle{
 			Worker:                             workerValue.Address.String(),
@@ -1165,18 +1292,33 @@ func GenerateSimpleLossBundles(
 
 		for j, worker := range workerValues {
 			if worker.Address.Equals(workerZeroAddress) {
-				valueBundle.InfererValues[j] = &types.WorkerAttributedValue{Worker: worker.Address.String(), Value: alloraMath.MustNewDecFromString(workerZeroInfererValue)}
+				valueBundle.InfererValues[j] = &types.WorkerAttributedValue{
+					Worker: worker.Address.String(),
+					Value:  alloraMath.MustNewDecFromString(workerZeroInfererValue),
+				}
 			} else {
 				valueBundle.InfererValues[j] = &types.WorkerAttributedValue{Worker: worker.Address.String(), Value: alloraMath.MustNewDecFromString(worker.Value)}
 			}
-			valueBundle.ForecasterValues[j] = &types.WorkerAttributedValue{Worker: worker.Address.String(), Value: alloraMath.MustNewDecFromString(worker.Value)}
+			valueBundle.ForecasterValues[j] = &types.WorkerAttributedValue{
+				Worker: worker.Address.String(),
+				Value:  alloraMath.MustNewDecFromString(worker.Value),
+			}
 			if worker.Address.Equals(workerZeroAddress) {
-				valueBundle.OneOutInfererValues[j] = &types.WithheldWorkerAttributedValue{Worker: worker.Address.String(), Value: alloraMath.MustNewDecFromString(workerZeroOneOutInfererValue)}
+				valueBundle.OneOutInfererValues[j] = &types.WithheldWorkerAttributedValue{
+					Worker: worker.Address.String(),
+					Value:  alloraMath.MustNewDecFromString(workerZeroOneOutInfererValue),
+				}
 			} else {
 				valueBundle.OneOutInfererValues[j] = &types.WithheldWorkerAttributedValue{Worker: worker.Address.String(), Value: alloraMath.MustNewDecFromString(worker.Value)}
 			}
-			valueBundle.OneOutForecasterValues[j] = &types.WithheldWorkerAttributedValue{Worker: worker.Address.String(), Value: alloraMath.MustNewDecFromString(worker.Value)}
-			valueBundle.OneInForecasterValues[j] = &types.WorkerAttributedValue{Worker: worker.Address.String(), Value: alloraMath.MustNewDecFromString(worker.Value)}
+			valueBundle.OneOutForecasterValues[j] = &types.WithheldWorkerAttributedValue{
+				Worker: worker.Address.String(),
+				Value:  alloraMath.MustNewDecFromString(worker.Value),
+			}
+			valueBundle.OneInForecasterValues[j] = &types.WorkerAttributedValue{
+				Worker: worker.Address.String(),
+				Value:  alloraMath.MustNewDecFromString(worker.Value),
+			}
 		}
 
 		sig, err := GenerateReputerSignature(s, valueBundle, reputer.Address)
@@ -1187,7 +1329,10 @@ func GenerateSimpleLossBundles(
 			Signature:   sig,
 			ValueBundle: valueBundle,
 		}
-		reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, bundle)
+		reputerValueBundles.ReputerValueBundles = append(
+			reputerValueBundles.ReputerValueBundles,
+			bundle,
+		)
 	}
 
 	return reputerValueBundles

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -60,7 +60,10 @@ func SafeApplyFuncOnAllActiveTopics(
 	topicPageKey := make([]byte, 0)
 	i := uint64(0)
 	for {
-		topicPageRequest := &types.SimpleCursorPaginationRequest{Limit: topicPageLimit, Key: topicPageKey}
+		topicPageRequest := &types.SimpleCursorPaginationRequest{
+			Limit: topicPageLimit,
+			Key:   topicPageKey,
+		}
 		topicsActive, topicPageResponse, err := k.GetIdsOfActiveTopics(ctx, topicPageRequest)
 		if err != nil {
 			ctx.Logger().Warn(fmt.Sprintf("Error getting ids of active topics: %s", err.Error()))
@@ -78,7 +81,8 @@ func SafeApplyFuncOnAllActiveTopics(
 				// All checks passed => Apply function on the topic
 				err = fn(ctx, &topic)
 				if err != nil {
-					ctx.Logger().Warn(fmt.Sprintf("Error applying function on topic: %s", err.Error()))
+					ctx.Logger().
+						Warn(fmt.Sprintf("Error applying function on topic: %s", err.Error()))
 					continue
 				}
 			}
@@ -193,9 +197,19 @@ func GetAndOptionallyUpdateActiveTopicWeights(
 
 	// default page limit for the max because default is 100 and max is 1000
 	// 1000 is excessive for the topic query
-	err = SafeApplyFuncOnAllActiveTopics(ctx, k, block, fn, moduleParams.DefaultPageLimit, moduleParams.DefaultPageLimit)
+	err = SafeApplyFuncOnAllActiveTopics(
+		ctx,
+		k,
+		block,
+		fn,
+		moduleParams.DefaultPageLimit,
+		moduleParams.DefaultPageLimit,
+	)
 	if err != nil {
-		return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to apply function on all reward ready topics to get weights")
+		return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(
+			err,
+			"failed to apply function on all reward ready topics to get weights",
+		)
 	}
 
 	return weights, sumWeight, totalRevenue, nil

--- a/x/emissions/module/rewards/topic_skimming.go
+++ b/x/emissions/module/rewards/topic_skimming.go
@@ -18,7 +18,11 @@ type SortableTopicId struct {
 
 // Sorts the given slice of topics in descending order according to their corresponding return, using pseudorandom tiebreaker
 // e.g. ([]uint64{1, 2, 3}, map[uint64]uint64{1: 2, 2: 2, 3: 3}, 0) -> [3, 1, 2] or [3, 2, 1]
-func SortTopicsByWeightDescWithRandomTiebreaker(topicIds []TopicId, weights map[TopicId]*alloraMath.Dec, randSeed BlockHeight) []TopicId {
+func SortTopicsByWeightDescWithRandomTiebreaker(
+	topicIds []TopicId,
+	weights map[TopicId]*alloraMath.Dec,
+	randSeed BlockHeight,
+) []TopicId {
 	// Convert the slice of Ts to a slice of SortableItems, each with a random tiebreaker
 	r := rand.New(rand.NewSource(randSeed))
 	items := make([]SortableTopicId, len(topicIds))
@@ -45,7 +49,12 @@ func SortTopicsByWeightDescWithRandomTiebreaker(topicIds []TopicId, weights map[
 
 // Returns a map of topicId to weights of the top N topics by weight in descending order
 // It is assumed that topicIds is of a reasonable size, throttled by perhaps MaxTopicsPerBlock global param
-func SkimTopTopicsByWeightDesc(sdkCtx sdk.Context, weights map[TopicId]*alloraMath.Dec, N uint64, block BlockHeight) (map[TopicId]*alloraMath.Dec, []TopicId) {
+func SkimTopTopicsByWeightDesc(
+	sdkCtx sdk.Context,
+	weights map[TopicId]*alloraMath.Dec,
+	N uint64,
+	block BlockHeight,
+) (map[TopicId]*alloraMath.Dec, []TopicId) {
 	topicIds := make([]TopicId, 0, len(weights))
 	for topicId := range weights {
 		topicIds = append(topicIds, topicId)

--- a/x/emissions/module/rewards/topic_skimming_test.go
+++ b/x/emissions/module/rewards/topic_skimming_test.go
@@ -35,12 +35,18 @@ func (s *RewardsTestSuite) TestSortTopicsByWeightDescWithRandomTiebreakerSimple(
 	}
 	sortedList := rewards.SortTopicsByWeightDescWithRandomTiebreaker(unsortedTopicIds, weights, 0)
 
-	s.Require().Equal(len(unsortedTopicIds), len(sortedList), "SortTopicsByWeightDescWithRandomTiebreaker should return the same length list")
-	s.Require().Equal(uint64(3), sortedList[0], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
-	s.Require().Equal(uint64(4), sortedList[1], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
-	s.Require().Equal(uint64(2), sortedList[2], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
-	s.Require().Equal(uint64(5), sortedList[3], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
-	s.Require().Equal(uint64(1), sortedList[4], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
+	s.Require().
+		Equal(len(unsortedTopicIds), len(sortedList), "SortTopicsByWeightDescWithRandomTiebreaker should return the same length list")
+	s.Require().
+		Equal(uint64(3), sortedList[0], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
+	s.Require().
+		Equal(uint64(4), sortedList[1], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
+	s.Require().
+		Equal(uint64(2), sortedList[2], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
+	s.Require().
+		Equal(uint64(5), sortedList[3], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
+	s.Require().
+		Equal(uint64(1), sortedList[4], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
 }
 
 func (s *RewardsTestSuite) TestSkimTopTopicsByWeightDescSimple() {
@@ -55,10 +61,14 @@ func (s *RewardsTestSuite) TestSkimTopTopicsByWeightDescSimple() {
 	mapOfTopN, listOfTopN := rewards.SkimTopTopicsByWeightDesc(s.ctx, weights, N, 0)
 
 	// Check that mapOfTopN has the expected keys
-	s.Require().Equal(N, uint64(len(mapOfTopN)), "SkimTopTopicsByWeightDesc should return a map with N keys")
-	s.Require().Equal("700", mapOfTopN[3].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
-	s.Require().Equal("400", mapOfTopN[4].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
-	s.Require().Equal("300", mapOfTopN[2].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
+	s.Require().
+		Equal(N, uint64(len(mapOfTopN)), "SkimTopTopicsByWeightDesc should return a map with N keys")
+	s.Require().
+		Equal("700", mapOfTopN[3].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
+	s.Require().
+		Equal("400", mapOfTopN[4].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
+	s.Require().
+		Equal("300", mapOfTopN[2].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
 	// Check that mapOfTopN does not have any other keys
 	_, ok := mapOfTopN[1]
 	s.Require().Equal(false, ok, "SkimTopTopicsByWeightDesc should not have any other keys")
@@ -66,8 +76,12 @@ func (s *RewardsTestSuite) TestSkimTopTopicsByWeightDescSimple() {
 	s.Require().Equal(false, ok, "SkimTopTopicsByWeightDesc should not have any other keys")
 
 	// Check that listOfTopN has the expected values and size
-	s.Require().Equal(N, uint64(len(listOfTopN)), "SkimTopTopicsByWeightDesc should return a list with N elements")
-	s.Require().Equal(uint64(3), listOfTopN[0], "SkimTopTopicsByWeightDesc should return the expected sorted list")
-	s.Require().Equal(uint64(4), listOfTopN[1], "SkimTopTopicsByWeightDesc should return the expected sorted list")
-	s.Require().Equal(uint64(2), listOfTopN[2], "SkimTopTopicsByWeightDesc should return the expected sorted list")
+	s.Require().
+		Equal(N, uint64(len(listOfTopN)), "SkimTopTopicsByWeightDesc should return a list with N elements")
+	s.Require().
+		Equal(uint64(3), listOfTopN[0], "SkimTopTopicsByWeightDesc should return the expected sorted list")
+	s.Require().
+		Equal(uint64(4), listOfTopN[1], "SkimTopTopicsByWeightDesc should return the expected sorted list")
+	s.Require().
+		Equal(uint64(2), listOfTopN[2], "SkimTopTopicsByWeightDesc should return the expected sorted list")
 }

--- a/x/emissions/module/rewards/worker_rewards.go
+++ b/x/emissions/module/rewards/worker_rewards.go
@@ -35,7 +35,16 @@ func GetInferenceTaskRewardFractions(
 	cReward alloraMath.Dec,
 	latestScores []types.Score,
 ) ([]string, []alloraMath.Dec, error) {
-	return GetWorkersRewardFractions(ctx, k, topicId, blockHeight, TASK_INFERENCE, pReward, cReward, latestScores)
+	return GetWorkersRewardFractions(
+		ctx,
+		k,
+		topicId,
+		blockHeight,
+		TASK_INFERENCE,
+		pReward,
+		cReward,
+		latestScores,
+	)
 }
 
 func GetForecastingTaskRewardFractions(
@@ -47,7 +56,16 @@ func GetForecastingTaskRewardFractions(
 	cReward alloraMath.Dec,
 	latestScores []types.Score,
 ) ([]string, []alloraMath.Dec, error) {
-	return GetWorkersRewardFractions(ctx, k, topicId, blockHeight, TASK_FORECAST, pReward, cReward, latestScores)
+	return GetWorkersRewardFractions(
+		ctx,
+		k,
+		topicId,
+		blockHeight,
+		TASK_FORECAST,
+		pReward,
+		cReward,
+		latestScores,
+	)
 }
 
 func GetWorkersRewardFractions(
@@ -73,9 +91,16 @@ func GetWorkersRewardFractions(
 		}
 
 		// Get worker scores from the latest time steps
-		latestScoresFromLastestTimeSteps, err := k.GetInferenceScoresUntilBlock(ctx, topicId, blockHeight)
+		latestScoresFromLastestTimeSteps, err := k.GetInferenceScoresUntilBlock(
+			ctx,
+			topicId,
+			blockHeight,
+		)
 		if err != nil {
-			return []string{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to get worker inference scores from the latest time steps")
+			return []string{}, []alloraMath.Dec{}, errors.Wrapf(
+				err,
+				"failed to get worker inference scores from the latest time steps",
+			)
 		}
 		var workerLastScoresDec []alloraMath.Dec
 		for _, score := range latestScoresFromLastestTimeSteps {
@@ -106,7 +131,13 @@ func GetWorkersRewardFractions(
 	if err != nil {
 		return []string{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to get epsilon")
 	}
-	rewardFractions, err := GetScoreFractions(latestWorkerScores, flatten(scores), pReward, cReward, moduleParams.Epsilon)
+	rewardFractions, err := GetScoreFractions(
+		latestWorkerScores,
+		flatten(scores),
+		pReward,
+		cReward,
+		moduleParams.Epsilon,
+	)
 	if err != nil {
 		return []string{}, []alloraMath.Dec{}, errors.Wrapf(err, "failed to get score fractions")
 	}
@@ -126,7 +157,16 @@ func GetInferenceTaskEntropy(
 	entropy alloraMath.Dec,
 	err error,
 ) {
-	return getInferenceOrForecastTaskEntropy(ctx, k, topicId, emaAlpha, betaEntropy, TASK_INFERENCE, workers, workersFractions)
+	return getInferenceOrForecastTaskEntropy(
+		ctx,
+		k,
+		topicId,
+		emaAlpha,
+		betaEntropy,
+		TASK_INFERENCE,
+		workers,
+		workersFractions,
+	)
 }
 
 func GetForecastingTaskEntropy(
@@ -141,7 +181,16 @@ func GetForecastingTaskEntropy(
 	entropy alloraMath.Dec,
 	err error,
 ) {
-	return getInferenceOrForecastTaskEntropy(ctx, k, topicId, emaAlpha, betaEntropy, TASK_FORECAST, workers, workersFractions)
+	return getInferenceOrForecastTaskEntropy(
+		ctx,
+		k,
+		topicId,
+		emaAlpha,
+		betaEntropy,
+		TASK_FORECAST,
+		workers,
+		workersFractions,
+	)
 }
 
 func getInferenceOrForecastTaskEntropy(
@@ -163,9 +212,16 @@ func getInferenceOrForecastTaskEntropy(
 	for i, worker := range workers {
 		noPriorScore := false
 		if which == TASK_INFERENCE {
-			previousRewardFraction, noPriorScore, err = k.GetPreviousInferenceRewardFraction(ctx, topicId, worker)
+			previousRewardFraction, noPriorScore, err = k.GetPreviousInferenceRewardFraction(
+				ctx,
+				topicId,
+				worker,
+			)
 			if err != nil {
-				return alloraMath.Dec{}, errors.Wrapf(err, "failed to get previous inference reward fraction")
+				return alloraMath.Dec{}, errors.Wrapf(
+					err,
+					"failed to get previous inference reward fraction",
+				)
 			}
 		} else { // TASK_FORECAST
 			previousRewardFraction, noPriorScore, err = k.GetPreviousForecastRewardFraction(ctx, topicId, worker)
@@ -195,9 +251,17 @@ func getInferenceOrForecastTaskEntropy(
 	}
 	if which == TASK_INFERENCE {
 		for i, worker := range workers {
-			err := k.SetPreviousInferenceRewardFraction(ctx, topicId, worker, modifiedRewardFractions[i])
+			err := k.SetPreviousInferenceRewardFraction(
+				ctx,
+				topicId,
+				worker,
+				modifiedRewardFractions[i],
+			)
 			if err != nil {
-				return alloraMath.Dec{}, errors.Wrapf(err, "failed to set previous inference reward fraction")
+				return alloraMath.Dec{}, errors.Wrapf(
+					err,
+					"failed to set previous inference reward fraction",
+				)
 			}
 		}
 	} else { // TASK_FORECAST
@@ -300,7 +364,9 @@ func NormalizationFactor(
 	if err != nil {
 		return alloraMath.Dec{}, err
 	}
-	oneMinusForecastingUtilityTimesEntropyInference, err := oneMinusForecastingUtility.Mul(entropyInference)
+	oneMinusForecastingUtilityTimesEntropyInference, err := oneMinusForecastingUtility.Mul(
+		entropyInference,
+	)
 	if err != nil {
 		return alloraMath.Dec{}, err
 	}
@@ -308,7 +374,9 @@ func NormalizationFactor(
 	if err != nil {
 		return alloraMath.Dec{}, err
 	}
-	denominator, err := oneMinusForecastingUtilityTimesEntropyInference.Add(forecastingUtilityTimesEntropyForecasting)
+	denominator, err := oneMinusForecastingUtilityTimesEntropyInference.Add(
+		forecastingUtilityTimesEntropyForecasting,
+	)
 	if err != nil {
 		return alloraMath.Dec{}, err
 	}
@@ -331,13 +399,19 @@ func getChiAndGamma(
 		networkInferenceLoss,
 	)
 	if err != nil {
-		return alloraMath.Dec{}, alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate forecasting performance score")
+		return alloraMath.Dec{}, alloraMath.Dec{}, errors.Wrapf(
+			err,
+			"failed to calculate forecasting performance score",
+		)
 	}
 	chi, err = ForecastingUtility(
 		forecastingTaskUtilityScore,
 	)
 	if err != nil {
-		return alloraMath.Dec{}, alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate forecasting utility")
+		return alloraMath.Dec{}, alloraMath.Dec{}, errors.Wrapf(
+			err,
+			"failed to calculate forecasting utility",
+		)
 	}
 	gamma, err = NormalizationFactor(
 		entropyInference,
@@ -345,7 +419,10 @@ func getChiAndGamma(
 		chi,
 	)
 	if err != nil {
-		return alloraMath.Dec{}, alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate normalization factor")
+		return alloraMath.Dec{}, alloraMath.Dec{}, errors.Wrapf(
+			err,
+			"failed to calculate normalization factor",
+		)
 	}
 	return chi, gamma, nil
 }

--- a/x/emissions/module/rewards/worker_rewards_test.go
+++ b/x/emissions/module/rewards/worker_rewards_test.go
@@ -33,11 +33,21 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsSimpleShouldOutputSameF
 			}
 
 			// Persist worker inference score
-			err := s.emissionsKeeper.InsertWorkerInferenceScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err := s.emissionsKeeper.InsertWorkerInferenceScore(
+				s.ctx,
+				topicId,
+				blockHeight,
+				scoreToAdd,
+			)
 			s.Require().NoError(err)
 
 			// Persist worker forecast score
-			err = s.emissionsKeeper.InsertWorkerForecastScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err = s.emissionsKeeper.InsertWorkerForecastScore(
+				s.ctx,
+				topicId,
+				blockHeight,
+				scoreToAdd,
+			)
 			s.Require().NoError(err)
 		}
 
@@ -120,11 +130,21 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsShouldOutputSameFraction
 			}
 
 			// Persist worker inference score
-			err := s.emissionsKeeper.InsertWorkerInferenceScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err := s.emissionsKeeper.InsertWorkerInferenceScore(
+				s.ctx,
+				topicId,
+				blockHeight,
+				scoreToAdd,
+			)
 			s.Require().NoError(err)
 
 			// Persist worker forecast score
-			err = s.emissionsKeeper.InsertWorkerForecastScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err = s.emissionsKeeper.InsertWorkerForecastScore(
+				s.ctx,
+				topicId,
+				blockHeight,
+				scoreToAdd,
+			)
 			s.Require().NoError(err)
 		}
 
@@ -241,7 +261,11 @@ func (s *RewardsTestSuite) TestGetWorkersRewardsForecastTask() {
 	s.Require().Equal(5, len(forecastRewards))
 }
 
-func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.ValueBundle, error) {
+func mockNetworkLosses(
+	s *RewardsTestSuite,
+	topicId uint64,
+	block int64,
+) (types.ValueBundle, error) {
 	oneOutInfererLosses := []*types.WithheldWorkerAttributedValue{
 		{
 			Worker: s.addrs[0].String(),
@@ -397,11 +421,31 @@ func mockWorkerLastScores(s *RewardsTestSuite, topicId uint64) ([]types.Score, e
 		1003,
 	}
 	var scores = [][]alloraMath.Dec{
-		{alloraMath.MustNewDecFromString("-0.00675"), alloraMath.MustNewDecFromString("-0.00622"), alloraMath.MustNewDecFromString("-0.00388")},
-		{alloraMath.MustNewDecFromString("-0.01502"), alloraMath.MustNewDecFromString("-0.01214"), alloraMath.MustNewDecFromString("-0.01554")},
-		{alloraMath.MustNewDecFromString("0.00392"), alloraMath.MustNewDecFromString("0.00559"), alloraMath.MustNewDecFromString("0.00545")},
-		{alloraMath.MustNewDecFromString("0.0438"), alloraMath.MustNewDecFromString("0.04304"), alloraMath.MustNewDecFromString("0.03906")},
-		{alloraMath.MustNewDecFromString("0.09719"), alloraMath.MustNewDecFromString("0.09675"), alloraMath.MustNewDecFromString("0.09418")},
+		{
+			alloraMath.MustNewDecFromString("-0.00675"),
+			alloraMath.MustNewDecFromString("-0.00622"),
+			alloraMath.MustNewDecFromString("-0.00388"),
+		},
+		{
+			alloraMath.MustNewDecFromString("-0.01502"),
+			alloraMath.MustNewDecFromString("-0.01214"),
+			alloraMath.MustNewDecFromString("-0.01554"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.00392"),
+			alloraMath.MustNewDecFromString("0.00559"),
+			alloraMath.MustNewDecFromString("0.00545"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.0438"),
+			alloraMath.MustNewDecFromString("0.04304"),
+			alloraMath.MustNewDecFromString("0.03906"),
+		},
+		{
+			alloraMath.MustNewDecFromString("0.09719"),
+			alloraMath.MustNewDecFromString("0.09675"),
+			alloraMath.MustNewDecFromString("0.09418"),
+		},
 	}
 
 	lastScores := make([]types.Score, 0)
@@ -415,7 +459,12 @@ func mockWorkerLastScores(s *RewardsTestSuite, topicId uint64) ([]types.Score, e
 			}
 
 			// Persist worker inference score
-			err := s.emissionsKeeper.InsertWorkerInferenceScore(s.ctx, topicId, blocks[j], scoreToAdd)
+			err := s.emissionsKeeper.InsertWorkerInferenceScore(
+				s.ctx,
+				topicId,
+				blocks[j],
+				scoreToAdd,
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/x/emissions/testutil/expected_keepers_mocks.go
+++ b/x/emissions/testutil/expected_keepers_mocks.go
@@ -45,11 +45,23 @@ func (m *MockBankKeeper) BurnCoins(arg0 context.Context, arg1 []byte, arg2 types
 // BurnCoins indicates an expected call of BurnCoins.
 func (mr *MockBankKeeperMockRecorder) BurnCoins(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BurnCoins", reflect.TypeOf((*MockBankKeeper)(nil).BurnCoins), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"BurnCoins",
+		reflect.TypeOf((*MockBankKeeper)(nil).BurnCoins),
+		arg0,
+		arg1,
+		arg2,
+	)
 }
 
 // DelegateCoinsFromAccountToModule mocks base method.
-func (m *MockBankKeeper) DelegateCoinsFromAccountToModule(ctx context.Context, senderAddr types0.AccAddress, recipientModule string, amt types0.Coins) error {
+func (m *MockBankKeeper) DelegateCoinsFromAccountToModule(
+	ctx context.Context,
+	senderAddr types0.AccAddress,
+	recipientModule string,
+	amt types0.Coins,
+) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DelegateCoinsFromAccountToModule", ctx, senderAddr, recipientModule, amt)
 	ret0, _ := ret[0].(error)
@@ -57,9 +69,19 @@ func (m *MockBankKeeper) DelegateCoinsFromAccountToModule(ctx context.Context, s
 }
 
 // DelegateCoinsFromAccountToModule indicates an expected call of DelegateCoinsFromAccountToModule.
-func (mr *MockBankKeeperMockRecorder) DelegateCoinsFromAccountToModule(ctx, senderAddr, recipientModule, amt interface{}) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) DelegateCoinsFromAccountToModule(
+	ctx, senderAddr, recipientModule, amt interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegateCoinsFromAccountToModule", reflect.TypeOf((*MockBankKeeper)(nil).DelegateCoinsFromAccountToModule), ctx, senderAddr, recipientModule, amt)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"DelegateCoinsFromAccountToModule",
+		reflect.TypeOf((*MockBankKeeper)(nil).DelegateCoinsFromAccountToModule),
+		ctx,
+		senderAddr,
+		recipientModule,
+		amt,
+	)
 }
 
 // GetAllBalances mocks base method.
@@ -73,11 +95,21 @@ func (m *MockBankKeeper) GetAllBalances(ctx context.Context, addr types0.AccAddr
 // GetAllBalances indicates an expected call of GetAllBalances.
 func (mr *MockBankKeeperMockRecorder) GetAllBalances(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllBalances", reflect.TypeOf((*MockBankKeeper)(nil).GetAllBalances), ctx, addr)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetAllBalances",
+		reflect.TypeOf((*MockBankKeeper)(nil).GetAllBalances),
+		ctx,
+		addr,
+	)
 }
 
 // GetBalance mocks base method.
-func (m *MockBankKeeper) GetBalance(ctx context.Context, addr types0.AccAddress, denom string) types0.Coin {
+func (m *MockBankKeeper) GetBalance(
+	ctx context.Context,
+	addr types0.AccAddress,
+	denom string,
+) types0.Coin {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBalance", ctx, addr, denom)
 	ret0, _ := ret[0].(types0.Coin)
@@ -87,7 +119,14 @@ func (m *MockBankKeeper) GetBalance(ctx context.Context, addr types0.AccAddress,
 // GetBalance indicates an expected call of GetBalance.
 func (mr *MockBankKeeperMockRecorder) GetBalance(ctx, addr, denom interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalance", reflect.TypeOf((*MockBankKeeper)(nil).GetBalance), ctx, addr, denom)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetBalance",
+		reflect.TypeOf((*MockBankKeeper)(nil).GetBalance),
+		ctx,
+		addr,
+		denom,
+	)
 }
 
 // GetSupply mocks base method.
@@ -101,7 +140,13 @@ func (m *MockBankKeeper) GetSupply(ctx context.Context, denom string) types0.Coi
 // GetSupply indicates an expected call of GetSupply.
 func (mr *MockBankKeeperMockRecorder) GetSupply(ctx, denom interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupply", reflect.TypeOf((*MockBankKeeper)(nil).GetSupply), ctx, denom)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetSupply",
+		reflect.TypeOf((*MockBankKeeper)(nil).GetSupply),
+		ctx,
+		denom,
+	)
 }
 
 // LockedCoins mocks base method.
@@ -115,11 +160,22 @@ func (m *MockBankKeeper) LockedCoins(ctx context.Context, addr types0.AccAddress
 // LockedCoins indicates an expected call of LockedCoins.
 func (mr *MockBankKeeperMockRecorder) LockedCoins(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LockedCoins", reflect.TypeOf((*MockBankKeeper)(nil).LockedCoins), ctx, addr)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"LockedCoins",
+		reflect.TypeOf((*MockBankKeeper)(nil).LockedCoins),
+		ctx,
+		addr,
+	)
 }
 
 // SendCoinsFromAccountToModule mocks base method.
-func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, senderAddr types0.AccAddress, recipientModule string, amt types0.Coins) error {
+func (m *MockBankKeeper) SendCoinsFromAccountToModule(
+	ctx context.Context,
+	senderAddr types0.AccAddress,
+	recipientModule string,
+	amt types0.Coins,
+) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendCoinsFromAccountToModule", ctx, senderAddr, recipientModule, amt)
 	ret0, _ := ret[0].(error)
@@ -127,13 +183,27 @@ func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, sende
 }
 
 // SendCoinsFromAccountToModule indicates an expected call of SendCoinsFromAccountToModule.
-func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(ctx, senderAddr, recipientModule, amt interface{}) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(
+	ctx, senderAddr, recipientModule, amt interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromAccountToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromAccountToModule), ctx, senderAddr, recipientModule, amt)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"SendCoinsFromAccountToModule",
+		reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromAccountToModule),
+		ctx,
+		senderAddr,
+		recipientModule,
+		amt,
+	)
 }
 
 // SendCoinsFromModuleToModule mocks base method.
-func (m *MockBankKeeper) SendCoinsFromModuleToModule(ctx context.Context, senderPool, recipientPool string, amt types0.Coins) error {
+func (m *MockBankKeeper) SendCoinsFromModuleToModule(
+	ctx context.Context,
+	senderPool, recipientPool string,
+	amt types0.Coins,
+) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendCoinsFromModuleToModule", ctx, senderPool, recipientPool, amt)
 	ret0, _ := ret[0].(error)
@@ -141,9 +211,19 @@ func (m *MockBankKeeper) SendCoinsFromModuleToModule(ctx context.Context, sender
 }
 
 // SendCoinsFromModuleToModule indicates an expected call of SendCoinsFromModuleToModule.
-func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToModule(ctx, senderPool, recipientPool, amt interface{}) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToModule(
+	ctx, senderPool, recipientPool, amt interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromModuleToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToModule), ctx, senderPool, recipientPool, amt)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"SendCoinsFromModuleToModule",
+		reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToModule),
+		ctx,
+		senderPool,
+		recipientPool,
+		amt,
+	)
 }
 
 // SpendableCoins mocks base method.
@@ -157,21 +237,49 @@ func (m *MockBankKeeper) SpendableCoins(ctx context.Context, addr types0.AccAddr
 // SpendableCoins indicates an expected call of SpendableCoins.
 func (mr *MockBankKeeperMockRecorder) SpendableCoins(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpendableCoins", reflect.TypeOf((*MockBankKeeper)(nil).SpendableCoins), ctx, addr)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"SpendableCoins",
+		reflect.TypeOf((*MockBankKeeper)(nil).SpendableCoins),
+		ctx,
+		addr,
+	)
 }
 
 // UndelegateCoinsFromModuleToAccount mocks base method.
-func (m *MockBankKeeper) UndelegateCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr types0.AccAddress, amt types0.Coins) error {
+func (m *MockBankKeeper) UndelegateCoinsFromModuleToAccount(
+	ctx context.Context,
+	senderModule string,
+	recipientAddr types0.AccAddress,
+	amt types0.Coins,
+) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UndelegateCoinsFromModuleToAccount", ctx, senderModule, recipientAddr, amt)
+	ret := m.ctrl.Call(
+		m,
+		"UndelegateCoinsFromModuleToAccount",
+		ctx,
+		senderModule,
+		recipientAddr,
+		amt,
+	)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UndelegateCoinsFromModuleToAccount indicates an expected call of UndelegateCoinsFromModuleToAccount.
-func (mr *MockBankKeeperMockRecorder) UndelegateCoinsFromModuleToAccount(ctx, senderModule, recipientAddr, amt interface{}) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) UndelegateCoinsFromModuleToAccount(
+	ctx, senderModule, recipientAddr, amt interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UndelegateCoinsFromModuleToAccount", reflect.TypeOf((*MockBankKeeper)(nil).UndelegateCoinsFromModuleToAccount), ctx, senderModule, recipientAddr, amt)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"UndelegateCoinsFromModuleToAccount",
+		reflect.TypeOf((*MockBankKeeper)(nil).UndelegateCoinsFromModuleToAccount),
+		ctx,
+		senderModule,
+		recipientAddr,
+		amt,
+	)
 }
 
 // BlockedAddr mocks base method.
@@ -185,7 +293,12 @@ func (m *MockBankKeeper) BlockedAddr(addr types0.AccAddress) bool {
 // BlockedAddr indicates an expected call of BlockedAddr.
 func (mr *MockBankKeeperMockRecorder) BlockedAddr(addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockedAddr", reflect.TypeOf((*MockBankKeeper)(nil).BlockedAddr), addr)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"BlockedAddr",
+		reflect.TypeOf((*MockBankKeeper)(nil).BlockedAddr),
+		addr,
+	)
 }
 
 // MintCoins mocks base method.
@@ -199,11 +312,23 @@ func (m *MockBankKeeper) MintCoins(ctx context.Context, moduleName string, amt t
 // MintCoins indicates an expected call of MintCoins.
 func (mr *MockBankKeeperMockRecorder) MintCoins(ctx, moduleName, amt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintCoins", reflect.TypeOf((*MockBankKeeper)(nil).MintCoins), ctx, moduleName, amt)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"MintCoins",
+		reflect.TypeOf((*MockBankKeeper)(nil).MintCoins),
+		ctx,
+		moduleName,
+		amt,
+	)
 }
 
 // SendCoinsFromModuleToAccount mocks base method.
-func (m *MockBankKeeper) SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr types0.AccAddress, amt types0.Coins) error {
+func (m *MockBankKeeper) SendCoinsFromModuleToAccount(
+	ctx context.Context,
+	senderModule string,
+	recipientAddr types0.AccAddress,
+	amt types0.Coins,
+) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendCoinsFromModuleToAccount", ctx, senderModule, recipientAddr, amt)
 	ret0, _ := ret[0].(error)
@@ -211,9 +336,19 @@ func (m *MockBankKeeper) SendCoinsFromModuleToAccount(ctx context.Context, sende
 }
 
 // SendCoinsFromModuleToAccount indicates an expected call of SendCoinsFromModuleToAccount.
-func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToAccount(ctx, senderModule, recipientAddr, amt interface{}) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToAccount(
+	ctx, senderModule, recipientAddr, amt interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromModuleToAccount", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToAccount), ctx, senderModule, recipientAddr, amt)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"SendCoinsFromModuleToAccount",
+		reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToAccount),
+		ctx,
+		senderModule,
+		recipientAddr,
+		amt,
+	)
 }
 
 // MockAccountKeeper is a mock of AccountKeeper interface.
@@ -250,11 +385,18 @@ func (m *MockAccountKeeper) AddressCodec() address.Codec {
 // AddressCodec indicates an expected call of AddressCodec.
 func (mr *MockAccountKeeperMockRecorder) AddressCodec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddressCodec", reflect.TypeOf((*MockAccountKeeper)(nil).AddressCodec))
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"AddressCodec",
+		reflect.TypeOf((*MockAccountKeeper)(nil).AddressCodec),
+	)
 }
 
 // GetAccount mocks base method.
-func (m *MockAccountKeeper) GetAccount(ctx context.Context, addr types0.AccAddress) types0.AccountI {
+func (m *MockAccountKeeper) GetAccount(
+	ctx context.Context,
+	addr types0.AccAddress,
+) types0.AccountI {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccount", ctx, addr)
 	ret0, _ := ret[0].(types0.AccountI)
@@ -264,7 +406,13 @@ func (m *MockAccountKeeper) GetAccount(ctx context.Context, addr types0.AccAddre
 // GetAccount indicates an expected call of GetAccount.
 func (mr *MockAccountKeeperMockRecorder) GetAccount(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccount", reflect.TypeOf((*MockAccountKeeper)(nil).GetAccount), ctx, addr)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetAccount",
+		reflect.TypeOf((*MockAccountKeeper)(nil).GetAccount),
+		ctx,
+		addr,
+	)
 }
 
 // GetAllAccounts mocks base method.
@@ -278,11 +426,19 @@ func (m *MockAccountKeeper) GetAllAccounts(ctx context.Context) []types0.Account
 // GetAllAccounts indicates an expected call of GetAllAccounts.
 func (mr *MockAccountKeeperMockRecorder) GetAllAccounts(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAccounts", reflect.TypeOf((*MockAccountKeeper)(nil).GetAllAccounts), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetAllAccounts",
+		reflect.TypeOf((*MockAccountKeeper)(nil).GetAllAccounts),
+		ctx,
+	)
 }
 
 // GetModuleAccount mocks base method.
-func (m *MockAccountKeeper) GetModuleAccount(ctx context.Context, moduleName string) types0.ModuleAccountI {
+func (m *MockAccountKeeper) GetModuleAccount(
+	ctx context.Context,
+	moduleName string,
+) types0.ModuleAccountI {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetModuleAccount", ctx, moduleName)
 	ret0, _ := ret[0].(types0.ModuleAccountI)
@@ -290,13 +446,24 @@ func (m *MockAccountKeeper) GetModuleAccount(ctx context.Context, moduleName str
 }
 
 // GetModuleAccount indicates an expected call of GetModuleAccount.
-func (mr *MockAccountKeeperMockRecorder) GetModuleAccount(ctx, moduleName interface{}) *gomock.Call {
+func (mr *MockAccountKeeperMockRecorder) GetModuleAccount(
+	ctx, moduleName interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleAccount", reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAccount), ctx, moduleName)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetModuleAccount",
+		reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAccount),
+		ctx,
+		moduleName,
+	)
 }
 
 // GetModuleAccountAndPermissions mocks base method.
-func (m *MockAccountKeeper) GetModuleAccountAndPermissions(ctx context.Context, moduleName string) (types0.ModuleAccountI, []string) {
+func (m *MockAccountKeeper) GetModuleAccountAndPermissions(
+	ctx context.Context,
+	moduleName string,
+) (types0.ModuleAccountI, []string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetModuleAccountAndPermissions", ctx, moduleName)
 	ret0, _ := ret[0].(types0.ModuleAccountI)
@@ -305,9 +472,17 @@ func (m *MockAccountKeeper) GetModuleAccountAndPermissions(ctx context.Context, 
 }
 
 // GetModuleAccountAndPermissions indicates an expected call of GetModuleAccountAndPermissions.
-func (mr *MockAccountKeeperMockRecorder) GetModuleAccountAndPermissions(ctx, moduleName interface{}) *gomock.Call {
+func (mr *MockAccountKeeperMockRecorder) GetModuleAccountAndPermissions(
+	ctx, moduleName interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleAccountAndPermissions", reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAccountAndPermissions), ctx, moduleName)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetModuleAccountAndPermissions",
+		reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAccountAndPermissions),
+		ctx,
+		moduleName,
+	)
 }
 
 // GetModuleAddress mocks base method.
@@ -321,11 +496,18 @@ func (m *MockAccountKeeper) GetModuleAddress(moduleName string) types0.AccAddres
 // GetModuleAddress indicates an expected call of GetModuleAddress.
 func (mr *MockAccountKeeperMockRecorder) GetModuleAddress(moduleName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleAddress", reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAddress), moduleName)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetModuleAddress",
+		reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAddress),
+		moduleName,
+	)
 }
 
 // GetModuleAddressAndPermissions mocks base method.
-func (m *MockAccountKeeper) GetModuleAddressAndPermissions(moduleName string) (types0.AccAddress, []string) {
+func (m *MockAccountKeeper) GetModuleAddressAndPermissions(
+	moduleName string,
+) (types0.AccAddress, []string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetModuleAddressAndPermissions", moduleName)
 	ret0, _ := ret[0].(types0.AccAddress)
@@ -334,9 +516,16 @@ func (m *MockAccountKeeper) GetModuleAddressAndPermissions(moduleName string) (t
 }
 
 // GetModuleAddressAndPermissions indicates an expected call of GetModuleAddressAndPermissions.
-func (mr *MockAccountKeeperMockRecorder) GetModuleAddressAndPermissions(moduleName interface{}) *gomock.Call {
+func (mr *MockAccountKeeperMockRecorder) GetModuleAddressAndPermissions(
+	moduleName interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleAddressAndPermissions", reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAddressAndPermissions), moduleName)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetModuleAddressAndPermissions",
+		reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAddressAndPermissions),
+		moduleName,
+	)
 }
 
 // GetModulePermissions mocks base method.
@@ -350,7 +539,11 @@ func (m *MockAccountKeeper) GetModulePermissions() map[string]types.PermissionsF
 // GetModulePermissions indicates an expected call of GetModulePermissions.
 func (mr *MockAccountKeeperMockRecorder) GetModulePermissions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModulePermissions", reflect.TypeOf((*MockAccountKeeper)(nil).GetModulePermissions))
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetModulePermissions",
+		reflect.TypeOf((*MockAccountKeeper)(nil).GetModulePermissions),
+	)
 }
 
 // HasAccount mocks base method.
@@ -364,11 +557,20 @@ func (m *MockAccountKeeper) HasAccount(ctx context.Context, addr types0.AccAddre
 // HasAccount indicates an expected call of HasAccount.
 func (mr *MockAccountKeeperMockRecorder) HasAccount(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasAccount", reflect.TypeOf((*MockAccountKeeper)(nil).HasAccount), ctx, addr)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"HasAccount",
+		reflect.TypeOf((*MockAccountKeeper)(nil).HasAccount),
+		ctx,
+		addr,
+	)
 }
 
 // IterateAccounts mocks base method.
-func (m *MockAccountKeeper) IterateAccounts(ctx context.Context, process func(types0.AccountI) bool) {
+func (m *MockAccountKeeper) IterateAccounts(
+	ctx context.Context,
+	process func(types0.AccountI) bool,
+) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "IterateAccounts", ctx, process)
 }
@@ -376,7 +578,13 @@ func (m *MockAccountKeeper) IterateAccounts(ctx context.Context, process func(ty
 // IterateAccounts indicates an expected call of IterateAccounts.
 func (mr *MockAccountKeeperMockRecorder) IterateAccounts(ctx, process interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IterateAccounts", reflect.TypeOf((*MockAccountKeeper)(nil).IterateAccounts), ctx, process)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"IterateAccounts",
+		reflect.TypeOf((*MockAccountKeeper)(nil).IterateAccounts),
+		ctx,
+		process,
+	)
 }
 
 // NewAccount mocks base method.
@@ -390,11 +598,20 @@ func (m *MockAccountKeeper) NewAccount(arg0 context.Context, arg1 types0.Account
 // NewAccount indicates an expected call of NewAccount.
 func (mr *MockAccountKeeperMockRecorder) NewAccount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAccount", reflect.TypeOf((*MockAccountKeeper)(nil).NewAccount), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"NewAccount",
+		reflect.TypeOf((*MockAccountKeeper)(nil).NewAccount),
+		arg0,
+		arg1,
+	)
 }
 
 // NewAccountWithAddress mocks base method.
-func (m *MockAccountKeeper) NewAccountWithAddress(ctx context.Context, addr types0.AccAddress) types0.AccountI {
+func (m *MockAccountKeeper) NewAccountWithAddress(
+	ctx context.Context,
+	addr types0.AccAddress,
+) types0.AccountI {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewAccountWithAddress", ctx, addr)
 	ret0, _ := ret[0].(types0.AccountI)
@@ -404,7 +621,13 @@ func (m *MockAccountKeeper) NewAccountWithAddress(ctx context.Context, addr type
 // NewAccountWithAddress indicates an expected call of NewAccountWithAddress.
 func (mr *MockAccountKeeperMockRecorder) NewAccountWithAddress(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAccountWithAddress", reflect.TypeOf((*MockAccountKeeper)(nil).NewAccountWithAddress), ctx, addr)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"NewAccountWithAddress",
+		reflect.TypeOf((*MockAccountKeeper)(nil).NewAccountWithAddress),
+		ctx,
+		addr,
+	)
 }
 
 // SetAccount mocks base method.
@@ -416,7 +639,13 @@ func (m *MockAccountKeeper) SetAccount(ctx context.Context, acc types0.AccountI)
 // SetAccount indicates an expected call of SetAccount.
 func (mr *MockAccountKeeperMockRecorder) SetAccount(ctx, acc interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAccount", reflect.TypeOf((*MockAccountKeeper)(nil).SetAccount), ctx, acc)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"SetAccount",
+		reflect.TypeOf((*MockAccountKeeper)(nil).SetAccount),
+		ctx,
+		acc,
+	)
 }
 
 // SetModuleAccount mocks base method.
@@ -428,7 +657,13 @@ func (m *MockAccountKeeper) SetModuleAccount(ctx context.Context, macc types0.Mo
 // SetModuleAccount indicates an expected call of SetModuleAccount.
 func (mr *MockAccountKeeperMockRecorder) SetModuleAccount(ctx, macc interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModuleAccount", reflect.TypeOf((*MockAccountKeeper)(nil).SetModuleAccount), ctx, macc)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"SetModuleAccount",
+		reflect.TypeOf((*MockAccountKeeper)(nil).SetModuleAccount),
+		ctx,
+		macc,
+	)
 }
 
 // ValidatePermissions mocks base method.
@@ -442,7 +677,12 @@ func (m *MockAccountKeeper) ValidatePermissions(macc types0.ModuleAccountI) erro
 // ValidatePermissions indicates an expected call of ValidatePermissions.
 func (mr *MockAccountKeeperMockRecorder) ValidatePermissions(macc interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePermissions", reflect.TypeOf((*MockAccountKeeper)(nil).ValidatePermissions), macc)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"ValidatePermissions",
+		reflect.TypeOf((*MockAccountKeeper)(nil).ValidatePermissions),
+		macc,
+	)
 }
 
 type MockTopicKeeper struct {
@@ -465,7 +705,10 @@ func (m *MockTopicKeeper) EXPECT() *MockTopicKeeperMockRecorder {
 }
 
 // GetTopicStake mocks base method
-func (m *MockTopicKeeper) GetTopicStake(ctx context.Context, topicId uint64) (cosmosMath.Int, error) {
+func (m *MockTopicKeeper) GetTopicStake(
+	ctx context.Context,
+	topicId uint64,
+) (cosmosMath.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTopicStake", ctx, topicId)
 	ret0, _ := ret[0].(cosmosMath.Int)
@@ -476,11 +719,20 @@ func (m *MockTopicKeeper) GetTopicStake(ctx context.Context, topicId uint64) (co
 // GetTopicStake indicates an expected call of GetTopicStake
 func (mr *MockTopicKeeperMockRecorder) GetTopicStake(ctx, topicId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTopicStake", reflect.TypeOf((*MockTopicKeeper)(nil).GetTopicStake), ctx, topicId)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetTopicStake",
+		reflect.TypeOf((*MockTopicKeeper)(nil).GetTopicStake),
+		ctx,
+		topicId,
+	)
 }
 
 // GetTopicFeeRevenue mocks base method
-func (m *MockTopicKeeper) GetTopicFeeRevenue(ctx context.Context, topicId uint64) (keeperTypes.TopicFeeRevenue, error) {
+func (m *MockTopicKeeper) GetTopicFeeRevenue(
+	ctx context.Context,
+	topicId uint64,
+) (keeperTypes.TopicFeeRevenue, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTopicFeeRevenue", ctx, topicId)
 	ret0, _ := ret[0].(keeperTypes.TopicFeeRevenue)
@@ -491,7 +743,13 @@ func (m *MockTopicKeeper) GetTopicFeeRevenue(ctx context.Context, topicId uint64
 // GetTopicFeeRevenue indicates an expected call of GetTopicFeeRevenue
 func (mr *MockTopicKeeperMockRecorder) GetTopicFeeRevenue(ctx, topicId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTopicFeeRevenue", reflect.TypeOf((*MockTopicKeeper)(nil).GetTopicFeeRevenue), ctx, topicId)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetTopicFeeRevenue",
+		reflect.TypeOf((*MockTopicKeeper)(nil).GetTopicFeeRevenue),
+		ctx,
+		topicId,
+	)
 }
 
 // NewDecFromSdkUint mocks base method
@@ -506,7 +764,12 @@ func (m *MockTopicKeeper) NewDecFromSdkUint(u cosmosMath.Uint) (alloraMath.Dec, 
 // NewDecFromSdkUint indicates an expected call of NewDecFromSdkUint
 func (mr *MockTopicKeeperMockRecorder) NewDecFromSdkUint(u interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewDecFromSdkUint", reflect.TypeOf((*MockTopicKeeper)(nil).NewDecFromSdkUint), u)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"NewDecFromSdkUint",
+		reflect.TypeOf((*MockTopicKeeper)(nil).NewDecFromSdkUint),
+		u,
+	)
 }
 
 // NewDecFromSdkInt mocks base method
@@ -521,26 +784,59 @@ func (m *MockTopicKeeper) NewDecFromSdkInt(i cosmosMath.Int) (alloraMath.Dec, er
 // NewDecFromSdkInt indicates an expected call of NewDecFromSdkInt
 func (mr *MockTopicKeeperMockRecorder) NewDecFromSdkInt(i interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewDecFromSdkInt", reflect.TypeOf((*MockTopicKeeper)(nil).NewDecFromSdkInt), i)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"NewDecFromSdkInt",
+		reflect.TypeOf((*MockTopicKeeper)(nil).NewDecFromSdkInt),
+		i,
+	)
 }
 
 // GetTargetWeight mocks base method
-func (m *MockTopicKeeper) GetTargetWeight(stakeDec alloraMath.Dec, epochLength keeperTypes.BlockHeight, feeRevenue alloraMath.Dec, stakeImportance alloraMath.Dec, feeImportance alloraMath.Dec) (alloraMath.Dec, error) {
+func (m *MockTopicKeeper) GetTargetWeight(
+	stakeDec alloraMath.Dec,
+	epochLength keeperTypes.BlockHeight,
+	feeRevenue alloraMath.Dec,
+	stakeImportance alloraMath.Dec,
+	feeImportance alloraMath.Dec,
+) (alloraMath.Dec, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTargetWeight", stakeDec, epochLength, feeRevenue, stakeImportance, feeImportance)
+	ret := m.ctrl.Call(
+		m,
+		"GetTargetWeight",
+		stakeDec,
+		epochLength,
+		feeRevenue,
+		stakeImportance,
+		feeImportance,
+	)
 	ret0, _ := ret[0].(alloraMath.Dec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTargetWeight indicates an expected call of GetTargetWeight
-func (mr *MockTopicKeeperMockRecorder) GetTargetWeight(stakeDec, epochLength, feeRevenue, stakeImportance, feeImportance interface{}) *gomock.Call {
+func (mr *MockTopicKeeperMockRecorder) GetTargetWeight(
+	stakeDec, epochLength, feeRevenue, stakeImportance, feeImportance interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTargetWeight", reflect.TypeOf((*MockTopicKeeper)(nil).GetTargetWeight), stakeDec, epochLength, feeRevenue, stakeImportance, feeImportance)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetTargetWeight",
+		reflect.TypeOf((*MockTopicKeeper)(nil).GetTargetWeight),
+		stakeDec,
+		epochLength,
+		feeRevenue,
+		stakeImportance,
+		feeImportance,
+	)
 }
 
 // GetPreviousTopicWeight mocks base method
-func (m *MockTopicKeeper) GetPreviousTopicWeight(ctx context.Context, topicId uint64) (alloraMath.Dec, bool, error) {
+func (m *MockTopicKeeper) GetPreviousTopicWeight(
+	ctx context.Context,
+	topicId uint64,
+) (alloraMath.Dec, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreviousTopicWeight", ctx, topicId)
 	ret0, _ := ret[0].(alloraMath.Dec)
@@ -550,13 +846,24 @@ func (m *MockTopicKeeper) GetPreviousTopicWeight(ctx context.Context, topicId ui
 }
 
 // GetPreviousTopicWeight indicates an expected call of GetPreviousTopicWeight
-func (mr *MockTopicKeeperMockRecorder) GetPreviousTopicWeight(ctx, topicId interface{}) *gomock.Call {
+func (mr *MockTopicKeeperMockRecorder) GetPreviousTopicWeight(
+	ctx, topicId interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreviousTopicWeight", reflect.TypeOf((*MockTopicKeeper)(nil).GetPreviousTopicWeight), ctx, topicId)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetPreviousTopicWeight",
+		reflect.TypeOf((*MockTopicKeeper)(nil).GetPreviousTopicWeight),
+		ctx,
+		topicId,
+	)
 }
 
 // CalcEma mocks base method
-func (m *MockTopicKeeper) CalcEma(alpha, current, previous alloraMath.Dec, noPrior bool) (alloraMath.Dec, error) {
+func (m *MockTopicKeeper) CalcEma(
+	alpha, current, previous alloraMath.Dec,
+	noPrior bool,
+) (alloraMath.Dec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalcEma", alpha, current, previous, noPrior)
 	ret0, _ := ret[0].(alloraMath.Dec)
@@ -565,7 +872,17 @@ func (m *MockTopicKeeper) CalcEma(alpha, current, previous alloraMath.Dec, noPri
 }
 
 // CalcEma indicates an expected call of CalcEma
-func (mr *MockTopicKeeperMockRecorder) CalcEma(alpha, current, previous, noPrior interface{}) *gomock.Call {
+func (mr *MockTopicKeeperMockRecorder) CalcEma(
+	alpha, current, previous, noPrior interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcEma", reflect.TypeOf((*MockTopicKeeper)(nil).CalcEma), alpha, current, previous, noPrior)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"CalcEma",
+		reflect.TypeOf((*MockTopicKeeper)(nil).CalcEma),
+		alpha,
+		current,
+		previous,
+		noPrior,
+	)
 }

--- a/x/emissions/types/errors.go
+++ b/x/emissions/types/errors.go
@@ -3,65 +3,297 @@ package types
 import "cosmossdk.io/errors"
 
 var (
-	ErrTopicReputerStakeDoesNotExist            = errors.Register(ModuleName, 1, "topic reputer stake does not exist")
-	ErrIntegerUnderflowTopicReputerStake        = errors.Register(ModuleName, 2, "integer underflow for topic reputer stake")
-	ErrIntegerUnderflowTopicStake               = errors.Register(ModuleName, 3, "integer underflow for topic stake")
-	ErrIntegerUnderflowTotalStake               = errors.Register(ModuleName, 4, "integer underflow for total stake")
-	ErrIterationLengthDoesNotMatch              = errors.Register(ModuleName, 5, "iteration length does not match")
-	ErrInvalidTopicId                           = errors.Register(ModuleName, 6, "invalid topic ID")
-	ErrReputerAlreadyRegisteredInTopic          = errors.Register(ModuleName, 7, "reputer already registered in topic")
-	ErrAddressAlreadyRegisteredInATopic         = errors.Register(ModuleName, 8, "address already registered in a topic")
-	ErrAddressIsNotRegisteredInAnyTopic         = errors.Register(ModuleName, 9, "address is not registered in any topic")
-	ErrAddressIsNotRegisteredInThisTopic        = errors.Register(ModuleName, 10, "address is not registered in this topic")
-	ErrInsufficientStakeToRegister              = errors.Register(ModuleName, 11, "insufficient stake to register")
-	ErrLibP2PKeyRequired                        = errors.Register(ModuleName, 12, "libp2p key required")
-	ErrAddressNotRegistered                     = errors.Register(ModuleName, 13, "address not registered")
-	ErrInsufficientStakeToRemove                = errors.Register(ModuleName, 14, "insufficient stake to remove")
-	ErrBlockHeightNegative                      = errors.Register(ModuleName, 15, "block height negative")
-	ErrBlockHeightLessThanPrevious              = errors.Register(ModuleName, 16, "block height less than previous")
-	ErrConfirmRemoveStakeNoRemovalStarted       = errors.Register(ModuleName, 17, "confirm remove stake no removal started")
-	ErrConfirmRemoveStakeTooEarly               = errors.Register(ModuleName, 18, "confirm remove stake too early")
-	ErrConfirmRemoveStakeTooLate                = errors.Register(ModuleName, 19, "confirm remove stake too late")
-	ErrTopicIdListValueDecodeInvalidLength      = errors.Register(ModuleName, 20, "topic ID list value decode invalid length")
-	ErrTopicIdListValueDecodeJsonInvalidLength  = errors.Register(ModuleName, 21, "topic ID list value decode JSON invalid length")
-	ErrTopicIdListValueDecodeJsonInvalidFormat  = errors.Register(ModuleName, 22, "topic ID list value decode JSON invalid format")
-	ErrTopicDoesNotExist                        = errors.Register(ModuleName, 23, "topic does not exist")
-	ErrOwnerCannotBeEmpty                       = errors.Register(ModuleName, 24, "owner cannot be empty")
-	ErrInsufficientStakeAfterRemoval            = errors.Register(ModuleName, 25, "insufficient stake after removal")
-	ErrFundAmountTooLow                         = errors.Register(ModuleName, 26, "topic fund amount too low")
-	ErrIntegerUnderflowUnmetDemand              = errors.Register(ModuleName, 27, "integer underflow for unmet demand")
-	ErrNotWhitelistAdmin                        = errors.Register(ModuleName, 28, "not whitelist admin")
-	ErrNotInReputerWhitelist                    = errors.Register(ModuleName, 30, "not in reputer whitelist")
-	ErrTopicNotEnoughDemand                     = errors.Register(ModuleName, 31, "topic not enough demand")
-	ErrIntegerUnderflowStakeFromDelegator       = errors.Register(ModuleName, 32, "integer underflow for stake from delegator")
-	ErrIntegerUnderflowDelegateStakePlacement   = errors.Register(ModuleName, 33, "integer underflow for delegate stake placement")
-	ErrIntegerUnderflowDelegateStakeUponReputer = errors.Register(ModuleName, 34, "integer underflow for delegate stake upon reputer")
-	ErrAdjustedStakeInvalidSliceLength          = errors.Register(ModuleName, 35, "adjusted stake: invalid slice length")
-	ErrFractionDivideByZero                     = errors.Register(ModuleName, 36, "fraction: divide by zero")
-	ErrNumberRatioDivideByZero                  = errors.Register(ModuleName, 37, "number ratio: divide by zero")
-	ErrNumberRatioInvalidSliceLength            = errors.Register(ModuleName, 38, "number ratio: invalid slice length")
-	ErrInvalidSliceLength                       = errors.Register(ModuleName, 39, "invalid slice length")
-	ErrTopicCadenceBelowMinimum                 = errors.Register(ModuleName, 40, "topic cadence must be at least 60 seconds (1 minute)")
-	ErrPhiCannotBeZero                          = errors.Register(ModuleName, 41, "phi: cannot be zero")
-	ErrSumWeightsLessThanEta                    = errors.Register(ModuleName, 42, "sum weights less than eta")
-	ErrSliceLengthMismatch                      = errors.Register(ModuleName, 43, "slice length mismatch")
-	ErrNonceAlreadyFulfilled                    = errors.Register(ModuleName, 44, "nonce already fulfilled")
-	ErrNonceStillUnfulfilled                    = errors.Register(ModuleName, 45, "nonce still unfulfilled")
-	ErrTopicCreatorNotEnoughDenom               = errors.Register(ModuleName, 46, "topic creator does not have enough denom")
-	ErrSignatureVerificationFailed              = errors.Register(ModuleName, 47, "signature verification was failed")
-	ErrTopicRegistrantNotEnoughDenom            = errors.Register(ModuleName, 48, "topic registrant does not have enough denom")
-	ErrInsufficientDelegateStakeToRemove        = errors.Register(ModuleName, 49, "insufficient delegate stake to remove")
-	ErrTopicMempoolAtCapacity                   = errors.Register(ModuleName, 50, "topic mempool at capacity")
-	ErrReceivedZeroAmount                       = errors.Register(ModuleName, 51, "received zero amount")
-	ErrInvalidValue                             = errors.Register(ModuleName, 52, "invalid value")
-	ErrQueryTooLarge                            = errors.Register(ModuleName, 53, "query is too large")
-	ErrFailedToSerializePayload                 = errors.Register(ModuleName, 54, "failed to serialize payload")
-	ErrNoValidBundles                           = errors.Register(ModuleName, 55, "no valid bundles found")
-	ErrInvalidReward                            = errors.Register(ModuleName, 56, "invalid reward")
-	ErrCantSelfDelegate                         = errors.Register(ModuleName, 57, "cant self delegate")
-	ErrValidationVersionEmpty                   = errors.Register(ModuleName, 58, "version cannot be empty")
-	ErrValidationVersionTooLong                 = errors.Register(ModuleName, 59, "version length cannot exceed 32 characters")
-	ErrValidationMustBeNonNegative              = errors.Register(ModuleName, 60, "value must be non-negative")
-	ErrValidationMustBeBetweenZeroAndOne        = errors.Register(ModuleName, 61, "value must be between 0 and 1")
-	ErrValidationMustBeGreaterthanZero          = errors.Register(ModuleName, 62, "value must be greater than 0")
+	ErrTopicReputerStakeDoesNotExist = errors.Register(
+		ModuleName,
+		1,
+		"topic reputer stake does not exist",
+	)
+	ErrIntegerUnderflowTopicReputerStake = errors.Register(
+		ModuleName,
+		2,
+		"integer underflow for topic reputer stake",
+	)
+	ErrIntegerUnderflowTopicStake = errors.Register(
+		ModuleName,
+		3,
+		"integer underflow for topic stake",
+	)
+	ErrIntegerUnderflowTotalStake = errors.Register(
+		ModuleName,
+		4,
+		"integer underflow for total stake",
+	)
+	ErrIterationLengthDoesNotMatch = errors.Register(
+		ModuleName,
+		5,
+		"iteration length does not match",
+	)
+	ErrInvalidTopicId                  = errors.Register(ModuleName, 6, "invalid topic ID")
+	ErrReputerAlreadyRegisteredInTopic = errors.Register(
+		ModuleName,
+		7,
+		"reputer already registered in topic",
+	)
+	ErrAddressAlreadyRegisteredInATopic = errors.Register(
+		ModuleName,
+		8,
+		"address already registered in a topic",
+	)
+	ErrAddressIsNotRegisteredInAnyTopic = errors.Register(
+		ModuleName,
+		9,
+		"address is not registered in any topic",
+	)
+	ErrAddressIsNotRegisteredInThisTopic = errors.Register(
+		ModuleName,
+		10,
+		"address is not registered in this topic",
+	)
+	ErrInsufficientStakeToRegister = errors.Register(
+		ModuleName,
+		11,
+		"insufficient stake to register",
+	)
+	ErrLibP2PKeyRequired = errors.Register(
+		ModuleName,
+		12,
+		"libp2p key required",
+	)
+	ErrAddressNotRegistered = errors.Register(
+		ModuleName,
+		13,
+		"address not registered",
+	)
+	ErrInsufficientStakeToRemove = errors.Register(
+		ModuleName,
+		14,
+		"insufficient stake to remove",
+	)
+	ErrBlockHeightNegative = errors.Register(
+		ModuleName,
+		15,
+		"block height negative",
+	)
+	ErrBlockHeightLessThanPrevious = errors.Register(
+		ModuleName,
+		16,
+		"block height less than previous",
+	)
+	ErrConfirmRemoveStakeNoRemovalStarted = errors.Register(
+		ModuleName,
+		17,
+		"confirm remove stake no removal started",
+	)
+	ErrConfirmRemoveStakeTooEarly = errors.Register(
+		ModuleName,
+		18,
+		"confirm remove stake too early",
+	)
+	ErrConfirmRemoveStakeTooLate = errors.Register(
+		ModuleName,
+		19,
+		"confirm remove stake too late",
+	)
+	ErrTopicIdListValueDecodeInvalidLength = errors.Register(
+		ModuleName,
+		20,
+		"topic ID list value decode invalid length",
+	)
+	ErrTopicIdListValueDecodeJsonInvalidLength = errors.Register(
+		ModuleName,
+		21,
+		"topic ID list value decode JSON invalid length",
+	)
+	ErrTopicIdListValueDecodeJsonInvalidFormat = errors.Register(
+		ModuleName,
+		22,
+		"topic ID list value decode JSON invalid format",
+	)
+	ErrTopicDoesNotExist = errors.Register(
+		ModuleName,
+		23,
+		"topic does not exist",
+	)
+	ErrOwnerCannotBeEmpty = errors.Register(
+		ModuleName,
+		24,
+		"owner cannot be empty",
+	)
+	ErrInsufficientStakeAfterRemoval = errors.Register(
+		ModuleName,
+		25,
+		"insufficient stake after removal",
+	)
+	ErrFundAmountTooLow = errors.Register(
+		ModuleName,
+		26,
+		"topic fund amount too low",
+	)
+	ErrIntegerUnderflowUnmetDemand = errors.Register(
+		ModuleName,
+		27,
+		"integer underflow for unmet demand",
+	)
+	ErrNotWhitelistAdmin = errors.Register(
+		ModuleName,
+		28,
+		"not whitelist admin",
+	)
+	ErrNotInReputerWhitelist = errors.Register(
+		ModuleName,
+		30,
+		"not in reputer whitelist",
+	)
+	ErrTopicNotEnoughDemand = errors.Register(
+		ModuleName,
+		31,
+		"topic not enough demand",
+	)
+	ErrIntegerUnderflowStakeFromDelegator = errors.Register(
+		ModuleName,
+		32,
+		"integer underflow for stake from delegator",
+	)
+	ErrIntegerUnderflowDelegateStakePlacement = errors.Register(
+		ModuleName,
+		33,
+		"integer underflow for delegate stake placement",
+	)
+	ErrIntegerUnderflowDelegateStakeUponReputer = errors.Register(
+		ModuleName,
+		34,
+		"integer underflow for delegate stake upon reputer",
+	)
+	ErrAdjustedStakeInvalidSliceLength = errors.Register(
+		ModuleName,
+		35,
+		"adjusted stake: invalid slice length",
+	)
+	ErrFractionDivideByZero = errors.Register(
+		ModuleName,
+		36,
+		"fraction: divide by zero",
+	)
+	ErrNumberRatioDivideByZero = errors.Register(
+		ModuleName,
+		37,
+		"number ratio: divide by zero",
+	)
+	ErrNumberRatioInvalidSliceLength = errors.Register(
+		ModuleName,
+		38,
+		"number ratio: invalid slice length",
+	)
+	ErrInvalidSliceLength = errors.Register(
+		ModuleName,
+		39,
+		"invalid slice length",
+	)
+	ErrTopicCadenceBelowMinimum = errors.Register(
+		ModuleName,
+		40,
+		"topic cadence must be at least 60 seconds (1 minute)",
+	)
+	ErrPhiCannotBeZero = errors.Register(
+		ModuleName,
+		41,
+		"phi: cannot be zero",
+	)
+	ErrSumWeightsLessThanEta = errors.Register(
+		ModuleName,
+		42,
+		"sum weights less than eta",
+	)
+	ErrSliceLengthMismatch = errors.Register(
+		ModuleName,
+		43,
+		"slice length mismatch",
+	)
+	ErrNonceAlreadyFulfilled = errors.Register(
+		ModuleName,
+		44,
+		"nonce already fulfilled",
+	)
+	ErrNonceStillUnfulfilled = errors.Register(
+		ModuleName,
+		45,
+		"nonce still unfulfilled",
+	)
+	ErrTopicCreatorNotEnoughDenom = errors.Register(
+		ModuleName,
+		46,
+		"topic creator does not have enough denom",
+	)
+	ErrSignatureVerificationFailed = errors.Register(
+		ModuleName,
+		47,
+		"signature verification was failed",
+	)
+	ErrTopicRegistrantNotEnoughDenom = errors.Register(
+		ModuleName,
+		48,
+		"topic registrant does not have enough denom",
+	)
+	ErrInsufficientDelegateStakeToRemove = errors.Register(
+		ModuleName,
+		49,
+		"insufficient delegate stake to remove",
+	)
+	ErrTopicMempoolAtCapacity = errors.Register(
+		ModuleName,
+		50,
+		"topic mempool at capacity",
+	)
+	ErrReceivedZeroAmount = errors.Register(
+		ModuleName,
+		51,
+		"received zero amount",
+	)
+	ErrInvalidValue  = errors.Register(ModuleName, 52, "invalid value")
+	ErrQueryTooLarge = errors.Register(
+		ModuleName,
+		53,
+		"query is too large",
+	)
+	ErrFailedToSerializePayload = errors.Register(
+		ModuleName,
+		54,
+		"failed to serialize payload",
+	)
+	ErrNoValidBundles = errors.Register(
+		ModuleName,
+		55,
+		"no valid bundles found",
+	)
+	ErrInvalidReward    = errors.Register(ModuleName, 56, "invalid reward")
+	ErrCantSelfDelegate = errors.Register(
+		ModuleName,
+		57,
+		"cant self delegate",
+	)
+	ErrValidationVersionEmpty = errors.Register(
+		ModuleName,
+		58,
+		"version cannot be empty",
+	)
+	ErrValidationVersionTooLong = errors.Register(
+		ModuleName,
+		59,
+		"version length cannot exceed 32 characters",
+	)
+	ErrValidationMustBeNonNegative = errors.Register(
+		ModuleName,
+		60,
+		"value must be non-negative",
+	)
+	ErrValidationMustBeBetweenZeroAndOne = errors.Register(
+		ModuleName,
+		61,
+		"value must be between 0 and 1",
+	)
+	ErrValidationMustBeGreaterthanZero = errors.Register(
+		ModuleName,
+		62,
+		"value must be greater than 0",
+	)
 )

--- a/x/emissions/types/forecast.go
+++ b/x/emissions/types/forecast.go
@@ -17,7 +17,10 @@ func (forecast *Forecast) Validate() error {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "forecaster cannot be empty")
 	}
 	if len(forecast.ForecastElements) == 0 {
-		return errors.Wrap(sdkerrors.ErrInvalidRequest, "at least one forecast element must be provided")
+		return errors.Wrap(
+			sdkerrors.ErrInvalidRequest,
+			"at least one forecast element must be provided",
+		)
 	}
 	for _, elem := range forecast.ForecastElements {
 		_, err := sdk.AccAddressFromBech32(elem.Inferer)

--- a/x/emissions/types/msg_create_topic.go
+++ b/x/emissions/types/msg_create_topic.go
@@ -35,9 +35,13 @@ func (msg *MsgCreateNewTopic) Validate() error {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "ground truth lag cannot be negative")
 	}
 	if msg.AlphaRegret.Lte(alloraMath.ZeroDec()) || msg.AlphaRegret.Gt(alloraMath.OneDec()) {
-		return errors.Wrap(sdkerrors.ErrInvalidRequest, "alpha regret must be greater than 0 and less than or equal to 1")
+		return errors.Wrap(
+			sdkerrors.ErrInvalidRequest,
+			"alpha regret must be greater than 0 and less than or equal to 1",
+		)
 	}
-	if msg.PNorm.Lt(alloraMath.MustNewDecFromString("2.5")) || msg.PNorm.Gt(alloraMath.MustNewDecFromString("4.5")) {
+	if msg.PNorm.Lt(alloraMath.MustNewDecFromString("2.5")) ||
+		msg.PNorm.Gt(alloraMath.MustNewDecFromString("4.5")) {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "p-norm must be between 2.5 and 4.5")
 	}
 

--- a/x/emissions/types/msg_insert_bulk_reputer_payload.go
+++ b/x/emissions/types/msg_insert_bulk_reputer_payload.go
@@ -22,7 +22,10 @@ func (msg *MsgInsertBulkReputerPayload) ValidateTopLevel() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "reputer nonce cannot be nil")
 	}
 	if len(msg.ReputerValueBundles) == 0 {
-		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "at least one reputer value bundle needs to be provided")
+		return errors.Wrapf(
+			sdkerrors.ErrInvalidRequest,
+			"at least one reputer value bundle needs to be provided",
+		)
 	}
 
 	return nil

--- a/x/emissions/types/msg_insert_bulk_worker_payload.go
+++ b/x/emissions/types/msg_insert_bulk_worker_payload.go
@@ -17,7 +17,10 @@ func (msg *MsgInsertBulkWorkerPayload) ValidateTopLevel() error {
 	}
 
 	if len(msg.WorkerDataBundles) == 0 {
-		return errors.Wrap(sdkerrors.ErrInvalidRequest, "at least one worker data bundle must be provided")
+		return errors.Wrap(
+			sdkerrors.ErrInvalidRequest,
+			"at least one worker data bundle must be provided",
+		)
 	}
 
 	return nil

--- a/x/emissions/types/params.go
+++ b/x/emissions/types/params.go
@@ -12,45 +12,119 @@ type BlockHeight = int64
 // DefaultParams returns default module parameters.
 func DefaultParams() Params {
 	return Params{
-		Version:                         "0.0.3",                                   // version of the protocol should be in lockstep with github release tag version
-		MinTopicWeight:                  alloraMath.MustNewDecFromString("100"),    // total weight for a topic < this => don't run inference solicatation or loss update
-		MaxTopicsPerBlock:               uint64(128),                               // max number of topics to run cadence for per block
-		RequiredMinimumStake:            cosmosMath.NewInt(100),                    // minimum stake required to be a worker or reputer
-		RemoveStakeDelayWindow:          int64(60 * 60 * 24 * 7 * 3),               // 3 weeks in seconds, number of seconds to wait before finalizing a stake withdrawal
-		MinEpochLength:                  1,                                         // 1 block, the shortest number of blocks per epoch topics are allowed to set as their cadence
-		BetaEntropy:                     alloraMath.MustNewDecFromString("0.25"),   // controls resilience of reward payouts against copycat workers
-		LearningRate:                    alloraMath.MustNewDecFromString("0.05"),   // speed of gradient descent
-		GradientDescentMaxIters:         uint64(10),                                // max iterations on gradient descent
-		MaxGradientThreshold:            alloraMath.MustNewDecFromString("0.001"),  // gradient descent stops when gradient falls below this
-		MinStakeFraction:                alloraMath.MustNewDecFromString("0.5"),    // minimum fraction of stake that should be listened to when setting consensus listening coefficients
-		Epsilon:                         alloraMath.MustNewDecFromString("0.0001"), // 0 threshold to prevent div by 0 and 0-approximation errors
-		MaxUnfulfilledWorkerRequests:    uint64(100),                               // maximum number of outstanding nonces for worker requests per topic from the chain; needs to be bigger to account for varying topic ground truth lag
-		MaxUnfulfilledReputerRequests:   uint64(100),                               // maximum number of outstanding nonces for reputer requests per topic from the chain; needs to be bigger to account for varying topic ground truth lag
-		TopicRewardStakeImportance:      alloraMath.MustNewDecFromString("0.5"),    // importance of stake in determining rewards for a topic
-		TopicRewardFeeRevenueImportance: alloraMath.MustNewDecFromString("0.5"),    // importance of fee revenue in determining rewards for a topic
-		TopicRewardAlpha:                alloraMath.MustNewDecFromString("0.5"),    // alpha for topic reward calculation; coupled with blocktime, or how often rewards are calculated
-		TaskRewardAlpha:                 alloraMath.MustNewDecFromString("0.1"),    // alpha for task reward calculation used to calculate  ~U_ij, ~V_ik, ~W_im
-		ValidatorsVsAlloraPercentReward: alloraMath.MustNewDecFromString("0.25"),   // 25% rewards go to cosmos network validators
-		MaxSamplesToScaleScores:         uint64(10),                                // maximum number of previous scores to store and use for standard deviation calculation
-		MaxTopInferersToReward:          uint64(24),                                // max this many top inferers by score are rewarded for a topic
-		MaxTopForecastersToReward:       uint64(6),                                 // max this many top forecasters by score are rewarded for a topic
-		MaxTopReputersToReward:          uint64(12),                                // max this many top reputers by score are rewarded for a topic
-		CreateTopicFee:                  cosmosMath.NewInt(10),                     // topic registration fee
-		MaxRetriesToFulfilNoncesWorker:  int64(1),                                  // max throttle of simultaneous unfulfilled worker requests
-		MaxRetriesToFulfilNoncesReputer: int64(3),                                  // max throttle of simultaneous unfulfilled reputer requests
-		RegistrationFee:                 cosmosMath.NewInt(6),                      // how much workers and reputers must pay to register per topic
-		DefaultPageLimit:                uint64(100),                               // how many topics to return per page during churn of requests
-		MaxPageLimit:                    uint64(1000),                              // max limit for pagination
-		MinEpochLengthRecordLimit:       int64(3),                                  // minimum number of epochs to keep records for a topic
-		MaxSerializedMsgLength:          int64(1000 * 1000),                        // maximum size of data to msg and query server in bytes
-		BlocksPerMonth:                  uint64(525960),                            // ~5 seconds block time, 6311520 per year, 525960 per month
-		PRewardInference:                alloraMath.NewDecFromInt64(1),             // fiducial value for rewards calculation
-		PRewardForecast:                 alloraMath.NewDecFromInt64(3),             // fiducial value for rewards calculation
-		PRewardReputer:                  alloraMath.NewDecFromInt64(3),             // fiducial value for rewards calculation
-		CRewardInference:                alloraMath.MustNewDecFromString("0.75"),   // fiducial value for rewards calculation
-		CRewardForecast:                 alloraMath.MustNewDecFromString("0.75"),   // fiducial value for rewards calculation
-		FTolerance:                      alloraMath.MustNewDecFromString("0.01"),   // fiducial value for rewards calculation
-		CNorm:                           alloraMath.MustNewDecFromString("0.75"),   // fiducial value for inference synthesis
+		Version: "0.0.3", // version of the protocol should be in lockstep with github release tag version
+		MinTopicWeight: alloraMath.MustNewDecFromString(
+			"100",
+		), // total weight for a topic < this => don't run inference solicatation or loss update
+		MaxTopicsPerBlock: uint64(
+			128,
+		), // max number of topics to run cadence for per block
+		RequiredMinimumStake: cosmosMath.NewInt(
+			100,
+		), // minimum stake required to be a worker or reputer
+		RemoveStakeDelayWindow: int64(
+			60 * 60 * 24 * 7 * 3,
+		), // 3 weeks in seconds, number of seconds to wait before finalizing a stake withdrawal
+		MinEpochLength: 1, // 1 block, the shortest number of blocks per epoch topics are allowed to set as their cadence
+		BetaEntropy: alloraMath.MustNewDecFromString(
+			"0.25",
+		), // controls resilience of reward payouts against copycat workers
+		LearningRate: alloraMath.MustNewDecFromString(
+			"0.05",
+		), // speed of gradient descent
+		GradientDescentMaxIters: uint64(
+			10,
+		), // max iterations on gradient descent
+		MaxGradientThreshold: alloraMath.MustNewDecFromString(
+			"0.001",
+		), // gradient descent stops when gradient falls below this
+		MinStakeFraction: alloraMath.MustNewDecFromString(
+			"0.5",
+		), // minimum fraction of stake that should be listened to when setting consensus listening coefficients
+		Epsilon: alloraMath.MustNewDecFromString(
+			"0.0001",
+		), // 0 threshold to prevent div by 0 and 0-approximation errors
+		MaxUnfulfilledWorkerRequests: uint64(
+			100,
+		), // maximum number of outstanding nonces for worker requests per topic from the chain; needs to be bigger to account for varying topic ground truth lag
+		MaxUnfulfilledReputerRequests: uint64(
+			100,
+		), // maximum number of outstanding nonces for reputer requests per topic from the chain; needs to be bigger to account for varying topic ground truth lag
+		TopicRewardStakeImportance: alloraMath.MustNewDecFromString(
+			"0.5",
+		), // importance of stake in determining rewards for a topic
+		TopicRewardFeeRevenueImportance: alloraMath.MustNewDecFromString(
+			"0.5",
+		), // importance of fee revenue in determining rewards for a topic
+		TopicRewardAlpha: alloraMath.MustNewDecFromString(
+			"0.5",
+		), // alpha for topic reward calculation; coupled with blocktime, or how often rewards are calculated
+		TaskRewardAlpha: alloraMath.MustNewDecFromString(
+			"0.1",
+		), // alpha for task reward calculation used to calculate  ~U_ij, ~V_ik, ~W_im
+		ValidatorsVsAlloraPercentReward: alloraMath.MustNewDecFromString(
+			"0.25",
+		), // 25% rewards go to cosmos network validators
+		MaxSamplesToScaleScores: uint64(
+			10,
+		), // maximum number of previous scores to store and use for standard deviation calculation
+		MaxTopInferersToReward: uint64(
+			24,
+		), // max this many top inferers by score are rewarded for a topic
+		MaxTopForecastersToReward: uint64(
+			6,
+		), // max this many top forecasters by score are rewarded for a topic
+		MaxTopReputersToReward: uint64(
+			12,
+		), // max this many top reputers by score are rewarded for a topic
+		CreateTopicFee: cosmosMath.NewInt(
+			10,
+		), // topic registration fee
+		MaxRetriesToFulfilNoncesWorker: int64(
+			1,
+		), // max throttle of simultaneous unfulfilled worker requests
+		MaxRetriesToFulfilNoncesReputer: int64(
+			3,
+		), // max throttle of simultaneous unfulfilled reputer requests
+		RegistrationFee: cosmosMath.NewInt(
+			6,
+		), // how much workers and reputers must pay to register per topic
+		DefaultPageLimit: uint64(
+			100,
+		), // how many topics to return per page during churn of requests
+		MaxPageLimit: uint64(
+			1000,
+		), // max limit for pagination
+		MinEpochLengthRecordLimit: int64(
+			3,
+		), // minimum number of epochs to keep records for a topic
+		MaxSerializedMsgLength: int64(
+			1000 * 1000,
+		), // maximum size of data to msg and query server in bytes
+		BlocksPerMonth: uint64(
+			525960,
+		), // ~5 seconds block time, 6311520 per year, 525960 per month
+		PRewardInference: alloraMath.NewDecFromInt64(
+			1,
+		), // fiducial value for rewards calculation
+		PRewardForecast: alloraMath.NewDecFromInt64(
+			3,
+		), // fiducial value for rewards calculation
+		PRewardReputer: alloraMath.NewDecFromInt64(
+			3,
+		), // fiducial value for rewards calculation
+		CRewardInference: alloraMath.MustNewDecFromString(
+			"0.75",
+		), // fiducial value for rewards calculation
+		CRewardForecast: alloraMath.MustNewDecFromString(
+			"0.75",
+		), // fiducial value for rewards calculation
+		FTolerance: alloraMath.MustNewDecFromString(
+			"0.01",
+		), // fiducial value for rewards calculation
+		CNorm: alloraMath.MustNewDecFromString(
+			"0.75",
+		), // fiducial value for inference synthesis
 	}
 }
 

--- a/x/emissions/types/reputer_value_bundle.go
+++ b/x/emissions/types/reputer_value_bundle.go
@@ -22,7 +22,10 @@ func (bundle *ReputerValueBundle) Validate() error {
 	}
 
 	if bundle.ValueBundle.ReputerRequestNonce == nil {
-		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "value bundle's reputer request nonce cannot be nil")
+		return errors.Wrapf(
+			sdkerrors.ErrInvalidRequest,
+			"value bundle's reputer request nonce cannot be nil",
+		)
 	}
 
 	// Validate all the values within bundle

--- a/x/emissions/types/withheld_worker_attributed_value.go
+++ b/x/emissions/types/withheld_worker_attributed_value.go
@@ -9,7 +9,11 @@ import (
 func (withheldWorkerValue *WithheldWorkerAttributedValue) Validate() error {
 	_, err := sdk.AccAddressFromBech32(withheldWorkerValue.Worker)
 	if err != nil {
-		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid withheld worker address (%s)", err)
+		return errors.Wrapf(
+			sdkerrors.ErrInvalidAddress,
+			"invalid withheld worker address (%s)",
+			err,
+		)
 	}
 
 	if withheldWorkerValue.Value.IsNaN() {

--- a/x/emissions/types/worker_data_bundle.go
+++ b/x/emissions/types/worker_data_bundle.go
@@ -27,7 +27,8 @@ func (bundle *WorkerDataBundle) Validate() error {
 	}
 
 	// Validate the inference and forecast of the bundle
-	if bundle.InferenceForecastsBundle.Inference == nil && bundle.InferenceForecastsBundle.Forecast == nil {
+	if bundle.InferenceForecastsBundle.Inference == nil &&
+		bundle.InferenceForecastsBundle.Forecast == nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "inference and forecast cannot both be nil")
 	}
 	if bundle.InferenceForecastsBundle.Inference != nil {

--- a/x/ibc/gmp/ibc_middleware.go
+++ b/x/ibc/gmp/ibc_middleware.go
@@ -34,7 +34,16 @@ func (im IBCMiddleware) OnChanOpenInit(
 	version string,
 ) (string, error) {
 	// call underlying callback
-	return im.app.OnChanOpenInit(ctx, order, connectionHops, portID, channelID, chanCap, counterparty, version)
+	return im.app.OnChanOpenInit(
+		ctx,
+		order,
+		connectionHops,
+		portID,
+		channelID,
+		chanCap,
+		counterparty,
+		version,
+	)
 }
 
 // OnChanOpenTry implements the IBCMiddleware interface
@@ -48,7 +57,16 @@ func (im IBCMiddleware) OnChanOpenTry(
 	counterparty channeltypes.Counterparty,
 	counterpartyVersion string,
 ) (string, error) {
-	return im.app.OnChanOpenTry(ctx, order, connectionHops, portID, channelID, channelCap, counterparty, counterpartyVersion)
+	return im.app.OnChanOpenTry(
+		ctx,
+		order,
+		connectionHops,
+		portID,
+		channelID,
+		channelCap,
+		counterparty,
+		counterpartyVersion,
+	)
 }
 
 // OnChanOpenAck implements the IBCMiddleware interface
@@ -97,7 +115,9 @@ func (im IBCMiddleware) OnRecvPacket(
 ) ibcexported.Acknowledgement {
 	var data transfertypes.FungibleTokenPacketData
 	if err := transfertypes.ModuleCdc.UnmarshalJSON(packet.GetData(), &data); err != nil {
-		return channeltypes.NewErrorAcknowledgement(fmt.Errorf("cannot unmarshal ICS-20 transfer packet data"))
+		return channeltypes.NewErrorAcknowledgement(
+			fmt.Errorf("cannot unmarshal ICS-20 transfer packet data"),
+		)
 	}
 
 	var msg Message
@@ -146,12 +166,16 @@ func (im IBCMiddleware) OnRecvPacket(
 		data.Memo = string(msg.Payload)
 		var dataBytes []byte
 		if dataBytes, err = transfertypes.ModuleCdc.MarshalJSON(&data); err != nil {
-			return channeltypes.NewErrorAcknowledgement(fmt.Errorf("cannot marshal ICS-20 post-processed transfer packet data"))
+			return channeltypes.NewErrorAcknowledgement(
+				fmt.Errorf("cannot marshal ICS-20 post-processed transfer packet data"),
+			)
 		}
 		packet.Data = dataBytes
 		return im.app.OnRecvPacket(ctx, packet, relayer)
 	default:
-		return channeltypes.NewErrorAcknowledgement(fmt.Errorf("unrecognized mesasge type: %d", msg.Type))
+		return channeltypes.NewErrorAcknowledgement(
+			fmt.Errorf("unrecognized mesasge type: %d", msg.Type),
+		)
 	}
 }
 

--- a/x/ibc/testing/ibc_middleware_test.go
+++ b/x/ibc/testing/ibc_middleware_test.go
@@ -16,7 +16,13 @@ func (s *IBCTestSuite) TestGMPMessageFrom_Success() {
 		Type:          gmp.TypeGeneralMessage,
 	}
 	generalMsgJson, _ := json.Marshal(generalMsg)
-	s.IBCTransferProviderToAllora(s.providerAddr, s.alloraAddr, nativeDenom, ibcTransferAmount, string(generalMsgJson))
+	s.IBCTransferProviderToAllora(
+		s.providerAddr,
+		s.alloraAddr,
+		nativeDenom,
+		ibcTransferAmount,
+		string(generalMsgJson),
+	)
 
 	generalMsgWithToken := gmp.Message{
 		SourceChain:   "axelar",
@@ -25,7 +31,13 @@ func (s *IBCTestSuite) TestGMPMessageFrom_Success() {
 		Type:          gmp.TypeGeneralMessageWithToken,
 	}
 	generalMsgWithTokenJson, _ := json.Marshal(generalMsgWithToken)
-	s.IBCTransferProviderToAllora(s.providerAddr, s.alloraAddr, nativeDenom, ibcTransferAmount, string(generalMsgWithTokenJson))
+	s.IBCTransferProviderToAllora(
+		s.providerAddr,
+		s.alloraAddr,
+		nativeDenom,
+		ibcTransferAmount,
+		string(generalMsgWithTokenJson),
+	)
 }
 
 func (s *IBCTestSuite) TestGMPMessageTo_Success() {
@@ -36,5 +48,11 @@ func (s *IBCTestSuite) TestGMPMessageTo_Success() {
 		Type:          gmp.TypeGeneralMessage,
 	}
 	generalMsgJson, _ := json.Marshal(generalMsg)
-	s.IBCTransferAlloraToProvider(s.alloraAddr, s.providerAddr, nativeDenom, ibcTransferAmount, string(generalMsgJson))
+	s.IBCTransferAlloraToProvider(
+		s.alloraAddr,
+		s.providerAddr,
+		nativeDenom,
+		ibcTransferAmount,
+		string(generalMsgJson),
+	)
 }

--- a/x/ibc/testing/ibc_setup_test.go
+++ b/x/ibc/testing/ibc_setup_test.go
@@ -1,10 +1,11 @@
 package testing
 
 import (
-	"cosmossdk.io/log"
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"cosmossdk.io/log"
 
 	"cosmossdk.io/math"
 	app2 "github.com/allora-network/allora-chain/app"

--- a/x/mint/keeper/emissions.go
+++ b/x/mint/keeper/emissions.go
@@ -144,7 +144,8 @@ func GetTargetRewardEmissionPerUnitStakedToken(
 	// N_{circ,i} = circulatingSupply
 	// N_{total,i} = totalSupply
 	ratioCirculating := circulatingSupply.ToLegacyDec().Quo(maxSupply.ToLegacyDec())
-	ratioEcosystemToStaked := ecosystemMintableRemaining.ToLegacyDec().Quo(networkStaked.ToLegacyDec())
+	ratioEcosystemToStaked := ecosystemMintableRemaining.ToLegacyDec().
+		Quo(networkStaked.ToLegacyDec())
 	ret := fEmission.
 		Mul(ratioEcosystemToStaked).
 		Mul(ratioCirculating)

--- a/x/mint/keeper/genesis.go
+++ b/x/mint/keeper/genesis.go
@@ -7,7 +7,11 @@ import (
 )
 
 // InitGenesis new mint genesis
-func (keeper Keeper) InitGenesis(ctx context.Context, ak types.AccountKeeper, data *types.GenesisState) {
+func (keeper Keeper) InitGenesis(
+	ctx context.Context,
+	ak types.AccountKeeper,
+	data *types.GenesisState,
+) {
 	if err := keeper.Params.Set(ctx, data.Params); err != nil {
 		panic(err)
 	}
@@ -39,7 +43,9 @@ func (keeper Keeper) ExportGenesis(ctx context.Context) *types.GenesisState {
 		panic(err)
 	}
 
-	previousRewardEmissionPerUnitStakedToken, err := keeper.PreviousRewardEmissionPerUnitStakedToken.Get(ctx)
+	previousRewardEmissionPerUnitStakedToken, err := keeper.PreviousRewardEmissionPerUnitStakedToken.Get(
+		ctx,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/x/mint/keeper/genesis_test.go
+++ b/x/mint/keeper/genesis_test.go
@@ -40,7 +40,11 @@ func TestGenesisTestSuite(t *testing.T) {
 
 func (s *GenesisTestSuite) SetupTest() {
 	key := storetypes.NewKVStoreKey(types.StoreKey)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+	testCtx := testutil.DefaultContextWithDB(
+		s.T(),
+		key,
+		storetypes.NewTransientStoreKey("transient_test"),
+	)
 	encCfg := moduletestutil.MakeTestEncodingConfig(mint.AppModuleBasic{})
 
 	// gomock initializations
@@ -57,7 +61,16 @@ func (s *GenesisTestSuite) SetupTest() {
 	accountKeeper.EXPECT().GetModuleAddress(minterAcc.Name).Return(minterAcc.GetAddress())
 	accountKeeper.EXPECT().GetModuleAccount(s.sdkCtx, minterAcc.Name).Return(minterAcc)
 
-	s.keeper = keeper.NewKeeper(s.cdc, runtime.NewKVStoreService(key), stakingKeeper, accountKeeper, bankKeeper, emissionsKeeper, "", "")
+	s.keeper = keeper.NewKeeper(
+		s.cdc,
+		runtime.NewKVStoreService(key),
+		stakingKeeper,
+		accountKeeper,
+		bankKeeper,
+		emissionsKeeper,
+		"",
+		"",
+	)
 }
 
 func (s *GenesisTestSuite) TestImportExportGenesis() {
@@ -85,7 +98,11 @@ func (s *GenesisTestSuite) TestImportExportGenesis() {
 
 	s.keeper.InitGenesis(s.sdkCtx, s.accountKeeper, genesisState)
 
-	invalidCtx := testutil.DefaultContextWithDB(s.T(), s.key, storetypes.NewTransientStoreKey("transient_test"))
+	invalidCtx := testutil.DefaultContextWithDB(
+		s.T(),
+		s.key,
+		storetypes.NewTransientStoreKey("transient_test"),
+	)
 	_, err := s.keeper.EcosystemTokensMinted.Get(invalidCtx.Ctx)
 	s.Require().ErrorIs(err, collections.ErrNotFound)
 
@@ -106,6 +123,7 @@ func (s *GenesisTestSuite) TestImportExportGenesis() {
 	// got to check the fields are equal one by one because the
 	// bigint params screw .Equal up
 	s.Require().Equal(genesisState.Params, genesisState2.Params)
-	s.Require().True(genesisState.PreviousRewardEmissionPerUnitStakedToken.Equal(genesisState2.PreviousRewardEmissionPerUnitStakedToken))
+	s.Require().
+		True(genesisState.PreviousRewardEmissionPerUnitStakedToken.Equal(genesisState2.PreviousRewardEmissionPerUnitStakedToken))
 	s.Require().True(genesisState.EcosystemTokensMinted.Equal(genesisState2.EcosystemTokensMinted))
 }

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -56,18 +56,38 @@ func NewKeeper(
 
 	sb := collections.NewSchemaBuilder(storeService)
 	k := Keeper{
-		cdc:                                      cdc,
-		storeService:                             storeService,
-		stakingKeeper:                            sk,
-		accountKeeper:                            ak,
-		bankKeeper:                               bk,
-		emissionsKeeper:                          ek,
-		feeCollectorName:                         feeCollectorName,
-		authority:                                authority,
-		Params:                                   collections.NewItem(sb, types.ParamsKey, "params", codec.CollValue[types.Params](cdc)),
-		PreviousRewardEmissionPerUnitStakedToken: collections.NewItem(sb, types.PreviousRewardEmissionPerUnitStakedTokenKey, "previousrewardsemissionsperunitstakedtoken", alloraMath.LegacyDecValue),
-		PreviousBlockEmission:                    collections.NewItem(sb, types.PreviousBlockEmissionKey, "previousblockemission", sdk.IntValue),
-		EcosystemTokensMinted:                    collections.NewItem(sb, types.EcosystemTokensMintedKey, "ecosystemtokensminted", sdk.IntValue),
+		cdc:              cdc,
+		storeService:     storeService,
+		stakingKeeper:    sk,
+		accountKeeper:    ak,
+		bankKeeper:       bk,
+		emissionsKeeper:  ek,
+		feeCollectorName: feeCollectorName,
+		authority:        authority,
+		Params: collections.NewItem(
+			sb,
+			types.ParamsKey,
+			"params",
+			codec.CollValue[types.Params](cdc),
+		),
+		PreviousRewardEmissionPerUnitStakedToken: collections.NewItem(
+			sb,
+			types.PreviousRewardEmissionPerUnitStakedTokenKey,
+			"previousrewardsemissionsperunitstakedtoken",
+			alloraMath.LegacyDecValue,
+		),
+		PreviousBlockEmission: collections.NewItem(
+			sb,
+			types.PreviousBlockEmissionKey,
+			"previousblockemission",
+			sdk.IntValue,
+		),
+		EcosystemTokensMinted: collections.NewItem(
+			sb,
+			types.EcosystemTokensMintedKey,
+			"ecosystemtokensminted",
+			sdk.IntValue,
+		),
 	}
 
 	schema, err := sb.Build()
@@ -197,7 +217,9 @@ func (k Keeper) GetValidatorsVsAlloraPercentReward(ctx context.Context) (alloraM
 
 // The last time we paid out rewards, what was the percentage of those rewards that went to staked reputers
 // (as opposed to forecaster workers and inferrer workers)
-func (k Keeper) GetPreviousPercentageRewardToStakedReputers(ctx context.Context) (math.LegacyDec, error) {
+func (k Keeper) GetPreviousPercentageRewardToStakedReputers(
+	ctx context.Context,
+) (math.LegacyDec, error) {
 	stakedPercent, err := k.emissionsKeeper.GetPreviousPercentageRewardToStakedReputers(ctx)
 	if err != nil {
 		return math.LegacyDec{}, err

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -42,7 +42,11 @@ func (s *IntegrationTestSuite) SetupTest() {
 	encCfg := moduletestutil.MakeTestEncodingConfig(mint.AppModuleBasic{})
 	key := storetypes.NewKVStoreKey(types.StoreKey)
 	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+	testCtx := testutil.DefaultContextWithDB(
+		s.T(),
+		key,
+		storetypes.NewTransientStoreKey("transient_test"),
+	)
 	s.ctx = testCtx.Ctx
 
 	// gomock initializations
@@ -90,6 +94,8 @@ func (s *IntegrationTestSuite) TestAliasFunctions() {
 	s.Require().Nil(s.mintKeeper.MintCoins(s.ctx, coins))
 
 	fees := sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(1000)))
-	s.bankKeeper.EXPECT().SendCoinsFromModuleToModule(s.ctx, types.EcosystemModuleName, emissionstypes.AlloraRewardsAccountName, fees).Return(nil)
+	s.bankKeeper.EXPECT().
+		SendCoinsFromModuleToModule(s.ctx, types.EcosystemModuleName, emissionstypes.AlloraRewardsAccountName, fees).
+		Return(nil)
 	s.Require().Nil(s.mintKeeper.PayAlloraRewardsFromEcosystem(s.ctx, fees))
 }

--- a/x/mint/keeper/msg_server.go
+++ b/x/mint/keeper/msg_server.go
@@ -22,9 +22,17 @@ func NewMsgServerImpl(k Keeper) types.MsgServer {
 }
 
 // UpdateParams updates the params.
-func (ms msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
+func (ms msgServer) UpdateParams(
+	ctx context.Context,
+	msg *types.MsgUpdateParams,
+) (*types.MsgUpdateParamsResponse, error) {
 	if ms.authority != msg.Authority {
-		return nil, errors.Wrapf(types.ErrInvalidSigner, "invalid authority; expected %s, got %s", ms.authority, msg.Authority)
+		return nil, errors.Wrapf(
+			types.ErrInvalidSigner,
+			"invalid authority; expected %s, got %s",
+			ms.authority,
+			msg.Authority,
+		)
 	}
 
 	if err := msg.Params.Validate(); err != nil {

--- a/x/mint/keeper/query_server.go
+++ b/x/mint/keeper/query_server.go
@@ -18,7 +18,10 @@ type queryServer struct {
 }
 
 // Params returns params of the mint module.
-func (q queryServer) Params(ctx context.Context, _ *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+func (q queryServer) Params(
+	ctx context.Context,
+	_ *types.QueryParamsRequest,
+) (*types.QueryParamsResponse, error) {
 	params, err := q.k.Params.Get(ctx)
 	if err != nil {
 		return nil, err
@@ -29,7 +32,10 @@ func (q queryServer) Params(ctx context.Context, _ *types.QueryParamsRequest) (*
 
 // Inflation returns the annual inflation rate of the mint module.
 // note this is the _current_ inflation rate, could change at any time
-func (q queryServer) Inflation(ctx context.Context, _ *types.QueryInflationRequest) (*types.QueryInflationResponse, error) {
+func (q queryServer) Inflation(
+	ctx context.Context,
+	_ *types.QueryInflationRequest,
+) (*types.QueryInflationResponse, error) {
 	// as a crude approximation we take the last blockEmission
 	// multiply by the amount of blocks in a year,
 	// then use that relative to the current supply as "inflation"

--- a/x/mint/keeper/query_server_test.go
+++ b/x/mint/keeper/query_server_test.go
@@ -33,7 +33,11 @@ func (suite *MintTestSuite) SetupTest() {
 	encCfg := moduletestutil.MakeTestEncodingConfig(mint.AppModuleBasic{})
 	key := storetypes.NewKVStoreKey(types.StoreKey)
 	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(suite.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+	testCtx := testutil.DefaultContextWithDB(
+		suite.T(),
+		key,
+		storetypes.NewTransientStoreKey("transient_test"),
+	)
 	suite.ctx = testCtx.Ctx
 
 	// gomock initializations

--- a/x/mint/module/abci.go
+++ b/x/mint/module/abci.go
@@ -64,7 +64,9 @@ func GetEmissionPerMonth(
 		targetRewardEmissionPerUnitStakedToken,
 		maximumMonthlyEmissionPerUnitStakedToken,
 	)
-	previousRewardEmissionPerUnitStakedToken, err := k.PreviousRewardEmissionPerUnitStakedToken.Get(ctx)
+	previousRewardEmissionPerUnitStakedToken, err := k.PreviousRewardEmissionPerUnitStakedToken.Get(
+		ctx,
+	)
 	if err != nil {
 		return math.Int{}, math.LegacyDec{}, err
 	}

--- a/x/mint/module/module.go
+++ b/x/mint/module/module.go
@@ -59,7 +59,11 @@ func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 }
 
 // ValidateGenesis performs genesis state validation for the mint module.
-func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncodingConfig, bz json.RawMessage) error {
+func (AppModuleBasic) ValidateGenesis(
+	cdc codec.JSONCodec,
+	config client.TxEncodingConfig,
+	bz json.RawMessage,
+) error {
 	var data types.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &data); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)

--- a/x/mint/module/module_test.go
+++ b/x/mint/module/module_test.go
@@ -62,8 +62,17 @@ func (s *MintModuleTestSuite) SetupTest() {
 	s.PKS = simtestutil.CreateTestPubKeys(4)
 	key := storetypes.NewKVStoreKey(types.StoreKey)
 	storeService := runtime.NewKVStoreService(key)
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, staking.AppModuleBasic{}, bank.AppModuleBasic{}, mint.AppModuleBasic{})
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+	encCfg := moduletestutil.MakeTestEncodingConfig(
+		auth.AppModuleBasic{},
+		staking.AppModuleBasic{},
+		bank.AppModuleBasic{},
+		mint.AppModuleBasic{},
+	)
+	testCtx := testutil.DefaultContextWithDB(
+		s.T(),
+		key,
+		storetypes.NewTransientStoreKey("transient_test"),
+	)
 	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()})
 
 	maccPerms := map[string][]string{
@@ -164,7 +173,11 @@ func (s *MintModuleTestSuite) TestMintingAtMaxSupply() {
 func (s *MintModuleTestSuite) TestTotalStakeGoUpTargetEmissionPerUnitStakeGoDown() {
 	params, err := s.mintKeeper.GetParams(s.ctx)
 	s.Require().NoError(err)
-	ecosystemMintSupplyRemaining, err := mint.GetEcosystemMintSupplyRemaining(s.ctx, s.mintKeeper, params)
+	ecosystemMintSupplyRemaining, err := mint.GetEcosystemMintSupplyRemaining(
+		s.ctx,
+		s.mintKeeper,
+		params,
+	)
 	s.Require().NoError(err)
 	// stake enough tokens so that the networkStaked is non zero
 	stake, ok := cosmosMath.NewIntFromString("300000000000000000000000000")
@@ -244,7 +257,9 @@ func (s *MintModuleTestSuite) TestEcosystemMintableRemainingGoDownTargetEmission
 	s.Require().True(ok)
 	maxSupply, ok := cosmosMath.NewIntFromString("1000000000000000000000000000") // 1e27
 	s.Require().True(ok)
-	ecosystemMintableRemainingBefore, ok := cosmosMath.NewIntFromString("367500000000000000000000000") // 1e27 * 0.3675
+	ecosystemMintableRemainingBefore, ok := cosmosMath.NewIntFromString(
+		"367500000000000000000000000",
+	) // 1e27 * 0.3675
 	s.Require().True(ok)
 
 	e_iBefore, err := keeper.GetTargetRewardEmissionPerUnitStakedToken(
@@ -256,7 +271,9 @@ func (s *MintModuleTestSuite) TestEcosystemMintableRemainingGoDownTargetEmission
 	)
 	s.Require().NoError(err)
 
-	ecosystemMintableRemainingAfter, ok := cosmosMath.NewIntFromString("300000000000000000000000000") // 1e27 * 0.3
+	ecosystemMintableRemainingAfter, ok := cosmosMath.NewIntFromString(
+		"300000000000000000000000000",
+	) // 1e27 * 0.3
 	s.Require().True(ok)
 	e_iAfter, err := keeper.GetTargetRewardEmissionPerUnitStakedToken(
 		fEmission,
@@ -275,10 +292,20 @@ func (s *MintModuleTestSuite) TestEcosystemMintableRemainingGoDownTargetEmission
 
 func (s *MintModuleTestSuite) TestNoNewMintedTokensIfInferenceRequestFeesEnoughToCoverInflation() {
 	feeCollectorAddress := s.accountKeeper.GetModuleAddress("fee_collector")
-	alloraRewardsAddress := s.accountKeeper.GetModuleAddress(emissionstypes.AlloraRewardsAccountName)
+	alloraRewardsAddress := s.accountKeeper.GetModuleAddress(
+		emissionstypes.AlloraRewardsAccountName,
+	)
 	ecosystemAddress := s.accountKeeper.GetModuleAddress(types.EcosystemModuleName)
-	feeCollectorBalBefore := s.bankKeeper.GetBalance(s.ctx, feeCollectorAddress, sdk.DefaultBondDenom)
-	alloraRewardsBalBefore := s.bankKeeper.GetBalance(s.ctx, alloraRewardsAddress, sdk.DefaultBondDenom)
+	feeCollectorBalBefore := s.bankKeeper.GetBalance(
+		s.ctx,
+		feeCollectorAddress,
+		sdk.DefaultBondDenom,
+	)
+	alloraRewardsBalBefore := s.bankKeeper.GetBalance(
+		s.ctx,
+		alloraRewardsAddress,
+		sdk.DefaultBondDenom,
+	)
 	s.ctx = s.ctx.WithBlockHeight(1)
 	// stake enough tokens so that the networkStaked is non zero
 	stake, ok := cosmosMath.NewIntFromString("40000000000000000000")
@@ -313,8 +340,16 @@ func (s *MintModuleTestSuite) TestNoNewMintedTokensIfInferenceRequestFeesEnoughT
 	err = mint.BeginBlocker(s.ctx, s.mintKeeper)
 	s.Require().NoError(err)
 
-	feeCollectorBalAfter := s.bankKeeper.GetBalance(s.ctx, feeCollectorAddress, sdk.DefaultBondDenom)
-	alloraRewardsBalAfter := s.bankKeeper.GetBalance(s.ctx, alloraRewardsAddress, sdk.DefaultBondDenom)
+	feeCollectorBalAfter := s.bankKeeper.GetBalance(
+		s.ctx,
+		feeCollectorAddress,
+		sdk.DefaultBondDenom,
+	)
+	alloraRewardsBalAfter := s.bankKeeper.GetBalance(
+		s.ctx,
+		alloraRewardsAddress,
+		sdk.DefaultBondDenom,
+	)
 	ecosystemBalAfter := s.bankKeeper.GetBalance(s.ctx, ecosystemAddress, sdk.DefaultBondDenom)
 	tokenSupplyAfter := s.bankKeeper.GetSupply(s.ctx, sdk.DefaultBondDenom)
 
@@ -346,10 +381,20 @@ func (s *MintModuleTestSuite) TestNoNewMintedTokensIfInferenceRequestFeesEnoughT
 
 func (s *MintModuleTestSuite) TestTokensAreMintedIfInferenceRequestFeesNotEnoughToCoverInflation() {
 	feeCollectorAddress := s.accountKeeper.GetModuleAddress("fee_collector")
-	alloraRewardsAddress := s.accountKeeper.GetModuleAddress(emissionstypes.AlloraRewardsAccountName)
+	alloraRewardsAddress := s.accountKeeper.GetModuleAddress(
+		emissionstypes.AlloraRewardsAccountName,
+	)
 	ecosystemAddress := s.accountKeeper.GetModuleAddress(types.EcosystemModuleName)
-	feeCollectorBalBefore := s.bankKeeper.GetBalance(s.ctx, feeCollectorAddress, sdk.DefaultBondDenom)
-	alloraRewardsBalBefore := s.bankKeeper.GetBalance(s.ctx, alloraRewardsAddress, sdk.DefaultBondDenom)
+	feeCollectorBalBefore := s.bankKeeper.GetBalance(
+		s.ctx,
+		feeCollectorAddress,
+		sdk.DefaultBondDenom,
+	)
+	alloraRewardsBalBefore := s.bankKeeper.GetBalance(
+		s.ctx,
+		alloraRewardsAddress,
+		sdk.DefaultBondDenom,
+	)
 	ecosystemBalBefore := s.bankKeeper.GetBalance(s.ctx, ecosystemAddress, sdk.DefaultBondDenom)
 	ecosystemTokensMintedBefore, err := s.mintKeeper.EcosystemTokensMinted.Get(s.ctx)
 	s.Require().NoError(err)
@@ -385,8 +430,16 @@ func (s *MintModuleTestSuite) TestTokensAreMintedIfInferenceRequestFeesNotEnough
 	err = mint.BeginBlocker(s.ctx, s.mintKeeper)
 	s.Require().NoError(err)
 
-	feeCollectorBalAfter := s.bankKeeper.GetBalance(s.ctx, feeCollectorAddress, sdk.DefaultBondDenom)
-	alloraRewardsBalAfter := s.bankKeeper.GetBalance(s.ctx, alloraRewardsAddress, sdk.DefaultBondDenom)
+	feeCollectorBalAfter := s.bankKeeper.GetBalance(
+		s.ctx,
+		feeCollectorAddress,
+		sdk.DefaultBondDenom,
+	)
+	alloraRewardsBalAfter := s.bankKeeper.GetBalance(
+		s.ctx,
+		alloraRewardsAddress,
+		sdk.DefaultBondDenom,
+	)
 	ecosystemBalAfter := s.bankKeeper.GetBalance(s.ctx, ecosystemAddress, sdk.DefaultBondDenom)
 	tokenSupplyAfter := s.bankKeeper.GetSupply(s.ctx, sdk.DefaultBondDenom)
 	ecosystemTokensMintedAfter, err := s.mintKeeper.EcosystemTokensMinted.Get(s.ctx)

--- a/x/mint/testutil/emissions_keeper_mocks.go
+++ b/x/mint/testutil/emissions_keeper_mocks.go
@@ -44,7 +44,12 @@ func (m *MockEmissionsKeeper) GetTotalStake(ctx context.Context) (math.Int, erro
 // GetTotalStake indicates an expected call of GetTotalStake.
 func (mr *MockEmissionsKeeperMockRecorder) GetTotalStake(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTotalStake", reflect.TypeOf((*MockEmissionsKeeper)(nil).GetTotalStake), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetTotalStake",
+		reflect.TypeOf((*MockEmissionsKeeper)(nil).GetTotalStake),
+		ctx,
+	)
 }
 
 func (m *MockEmissionsKeeper) GetParams(ctx context.Context) (emissionstypes.Params, error) {
@@ -57,12 +62,22 @@ func (m *MockEmissionsKeeper) GetParams(ctx context.Context) (emissionstypes.Par
 
 func (mr *MockEmissionsKeeperMockRecorder) GetParams(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParams", reflect.TypeOf((*MockEmissionsKeeper)(nil).GetParams), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetParams",
+		reflect.TypeOf((*MockEmissionsKeeper)(nil).GetParams),
+		ctx,
+	)
 }
 
 func (mr *MockEmissionsKeeperMockRecorder) GetParamsBlocksPerMonth(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParamsBlocksPerMonth", reflect.TypeOf((*MockEmissionsKeeper)(nil).GetParamsBlocksPerMonth), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetParamsBlocksPerMonth",
+		reflect.TypeOf((*MockEmissionsKeeper)(nil).GetParamsBlocksPerMonth),
+		ctx,
+	)
 }
 
 func (m *MockEmissionsKeeper) GetParamsBlocksPerMonth(ctx context.Context) (uint64, error) {
@@ -73,12 +88,21 @@ func (m *MockEmissionsKeeper) GetParamsBlocksPerMonth(ctx context.Context) (uint
 	return ret0, ret1
 }
 
-func (mr *MockEmissionsKeeperMockRecorder) GetPreviousPercentageRewardToStakedReputers(ctx interface{}) *gomock.Call {
+func (mr *MockEmissionsKeeperMockRecorder) GetPreviousPercentageRewardToStakedReputers(
+	ctx interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreviousPercentageRewardToStakedReputers", reflect.TypeOf((*MockEmissionsKeeper)(nil).GetPreviousPercentageRewardToStakedReputers), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetPreviousPercentageRewardToStakedReputers",
+		reflect.TypeOf((*MockEmissionsKeeper)(nil).GetPreviousPercentageRewardToStakedReputers),
+		ctx,
+	)
 }
 
-func (m *MockEmissionsKeeper) GetPreviousPercentageRewardToStakedReputers(ctx context.Context) (alloraMath.Dec, error) {
+func (m *MockEmissionsKeeper) GetPreviousPercentageRewardToStakedReputers(
+	ctx context.Context,
+) (alloraMath.Dec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreviousPercentageRewardToStakedReputers", ctx)
 	ret0, _ := ret[0].(alloraMath.Dec)

--- a/x/mint/types/errors.go
+++ b/x/mint/types/errors.go
@@ -3,9 +3,29 @@ package types
 import "cosmossdk.io/errors"
 
 var (
-	ErrInvalidSigner                                   = errors.Register(ModuleName, 1, "expected authority account as only signer for proposal message")
-	ErrNegativeTargetEmissionPerToken                  = errors.Register(ModuleName, 2, "negative target emission per token")
-	ErrInvalidPreviousRewardEmissionPerUnitStakedToken = errors.Register(ModuleName, 3, "invalid previous reward")
-	ErrInvalidEcosystemTokensMinted                    = errors.Register(ModuleName, 4, "invalid ecosystem tokens minted")
-	ErrZeroDenominator                                 = errors.Register(ModuleName, 5, "zero denominator")
+	ErrInvalidSigner = errors.Register(
+		ModuleName,
+		1,
+		"expected authority account as only signer for proposal message",
+	)
+	ErrNegativeTargetEmissionPerToken = errors.Register(
+		ModuleName,
+		2,
+		"negative target emission per token",
+	)
+	ErrInvalidPreviousRewardEmissionPerUnitStakedToken = errors.Register(
+		ModuleName,
+		3,
+		"invalid previous reward",
+	)
+	ErrInvalidEcosystemTokensMinted = errors.Register(
+		ModuleName,
+		4,
+		"invalid ecosystem tokens minted",
+	)
+	ErrZeroDenominator = errors.Register(
+		ModuleName,
+		5,
+		"zero denominator",
+	)
 )

--- a/x/mint/types/expected_keepers.go
+++ b/x/mint/types/expected_keepers.go
@@ -30,8 +30,17 @@ type AccountKeeper interface {
 // BankKeeper defines the contract needed to be fulfilled for banking and supply
 // dependencies.
 type BankKeeper interface {
-	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
-	SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(
+		ctx context.Context,
+		senderModule string,
+		recipientAddr sdk.AccAddress,
+		amt sdk.Coins,
+	) error
+	SendCoinsFromModuleToModule(
+		ctx context.Context,
+		senderModule, recipientModule string,
+		amt sdk.Coins,
+	) error
 	MintCoins(ctx context.Context, name string, amt sdk.Coins) error
 	GetSupply(ctx context.Context, denom string) sdk.Coin
 	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -44,16 +44,22 @@ func DefaultParams() Params {
 		panic("failed to parse max supply")
 	}
 	return Params{
-		MintDenom:                              sdk.DefaultBondDenom,
-		MaxSupply:                              maxSupply,                              // 1 billion allo * 1e18 (exponent) = 1e27 uallo
-		FEmission:                              math.LegacyMustNewDecFromStr("0.025"),  // 0.025 per month
-		OneMonthSmoothingDegree:                math.LegacyMustNewDecFromStr("0.1"),    // 0.1 at 1 month cadence
+		MintDenom: sdk.DefaultBondDenom,
+		MaxSupply: maxSupply, // 1 billion allo * 1e18 (exponent) = 1e27 uallo
+		FEmission: math.LegacyMustNewDecFromStr(
+			"0.025",
+		), // 0.025 per month
+		OneMonthSmoothingDegree: math.LegacyMustNewDecFromStr(
+			"0.1",
+		), // 0.1 at 1 month cadence
 		EcosystemTreasuryPercentOfTotalSupply:  math.LegacyMustNewDecFromStr("0.3595"), // 35.95%
 		FoundationTreasuryPercentOfTotalSupply: math.LegacyMustNewDecFromStr("0.1"),    // 10%
 		ParticipantsPercentOfTotalSupply:       math.LegacyMustNewDecFromStr("0.055"),  // 5.5%
 		InvestorsPercentOfTotalSupply:          math.LegacyMustNewDecFromStr("0.3105"), // 31.05%
 		TeamPercentOfTotalSupply:               math.LegacyMustNewDecFromStr("0.175"),  // 17.5%
-		MaximumMonthlyPercentageYield:          math.LegacyMustNewDecFromStr("0.0095"), // .95% per month
+		MaximumMonthlyPercentageYield: math.LegacyMustNewDecFromStr(
+			"0.0095",
+		), // .95% per month
 	}
 }
 
@@ -156,7 +162,10 @@ func validateAFractionValue(i interface{}) error {
 		return fmt.Errorf("fractional value cannot be nil: %s", v)
 	}
 	if v.LT(math.LegacyNewDec(0)) {
-		return fmt.Errorf("fractional value should be between 0 and 1, greater or equal to 0: %s", v)
+		return fmt.Errorf(
+			"fractional value should be between 0 and 1, greater or equal to 0: %s",
+			v,
+		)
 	}
 	if v.GT(math.LegacyNewDec(1)) {
 		return fmt.Errorf("fractional value should be between 0 and 1, less or equal to 1: %s", v)


### PR DESCRIPTION
Opinionated change obviously, but some of the long lines in this repo have become excessive to the point of making the code harder to read.

This PR adds the [golines](https://github.com/segmentio/golines) tool to the repo to make sure that lines are not too long. It modifies our CI action to also check line length is less than 100 characters. The reason why we need a separate tool is because the golang devs have [deliberately chosen not to enforce line length in their gofmt tool](https://github.com/golang/go/issues/11915) even though they make all sorts of other arbitrary decisions for users, like using tabs instead of spaces.

to run and fix issues yourself you can do something like this from the root of the repo:

```
find . -name "*.go" -exec golines -w {} \;
```