### PR TITLE
ORA1556 allPeersAreNew

### DIFF
--- a/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied_test.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied_test.go
@@ -34,7 +34,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromRegret() {
 		regretFrac := alloraMath.MustNewDecFromString(tc.regretFrac)
 		maxRegret := alloraMath.MustNewDecFromString(tc.maxRegret)
 
-		weight, err := inferencesynthesis.CalcWeightFromRegret(regretFrac, maxRegret, pNorm, cNorm)
+		weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm, cNorm)
 		s.Require().NoError(err)
 
 		testutil.InEpsilon5(s.T(), weight, tc.expectedWeight)

--- a/x/emissions/keeper/inference_synthesis/synth_palette_weight.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_weight.go
@@ -95,12 +95,14 @@ func (p *SynthPalette) CalcWeightedInference(weights RegretInformedWeights) (Inf
 	sumWeights := alloraMath.ZeroDec()
 	err := error(nil)
 
+	allPeersAreNew := p.AllForecastersAreNew && p.AllInferersAreNew
+
 	for _, inferer := range p.Inferers {
 		runningUnnormalizedI_i, sumWeights, err = AccumulateWeights(
 			p.InferenceByWorker[inferer],
 			weights.inferers[inferer],
 			p.InfererRegrets[inferer].noPriorRegret,
-			p.AllInferersAreNew,
+			allPeersAreNew,
 			runningUnnormalizedI_i,
 			sumWeights,
 		)
@@ -114,7 +116,7 @@ func (p *SynthPalette) CalcWeightedInference(weights RegretInformedWeights) (Inf
 			p.InferenceByWorker[forecaster],
 			weights.forecasters[forecaster],
 			p.ForecasterRegrets[forecaster].noPriorRegret,
-			p.AllForecastersAreNew,
+			allPeersAreNew,
 			runningUnnormalizedI_i,
 			sumWeights,
 		)


### PR DESCRIPTION
If we don't do this then the quotient in `CalcWeightedInference` will be incorrect. 