### PR TITLE
Cover regrets/weights new participants edge cases

### DIFF
--- a/x/emissions/keeper/inference_synthesis/network_inferences_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences_test.go
@@ -2,11 +2,12 @@ package inference_synthesis_test
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 
-	// cosmosMath "cosmossdk.io/math"
+	cosmosMath "cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
-	// "github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/test/testutil"
 	"github.com/stretchr/testify/assert"
 
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
@@ -80,9 +81,9 @@ func TestMakeMapFromWorkerToTheirWork(t *testing.T) {
 	}
 }
 
-/*
 func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 	epochGet := GetSimulatedValuesGetterForEpochs()
+	epoch2Get := epochGet[2]
 	epoch3Get := epochGet[3]
 
 	require := s.Require()
@@ -132,7 +133,7 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 			{
 				ValueBundle: &emissionstypes.ValueBundle{
 					Reputer:             reputer0,
-					CombinedValue:       epoch3Get("reputer_0_loss_network_inference"),
+					CombinedValue:       epoch2Get("reputer_0_loss_network_inference"),
 					ReputerRequestNonce: reputerRequestNonce,
 					TopicId:             topicId,
 				},
@@ -140,7 +141,7 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 			{
 				ValueBundle: &emissionstypes.ValueBundle{
 					Reputer:             reputer1,
-					CombinedValue:       epoch3Get("reputer_1_loss_network_inference"),
+					CombinedValue:       epoch2Get("reputer_1_loss_network_inference"),
 					ReputerRequestNonce: reputerRequestNonce,
 					TopicId:             topicId,
 				},
@@ -148,7 +149,7 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 			{
 				ValueBundle: &emissionstypes.ValueBundle{
 					Reputer:             reputer2,
-					CombinedValue:       epoch3Get("reputer_2_loss_network_inference"),
+					CombinedValue:       epoch2Get("reputer_2_loss_network_inference"),
 					ReputerRequestNonce: reputerRequestNonce,
 					TopicId:             topicId,
 				},
@@ -156,7 +157,7 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 			{
 				ValueBundle: &emissionstypes.ValueBundle{
 					Reputer:             reputer3,
-					CombinedValue:       epoch3Get("reputer_3_loss_network_inference"),
+					CombinedValue:       epoch2Get("reputer_3_loss_network_inference"),
 					ReputerRequestNonce: reputerRequestNonce,
 					TopicId:             topicId,
 				},
@@ -164,7 +165,7 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 			{
 				ValueBundle: &emissionstypes.ValueBundle{
 					Reputer:             reputer4,
-					CombinedValue:       epoch3Get("reputer_4_loss_network_inference"),
+					CombinedValue:       epoch2Get("reputer_4_loss_network_inference"),
 					ReputerRequestNonce: reputerRequestNonce,
 					TopicId:             topicId,
 				},
@@ -193,6 +194,23 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 	stake5 := cosmosMath.NewInt(205385).Mul(cosmosOneE18)
 	err = keeper.AddStake(s.ctx, topicId, reputer4, stake5)
 	require.NoError(err)
+
+	reputerAddresses := []string{reputer0, reputer1, reputer2, reputer3, reputer4}
+	for workerIndex, reputer := range reputerAddresses {
+		stakeValue := epoch3Get("reputer_stake_" + strconv.Itoa(workerIndex))
+
+		stakeValueScaled, err := stakeValue.Mul(alloraMath.MustNewDecFromString("1e18"))
+		s.Require().NoError(err)
+
+		stakeValueFloored, err := stakeValueScaled.Floor()
+		s.Require().NoError(err)
+
+		stakeInt, ok := cosmosMath.NewIntFromString(stakeValueFloored.String())
+		s.Require().True(ok)
+
+		err = keeper.AddStake(s.ctx, topicId, reputer, stakeInt)
+		s.Require().NoError(err)
+	}
 
 	// Set Inferences
 	inferences := emissionstypes.Inferences{
@@ -325,11 +343,11 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 
 	// Set inferer network regrets
 	infererNetworkRegrets := map[string]inferencesynthesis.Regret{
-		reputer0: epoch3Get("inference_regret_worker_0"),
-		reputer1: epoch3Get("inference_regret_worker_1"),
-		reputer2: epoch3Get("inference_regret_worker_2"),
-		reputer3: epoch3Get("inference_regret_worker_3"),
-		reputer4: epoch3Get("inference_regret_worker_4"),
+		reputer0: epoch2Get("inference_regret_worker_0"),
+		reputer1: epoch2Get("inference_regret_worker_1"),
+		reputer2: epoch2Get("inference_regret_worker_2"),
+		reputer3: epoch2Get("inference_regret_worker_3"),
+		reputer4: epoch2Get("inference_regret_worker_4"),
 	}
 
 	for inferer, regret := range infererNetworkRegrets {
@@ -343,9 +361,9 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 
 	// Set forecaster network regrets
 	forecasterNetworkRegrets := map[string]inferencesynthesis.Regret{
-		forecaster0: epoch3Get("inference_regret_worker_5"),
-		forecaster1: epoch3Get("inference_regret_worker_6"),
-		forecaster2: epoch3Get("inference_regret_worker_7"),
+		forecaster0: epoch2Get("inference_regret_worker_5"),
+		forecaster1: epoch2Get("inference_regret_worker_6"),
+		forecaster2: epoch2Get("inference_regret_worker_7"),
 	}
 
 	for forecaster, regret := range forecasterNetworkRegrets {
@@ -372,29 +390,38 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 	}
 
 	/// Epoch 3 values
-	setOneInForecasterNetworkRegret(forecaster0, reputer0, epoch3Get("inference_regret_worker_0_onein_0").String())
-	setOneInForecasterNetworkRegret(forecaster0, reputer1, epoch3Get("inference_regret_worker_1_onein_0").String())
-	setOneInForecasterNetworkRegret(forecaster0, reputer2, epoch3Get("inference_regret_worker_2_onein_0").String())
-	setOneInForecasterNetworkRegret(forecaster0, reputer3, epoch3Get("inference_regret_worker_3_onein_0").String())
-	setOneInForecasterNetworkRegret(forecaster0, reputer4, epoch3Get("inference_regret_worker_4_onein_0").String())
+	setOneInForecasterNetworkRegret(forecaster0, reputer0, epoch2Get("inference_regret_worker_0_onein_0").String())
+	setOneInForecasterNetworkRegret(forecaster0, reputer1, epoch2Get("inference_regret_worker_1_onein_0").String())
+	setOneInForecasterNetworkRegret(forecaster0, reputer2, epoch2Get("inference_regret_worker_2_onein_0").String())
+	setOneInForecasterNetworkRegret(forecaster0, reputer3, epoch2Get("inference_regret_worker_3_onein_0").String())
+	setOneInForecasterNetworkRegret(forecaster0, reputer4, epoch2Get("inference_regret_worker_4_onein_0").String())
 
-	setOneInForecasterNetworkRegret(forecaster0, forecaster0, epoch3Get("inference_regret_worker_5_onein_0").String())
+	keeper.SetOneInForecasterSelfNetworkRegret(s.ctx, topicId, forecaster0, emissionstypes.TimestampedValue{
+		BlockHeight: blockHeight,
+		Value:       epoch2Get("inference_regret_worker_5_onein_0"),
+	})
 
-	setOneInForecasterNetworkRegret(forecaster1, reputer0, epoch3Get("inference_regret_worker_0_onein_1").String())
-	setOneInForecasterNetworkRegret(forecaster1, reputer1, epoch3Get("inference_regret_worker_1_onein_1").String())
-	setOneInForecasterNetworkRegret(forecaster1, reputer2, epoch3Get("inference_regret_worker_2_onein_1").String())
-	setOneInForecasterNetworkRegret(forecaster1, reputer3, epoch3Get("inference_regret_worker_3_onein_1").String())
-	setOneInForecasterNetworkRegret(forecaster1, reputer4, epoch3Get("inference_regret_worker_4_onein_1").String())
+	setOneInForecasterNetworkRegret(forecaster1, reputer0, epoch2Get("inference_regret_worker_0_onein_1").String())
+	setOneInForecasterNetworkRegret(forecaster1, reputer1, epoch2Get("inference_regret_worker_1_onein_1").String())
+	setOneInForecasterNetworkRegret(forecaster1, reputer2, epoch2Get("inference_regret_worker_2_onein_1").String())
+	setOneInForecasterNetworkRegret(forecaster1, reputer3, epoch2Get("inference_regret_worker_3_onein_1").String())
+	setOneInForecasterNetworkRegret(forecaster1, reputer4, epoch2Get("inference_regret_worker_4_onein_1").String())
 
-	setOneInForecasterNetworkRegret(forecaster1, forecaster1, epoch3Get("inference_regret_worker_5_onein_1").String())
+	keeper.SetOneInForecasterSelfNetworkRegret(s.ctx, topicId, forecaster1, emissionstypes.TimestampedValue{
+		BlockHeight: blockHeight,
+		Value:       epoch2Get("inference_regret_worker_5_onein_1"),
+	})
 
-	setOneInForecasterNetworkRegret(forecaster2, reputer0, epoch3Get("inference_regret_worker_0_onein_2").String())
-	setOneInForecasterNetworkRegret(forecaster2, reputer1, epoch3Get("inference_regret_worker_1_onein_2").String())
-	setOneInForecasterNetworkRegret(forecaster2, reputer2, epoch3Get("inference_regret_worker_2_onein_2").String())
-	setOneInForecasterNetworkRegret(forecaster2, reputer3, epoch3Get("inference_regret_worker_3_onein_2").String())
-	setOneInForecasterNetworkRegret(forecaster2, reputer4, epoch3Get("inference_regret_worker_4_onein_2").String())
+	setOneInForecasterNetworkRegret(forecaster2, reputer0, epoch2Get("inference_regret_worker_0_onein_2").String())
+	setOneInForecasterNetworkRegret(forecaster2, reputer1, epoch2Get("inference_regret_worker_1_onein_2").String())
+	setOneInForecasterNetworkRegret(forecaster2, reputer2, epoch2Get("inference_regret_worker_2_onein_2").String())
+	setOneInForecasterNetworkRegret(forecaster2, reputer3, epoch2Get("inference_regret_worker_3_onein_2").String())
+	setOneInForecasterNetworkRegret(forecaster2, reputer4, epoch2Get("inference_regret_worker_4_onein_2").String())
 
-	setOneInForecasterNetworkRegret(forecaster2, forecaster2, epoch3Get("inference_regret_worker_5_onein_2").String())
+	keeper.SetOneInForecasterSelfNetworkRegret(s.ctx, topicId, forecaster2, emissionstypes.TimestampedValue{
+		BlockHeight: blockHeight,
+		Value:       epoch2Get("inference_regret_worker_5_onein_2"),
+	})
 
 	// Calculate
 	valueBundle, err :=
@@ -407,7 +434,7 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 		)
 	require.NoError(err)
 	testutil.InEpsilon2(s.T(), valueBundle.CombinedValue, epoch3Get("network_inference").String())
-	testutil.InEpsilon3(s.T(), valueBundle.NaiveValue, epoch3Get("network_naive_inference").String())
+	testutil.InEpsilon2(s.T(), valueBundle.NaiveValue, epoch3Get("network_naive_inference").String())
 
 	for _, inference := range inferences.Inferences {
 		found := false
@@ -422,11 +449,11 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 	for _, forecasterValue := range valueBundle.ForecasterValues {
 		switch string(forecasterValue.Worker) {
 		case forecaster0:
-			testutil.InEpsilon2(s.T(), forecasterValue.Value, epoch3Get("forecast_implied_inference_loss_0").String())
+			testutil.InEpsilon2(s.T(), forecasterValue.Value, epoch3Get("forecast_implied_inference_0").String())
 		case forecaster1:
-			testutil.InEpsilon2(s.T(), forecasterValue.Value, epoch3Get("forecast_implied_inference_loss_1").String())
+			testutil.InEpsilon2(s.T(), forecasterValue.Value, epoch3Get("forecast_implied_inference_1").String())
 		case forecaster2:
-			testutil.InEpsilon2(s.T(), forecasterValue.Value, epoch3Get("forecast_implied_inference_loss_2").String())
+			testutil.InEpsilon2(s.T(), forecasterValue.Value, epoch3Get("forecast_implied_inference_2").String())
 		default:
 			require.Fail("Unexpected forecaster %v", forecasterValue.Worker)
 		}
@@ -475,4 +502,3 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 		}
 	}
 }
-*/

--- a/x/emissions/keeper/inference_synthesis/network_inferences_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences_test.go
@@ -14,14 +14,6 @@ import (
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-// instantiate a AllWorkersAreNew struct
-// func NewWorkersAreNew(v bool) inference_synthesis.AllWorkersAreNew {
-// 	return inference_synthesis.AllWorkersAreNew{
-// 		AllInferersAreNew:    v,
-// 		AllForecastersAreNew: v,
-// 	}
-// }
-
 // TestMakeMapFromWorkerToTheirWork tests the makeMapFromWorkerToTheirWork function for correctly mapping workers to their inferences.
 func TestMakeMapFromWorkerToTheirWork(t *testing.T) {
 	tests := []struct {

--- a/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
@@ -32,7 +32,8 @@ func (p *SynthPalette) BootstrapRegretData() error {
 	if notNewInfererCount == 1 {
 		// There is exactly one not-new inferer
 		// Save the address of the not-new inferer
-		p.SingleInfererNotNew = notNewInfererAddress
+		p.SingleInfererNotNewAddress = notNewInfererAddress
+		p.SingleInfererNotNew = true
 	}
 
 	for _, forecaster := range p.Forecasters {
@@ -89,6 +90,7 @@ func (p SynthPalette) Clone() SynthPalette {
 		ForecastByWorker:                 forecastByWorker,
 		ForecastImpliedInferenceByWorker: forecastImpliedInferenceByWorker,
 		ForecasterRegrets:                forecasterRegrets,
+		SingleInfererNotNewAddress:       p.SingleInfererNotNewAddress,
 		SingleInfererNotNew:              p.SingleInfererNotNew,
 		NetworkCombinedLoss:              p.NetworkCombinedLoss,
 		Epsilon:                          p.Epsilon,

--- a/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
@@ -9,10 +9,17 @@ import (
 // Just requires these props:: ctx, k, topicId, inferers, forecasts
 func (p *SynthPalette) BootstrapRegretData() error {
 	p.AllInferersAreNew = true
+	var notNewInfererAddress string
+	notNewInfererCount := 0
 	for _, inferer := range p.Inferers {
 		regret, noPriorRegret, err := p.K.GetInfererNetworkRegret(p.Ctx, p.TopicId, inferer)
 		if err != nil {
 			return errorsmod.Wrapf(err, "Error getting inferer regret")
+		}
+
+		if !noPriorRegret {
+			notNewInfererCount++
+			notNewInfererAddress = inferer
 		}
 
 		p.AllInferersAreNew = p.AllInferersAreNew && noPriorRegret
@@ -22,14 +29,18 @@ func (p *SynthPalette) BootstrapRegretData() error {
 		}
 	}
 
-	p.AllForecastersAreNew = true
+	if notNewInfererCount == 1 {
+		// There is exactly one not-new inferer
+		// Save the address of the not-new inferer
+		p.SingleInfererNotNew = notNewInfererAddress
+	}
+
 	for _, forecaster := range p.Forecasters {
 		regret, noPriorRegret, err := p.K.GetForecasterNetworkRegret(p.Ctx, p.TopicId, forecaster)
 		if err != nil {
 			return errorsmod.Wrapf(err, "Error getting forecaster regret")
 		}
 
-		p.AllForecastersAreNew = p.AllForecastersAreNew && noPriorRegret
 		p.ForecasterRegrets[forecaster] = &StatefulRegret{
 			regret:        regret.Value,
 			noPriorRegret: noPriorRegret,
@@ -78,8 +89,7 @@ func (p SynthPalette) Clone() SynthPalette {
 		ForecastByWorker:                 forecastByWorker,
 		ForecastImpliedInferenceByWorker: forecastImpliedInferenceByWorker,
 		ForecasterRegrets:                forecasterRegrets,
-		AllForecastersAreNew:             p.AllForecastersAreNew,
-		AllWorkersAreNew:                 p.AllWorkersAreNew,
+		SingleInfererNotNew:              p.SingleInfererNotNew,
 		NetworkCombinedLoss:              p.NetworkCombinedLoss,
 		Epsilon:                          p.Epsilon,
 		FTolerance:                       p.FTolerance,

--- a/x/emissions/keeper/inference_synthesis/synth_palette_factory.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_factory.go
@@ -24,7 +24,8 @@ func (f *SynthPaletteFactory) BuildPaletteFromRequest(req SynthRequest) (SynthPa
 		ForecastImpliedInferenceByWorker: nil,                              // Populated below
 		ForecasterRegrets:                make(map[string]*StatefulRegret), // Populated below
 		AllInferersAreNew:                true,                             // Populated below
-		SingleInfererNotNew:              "",                               // Populated below
+		SingleInfererNotNewAddress:       "",                               // Populated below
+		SingleInfererNotNew:              false,                            // Populated below
 		NetworkCombinedLoss:              req.NetworkCombinedLoss,
 		Epsilon:                          req.Epsilon,
 		FTolerance:                       req.FTolerance,

--- a/x/emissions/keeper/inference_synthesis/synth_palette_factory.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_factory.go
@@ -24,8 +24,7 @@ func (f *SynthPaletteFactory) BuildPaletteFromRequest(req SynthRequest) (SynthPa
 		ForecastImpliedInferenceByWorker: nil,                              // Populated below
 		ForecasterRegrets:                make(map[string]*StatefulRegret), // Populated below
 		AllInferersAreNew:                true,                             // Populated below
-		AllForecastersAreNew:             true,                             // Populated below
-		AllWorkersAreNew:                 true,                             // Populated below
+		SingleInfererNotNew:              "",                               // Populated below
 		NetworkCombinedLoss:              req.NetworkCombinedLoss,
 		Epsilon:                          req.Epsilon,
 		FTolerance:                       req.FTolerance,
@@ -33,9 +32,8 @@ func (f *SynthPaletteFactory) BuildPaletteFromRequest(req SynthRequest) (SynthPa
 		CNorm:                            req.CNorm,
 	}
 
-	// Populates: infererRegrets, forecasterRegrets, allInferersAreNew, allForecastersAreNew
+	// Populates: infererRegrets, forecasterRegrets, allInferersAreNew
 	palette.BootstrapRegretData()
-	palette.AllWorkersAreNew = palette.AllInferersAreNew && palette.AllForecastersAreNew
 
 	paletteCopy := palette.Clone()
 	// Populates: forecastImpliedInferenceByWorker,

--- a/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied_test.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied_test.go
@@ -133,16 +133,18 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch2() {
 		"worker4": {Value: epoch2Get("inference_4")},
 	}
 	palette := inferencesynthesis.SynthPalette{
-		InferenceByWorker:   inferenceByWorker,
-		ForecastByWorker:    map[string]*emissionstypes.Forecast{"forecaster0": forecasts.Forecasts[0]},
-		Forecasters:         []string{"forecaster0"},
-		Inferers:            []string{"worker0", "worker1", "worker2", "worker3", "worker4"},
-		AllInferersAreNew:   false,
-		NetworkCombinedLoss: networkCombinedLoss,
-		Epsilon:             epsilon,
-		FTolerance:          fTolerance,
-		PNorm:               pNorm,
-		CNorm:               cNorm,
+		InferenceByWorker:          inferenceByWorker,
+		ForecastByWorker:           map[string]*emissionstypes.Forecast{"forecaster0": forecasts.Forecasts[0]},
+		Forecasters:                []string{"forecaster0"},
+		Inferers:                   []string{"worker0", "worker1", "worker2", "worker3", "worker4"},
+		AllInferersAreNew:          false,
+		SingleInfererNotNew:        false,
+		SingleInfererNotNewAddress: "",
+		NetworkCombinedLoss:        networkCombinedLoss,
+		Epsilon:                    epsilon,
+		FTolerance:                 fTolerance,
+		PNorm:                      pNorm,
+		CNorm:                      cNorm,
 	}
 	result, err := palette.CalcForecastImpliedInferences()
 	s.Require().NoError(err)

--- a/x/emissions/keeper/inference_synthesis/synth_palette_weight.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_weight.go
@@ -67,7 +67,7 @@ func (p *SynthPalette) CalcWeightsGivenWorkers() (RegretInformedWeights, error) 
 
 	infererWeights := make(map[Worker]Weight)
 	forecasterWeights := make(map[Worker]Weight)
-	if p.SingleInfererNotNew {
+	if !p.SingleInfererNotNew {
 		// Calculate the weights from the normalized regrets
 		for _, worker := range p.Inferers {
 			// If there is more than one not-new inferer, calculate the weight for the ones that are not new

--- a/x/emissions/keeper/inference_synthesis/synth_palette_weight.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_weight.go
@@ -14,6 +14,7 @@ func (p *SynthPalette) CalcWeightsGivenWorkers() (RegretInformedWeights, error) 
 	infererRegrets := p.GetInfererRegretsSlice()
 	forecasterRegrets := p.GetForecasterRegretsSlice()
 	var err error
+
 	if len(infererRegrets) > 0 {
 		regrets = append(regrets, infererRegrets...)
 	}
@@ -64,23 +65,34 @@ func (p *SynthPalette) CalcWeightsGivenWorkers() (RegretInformedWeights, error) 
 		}
 	}
 
+	moreThanOneNotNewInferer := p.SingleInfererNotNew == ""
+
 	// Calculate the weights from the normalized regrets
 	infererWeights := make(map[Worker]Weight)
 	for _, worker := range p.Inferers {
-		infererWeight, err := CalcWeightFromNormalizedRegret(normalizedInfererRegrets[worker], maxRegret, p.PNorm, p.CNorm)
-		if err != nil {
-			return RegretInformedWeights{}, errorsmod.Wrapf(err, "Error calculating inferer weight")
+		// If there is more than one not-new inferer, calculate the weight for the ones that are not new
+		var infererWeight = alloraMath.ZeroDec()
+		if moreThanOneNotNewInferer && !p.InfererRegrets[worker].noPriorRegret {
+			infererWeight, err = CalcWeightFromNormalizedRegret(normalizedInfererRegrets[worker], maxRegret, p.PNorm, p.CNorm)
+			if err != nil {
+				return RegretInformedWeights{}, errorsmod.Wrapf(err, "Error calculating inferer weight")
+			}
 		}
 		infererWeights[worker] = infererWeight
 	}
 
 	forecasterWeights := make(map[Worker]Weight)
-	for _, worker := range p.Forecasters {
-		forecasterWeight, err := CalcWeightFromNormalizedRegret(normalizedForecasterRegrets[worker], maxRegret, p.PNorm, p.CNorm)
-		if err != nil {
-			return RegretInformedWeights{}, errorsmod.Wrapf(err, "Error calculating forecaster weight")
+	if len(p.ForecasterRegrets) > 0 {
+		for _, worker := range p.Forecasters {
+			var forecasterWeight = alloraMath.ZeroDec()
+			if moreThanOneNotNewInferer && !p.ForecasterRegrets[worker].noPriorRegret {
+				forecasterWeight, err = CalcWeightFromNormalizedRegret(normalizedForecasterRegrets[worker], maxRegret, p.PNorm, p.CNorm)
+				if err != nil {
+					return RegretInformedWeights{}, errorsmod.Wrapf(err, "Error calculating forecaster weight")
+				}
+			}
+			forecasterWeights[worker] = forecasterWeight
 		}
-		forecasterWeights[worker] = forecasterWeight
 	}
 
 	return RegretInformedWeights{
@@ -88,20 +100,6 @@ func (p *SynthPalette) CalcWeightsGivenWorkers() (RegretInformedWeights, error) 
 		forecasters: forecasterWeights,
 	}, nil
 }
-
-// // Given the current set of inferers and forecasters in the palette, calculate their
-// // weights using the provided forecasted regrets
-// func (p *SynthPalette) CalcWeightsWithForecastedRegretOverride(
-// 	inferers []Worker,
-// 	forecastedRegrets map[string]StatefulRegret,
-// ) (RegretInformedWeights, error) {
-// 	if inferers != nil && len(inferers) > 0 && forecastedRegrets != nil {
-// 		p.InfererRegrets = forecastedRegrets
-// 		p.ForecasterRegrets = forecastedRegrets
-// 	}
-
-// 	return p.CalcWeightsGivenWorkers()
-// }
 
 // Calculates network combined inference I_i, network per worker regret R_i-1,l, and weights w_il from the litepaper:
 // I_i = Σ_l w_il I_il / Σ_l w_il
@@ -113,31 +111,48 @@ func (p *SynthPalette) CalcWeightedInference(weights RegretInformedWeights) (Inf
 	sumWeights := alloraMath.ZeroDec()
 	err := error(nil)
 
-	for _, inferer := range p.Inferers {
-		runningUnnormalizedI_i, sumWeights, err = AccumulateWeights(
-			p.InferenceByWorker[inferer],
-			weights.inferers[inferer],
-			p.InfererRegrets[inferer].noPriorRegret,
-			p.AllInferersAreNew,
-			runningUnnormalizedI_i,
-			sumWeights,
-		)
-		if err != nil {
-			return InferenceValue{}, errorsmod.Wrapf(err, "Error accumulating weight of inferer")
-		}
-	}
+	// If there is only one not-new inferer, then just consider that inferer
+	if p.SingleInfererNotNew != "" {
+		singleInferer := p.SingleInfererNotNew
 
-	for _, forecaster := range p.Forecasters {
-		runningUnnormalizedI_i, sumWeights, err = AccumulateWeights(
-			p.ForecastImpliedInferenceByWorker[forecaster],
-			weights.forecasters[forecaster],
-			p.ForecasterRegrets[forecaster].noPriorRegret,
-			p.AllForecastersAreNew,
-			runningUnnormalizedI_i,
-			sumWeights,
-		)
+		runningUnnormalizedI_i, err = runningUnnormalizedI_i.Add(p.InferenceByWorker[singleInferer].Value)
 		if err != nil {
-			return InferenceValue{}, errorsmod.Wrapf(err, "Error accumulating weight of forecaster")
+			return InferenceValue{}, errorsmod.Wrapf(err, "Error adding weight by worker value")
+		}
+		sumWeights, err = sumWeights.Add(alloraMath.OneDec())
+		if err != nil {
+			return InferenceValue{}, errorsmod.Wrapf(err, "Error adding weight")
+		}
+	} else {
+		for _, inferer := range p.Inferers {
+			runningUnnormalizedI_i, sumWeights, err = AccumulateWeights(
+				p.InferenceByWorker[inferer],
+				weights.inferers[inferer],
+				p.InfererRegrets[inferer].noPriorRegret,
+				p.AllInferersAreNew,
+				runningUnnormalizedI_i,
+				sumWeights,
+			)
+			if err != nil {
+				return InferenceValue{}, errorsmod.Wrapf(err, "Error accumulating weight of inferer")
+			}
+		}
+
+		// If all inferers are new, forecasters are not considered
+		if !p.AllInferersAreNew {
+			for _, forecaster := range p.Forecasters {
+				runningUnnormalizedI_i, sumWeights, err = AccumulateWeights(
+					p.ForecastImpliedInferenceByWorker[forecaster],
+					weights.forecasters[forecaster],
+					p.ForecasterRegrets[forecaster].noPriorRegret,
+					false,
+					runningUnnormalizedI_i,
+					sumWeights,
+				)
+				if err != nil {
+					return InferenceValue{}, errorsmod.Wrapf(err, "Error accumulating weight of forecaster")
+				}
+			}
 		}
 	}
 

--- a/x/emissions/keeper/inference_synthesis/types.go
+++ b/x/emissions/keeper/inference_synthesis/types.go
@@ -68,13 +68,12 @@ type SynthPalette struct {
 	ForecastByWorker                 map[Worker]*emissions.Forecast
 	ForecastImpliedInferenceByWorker map[Worker]*emissions.Inference
 	// Must respect the order of sister `forecasters` property
-	ForecasterRegrets    map[Worker]*StatefulRegret
-	AllInferersAreNew    bool
-	AllForecastersAreNew bool
-	AllWorkersAreNew     bool // Simple conjunction of the two above
-	NetworkCombinedLoss  Loss
-	Epsilon              alloraMath.Dec
-	FTolerance           alloraMath.Dec
-	PNorm                alloraMath.Dec
-	CNorm                alloraMath.Dec
+	ForecasterRegrets   map[Worker]*StatefulRegret
+	AllInferersAreNew   bool
+	SingleInfererNotNew Worker
+	NetworkCombinedLoss Loss
+	Epsilon             alloraMath.Dec
+	FTolerance          alloraMath.Dec
+	PNorm               alloraMath.Dec
+	CNorm               alloraMath.Dec
 }

--- a/x/emissions/keeper/inference_synthesis/types.go
+++ b/x/emissions/keeper/inference_synthesis/types.go
@@ -68,12 +68,13 @@ type SynthPalette struct {
 	ForecastByWorker                 map[Worker]*emissions.Forecast
 	ForecastImpliedInferenceByWorker map[Worker]*emissions.Inference
 	// Must respect the order of sister `forecasters` property
-	ForecasterRegrets   map[Worker]*StatefulRegret
-	AllInferersAreNew   bool
-	SingleInfererNotNew Worker
-	NetworkCombinedLoss Loss
-	Epsilon             alloraMath.Dec
-	FTolerance          alloraMath.Dec
-	PNorm               alloraMath.Dec
-	CNorm               alloraMath.Dec
+	ForecasterRegrets          map[Worker]*StatefulRegret
+	AllInferersAreNew          bool
+	SingleInfererNotNew        bool
+	SingleInfererNotNewAddress Worker
+	NetworkCombinedLoss        Loss
+	Epsilon                    alloraMath.Dec
+	FTolerance                 alloraMath.Dec
+	PNorm                      alloraMath.Dec
+	CNorm                      alloraMath.Dec
 }


### PR DESCRIPTION
Consider the edge cases:
- If all inferers are new, ignore the forecasters, and set the weights of all inferers to 1, irrespectively of the number of not-new forecasters.
- If one inferer is not new and all other inferers are new, set the weight of the not-new inferer to 1, and all others (including the forecasters, because we don’t need them anyway in this case) get a zero weight.
- If >1 inferer is not new, calculate weight as in the paper for all not-new workers (inferer and forecaster), and don’t include any new workers in the regret calculation.