### PR TITLE
Added context specific wrapped loggers

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -60,7 +60,7 @@ func generateLossesRequest(
 
 	inferencesPayloadJSON, err := json.Marshal(inferences)
 	if err != nil {
-		ctx.Logger().Warn(fmt.Sprintf("Error marshalling JSON: %s", err.Error()))
+		Logger(ctx).Warn(fmt.Sprintf("Error marshalling JSON: %s", err.Error()))
 		return
 	}
 
@@ -102,14 +102,14 @@ func generateLossesRequest(
 
 	payload, err := json.Marshal(calcWeightsReq)
 	if err != nil {
-		ctx.Logger().Warn(fmt.Sprintf("Error marshalling outer JSON: %s", err.Error()))
+		Logger(ctx).Warn(fmt.Sprintf("Error marshalling outer JSON: %s", err.Error()))
 		return
 	}
 	payloadStr := string(payload)
-	ctx.Logger().Debug(fmt.Sprintf("Making API call - losses, with payload: %s", payloadStr))
+	Logger(ctx).Debug(fmt.Sprintf("Making API call - losses, with payload: %s", payloadStr))
 	err = makeApiCall(payloadStr)
 	if err != nil {
-		ctx.Logger().Warn("Error making API call - losses: " + err.Error())
+		Logger(ctx).Warn("Error making API call - losses: " + err.Error())
 	}
 }
 
@@ -152,14 +152,14 @@ func generateInferencesRequest(
 	}
 	payload, err := json.Marshal(payloadJson)
 	if err != nil {
-		ctx.Logger().Warn(fmt.Sprintf("Error marshalling outer JSON: %s", err.Error()))
+		Logger(ctx).Warn(fmt.Sprintf("Error marshalling outer JSON: %s", err.Error()))
 	}
 	payloadStr := string(payload)
 
-	ctx.Logger().Debug(fmt.Sprintf("Making API call - inferences, with payload: %s", payloadStr))
+	Logger(ctx).Debug(fmt.Sprintf("Making API call - inferences, with payload: %s", payloadStr))
 	err = makeApiCall(payloadStr)
 	if err != nil {
-		ctx.Logger().Warn(fmt.Sprintf("Error making API call: %s", err.Error()))
+		Logger(ctx).Warn(fmt.Sprintf("Error making API call: %s", err.Error()))
 	}
 }
 

--- a/app/topics_handler.go
+++ b/app/topics_handler.go
@@ -160,5 +160,5 @@ func (th *TopicsHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 }
 
 func Logger(ctx sdk.Context) log.Logger {
-	return Logger(ctx).With("module", "topic_handler")
+	return ctx.Logger().With("module", "topic_handler")
 }

--- a/scripts/l1_node.sh
+++ b/scripts/l1_node.sh
@@ -52,5 +52,7 @@ allorad \
     --moniker=${MONIKER} \
     --minimum-gas-prices=0${DENOM} \
     --rpc.laddr=tcp://0.0.0.0:26657 \
-    --p2p.seeds=$SEEDS
+    --p2p.seeds=$SEEDS \
+    --log_level "*:error,state:info,server:info,rewards:debug,inference_synthesis:debug,topic_handler:debug" 
+
 

--- a/x/emissions/keeper/inference_synthesis/common.go
+++ b/x/emissions/keeper/inference_synthesis/common.go
@@ -1,8 +1,10 @@
 package inference_synthesis
 
 import (
+	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
 	emissions "github.com/allora-network/allora-chain/x/emissions/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func CosmosIntOneE18() cosmosMath.Int {
@@ -29,4 +31,8 @@ func MakeMapFromForecasterToTheirForecast(forecasts []*emissions.Forecast) map[W
 		forecastsByWorker[forecast.Forecaster] = forecast
 	}
 	return forecastsByWorker
+}
+
+func Logger(ctx sdk.Context) log.Logger {
+	return ctx.Logger().With("module", "inference_synthesis")
 }

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
+	"cosmossdk.io/log"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	emissions "github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -11,6 +12,7 @@ import (
 
 type NetworkInferenceBuilder struct {
 	ctx     sdk.Context
+	logger  log.Logger
 	palette SynthPalette
 	// Network Inferences Properties
 	inferences                 []*emissions.WorkerAttributedValue
@@ -32,26 +34,29 @@ func NewNetworkInferenceBuilderFromSynthRequest(
 	}
 	return &NetworkInferenceBuilder{
 		ctx:     req.Ctx,
+		logger:  Logger(req.Ctx),
 		palette: palette,
 	}, nil
 }
 
 // Calculates the network combined inference I_i, Equation 9
 func (b *NetworkInferenceBuilder) SetCombinedValue() *NetworkInferenceBuilder {
+	b.logger.Debug(fmt.Sprintf("Calculating combined inference for topic %v", b.palette.TopicId))
 	palette := b.palette.Clone()
 
 	weights, err := palette.CalcWeightsGivenWorkers()
 	if err != nil {
-		b.ctx.Logger().Warn(fmt.Sprintf("Error calculating weights for combined inference: %s", err.Error()))
+		b.logger.Warn(fmt.Sprintf("Error calculating weights for combined inference: %s", err.Error()))
 		return b
 	}
 
 	combinedInference, err := palette.CalcWeightedInference(weights)
 	if err != nil {
-		b.ctx.Logger().Warn(fmt.Sprintf("Error calculating combined inference: %s", err.Error()))
+		b.logger.Warn(fmt.Sprintf("Error calculating combined inference: %s", err.Error()))
 		return b
 	}
 
+	b.logger.Debug(fmt.Sprintf("Combined inference calculated for topic %v is %v", b.palette.TopicId, combinedInference))
 	b.combinedInference = combinedInference
 	return b
 }
@@ -84,27 +89,30 @@ func (b *NetworkInferenceBuilder) SetForecasterValues() *NetworkInferenceBuilder
 
 // Calculates the network naive inference I^-_i
 func (b *NetworkInferenceBuilder) SetNaiveValue() *NetworkInferenceBuilder {
+	b.logger.Debug(fmt.Sprintf("Calculating naive inference for topic %v", b.palette.TopicId))
 	palette := b.palette.Clone()
 
 	palette.Forecasters = nil
 	weights, err := palette.CalcWeightsGivenWorkers()
 	if err != nil {
-		b.ctx.Logger().Warn(fmt.Sprintf("Error calculating weights for naive inference: %s", err.Error()))
+		b.logger.Warn(fmt.Sprintf("Error calculating weights for naive inference: %s", err.Error()))
 		return b
 	}
 
 	naiveInference, err := palette.CalcWeightedInference(weights)
 	if err != nil {
-		b.ctx.Logger().Warn(fmt.Sprintf("Error calculating naive inference: %s", err.Error()))
+		b.logger.Warn(fmt.Sprintf("Error calculating naive inference: %s", err.Error()))
 		return b
 	}
 
+	b.logger.Debug(fmt.Sprintf("Naive inference calculated for topic %v is %v", b.palette.TopicId, naiveInference))
 	b.naiveInference = naiveInference
 	return b
 }
 
 // Calculate the one-out inference given a withheld inferer
 func (b *NetworkInferenceBuilder) calcOneOutInfererInference(withheldInferer Worker) (alloraMath.Dec, error) {
+	b.logger.Debug(fmt.Sprintf("Calculating one-out inference for topic %v withheld inferer %s", b.palette.TopicId, withheldInferer))
 	palette := b.palette.Clone()
 	paletteCopy := palette.Clone()
 
@@ -134,6 +142,7 @@ func (b *NetworkInferenceBuilder) calcOneOutInfererInference(withheldInferer Wor
 		return alloraMath.Dec{}, errorsmod.Wrapf(err, "Error calculating one-out inference for inferer")
 	}
 
+	b.logger.Debug(fmt.Sprintf("One-out inference calculated for topic %v withheld inferer %s is %v", b.palette.TopicId, withheldInferer, oneOutNetworkInferenceWithoutInferer))
 	return oneOutNetworkInferenceWithoutInferer, nil
 }
 
@@ -142,12 +151,13 @@ func (b *NetworkInferenceBuilder) calcOneOutInfererInference(withheldInferer Wor
 // Loop over all inferences and withold one, then calculate the network inference less that witheld inference
 // This involves recalculating the forecast-implied inferences for each withheld inferer
 func (b *NetworkInferenceBuilder) SetOneOutInfererValues() *NetworkInferenceBuilder {
+	b.logger.Debug(fmt.Sprintf("Calculating one-out inferer inferences for topic %v with %v inferers", b.palette.TopicId, len(b.palette.Inferers)))
 	// Calculate the one-out inferences per inferer
 	oneOutInferences := make([]*emissions.WithheldWorkerAttributedValue, 0)
 	for _, worker := range b.palette.Inferers {
 		oneOutInference, err := b.calcOneOutInfererInference(worker)
 		if err != nil {
-			b.palette.Ctx.Logger().Warn(fmt.Sprintf("Error calculating one-out inferer inferences: %s", err.Error()))
+			b.logger.Warn(fmt.Sprintf("Error calculating one-out inferer inferences: %s", err.Error()))
 			b.oneOutInfererInferences = make([]*emissions.WithheldWorkerAttributedValue, 0)
 			return b
 		}
@@ -157,12 +167,15 @@ func (b *NetworkInferenceBuilder) SetOneOutInfererValues() *NetworkInferenceBuil
 		})
 	}
 
+	b.logger.Debug(fmt.Sprintf("One-out inferer inferences calculated for topic %v", b.palette.TopicId))
 	b.oneOutInfererInferences = oneOutInferences
 	return b
 }
 
 // Calculate the one-out inference given a withheld forecaster
 func (b *NetworkInferenceBuilder) calcOneOutForecasterInference(withheldForecaster Worker) (alloraMath.Dec, error) {
+	b.logger.Debug(fmt.Sprintf("Calculating one-out inference for topic %v withheld forecaster %s", b.palette.TopicId, withheldForecaster))
+
 	palette := b.palette.Clone()
 	// Remove the withheldForecaster from the palette's forecasters
 	remainingForecasters := make([]Worker, 0)
@@ -183,6 +196,7 @@ func (b *NetworkInferenceBuilder) calcOneOutForecasterInference(withheldForecast
 		return alloraMath.Dec{}, errorsmod.Wrapf(err, "Error calculating one-out inference for inferer")
 	}
 
+	b.logger.Debug(fmt.Sprintf("One-out inference calculated for topic %v withheld forecaster %s is %v", b.palette.TopicId, withheldForecaster, oneOutNetworkInferenceWithoutInferer))
 	return oneOutNetworkInferenceWithoutInferer, nil
 }
 
@@ -190,12 +204,13 @@ func (b *NetworkInferenceBuilder) calcOneOutForecasterInference(withheldForecast
 // Assume that there is at most 1 forecast-implied inference per forecaster
 // Loop over all forecast-implied inferences and withold one, then calculate the network inference less that witheld value
 func (b *NetworkInferenceBuilder) SetOneOutForecasterValues() *NetworkInferenceBuilder {
+	b.logger.Debug(fmt.Sprintf("Calculating one-out forecaster inferences for topic %v with %v forecasters", b.palette.TopicId, len(b.palette.Forecasters)))
 	// Calculate the one-out forecast-implied inferences per forecaster
 	oneOutImpliedInferences := make([]*emissions.WithheldWorkerAttributedValue, 0)
 	for _, worker := range b.palette.Forecasters {
 		oneOutInference, err := b.calcOneOutForecasterInference(worker)
 		if err != nil {
-			b.palette.Ctx.Logger().Warn(fmt.Sprintf("Error calculating one-out forecaster inferences: %s", err.Error()))
+			b.logger.Warn(fmt.Sprintf("Error calculating one-out forecaster inferences: %s", err.Error()))
 			b.oneOutForecasterInferences = make([]*emissions.WithheldWorkerAttributedValue, 0)
 			return b
 		}
@@ -205,11 +220,13 @@ func (b *NetworkInferenceBuilder) SetOneOutForecasterValues() *NetworkInferenceB
 		})
 	}
 
+	b.logger.Debug(fmt.Sprintf("One-out forecaster inferences calculated for topic %v", b.palette.TopicId))
 	b.oneOutForecasterInferences = oneOutImpliedInferences
 	return b
 }
 
 func (b *NetworkInferenceBuilder) calcOneInValue(oneInForecaster Worker) (alloraMath.Dec, error) {
+	b.logger.Debug(fmt.Sprintf("Calculating one-in inference for forecaster: %s", oneInForecaster))
 	palette := b.palette.Clone()
 
 	// In each loop, remove all forecast-implied inferences except one
@@ -262,7 +279,7 @@ func (b *NetworkInferenceBuilder) SetOneInValues() *NetworkInferenceBuilder {
 	for _, oneInForecaster := range b.palette.Forecasters {
 		oneInValue, err := b.calcOneInValue(oneInForecaster)
 		if err != nil {
-			b.ctx.Logger().Warn(fmt.Sprintf("Error calculating one-in inferences: %s", err.Error()))
+			b.logger.Warn(fmt.Sprintf("Error calculating one-in inferences: %s", err.Error()))
 			oneInInferences = make([]*emissions.WorkerAttributedValue, 0)
 			return b
 		}

--- a/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
@@ -84,6 +84,7 @@ func (p SynthPalette) Clone() SynthPalette {
 	return SynthPalette{
 		Ctx:                              p.Ctx,
 		K:                                p.K,
+		Logger:                           p.Logger,
 		TopicId:                          p.TopicId,
 		Inferers:                         append([]Worker(nil), p.Inferers...),
 		InferenceByWorker:                inferenceByWorker,

--- a/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
@@ -1,6 +1,8 @@
 package inference_synthesis
 
 import (
+	"fmt"
+
 	errorsmod "cosmossdk.io/errors"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
@@ -8,6 +10,8 @@ import (
 // Bootstraps xRegrets, allxsAreNew (x="inferer"|"forecasters") for the inferers and forecasters in the palette
 // Just requires these props:: ctx, k, topicId, inferers, forecasts
 func (p *SynthPalette) BootstrapRegretData() error {
+	p.Logger.Debug(fmt.Sprintf("Bootstrapping regret data for topic %v", p.TopicId))
+
 	p.InferersNewStatus = InferersAllNew
 
 	for _, inferer := range p.Inferers {
@@ -26,6 +30,7 @@ func (p *SynthPalette) BootstrapRegretData() error {
 			}
 		}
 
+		p.Logger.Debug(fmt.Sprintf("Inferer %v has regret %v", inferer, regret.Value))
 		p.InfererRegrets[inferer] = &StatefulRegret{
 			regret:        regret.Value,
 			noPriorRegret: noPriorRegret,
@@ -38,6 +43,7 @@ func (p *SynthPalette) BootstrapRegretData() error {
 			return errorsmod.Wrapf(err, "Error getting forecaster regret")
 		}
 
+		p.Logger.Debug(fmt.Sprintf("Forecaster %v has regret %v", forecaster, regret.Value))
 		p.ForecasterRegrets[forecaster] = &StatefulRegret{
 			regret:        regret.Value,
 			noPriorRegret: noPriorRegret,

--- a/x/emissions/keeper/inference_synthesis/synth_palette_factory.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_factory.go
@@ -15,6 +15,7 @@ func (f *SynthPaletteFactory) BuildPaletteFromRequest(req SynthRequest) (SynthPa
 	palette := SynthPalette{
 		Ctx:                              req.Ctx,
 		K:                                req.K,
+		Logger:                           Logger(req.Ctx),
 		TopicId:                          req.TopicId,
 		Inferers:                         sortedInferers,
 		InferenceByWorker:                inferenceByWorker,
@@ -33,11 +34,14 @@ func (f *SynthPaletteFactory) BuildPaletteFromRequest(req SynthRequest) (SynthPa
 	}
 
 	// Populates: infererRegrets, forecasterRegrets, allInferersAreNew
-	palette.BootstrapRegretData()
+	err := palette.BootstrapRegretData()
+	if err != nil {
+		return SynthPalette{}, err
+	}
 
 	paletteCopy := palette.Clone()
 	// Populates: forecastImpliedInferenceByWorker,
-	err := paletteCopy.UpdateForecastImpliedInferences()
+	err = paletteCopy.UpdateForecastImpliedInferences()
 	if err != nil {
 		return SynthPalette{}, err
 	}

--- a/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied.go
@@ -1,6 +1,8 @@
 package inference_synthesis
 
 import (
+	"fmt"
+
 	errorsmod "cosmossdk.io/errors"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
@@ -130,10 +132,14 @@ func (p *SynthPalette) CalcForecastImpliedInferences() (map[Worker]*emissionstyp
 // Requires: forecasts, inferenceByWorker, allInferersAreNew, networkCombinedLoss, epsilon, pNorm, cNorm
 // Updates: forecastImpliedInferenceByWorker
 func (p *SynthPalette) UpdateForecastImpliedInferences() error {
+	p.Logger.Debug(fmt.Sprintf("Calculating forecast-implied inferences for topic %v", p.TopicId))
+
 	I_i, err := p.CalcForecastImpliedInferences()
 	if err != nil {
 		return errorsmod.Wrapf(err, "error calculating forecast-implied inferences")
 	}
+
+	p.Logger.Debug(fmt.Sprintf("Forecast-implied inferences: %v", I_i))
 
 	p.ForecastImpliedInferenceByWorker = I_i
 	return nil

--- a/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied_test.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied_test.go
@@ -118,6 +118,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 		"worker1": {Value: alloraMath.MustNewDecFromString("2")},
 	}
 	palette := inferencesynthesis.SynthPalette{
+		Logger:              inferencesynthesis.Logger(s.ctx),
 		InferenceByWorker:   inferenceByWorker,
 		ForecastByWorker:    map[string]*emissionstypes.Forecast{"forecaster0": forecasts.Forecasts[0]},
 		Forecasters:         []string{"forecaster0"},
@@ -246,6 +247,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch3() {
 		"worker4": {Value: epoch3Get("inference_4")},
 	}
 	palette := inferencesynthesis.SynthPalette{
+		Logger:              inferencesynthesis.Logger(s.ctx),
 		InferenceByWorker:   inferenceByWorker,
 		ForecastByWorker:    map[string]*emissionstypes.Forecast{"forecaster0": forecasts.Forecasts[0]},
 		Forecasters:         []string{"forecaster0"},

--- a/x/emissions/keeper/inference_synthesis/types.go
+++ b/x/emissions/keeper/inference_synthesis/types.go
@@ -1,6 +1,7 @@
 package inference_synthesis
 
 import (
+	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
@@ -61,6 +62,7 @@ type SynthPaletteFactory struct{}
 type SynthPalette struct {
 	Ctx     sdk.Context
 	K       keeper.Keeper
+	Logger  log.Logger
 	TopicId TopicId
 	// Should use this as a source of truth regarding for which inferers to have data calculated
 	// i.e. if an inferer is not present here, calculate a network inference without their data

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"cosmossdk.io/errors"
+	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
@@ -21,12 +22,12 @@ func EmitRewards(
 	totalRevenue cosmosMath.Int,
 ) error {
 	totalReward, err := k.GetTotalRewardToDistribute(ctx)
-	ctx.Logger().Debug(fmt.Sprintf("Reward to distribute this epoch: %s", totalReward.String()))
+	Logger(ctx).Debug(fmt.Sprintf("Reward to distribute this epoch: %s", totalReward.String()))
 	if err != nil {
 		return errors.Wrapf(err, "failed to get total reward to distribute")
 	}
 	if totalReward.IsZero() {
-		ctx.Logger().Warn("The total scheduled rewards to distribute this epoch are zero!")
+		Logger(ctx).Warn("The total scheduled rewards to distribute this epoch are zero!")
 		return nil
 	}
 
@@ -43,7 +44,7 @@ func EmitRewards(
 	sortedChurnableTopics := alloraMath.GetSortedElementsByDecWeightDesc(rewardableTopics, weights)
 
 	if len(sortedChurnableTopics) == 0 {
-		ctx.Logger().Warn("No churnable topics found")
+		Logger(ctx).Warn("No churnable topics found")
 		return nil
 	}
 
@@ -73,7 +74,7 @@ func EmitRewards(
 	for _, topicId := range sortedChurnableTopics {
 		topicReward := topicRewards[topicId]
 		if topicReward == nil {
-			ctx.Logger().Warn(fmt.Sprintf("Topic %d has no reward, skipping", topicId))
+			Logger(ctx).Warn(fmt.Sprintf("Topic %d has no reward, skipping", topicId))
 			continue
 		}
 		// Get topic reward nonce/block height
@@ -87,7 +88,7 @@ func EmitRewards(
 		totalRewardsDistribution, rewardInTopicToReputers, err := GenerateRewardsDistributionByTopicParticipant(ctx, k, topicId, topicReward, topicRewardNonce, moduleParams)
 		if err != nil {
 			topicRewardString := "nil"
-			ctx.Logger().Warn(
+			Logger(ctx).Warn(
 				fmt.Sprintf(
 					"Failed to Generate Rewards for Topic, Skipping:\nTopic Id %d\nTopic Reward Amount %s\nError:\n%s\n\n",
 					topicId,
@@ -111,7 +112,7 @@ func EmitRewards(
 		payoutErrors := payoutRewards(ctx, k, totalRewardsDistribution)
 		if len(payoutErrors) > 0 {
 			for _, err := range payoutErrors {
-				ctx.Logger().Warn(
+				Logger(ctx).Warn(
 					fmt.Sprintf(
 						"Failed to pay out rewards to participant in Topic:\nTopic Id %d\nTopic Reward Amount %s\nError:\n%s\n\n",
 						topicId,
@@ -126,7 +127,7 @@ func EmitRewards(
 		// Prune records after rewards have been paid out
 		err = pruneRecordsAfterRewards(ctx, k, moduleParams.MinEpochLengthRecordLimit, topicId, topicRewardNonce)
 		if err != nil {
-			ctx.Logger().Warn(
+			Logger(ctx).Warn(
 				fmt.Sprintf(
 					"Failed to prune records after rewards for Topic, Skipping:\nTopic Id %d\nTopic Reward Amount %s\nError:\n%s\n\n",
 					topicId,
@@ -139,7 +140,7 @@ func EmitRewards(
 
 		err = k.RemoveRewardableTopic(ctx, topicId)
 		if err != nil {
-			ctx.Logger().Warn(
+			Logger(ctx).Warn(
 				fmt.Sprintf(
 					"Failed to remove rewardable topic:\nTopic Id %d\nError:\n%s\n\n",
 					topicId,
@@ -149,7 +150,7 @@ func EmitRewards(
 			continue
 		}
 	}
-	ctx.Logger().Debug(
+	Logger(ctx).Debug(
 		fmt.Sprintf("Paid out %s to staked reputers over %d topics",
 			totalRewardToStakedReputers.String(),
 			len(topicRewards)))
@@ -524,4 +525,8 @@ func pruneRecordsAfterRewards(
 	}
 
 	return nil
+}
+
+func Logger(ctx sdk.Context) log.Logger {
+	return Logger(ctx).With("module", "rewards")
 }

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -528,5 +528,5 @@ func pruneRecordsAfterRewards(
 }
 
 func Logger(ctx sdk.Context) log.Logger {
-	return Logger(ctx).With("module", "rewards")
+	return ctx.Logger().With("module", "rewards")
 }

--- a/x/emissions/module/rewards/topic_skimming.go
+++ b/x/emissions/module/rewards/topic_skimming.go
@@ -45,7 +45,7 @@ func SortTopicsByWeightDescWithRandomTiebreaker(topicIds []TopicId, weights map[
 
 // Returns a map of topicId to weights of the top N topics by weight in descending order
 // It is assumed that topicIds is of a reasonable size, throttled by perhaps MaxTopicsPerBlock global param
-func SkimTopTopicsByWeightDesc(sdkCtx sdk.Context, weights map[TopicId]*alloraMath.Dec, N uint64, block BlockHeight) (map[TopicId]*alloraMath.Dec, []TopicId) {
+func SkimTopTopicsByWeightDesc(ctx sdk.Context, weights map[TopicId]*alloraMath.Dec, N uint64, block BlockHeight) (map[TopicId]*alloraMath.Dec, []TopicId) {
 	topicIds := make([]TopicId, 0, len(weights))
 	for topicId := range weights {
 		topicIds = append(topicIds, topicId)
@@ -71,7 +71,7 @@ func SkimTopTopicsByWeightDesc(sdkCtx sdk.Context, weights map[TopicId]*alloraMa
 		listOfTopN[i] = sortedTopicIds[i]
 	}
 
-	sdkCtx.Logger().Debug(
+	Logger(ctx).Debug(
 		fmt.Sprintf("SkimTopTopicsByWeightDesc took top %d topics out of %d",
 			numberToAdd, len(sortedTopicIds)))
 


### PR DESCRIPTION
Added context specific wrapped loggers for better logs.

When initializing the chain we can now set the log level of specific processes like `rewards`, `inference_synthesis` and `topic_handler`.

To do this, the chain needs to be initialized like this: 
```
allorad start --log_level "*:error,state:info,server:info,rewards:debug,inference_synthesis:debug,topic_handler:debug"
```

Ticket: https://linear.app/upshot/issue/ORA-1602/improve-logs-for-inference-synthesis-and-rewards
