### PR TITLE
[ORA-1620] Clear data from stake removal queue after a ConfirmStakeRemoval call is completed

### DIFF
--- a/x/emissions/api/v1/stake.pulsar.go
+++ b/x/emissions/api/v1/stake.pulsar.go
@@ -16,15 +16,17 @@ import (
 )
 
 var (
-	md_StakePlacement          protoreflect.MessageDescriptor
-	fd_StakePlacement_topic_id protoreflect.FieldDescriptor
-	fd_StakePlacement_reputer  protoreflect.FieldDescriptor
-	fd_StakePlacement_amount   protoreflect.FieldDescriptor
+	md_StakePlacement                       protoreflect.MessageDescriptor
+	fd_StakePlacement_block_removal_started protoreflect.FieldDescriptor
+	fd_StakePlacement_topic_id              protoreflect.FieldDescriptor
+	fd_StakePlacement_reputer               protoreflect.FieldDescriptor
+	fd_StakePlacement_amount                protoreflect.FieldDescriptor
 )
 
 func init() {
 	file_emissions_v1_stake_proto_init()
 	md_StakePlacement = File_emissions_v1_stake_proto.Messages().ByName("StakePlacement")
+	fd_StakePlacement_block_removal_started = md_StakePlacement.Fields().ByName("block_removal_started")
 	fd_StakePlacement_topic_id = md_StakePlacement.Fields().ByName("topic_id")
 	fd_StakePlacement_reputer = md_StakePlacement.Fields().ByName("reputer")
 	fd_StakePlacement_amount = md_StakePlacement.Fields().ByName("amount")
@@ -95,6 +97,12 @@ func (x *fastReflection_StakePlacement) Interface() protoreflect.ProtoMessage {
 // While iterating, mutating operations may only be performed
 // on the current field descriptor.
 func (x *fastReflection_StakePlacement) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.BlockRemovalStarted != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockRemovalStarted)
+		if !f(fd_StakePlacement_block_removal_started, value) {
+			return
+		}
+	}
 	if x.TopicId != uint64(0) {
 		value := protoreflect.ValueOfUint64(x.TopicId)
 		if !f(fd_StakePlacement_topic_id, value) {
@@ -128,6 +136,8 @@ func (x *fastReflection_StakePlacement) Range(f func(protoreflect.FieldDescripto
 // a repeated field is populated if it is non-empty.
 func (x *fastReflection_StakePlacement) Has(fd protoreflect.FieldDescriptor) bool {
 	switch fd.FullName() {
+	case "emissions.v1.StakePlacement.block_removal_started":
+		return x.BlockRemovalStarted != int64(0)
 	case "emissions.v1.StakePlacement.topic_id":
 		return x.TopicId != uint64(0)
 	case "emissions.v1.StakePlacement.reputer":
@@ -150,6 +160,8 @@ func (x *fastReflection_StakePlacement) Has(fd protoreflect.FieldDescriptor) boo
 // Clear is a mutating operation and unsafe for concurrent use.
 func (x *fastReflection_StakePlacement) Clear(fd protoreflect.FieldDescriptor) {
 	switch fd.FullName() {
+	case "emissions.v1.StakePlacement.block_removal_started":
+		x.BlockRemovalStarted = int64(0)
 	case "emissions.v1.StakePlacement.topic_id":
 		x.TopicId = uint64(0)
 	case "emissions.v1.StakePlacement.reputer":
@@ -172,6 +184,9 @@ func (x *fastReflection_StakePlacement) Clear(fd protoreflect.FieldDescriptor) {
 // of the value; to obtain a mutable reference, use Mutable.
 func (x *fastReflection_StakePlacement) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
 	switch descriptor.FullName() {
+	case "emissions.v1.StakePlacement.block_removal_started":
+		value := x.BlockRemovalStarted
+		return protoreflect.ValueOfInt64(value)
 	case "emissions.v1.StakePlacement.topic_id":
 		value := x.TopicId
 		return protoreflect.ValueOfUint64(value)
@@ -201,6 +216,8 @@ func (x *fastReflection_StakePlacement) Get(descriptor protoreflect.FieldDescrip
 // Set is a mutating operation and unsafe for concurrent use.
 func (x *fastReflection_StakePlacement) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
 	switch fd.FullName() {
+	case "emissions.v1.StakePlacement.block_removal_started":
+		x.BlockRemovalStarted = value.Int()
 	case "emissions.v1.StakePlacement.topic_id":
 		x.TopicId = value.Uint()
 	case "emissions.v1.StakePlacement.reputer":
@@ -227,6 +244,8 @@ func (x *fastReflection_StakePlacement) Set(fd protoreflect.FieldDescriptor, val
 // Mutable is a mutating operation and unsafe for concurrent use.
 func (x *fastReflection_StakePlacement) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
 	switch fd.FullName() {
+	case "emissions.v1.StakePlacement.block_removal_started":
+		panic(fmt.Errorf("field block_removal_started of message emissions.v1.StakePlacement is not mutable"))
 	case "emissions.v1.StakePlacement.topic_id":
 		panic(fmt.Errorf("field topic_id of message emissions.v1.StakePlacement is not mutable"))
 	case "emissions.v1.StakePlacement.reputer":
@@ -246,6 +265,8 @@ func (x *fastReflection_StakePlacement) Mutable(fd protoreflect.FieldDescriptor)
 // For lists, maps, and messages, this returns a new, empty, mutable value.
 func (x *fastReflection_StakePlacement) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
 	switch fd.FullName() {
+	case "emissions.v1.StakePlacement.block_removal_started":
+		return protoreflect.ValueOfInt64(int64(0))
 	case "emissions.v1.StakePlacement.topic_id":
 		return protoreflect.ValueOfUint64(uint64(0))
 	case "emissions.v1.StakePlacement.reputer":
@@ -321,6 +342,9 @@ func (x *fastReflection_StakePlacement) ProtoMethods() *protoiface.Methods {
 		var n int
 		var l int
 		_ = l
+		if x.BlockRemovalStarted != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockRemovalStarted))
+		}
 		if x.TopicId != 0 {
 			n += 1 + runtime.Sov(uint64(x.TopicId))
 		}
@@ -366,17 +390,22 @@ func (x *fastReflection_StakePlacement) ProtoMethods() *protoiface.Methods {
 			copy(dAtA[i:], x.Amount)
 			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Amount)))
 			i--
-			dAtA[i] = 0x1a
+			dAtA[i] = 0x22
 		}
 		if len(x.Reputer) > 0 {
 			i -= len(x.Reputer)
 			copy(dAtA[i:], x.Reputer)
 			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Reputer)))
 			i--
-			dAtA[i] = 0x12
+			dAtA[i] = 0x1a
 		}
 		if x.TopicId != 0 {
 			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.BlockRemovalStarted != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockRemovalStarted))
 			i--
 			dAtA[i] = 0x8
 		}
@@ -431,6 +460,25 @@ func (x *fastReflection_StakePlacement) ProtoMethods() *protoiface.Methods {
 			switch fieldNum {
 			case 1:
 				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockRemovalStarted", wireType)
+				}
+				x.BlockRemovalStarted = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockRemovalStarted |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
 				}
 				x.TopicId = 0
@@ -448,7 +496,7 @@ func (x *fastReflection_StakePlacement) ProtoMethods() *protoiface.Methods {
 						break
 					}
 				}
-			case 2:
+			case 3:
 				if wireType != 2 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Reputer", wireType)
 				}
@@ -480,7 +528,7 @@ func (x *fastReflection_StakePlacement) ProtoMethods() *protoiface.Methods {
 				}
 				x.Reputer = string(dAtA[iNdEx:postIndex])
 				iNdEx = postIndex
-			case 3:
+			case 4:
 				if wireType != 2 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
 				}
@@ -548,499 +596,18 @@ func (x *fastReflection_StakePlacement) ProtoMethods() *protoiface.Methods {
 }
 
 var (
-	md_StakeRemoval                       protoreflect.MessageDescriptor
-	fd_StakeRemoval_block_removal_started protoreflect.FieldDescriptor
-	fd_StakeRemoval_placement             protoreflect.FieldDescriptor
-)
-
-func init() {
-	file_emissions_v1_stake_proto_init()
-	md_StakeRemoval = File_emissions_v1_stake_proto.Messages().ByName("StakeRemoval")
-	fd_StakeRemoval_block_removal_started = md_StakeRemoval.Fields().ByName("block_removal_started")
-	fd_StakeRemoval_placement = md_StakeRemoval.Fields().ByName("placement")
-}
-
-var _ protoreflect.Message = (*fastReflection_StakeRemoval)(nil)
-
-type fastReflection_StakeRemoval StakeRemoval
-
-func (x *StakeRemoval) ProtoReflect() protoreflect.Message {
-	return (*fastReflection_StakeRemoval)(x)
-}
-
-func (x *StakeRemoval) slowProtoReflect() protoreflect.Message {
-	mi := &file_emissions_v1_stake_proto_msgTypes[1]
-	if protoimpl.UnsafeEnabled && x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-var _fastReflection_StakeRemoval_messageType fastReflection_StakeRemoval_messageType
-var _ protoreflect.MessageType = fastReflection_StakeRemoval_messageType{}
-
-type fastReflection_StakeRemoval_messageType struct{}
-
-func (x fastReflection_StakeRemoval_messageType) Zero() protoreflect.Message {
-	return (*fastReflection_StakeRemoval)(nil)
-}
-func (x fastReflection_StakeRemoval_messageType) New() protoreflect.Message {
-	return new(fastReflection_StakeRemoval)
-}
-func (x fastReflection_StakeRemoval_messageType) Descriptor() protoreflect.MessageDescriptor {
-	return md_StakeRemoval
-}
-
-// Descriptor returns message descriptor, which contains only the protobuf
-// type information for the message.
-func (x *fastReflection_StakeRemoval) Descriptor() protoreflect.MessageDescriptor {
-	return md_StakeRemoval
-}
-
-// Type returns the message type, which encapsulates both Go and protobuf
-// type information. If the Go type information is not needed,
-// it is recommended that the message descriptor be used instead.
-func (x *fastReflection_StakeRemoval) Type() protoreflect.MessageType {
-	return _fastReflection_StakeRemoval_messageType
-}
-
-// New returns a newly allocated and mutable empty message.
-func (x *fastReflection_StakeRemoval) New() protoreflect.Message {
-	return new(fastReflection_StakeRemoval)
-}
-
-// Interface unwraps the message reflection interface and
-// returns the underlying ProtoMessage interface.
-func (x *fastReflection_StakeRemoval) Interface() protoreflect.ProtoMessage {
-	return (*StakeRemoval)(x)
-}
-
-// Range iterates over every populated field in an undefined order,
-// calling f for each field descriptor and value encountered.
-// Range returns immediately if f returns false.
-// While iterating, mutating operations may only be performed
-// on the current field descriptor.
-func (x *fastReflection_StakeRemoval) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
-	if x.BlockRemovalStarted != int64(0) {
-		value := protoreflect.ValueOfInt64(x.BlockRemovalStarted)
-		if !f(fd_StakeRemoval_block_removal_started, value) {
-			return
-		}
-	}
-	if x.Placement != nil {
-		value := protoreflect.ValueOfMessage(x.Placement.ProtoReflect())
-		if !f(fd_StakeRemoval_placement, value) {
-			return
-		}
-	}
-}
-
-// Has reports whether a field is populated.
-//
-// Some fields have the property of nullability where it is possible to
-// distinguish between the default value of a field and whether the field
-// was explicitly populated with the default value. Singular message fields,
-// member fields of a oneof, and proto2 scalar fields are nullable. Such
-// fields are populated only if explicitly set.
-//
-// In other cases (aside from the nullable cases above),
-// a proto3 scalar field is populated if it contains a non-zero value, and
-// a repeated field is populated if it is non-empty.
-func (x *fastReflection_StakeRemoval) Has(fd protoreflect.FieldDescriptor) bool {
-	switch fd.FullName() {
-	case "emissions.v1.StakeRemoval.block_removal_started":
-		return x.BlockRemovalStarted != int64(0)
-	case "emissions.v1.StakeRemoval.placement":
-		return x.Placement != nil
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.StakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.StakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// Clear clears the field such that a subsequent Has call reports false.
-//
-// Clearing an extension field clears both the extension type and value
-// associated with the given field number.
-//
-// Clear is a mutating operation and unsafe for concurrent use.
-func (x *fastReflection_StakeRemoval) Clear(fd protoreflect.FieldDescriptor) {
-	switch fd.FullName() {
-	case "emissions.v1.StakeRemoval.block_removal_started":
-		x.BlockRemovalStarted = int64(0)
-	case "emissions.v1.StakeRemoval.placement":
-		x.Placement = nil
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.StakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.StakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// Get retrieves the value for a field.
-//
-// For unpopulated scalars, it returns the default value, where
-// the default value of a bytes scalar is guaranteed to be a copy.
-// For unpopulated composite types, it returns an empty, read-only view
-// of the value; to obtain a mutable reference, use Mutable.
-func (x *fastReflection_StakeRemoval) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
-	switch descriptor.FullName() {
-	case "emissions.v1.StakeRemoval.block_removal_started":
-		value := x.BlockRemovalStarted
-		return protoreflect.ValueOfInt64(value)
-	case "emissions.v1.StakeRemoval.placement":
-		value := x.Placement
-		return protoreflect.ValueOfMessage(value.ProtoReflect())
-	default:
-		if descriptor.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.StakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.StakeRemoval does not contain field %s", descriptor.FullName()))
-	}
-}
-
-// Set stores the value for a field.
-//
-// For a field belonging to a oneof, it implicitly clears any other field
-// that may be currently set within the same oneof.
-// For extension fields, it implicitly stores the provided ExtensionType.
-// When setting a composite type, it is unspecified whether the stored value
-// aliases the source's memory in any way. If the composite value is an
-// empty, read-only value, then it panics.
-//
-// Set is a mutating operation and unsafe for concurrent use.
-func (x *fastReflection_StakeRemoval) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
-	switch fd.FullName() {
-	case "emissions.v1.StakeRemoval.block_removal_started":
-		x.BlockRemovalStarted = value.Int()
-	case "emissions.v1.StakeRemoval.placement":
-		x.Placement = value.Message().Interface().(*StakePlacement)
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.StakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.StakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// Mutable returns a mutable reference to a composite type.
-//
-// If the field is unpopulated, it may allocate a composite value.
-// For a field belonging to a oneof, it implicitly clears any other field
-// that may be currently set within the same oneof.
-// For extension fields, it implicitly stores the provided ExtensionType
-// if not already stored.
-// It panics if the field does not contain a composite type.
-//
-// Mutable is a mutating operation and unsafe for concurrent use.
-func (x *fastReflection_StakeRemoval) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
-	switch fd.FullName() {
-	case "emissions.v1.StakeRemoval.placement":
-		if x.Placement == nil {
-			x.Placement = new(StakePlacement)
-		}
-		return protoreflect.ValueOfMessage(x.Placement.ProtoReflect())
-	case "emissions.v1.StakeRemoval.block_removal_started":
-		panic(fmt.Errorf("field block_removal_started of message emissions.v1.StakeRemoval is not mutable"))
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.StakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.StakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// NewField returns a new value that is assignable to the field
-// for the given descriptor. For scalars, this returns the default value.
-// For lists, maps, and messages, this returns a new, empty, mutable value.
-func (x *fastReflection_StakeRemoval) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
-	switch fd.FullName() {
-	case "emissions.v1.StakeRemoval.block_removal_started":
-		return protoreflect.ValueOfInt64(int64(0))
-	case "emissions.v1.StakeRemoval.placement":
-		m := new(StakePlacement)
-		return protoreflect.ValueOfMessage(m.ProtoReflect())
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.StakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.StakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// WhichOneof reports which field within the oneof is populated,
-// returning nil if none are populated.
-// It panics if the oneof descriptor does not belong to this message.
-func (x *fastReflection_StakeRemoval) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
-	switch d.FullName() {
-	default:
-		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.StakeRemoval", d.FullName()))
-	}
-	panic("unreachable")
-}
-
-// GetUnknown retrieves the entire list of unknown fields.
-// The caller may only mutate the contents of the RawFields
-// if the mutated bytes are stored back into the message with SetUnknown.
-func (x *fastReflection_StakeRemoval) GetUnknown() protoreflect.RawFields {
-	return x.unknownFields
-}
-
-// SetUnknown stores an entire list of unknown fields.
-// The raw fields must be syntactically valid according to the wire format.
-// An implementation may panic if this is not the case.
-// Once stored, the caller must not mutate the content of the RawFields.
-// An empty RawFields may be passed to clear the fields.
-//
-// SetUnknown is a mutating operation and unsafe for concurrent use.
-func (x *fastReflection_StakeRemoval) SetUnknown(fields protoreflect.RawFields) {
-	x.unknownFields = fields
-}
-
-// IsValid reports whether the message is valid.
-//
-// An invalid message is an empty, read-only value.
-//
-// An invalid message often corresponds to a nil pointer of the concrete
-// message type, but the details are implementation dependent.
-// Validity is not part of the protobuf data model, and may not
-// be preserved in marshaling or other operations.
-func (x *fastReflection_StakeRemoval) IsValid() bool {
-	return x != nil
-}
-
-// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
-// This method may return nil.
-//
-// The returned methods type is identical to
-// "google.golang.org/protobuf/runtime/protoiface".Methods.
-// Consult the protoiface package documentation for details.
-func (x *fastReflection_StakeRemoval) ProtoMethods() *protoiface.Methods {
-	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
-		x := input.Message.Interface().(*StakeRemoval)
-		if x == nil {
-			return protoiface.SizeOutput{
-				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-				Size:              0,
-			}
-		}
-		options := runtime.SizeInputToOptions(input)
-		_ = options
-		var n int
-		var l int
-		_ = l
-		if x.BlockRemovalStarted != 0 {
-			n += 1 + runtime.Sov(uint64(x.BlockRemovalStarted))
-		}
-		if x.Placement != nil {
-			l = options.Size(x.Placement)
-			n += 1 + l + runtime.Sov(uint64(l))
-		}
-		if x.unknownFields != nil {
-			n += len(x.unknownFields)
-		}
-		return protoiface.SizeOutput{
-			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-			Size:              n,
-		}
-	}
-
-	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
-		x := input.Message.Interface().(*StakeRemoval)
-		if x == nil {
-			return protoiface.MarshalOutput{
-				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-				Buf:               input.Buf,
-			}, nil
-		}
-		options := runtime.MarshalInputToOptions(input)
-		_ = options
-		size := options.Size(x)
-		dAtA := make([]byte, size)
-		i := len(dAtA)
-		_ = i
-		var l int
-		_ = l
-		if x.unknownFields != nil {
-			i -= len(x.unknownFields)
-			copy(dAtA[i:], x.unknownFields)
-		}
-		if x.Placement != nil {
-			encoded, err := options.Marshal(x.Placement)
-			if err != nil {
-				return protoiface.MarshalOutput{
-					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-					Buf:               input.Buf,
-				}, err
-			}
-			i -= len(encoded)
-			copy(dAtA[i:], encoded)
-			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
-			i--
-			dAtA[i] = 0x12
-		}
-		if x.BlockRemovalStarted != 0 {
-			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockRemovalStarted))
-			i--
-			dAtA[i] = 0x8
-		}
-		if input.Buf != nil {
-			input.Buf = append(input.Buf, dAtA...)
-		} else {
-			input.Buf = dAtA
-		}
-		return protoiface.MarshalOutput{
-			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-			Buf:               input.Buf,
-		}, nil
-	}
-	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
-		x := input.Message.Interface().(*StakeRemoval)
-		if x == nil {
-			return protoiface.UnmarshalOutput{
-				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-				Flags:             input.Flags,
-			}, nil
-		}
-		options := runtime.UnmarshalInputToOptions(input)
-		_ = options
-		dAtA := input.Buf
-		l := len(dAtA)
-		iNdEx := 0
-		for iNdEx < l {
-			preIndex := iNdEx
-			var wire uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				wire |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			fieldNum := int32(wire >> 3)
-			wireType := int(wire & 0x7)
-			if wireType == 4 {
-				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: StakeRemoval: wiretype end group for non-group")
-			}
-			if fieldNum <= 0 {
-				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: StakeRemoval: illegal tag %d (wire type %d)", fieldNum, wire)
-			}
-			switch fieldNum {
-			case 1:
-				if wireType != 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockRemovalStarted", wireType)
-				}
-				x.BlockRemovalStarted = 0
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					x.BlockRemovalStarted |= int64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-			case 2:
-				if wireType != 2 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Placement", wireType)
-				}
-				var msglen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					msglen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if msglen < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				postIndex := iNdEx + msglen
-				if postIndex < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				if postIndex > l {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-				}
-				if x.Placement == nil {
-					x.Placement = &StakePlacement{}
-				}
-				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Placement); err != nil {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
-				}
-				iNdEx = postIndex
-			default:
-				iNdEx = preIndex
-				skippy, err := runtime.Skip(dAtA[iNdEx:])
-				if err != nil {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
-				}
-				if (skippy < 0) || (iNdEx+skippy) < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				if (iNdEx + skippy) > l {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-				}
-				if !options.DiscardUnknown {
-					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
-				}
-				iNdEx += skippy
-			}
-		}
-
-		if iNdEx > l {
-			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-		}
-		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
-	}
-	return &protoiface.Methods{
-		NoUnkeyedLiterals: struct{}{},
-		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
-		Size:              size,
-		Marshal:           marshal,
-		Unmarshal:         unmarshal,
-		Merge:             nil,
-		CheckInitialized:  nil,
-	}
-}
-
-var (
-	md_DelegateStakePlacement           protoreflect.MessageDescriptor
-	fd_DelegateStakePlacement_topic_id  protoreflect.FieldDescriptor
-	fd_DelegateStakePlacement_reputer   protoreflect.FieldDescriptor
-	fd_DelegateStakePlacement_delegator protoreflect.FieldDescriptor
-	fd_DelegateStakePlacement_amount    protoreflect.FieldDescriptor
+	md_DelegateStakePlacement                       protoreflect.MessageDescriptor
+	fd_DelegateStakePlacement_block_removal_started protoreflect.FieldDescriptor
+	fd_DelegateStakePlacement_topic_id              protoreflect.FieldDescriptor
+	fd_DelegateStakePlacement_reputer               protoreflect.FieldDescriptor
+	fd_DelegateStakePlacement_delegator             protoreflect.FieldDescriptor
+	fd_DelegateStakePlacement_amount                protoreflect.FieldDescriptor
 )
 
 func init() {
 	file_emissions_v1_stake_proto_init()
 	md_DelegateStakePlacement = File_emissions_v1_stake_proto.Messages().ByName("DelegateStakePlacement")
+	fd_DelegateStakePlacement_block_removal_started = md_DelegateStakePlacement.Fields().ByName("block_removal_started")
 	fd_DelegateStakePlacement_topic_id = md_DelegateStakePlacement.Fields().ByName("topic_id")
 	fd_DelegateStakePlacement_reputer = md_DelegateStakePlacement.Fields().ByName("reputer")
 	fd_DelegateStakePlacement_delegator = md_DelegateStakePlacement.Fields().ByName("delegator")
@@ -1056,7 +623,7 @@ func (x *DelegateStakePlacement) ProtoReflect() protoreflect.Message {
 }
 
 func (x *DelegateStakePlacement) slowProtoReflect() protoreflect.Message {
-	mi := &file_emissions_v1_stake_proto_msgTypes[2]
+	mi := &file_emissions_v1_stake_proto_msgTypes[1]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1112,6 +679,12 @@ func (x *fastReflection_DelegateStakePlacement) Interface() protoreflect.ProtoMe
 // While iterating, mutating operations may only be performed
 // on the current field descriptor.
 func (x *fastReflection_DelegateStakePlacement) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.BlockRemovalStarted != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockRemovalStarted)
+		if !f(fd_DelegateStakePlacement_block_removal_started, value) {
+			return
+		}
+	}
 	if x.TopicId != uint64(0) {
 		value := protoreflect.ValueOfUint64(x.TopicId)
 		if !f(fd_DelegateStakePlacement_topic_id, value) {
@@ -1151,6 +724,8 @@ func (x *fastReflection_DelegateStakePlacement) Range(f func(protoreflect.FieldD
 // a repeated field is populated if it is non-empty.
 func (x *fastReflection_DelegateStakePlacement) Has(fd protoreflect.FieldDescriptor) bool {
 	switch fd.FullName() {
+	case "emissions.v1.DelegateStakePlacement.block_removal_started":
+		return x.BlockRemovalStarted != int64(0)
 	case "emissions.v1.DelegateStakePlacement.topic_id":
 		return x.TopicId != uint64(0)
 	case "emissions.v1.DelegateStakePlacement.reputer":
@@ -1175,6 +750,8 @@ func (x *fastReflection_DelegateStakePlacement) Has(fd protoreflect.FieldDescrip
 // Clear is a mutating operation and unsafe for concurrent use.
 func (x *fastReflection_DelegateStakePlacement) Clear(fd protoreflect.FieldDescriptor) {
 	switch fd.FullName() {
+	case "emissions.v1.DelegateStakePlacement.block_removal_started":
+		x.BlockRemovalStarted = int64(0)
 	case "emissions.v1.DelegateStakePlacement.topic_id":
 		x.TopicId = uint64(0)
 	case "emissions.v1.DelegateStakePlacement.reputer":
@@ -1199,6 +776,9 @@ func (x *fastReflection_DelegateStakePlacement) Clear(fd protoreflect.FieldDescr
 // of the value; to obtain a mutable reference, use Mutable.
 func (x *fastReflection_DelegateStakePlacement) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
 	switch descriptor.FullName() {
+	case "emissions.v1.DelegateStakePlacement.block_removal_started":
+		value := x.BlockRemovalStarted
+		return protoreflect.ValueOfInt64(value)
 	case "emissions.v1.DelegateStakePlacement.topic_id":
 		value := x.TopicId
 		return protoreflect.ValueOfUint64(value)
@@ -1231,6 +811,8 @@ func (x *fastReflection_DelegateStakePlacement) Get(descriptor protoreflect.Fiel
 // Set is a mutating operation and unsafe for concurrent use.
 func (x *fastReflection_DelegateStakePlacement) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
 	switch fd.FullName() {
+	case "emissions.v1.DelegateStakePlacement.block_removal_started":
+		x.BlockRemovalStarted = value.Int()
 	case "emissions.v1.DelegateStakePlacement.topic_id":
 		x.TopicId = value.Uint()
 	case "emissions.v1.DelegateStakePlacement.reputer":
@@ -1259,6 +841,8 @@ func (x *fastReflection_DelegateStakePlacement) Set(fd protoreflect.FieldDescrip
 // Mutable is a mutating operation and unsafe for concurrent use.
 func (x *fastReflection_DelegateStakePlacement) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
 	switch fd.FullName() {
+	case "emissions.v1.DelegateStakePlacement.block_removal_started":
+		panic(fmt.Errorf("field block_removal_started of message emissions.v1.DelegateStakePlacement is not mutable"))
 	case "emissions.v1.DelegateStakePlacement.topic_id":
 		panic(fmt.Errorf("field topic_id of message emissions.v1.DelegateStakePlacement is not mutable"))
 	case "emissions.v1.DelegateStakePlacement.reputer":
@@ -1280,6 +864,8 @@ func (x *fastReflection_DelegateStakePlacement) Mutable(fd protoreflect.FieldDes
 // For lists, maps, and messages, this returns a new, empty, mutable value.
 func (x *fastReflection_DelegateStakePlacement) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
 	switch fd.FullName() {
+	case "emissions.v1.DelegateStakePlacement.block_removal_started":
+		return protoreflect.ValueOfInt64(int64(0))
 	case "emissions.v1.DelegateStakePlacement.topic_id":
 		return protoreflect.ValueOfUint64(uint64(0))
 	case "emissions.v1.DelegateStakePlacement.reputer":
@@ -1357,6 +943,9 @@ func (x *fastReflection_DelegateStakePlacement) ProtoMethods() *protoiface.Metho
 		var n int
 		var l int
 		_ = l
+		if x.BlockRemovalStarted != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockRemovalStarted))
+		}
 		if x.TopicId != 0 {
 			n += 1 + runtime.Sov(uint64(x.TopicId))
 		}
@@ -1406,24 +995,29 @@ func (x *fastReflection_DelegateStakePlacement) ProtoMethods() *protoiface.Metho
 			copy(dAtA[i:], x.Amount)
 			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Amount)))
 			i--
-			dAtA[i] = 0x22
+			dAtA[i] = 0x2a
 		}
 		if len(x.Delegator) > 0 {
 			i -= len(x.Delegator)
 			copy(dAtA[i:], x.Delegator)
 			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Delegator)))
 			i--
-			dAtA[i] = 0x1a
+			dAtA[i] = 0x22
 		}
 		if len(x.Reputer) > 0 {
 			i -= len(x.Reputer)
 			copy(dAtA[i:], x.Reputer)
 			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Reputer)))
 			i--
-			dAtA[i] = 0x12
+			dAtA[i] = 0x1a
 		}
 		if x.TopicId != 0 {
 			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.BlockRemovalStarted != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockRemovalStarted))
 			i--
 			dAtA[i] = 0x8
 		}
@@ -1478,6 +1072,25 @@ func (x *fastReflection_DelegateStakePlacement) ProtoMethods() *protoiface.Metho
 			switch fieldNum {
 			case 1:
 				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockRemovalStarted", wireType)
+				}
+				x.BlockRemovalStarted = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockRemovalStarted |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
 				}
 				x.TopicId = 0
@@ -1495,7 +1108,7 @@ func (x *fastReflection_DelegateStakePlacement) ProtoMethods() *protoiface.Metho
 						break
 					}
 				}
-			case 2:
+			case 3:
 				if wireType != 2 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Reputer", wireType)
 				}
@@ -1527,7 +1140,7 @@ func (x *fastReflection_DelegateStakePlacement) ProtoMethods() *protoiface.Metho
 				}
 				x.Reputer = string(dAtA[iNdEx:postIndex])
 				iNdEx = postIndex
-			case 3:
+			case 4:
 				if wireType != 2 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Delegator", wireType)
 				}
@@ -1559,7 +1172,7 @@ func (x *fastReflection_DelegateStakePlacement) ProtoMethods() *protoiface.Metho
 				}
 				x.Delegator = string(dAtA[iNdEx:postIndex])
 				iNdEx = postIndex
-			case 4:
+			case 5:
 				if wireType != 2 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
 				}
@@ -1627,489 +1240,6 @@ func (x *fastReflection_DelegateStakePlacement) ProtoMethods() *protoiface.Metho
 }
 
 var (
-	md_DelegateStakeRemoval                       protoreflect.MessageDescriptor
-	fd_DelegateStakeRemoval_block_removal_started protoreflect.FieldDescriptor
-	fd_DelegateStakeRemoval_placement             protoreflect.FieldDescriptor
-)
-
-func init() {
-	file_emissions_v1_stake_proto_init()
-	md_DelegateStakeRemoval = File_emissions_v1_stake_proto.Messages().ByName("DelegateStakeRemoval")
-	fd_DelegateStakeRemoval_block_removal_started = md_DelegateStakeRemoval.Fields().ByName("block_removal_started")
-	fd_DelegateStakeRemoval_placement = md_DelegateStakeRemoval.Fields().ByName("placement")
-}
-
-var _ protoreflect.Message = (*fastReflection_DelegateStakeRemoval)(nil)
-
-type fastReflection_DelegateStakeRemoval DelegateStakeRemoval
-
-func (x *DelegateStakeRemoval) ProtoReflect() protoreflect.Message {
-	return (*fastReflection_DelegateStakeRemoval)(x)
-}
-
-func (x *DelegateStakeRemoval) slowProtoReflect() protoreflect.Message {
-	mi := &file_emissions_v1_stake_proto_msgTypes[3]
-	if protoimpl.UnsafeEnabled && x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-var _fastReflection_DelegateStakeRemoval_messageType fastReflection_DelegateStakeRemoval_messageType
-var _ protoreflect.MessageType = fastReflection_DelegateStakeRemoval_messageType{}
-
-type fastReflection_DelegateStakeRemoval_messageType struct{}
-
-func (x fastReflection_DelegateStakeRemoval_messageType) Zero() protoreflect.Message {
-	return (*fastReflection_DelegateStakeRemoval)(nil)
-}
-func (x fastReflection_DelegateStakeRemoval_messageType) New() protoreflect.Message {
-	return new(fastReflection_DelegateStakeRemoval)
-}
-func (x fastReflection_DelegateStakeRemoval_messageType) Descriptor() protoreflect.MessageDescriptor {
-	return md_DelegateStakeRemoval
-}
-
-// Descriptor returns message descriptor, which contains only the protobuf
-// type information for the message.
-func (x *fastReflection_DelegateStakeRemoval) Descriptor() protoreflect.MessageDescriptor {
-	return md_DelegateStakeRemoval
-}
-
-// Type returns the message type, which encapsulates both Go and protobuf
-// type information. If the Go type information is not needed,
-// it is recommended that the message descriptor be used instead.
-func (x *fastReflection_DelegateStakeRemoval) Type() protoreflect.MessageType {
-	return _fastReflection_DelegateStakeRemoval_messageType
-}
-
-// New returns a newly allocated and mutable empty message.
-func (x *fastReflection_DelegateStakeRemoval) New() protoreflect.Message {
-	return new(fastReflection_DelegateStakeRemoval)
-}
-
-// Interface unwraps the message reflection interface and
-// returns the underlying ProtoMessage interface.
-func (x *fastReflection_DelegateStakeRemoval) Interface() protoreflect.ProtoMessage {
-	return (*DelegateStakeRemoval)(x)
-}
-
-// Range iterates over every populated field in an undefined order,
-// calling f for each field descriptor and value encountered.
-// Range returns immediately if f returns false.
-// While iterating, mutating operations may only be performed
-// on the current field descriptor.
-func (x *fastReflection_DelegateStakeRemoval) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
-	if x.BlockRemovalStarted != int64(0) {
-		value := protoreflect.ValueOfInt64(x.BlockRemovalStarted)
-		if !f(fd_DelegateStakeRemoval_block_removal_started, value) {
-			return
-		}
-	}
-	if x.Placement != nil {
-		value := protoreflect.ValueOfMessage(x.Placement.ProtoReflect())
-		if !f(fd_DelegateStakeRemoval_placement, value) {
-			return
-		}
-	}
-}
-
-// Has reports whether a field is populated.
-//
-// Some fields have the property of nullability where it is possible to
-// distinguish between the default value of a field and whether the field
-// was explicitly populated with the default value. Singular message fields,
-// member fields of a oneof, and proto2 scalar fields are nullable. Such
-// fields are populated only if explicitly set.
-//
-// In other cases (aside from the nullable cases above),
-// a proto3 scalar field is populated if it contains a non-zero value, and
-// a repeated field is populated if it is non-empty.
-func (x *fastReflection_DelegateStakeRemoval) Has(fd protoreflect.FieldDescriptor) bool {
-	switch fd.FullName() {
-	case "emissions.v1.DelegateStakeRemoval.block_removal_started":
-		return x.BlockRemovalStarted != int64(0)
-	case "emissions.v1.DelegateStakeRemoval.placement":
-		return x.Placement != nil
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegateStakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.DelegateStakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// Clear clears the field such that a subsequent Has call reports false.
-//
-// Clearing an extension field clears both the extension type and value
-// associated with the given field number.
-//
-// Clear is a mutating operation and unsafe for concurrent use.
-func (x *fastReflection_DelegateStakeRemoval) Clear(fd protoreflect.FieldDescriptor) {
-	switch fd.FullName() {
-	case "emissions.v1.DelegateStakeRemoval.block_removal_started":
-		x.BlockRemovalStarted = int64(0)
-	case "emissions.v1.DelegateStakeRemoval.placement":
-		x.Placement = nil
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegateStakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.DelegateStakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// Get retrieves the value for a field.
-//
-// For unpopulated scalars, it returns the default value, where
-// the default value of a bytes scalar is guaranteed to be a copy.
-// For unpopulated composite types, it returns an empty, read-only view
-// of the value; to obtain a mutable reference, use Mutable.
-func (x *fastReflection_DelegateStakeRemoval) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
-	switch descriptor.FullName() {
-	case "emissions.v1.DelegateStakeRemoval.block_removal_started":
-		value := x.BlockRemovalStarted
-		return protoreflect.ValueOfInt64(value)
-	case "emissions.v1.DelegateStakeRemoval.placement":
-		value := x.Placement
-		return protoreflect.ValueOfMessage(value.ProtoReflect())
-	default:
-		if descriptor.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegateStakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.DelegateStakeRemoval does not contain field %s", descriptor.FullName()))
-	}
-}
-
-// Set stores the value for a field.
-//
-// For a field belonging to a oneof, it implicitly clears any other field
-// that may be currently set within the same oneof.
-// For extension fields, it implicitly stores the provided ExtensionType.
-// When setting a composite type, it is unspecified whether the stored value
-// aliases the source's memory in any way. If the composite value is an
-// empty, read-only value, then it panics.
-//
-// Set is a mutating operation and unsafe for concurrent use.
-func (x *fastReflection_DelegateStakeRemoval) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
-	switch fd.FullName() {
-	case "emissions.v1.DelegateStakeRemoval.block_removal_started":
-		x.BlockRemovalStarted = value.Int()
-	case "emissions.v1.DelegateStakeRemoval.placement":
-		x.Placement = value.Message().Interface().(*DelegateStakePlacement)
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegateStakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.DelegateStakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// Mutable returns a mutable reference to a composite type.
-//
-// If the field is unpopulated, it may allocate a composite value.
-// For a field belonging to a oneof, it implicitly clears any other field
-// that may be currently set within the same oneof.
-// For extension fields, it implicitly stores the provided ExtensionType
-// if not already stored.
-// It panics if the field does not contain a composite type.
-//
-// Mutable is a mutating operation and unsafe for concurrent use.
-func (x *fastReflection_DelegateStakeRemoval) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
-	switch fd.FullName() {
-	case "emissions.v1.DelegateStakeRemoval.placement":
-		if x.Placement == nil {
-			x.Placement = new(DelegateStakePlacement)
-		}
-		return protoreflect.ValueOfMessage(x.Placement.ProtoReflect())
-	case "emissions.v1.DelegateStakeRemoval.block_removal_started":
-		panic(fmt.Errorf("field block_removal_started of message emissions.v1.DelegateStakeRemoval is not mutable"))
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegateStakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.DelegateStakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// NewField returns a new value that is assignable to the field
-// for the given descriptor. For scalars, this returns the default value.
-// For lists, maps, and messages, this returns a new, empty, mutable value.
-func (x *fastReflection_DelegateStakeRemoval) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
-	switch fd.FullName() {
-	case "emissions.v1.DelegateStakeRemoval.block_removal_started":
-		return protoreflect.ValueOfInt64(int64(0))
-	case "emissions.v1.DelegateStakeRemoval.placement":
-		m := new(DelegateStakePlacement)
-		return protoreflect.ValueOfMessage(m.ProtoReflect())
-	default:
-		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegateStakeRemoval"))
-		}
-		panic(fmt.Errorf("message emissions.v1.DelegateStakeRemoval does not contain field %s", fd.FullName()))
-	}
-}
-
-// WhichOneof reports which field within the oneof is populated,
-// returning nil if none are populated.
-// It panics if the oneof descriptor does not belong to this message.
-func (x *fastReflection_DelegateStakeRemoval) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
-	switch d.FullName() {
-	default:
-		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.DelegateStakeRemoval", d.FullName()))
-	}
-	panic("unreachable")
-}
-
-// GetUnknown retrieves the entire list of unknown fields.
-// The caller may only mutate the contents of the RawFields
-// if the mutated bytes are stored back into the message with SetUnknown.
-func (x *fastReflection_DelegateStakeRemoval) GetUnknown() protoreflect.RawFields {
-	return x.unknownFields
-}
-
-// SetUnknown stores an entire list of unknown fields.
-// The raw fields must be syntactically valid according to the wire format.
-// An implementation may panic if this is not the case.
-// Once stored, the caller must not mutate the content of the RawFields.
-// An empty RawFields may be passed to clear the fields.
-//
-// SetUnknown is a mutating operation and unsafe for concurrent use.
-func (x *fastReflection_DelegateStakeRemoval) SetUnknown(fields protoreflect.RawFields) {
-	x.unknownFields = fields
-}
-
-// IsValid reports whether the message is valid.
-//
-// An invalid message is an empty, read-only value.
-//
-// An invalid message often corresponds to a nil pointer of the concrete
-// message type, but the details are implementation dependent.
-// Validity is not part of the protobuf data model, and may not
-// be preserved in marshaling or other operations.
-func (x *fastReflection_DelegateStakeRemoval) IsValid() bool {
-	return x != nil
-}
-
-// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
-// This method may return nil.
-//
-// The returned methods type is identical to
-// "google.golang.org/protobuf/runtime/protoiface".Methods.
-// Consult the protoiface package documentation for details.
-func (x *fastReflection_DelegateStakeRemoval) ProtoMethods() *protoiface.Methods {
-	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
-		x := input.Message.Interface().(*DelegateStakeRemoval)
-		if x == nil {
-			return protoiface.SizeOutput{
-				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-				Size:              0,
-			}
-		}
-		options := runtime.SizeInputToOptions(input)
-		_ = options
-		var n int
-		var l int
-		_ = l
-		if x.BlockRemovalStarted != 0 {
-			n += 1 + runtime.Sov(uint64(x.BlockRemovalStarted))
-		}
-		if x.Placement != nil {
-			l = options.Size(x.Placement)
-			n += 1 + l + runtime.Sov(uint64(l))
-		}
-		if x.unknownFields != nil {
-			n += len(x.unknownFields)
-		}
-		return protoiface.SizeOutput{
-			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-			Size:              n,
-		}
-	}
-
-	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
-		x := input.Message.Interface().(*DelegateStakeRemoval)
-		if x == nil {
-			return protoiface.MarshalOutput{
-				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-				Buf:               input.Buf,
-			}, nil
-		}
-		options := runtime.MarshalInputToOptions(input)
-		_ = options
-		size := options.Size(x)
-		dAtA := make([]byte, size)
-		i := len(dAtA)
-		_ = i
-		var l int
-		_ = l
-		if x.unknownFields != nil {
-			i -= len(x.unknownFields)
-			copy(dAtA[i:], x.unknownFields)
-		}
-		if x.Placement != nil {
-			encoded, err := options.Marshal(x.Placement)
-			if err != nil {
-				return protoiface.MarshalOutput{
-					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-					Buf:               input.Buf,
-				}, err
-			}
-			i -= len(encoded)
-			copy(dAtA[i:], encoded)
-			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
-			i--
-			dAtA[i] = 0x12
-		}
-		if x.BlockRemovalStarted != 0 {
-			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockRemovalStarted))
-			i--
-			dAtA[i] = 0x8
-		}
-		if input.Buf != nil {
-			input.Buf = append(input.Buf, dAtA...)
-		} else {
-			input.Buf = dAtA
-		}
-		return protoiface.MarshalOutput{
-			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-			Buf:               input.Buf,
-		}, nil
-	}
-	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
-		x := input.Message.Interface().(*DelegateStakeRemoval)
-		if x == nil {
-			return protoiface.UnmarshalOutput{
-				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
-				Flags:             input.Flags,
-			}, nil
-		}
-		options := runtime.UnmarshalInputToOptions(input)
-		_ = options
-		dAtA := input.Buf
-		l := len(dAtA)
-		iNdEx := 0
-		for iNdEx < l {
-			preIndex := iNdEx
-			var wire uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				wire |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			fieldNum := int32(wire >> 3)
-			wireType := int(wire & 0x7)
-			if wireType == 4 {
-				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: DelegateStakeRemoval: wiretype end group for non-group")
-			}
-			if fieldNum <= 0 {
-				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: DelegateStakeRemoval: illegal tag %d (wire type %d)", fieldNum, wire)
-			}
-			switch fieldNum {
-			case 1:
-				if wireType != 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockRemovalStarted", wireType)
-				}
-				x.BlockRemovalStarted = 0
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					x.BlockRemovalStarted |= int64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-			case 2:
-				if wireType != 2 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Placement", wireType)
-				}
-				var msglen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					msglen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if msglen < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				postIndex := iNdEx + msglen
-				if postIndex < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				if postIndex > l {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-				}
-				if x.Placement == nil {
-					x.Placement = &DelegateStakePlacement{}
-				}
-				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Placement); err != nil {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
-				}
-				iNdEx = postIndex
-			default:
-				iNdEx = preIndex
-				skippy, err := runtime.Skip(dAtA[iNdEx:])
-				if err != nil {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
-				}
-				if (skippy < 0) || (iNdEx+skippy) < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				if (iNdEx + skippy) > l {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-				}
-				if !options.DiscardUnknown {
-					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
-				}
-				iNdEx += skippy
-			}
-		}
-
-		if iNdEx > l {
-			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-		}
-		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
-	}
-	return &protoiface.Methods{
-		NoUnkeyedLiterals: struct{}{},
-		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
-		Size:              size,
-		Marshal:           marshal,
-		Unmarshal:         unmarshal,
-		Merge:             nil,
-		CheckInitialized:  nil,
-	}
-}
-
-var (
 	md_DelegatorInfo             protoreflect.MessageDescriptor
 	fd_DelegatorInfo_amount      protoreflect.FieldDescriptor
 	fd_DelegatorInfo_reward_debt protoreflect.FieldDescriptor
@@ -2131,7 +1261,7 @@ func (x *DelegatorInfo) ProtoReflect() protoreflect.Message {
 }
 
 func (x *DelegatorInfo) slowProtoReflect() protoreflect.Message {
-	mi := &file_emissions_v1_stake_proto_msgTypes[4]
+	mi := &file_emissions_v1_stake_proto_msgTypes[2]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2611,9 +1741,10 @@ type StakePlacement struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	TopicId uint64 `protobuf:"varint,1,opt,name=topic_id,json=topicId,proto3" json:"topic_id,omitempty"`
-	Reputer string `protobuf:"bytes,2,opt,name=reputer,proto3" json:"reputer,omitempty"`
-	Amount  string `protobuf:"bytes,3,opt,name=amount,proto3" json:"amount,omitempty"`
+	BlockRemovalStarted int64  `protobuf:"varint,1,opt,name=block_removal_started,json=blockRemovalStarted,proto3" json:"block_removal_started,omitempty"`
+	TopicId             uint64 `protobuf:"varint,2,opt,name=topic_id,json=topicId,proto3" json:"topic_id,omitempty"`
+	Reputer             string `protobuf:"bytes,3,opt,name=reputer,proto3" json:"reputer,omitempty"`
+	Amount              string `protobuf:"bytes,4,opt,name=amount,proto3" json:"amount,omitempty"`
 }
 
 func (x *StakePlacement) Reset() {
@@ -2634,6 +1765,13 @@ func (*StakePlacement) ProtoMessage() {}
 // Deprecated: Use StakePlacement.ProtoReflect.Descriptor instead.
 func (*StakePlacement) Descriptor() ([]byte, []int) {
 	return file_emissions_v1_stake_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *StakePlacement) GetBlockRemovalStarted() int64 {
+	if x != nil {
+		return x.BlockRemovalStarted
+	}
+	return 0
 }
 
 func (x *StakePlacement) GetTopicId() uint64 {
@@ -2657,64 +1795,22 @@ func (x *StakePlacement) GetAmount() string {
 	return ""
 }
 
-type StakeRemoval struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
-
-	BlockRemovalStarted int64           `protobuf:"varint,1,opt,name=block_removal_started,json=blockRemovalStarted,proto3" json:"block_removal_started,omitempty"`
-	Placement           *StakePlacement `protobuf:"bytes,2,opt,name=placement,proto3" json:"placement,omitempty"`
-}
-
-func (x *StakeRemoval) Reset() {
-	*x = StakeRemoval{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_emissions_v1_stake_proto_msgTypes[1]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
-}
-
-func (x *StakeRemoval) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*StakeRemoval) ProtoMessage() {}
-
-// Deprecated: Use StakeRemoval.ProtoReflect.Descriptor instead.
-func (*StakeRemoval) Descriptor() ([]byte, []int) {
-	return file_emissions_v1_stake_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *StakeRemoval) GetBlockRemovalStarted() int64 {
-	if x != nil {
-		return x.BlockRemovalStarted
-	}
-	return 0
-}
-
-func (x *StakeRemoval) GetPlacement() *StakePlacement {
-	if x != nil {
-		return x.Placement
-	}
-	return nil
-}
-
 type DelegateStakePlacement struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	TopicId   uint64 `protobuf:"varint,1,opt,name=topic_id,json=topicId,proto3" json:"topic_id,omitempty"`
-	Reputer   string `protobuf:"bytes,2,opt,name=reputer,proto3" json:"reputer,omitempty"`
-	Delegator string `protobuf:"bytes,3,opt,name=delegator,proto3" json:"delegator,omitempty"`
-	Amount    string `protobuf:"bytes,4,opt,name=amount,proto3" json:"amount,omitempty"`
+	BlockRemovalStarted int64  `protobuf:"varint,1,opt,name=block_removal_started,json=blockRemovalStarted,proto3" json:"block_removal_started,omitempty"`
+	TopicId             uint64 `protobuf:"varint,2,opt,name=topic_id,json=topicId,proto3" json:"topic_id,omitempty"`
+	Reputer             string `protobuf:"bytes,3,opt,name=reputer,proto3" json:"reputer,omitempty"`
+	Delegator           string `protobuf:"bytes,4,opt,name=delegator,proto3" json:"delegator,omitempty"`
+	Amount              string `protobuf:"bytes,5,opt,name=amount,proto3" json:"amount,omitempty"`
 }
 
 func (x *DelegateStakePlacement) Reset() {
 	*x = DelegateStakePlacement{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_emissions_v1_stake_proto_msgTypes[2]
+		mi := &file_emissions_v1_stake_proto_msgTypes[1]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2728,7 +1824,14 @@ func (*DelegateStakePlacement) ProtoMessage() {}
 
 // Deprecated: Use DelegateStakePlacement.ProtoReflect.Descriptor instead.
 func (*DelegateStakePlacement) Descriptor() ([]byte, []int) {
-	return file_emissions_v1_stake_proto_rawDescGZIP(), []int{2}
+	return file_emissions_v1_stake_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *DelegateStakePlacement) GetBlockRemovalStarted() int64 {
+	if x != nil {
+		return x.BlockRemovalStarted
+	}
+	return 0
 }
 
 func (x *DelegateStakePlacement) GetTopicId() uint64 {
@@ -2759,49 +1862,6 @@ func (x *DelegateStakePlacement) GetAmount() string {
 	return ""
 }
 
-type DelegateStakeRemoval struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
-
-	BlockRemovalStarted int64                   `protobuf:"varint,1,opt,name=block_removal_started,json=blockRemovalStarted,proto3" json:"block_removal_started,omitempty"`
-	Placement           *DelegateStakePlacement `protobuf:"bytes,2,opt,name=placement,proto3" json:"placement,omitempty"`
-}
-
-func (x *DelegateStakeRemoval) Reset() {
-	*x = DelegateStakeRemoval{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_emissions_v1_stake_proto_msgTypes[3]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
-}
-
-func (x *DelegateStakeRemoval) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*DelegateStakeRemoval) ProtoMessage() {}
-
-// Deprecated: Use DelegateStakeRemoval.ProtoReflect.Descriptor instead.
-func (*DelegateStakeRemoval) Descriptor() ([]byte, []int) {
-	return file_emissions_v1_stake_proto_rawDescGZIP(), []int{3}
-}
-
-func (x *DelegateStakeRemoval) GetBlockRemovalStarted() int64 {
-	if x != nil {
-		return x.BlockRemovalStarted
-	}
-	return 0
-}
-
-func (x *DelegateStakeRemoval) GetPlacement() *DelegateStakePlacement {
-	if x != nil {
-		return x.Placement
-	}
-	return nil
-}
-
 type DelegatorInfo struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2814,7 +1874,7 @@ type DelegatorInfo struct {
 func (x *DelegatorInfo) Reset() {
 	*x = DelegatorInfo{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_emissions_v1_stake_proto_msgTypes[4]
+		mi := &file_emissions_v1_stake_proto_msgTypes[2]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2828,7 +1888,7 @@ func (*DelegatorInfo) ProtoMessage() {}
 
 // Deprecated: Use DelegatorInfo.ProtoReflect.Descriptor instead.
 func (*DelegatorInfo) Descriptor() ([]byte, []int) {
-	return file_emissions_v1_stake_proto_rawDescGZIP(), []int{4}
+	return file_emissions_v1_stake_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *DelegatorInfo) GetAmount() string {
@@ -2854,69 +1914,59 @@ var file_emissions_v1_stake_proto_rawDesc = []byte{
 	0x5f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x70, 0x72,
 	0x6f, 0x74, 0x6f, 0x1a, 0x11, 0x61, 0x6d, 0x69, 0x6e, 0x6f, 0x2f, 0x61, 0x6d, 0x69, 0x6e, 0x6f,
 	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x14, 0x67, 0x6f, 0x67, 0x6f, 0x70, 0x72, 0x6f, 0x74,
-	0x6f, 0x2f, 0x67, 0x6f, 0x67, 0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x8f, 0x01, 0x0a,
+	0x6f, 0x2f, 0x67, 0x6f, 0x67, 0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0xc3, 0x01, 0x0a,
 	0x0e, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x50, 0x6c, 0x61, 0x63, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x12,
-	0x19, 0x0a, 0x08, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
-	0x04, 0x52, 0x07, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x72, 0x65,
-	0x70, 0x75, 0x74, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x72, 0x65, 0x70,
-	0x75, 0x74, 0x65, 0x72, 0x12, 0x48, 0x0a, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x03,
-	0x20, 0x01, 0x28, 0x09, 0x42, 0x30, 0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f, 0x15, 0x63, 0x6f,
-	0x73, 0x6d, 0x6f, 0x73, 0x73, 0x64, 0x6b, 0x2e, 0x69, 0x6f, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e,
-	0x49, 0x6e, 0x74, 0xd2, 0xb4, 0x2d, 0x0a, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x49, 0x6e,
-	0x74, 0xa8, 0xe7, 0xb0, 0x2a, 0x01, 0x52, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x22, 0x7e,
-	0x0a, 0x0c, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x12, 0x32,
-	0x0a, 0x15, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x72, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x5f,
-	0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x52, 0x13, 0x62,
-	0x6c, 0x6f, 0x63, 0x6b, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x53, 0x74, 0x61, 0x72, 0x74,
-	0x65, 0x64, 0x12, 0x3a, 0x0a, 0x09, 0x70, 0x6c, 0x61, 0x63, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x18,
-	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e,
-	0x73, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x50, 0x6c, 0x61, 0x63, 0x65, 0x6d,
-	0x65, 0x6e, 0x74, 0x52, 0x09, 0x70, 0x6c, 0x61, 0x63, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x22, 0xb5,
-	0x01, 0x0a, 0x16, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x53, 0x74, 0x61, 0x6b, 0x65,
-	0x50, 0x6c, 0x61, 0x63, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x12, 0x19, 0x0a, 0x08, 0x74, 0x6f, 0x70,
-	0x69, 0x63, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x74, 0x6f, 0x70,
-	0x69, 0x63, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x18,
-	0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x12, 0x1c,
-	0x0a, 0x09, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28,
-	0x09, 0x52, 0x09, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x12, 0x48, 0x0a, 0x06,
-	0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x42, 0x30, 0xc8, 0xde,
-	0x1f, 0x00, 0xda, 0xde, 0x1f, 0x15, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x73, 0x64, 0x6b, 0x2e,
-	0x69, 0x6f, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x49, 0x6e, 0x74, 0xd2, 0xb4, 0x2d, 0x0a, 0x63,
-	0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x49, 0x6e, 0x74, 0xa8, 0xe7, 0xb0, 0x2a, 0x01, 0x52, 0x06,
-	0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x22, 0x8e, 0x01, 0x0a, 0x14, 0x44, 0x65, 0x6c, 0x65, 0x67,
-	0x61, 0x74, 0x65, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x12,
 	0x32, 0x0a, 0x15, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x72, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c,
 	0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x52, 0x13,
 	0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x53, 0x74, 0x61, 0x72,
-	0x74, 0x65, 0x64, 0x12, 0x42, 0x0a, 0x09, 0x70, 0x6c, 0x61, 0x63, 0x65, 0x6d, 0x65, 0x6e, 0x74,
-	0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f,
-	0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x53, 0x74,
-	0x61, 0x6b, 0x65, 0x50, 0x6c, 0x61, 0x63, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x52, 0x09, 0x70, 0x6c,
-	0x61, 0x63, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x22, 0xba, 0x01, 0x0a, 0x0d, 0x44, 0x65, 0x6c, 0x65,
-	0x67, 0x61, 0x74, 0x6f, 0x72, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4f, 0x0a, 0x06, 0x61, 0x6d, 0x6f,
-	0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x37, 0xc8, 0xde, 0x1f, 0x00, 0xda,
-	0xde, 0x1f, 0x2f, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x6c,
-	0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x2f, 0x61, 0x6c, 0x6c,
-	0x6f, 0x72, 0x61, 0x2d, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x44,
-	0x65, 0x63, 0x52, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x12, 0x58, 0x0a, 0x0b, 0x72, 0x65,
-	0x77, 0x61, 0x72, 0x64, 0x5f, 0x64, 0x65, 0x62, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x42,
-	0x37, 0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f, 0x2f, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e,
-	0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x6e, 0x65, 0x74, 0x77, 0x6f,
-	0x72, 0x6b, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x2f,
-	0x6d, 0x61, 0x74, 0x68, 0x2e, 0x44, 0x65, 0x63, 0x52, 0x0a, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64,
-	0x44, 0x65, 0x62, 0x74, 0x42, 0xc0, 0x01, 0x0a, 0x10, 0x63, 0x6f, 0x6d, 0x2e, 0x65, 0x6d, 0x69,
-	0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x42, 0x0a, 0x53, 0x74, 0x61, 0x6b, 0x65,
-	0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x4f, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e,
-	0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x6e, 0x65, 0x74, 0x77, 0x6f,
-	0x72, 0x6b, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x2f,
-	0x78, 0x2f, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x61, 0x70, 0x69, 0x2f,
-	0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x3b, 0x65, 0x6d, 0x69,
-	0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x76, 0x31, 0xa2, 0x02, 0x03, 0x45, 0x58, 0x58, 0xaa, 0x02,
-	0x0c, 0x45, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x0c,
-	0x45, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x5c, 0x56, 0x31, 0xe2, 0x02, 0x18, 0x45,
-	0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x5c, 0x56, 0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d,
-	0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x0d, 0x45, 0x6d, 0x69, 0x73, 0x73, 0x69,
-	0x6f, 0x6e, 0x73, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x08, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x5f, 0x69, 0x64, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x18,
+	0x0a, 0x07, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x07, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x12, 0x48, 0x0a, 0x06, 0x61, 0x6d, 0x6f, 0x75,
+	0x6e, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x42, 0x30, 0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde,
+	0x1f, 0x15, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x73, 0x64, 0x6b, 0x2e, 0x69, 0x6f, 0x2f, 0x6d,
+	0x61, 0x74, 0x68, 0x2e, 0x49, 0x6e, 0x74, 0xd2, 0xb4, 0x2d, 0x0a, 0x63, 0x6f, 0x73, 0x6d, 0x6f,
+	0x73, 0x2e, 0x49, 0x6e, 0x74, 0xa8, 0xe7, 0xb0, 0x2a, 0x01, 0x52, 0x06, 0x61, 0x6d, 0x6f, 0x75,
+	0x6e, 0x74, 0x22, 0xe9, 0x01, 0x0a, 0x16, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x53,
+	0x74, 0x61, 0x6b, 0x65, 0x50, 0x6c, 0x61, 0x63, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x12, 0x32, 0x0a,
+	0x15, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x72, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x5f, 0x73,
+	0x74, 0x61, 0x72, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x52, 0x13, 0x62, 0x6c,
+	0x6f, 0x63, 0x6b, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x53, 0x74, 0x61, 0x72, 0x74, 0x65,
+	0x64, 0x12, 0x19, 0x0a, 0x08, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x5f, 0x69, 0x64, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x04, 0x52, 0x07, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07,
+	0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x72,
+	0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x12, 0x1c, 0x0a, 0x09, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61,
+	0x74, 0x6f, 0x72, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x64, 0x65, 0x6c, 0x65, 0x67,
+	0x61, 0x74, 0x6f, 0x72, 0x12, 0x48, 0x0a, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x05,
+	0x20, 0x01, 0x28, 0x09, 0x42, 0x30, 0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f, 0x15, 0x63, 0x6f,
+	0x73, 0x6d, 0x6f, 0x73, 0x73, 0x64, 0x6b, 0x2e, 0x69, 0x6f, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e,
+	0x49, 0x6e, 0x74, 0xd2, 0xb4, 0x2d, 0x0a, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x49, 0x6e,
+	0x74, 0xa8, 0xe7, 0xb0, 0x2a, 0x01, 0x52, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x22, 0xba,
+	0x01, 0x0a, 0x0d, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x49, 0x6e, 0x66, 0x6f,
+	0x12, 0x4f, 0x0a, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
+	0x42, 0x37, 0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f, 0x2f, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62,
+	0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x6e, 0x65, 0x74, 0x77,
+	0x6f, 0x72, 0x6b, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x63, 0x68, 0x61, 0x69, 0x6e,
+	0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x44, 0x65, 0x63, 0x52, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e,
+	0x74, 0x12, 0x58, 0x0a, 0x0b, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64, 0x5f, 0x64, 0x65, 0x62, 0x74,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x42, 0x37, 0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f, 0x2f,
+	0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72,
+	0x61, 0x2d, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61,
+	0x2d, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x44, 0x65, 0x63, 0x52,
+	0x0a, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64, 0x44, 0x65, 0x62, 0x74, 0x42, 0xc0, 0x01, 0x0a, 0x10,
+	0x63, 0x6f, 0x6d, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31,
+	0x42, 0x0a, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x4f,
+	0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72,
+	0x61, 0x2d, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61,
+	0x2d, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x2f, 0x78, 0x2f, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f,
+	0x6e, 0x73, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73,
+	0x2f, 0x76, 0x31, 0x3b, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x76, 0x31, 0xa2,
+	0x02, 0x03, 0x45, 0x58, 0x58, 0xaa, 0x02, 0x0c, 0x45, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e,
+	0x73, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x0c, 0x45, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73,
+	0x5c, 0x56, 0x31, 0xe2, 0x02, 0x18, 0x45, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x5c,
+	0x56, 0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02,
+	0x0d, 0x45, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -2931,22 +1981,18 @@ func file_emissions_v1_stake_proto_rawDescGZIP() []byte {
 	return file_emissions_v1_stake_proto_rawDescData
 }
 
-var file_emissions_v1_stake_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_emissions_v1_stake_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_emissions_v1_stake_proto_goTypes = []interface{}{
 	(*StakePlacement)(nil),         // 0: emissions.v1.StakePlacement
-	(*StakeRemoval)(nil),           // 1: emissions.v1.StakeRemoval
-	(*DelegateStakePlacement)(nil), // 2: emissions.v1.DelegateStakePlacement
-	(*DelegateStakeRemoval)(nil),   // 3: emissions.v1.DelegateStakeRemoval
-	(*DelegatorInfo)(nil),          // 4: emissions.v1.DelegatorInfo
+	(*DelegateStakePlacement)(nil), // 1: emissions.v1.DelegateStakePlacement
+	(*DelegatorInfo)(nil),          // 2: emissions.v1.DelegatorInfo
 }
 var file_emissions_v1_stake_proto_depIdxs = []int32{
-	0, // 0: emissions.v1.StakeRemoval.placement:type_name -> emissions.v1.StakePlacement
-	2, // 1: emissions.v1.DelegateStakeRemoval.placement:type_name -> emissions.v1.DelegateStakePlacement
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	0, // [0:0] is the sub-list for method output_type
+	0, // [0:0] is the sub-list for method input_type
+	0, // [0:0] is the sub-list for extension type_name
+	0, // [0:0] is the sub-list for extension extendee
+	0, // [0:0] is the sub-list for field type_name
 }
 
 func init() { file_emissions_v1_stake_proto_init() }
@@ -2968,18 +2014,6 @@ func file_emissions_v1_stake_proto_init() {
 			}
 		}
 		file_emissions_v1_stake_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*StakeRemoval); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_emissions_v1_stake_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DelegateStakePlacement); i {
 			case 0:
 				return &v.state
@@ -2991,19 +2025,7 @@ func file_emissions_v1_stake_proto_init() {
 				return nil
 			}
 		}
-		file_emissions_v1_stake_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*DelegateStakeRemoval); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_emissions_v1_stake_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_emissions_v1_stake_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DelegatorInfo); i {
 			case 0:
 				return &v.state
@@ -3022,7 +2044,7 @@ func file_emissions_v1_stake_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_emissions_v1_stake_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/x/emissions/keeper/msgserver/msg_server_demand_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand_test.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *KeeperTestSuite) TestFundTopicSimple() {
+func (s *MsgServerTestSuite) TestFundTopicSimple() {
 	senderAddr := sdk.AccAddress(PKS[0].Address())
 	sender := senderAddr.String()
 	topicId := s.CreateOneTopic()
@@ -59,7 +59,7 @@ func (s *KeeperTestSuite) TestFundTopicSimple() {
 	s.Require().True(topicWeightAfter.Gt(topicWeightBefore), "Topic weight should be greater after funding the topic")
 }
 
-func (s *KeeperTestSuite) TestHighWeightForHighFundedTopic() {
+func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
 	senderAddr := sdk.AccAddress(PKS[0].Address())
 	sender := senderAddr.String()
 	topicId := s.CreateOneTopic()

--- a/x/emissions/keeper/msgserver/msg_server_losses_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses_test.go
@@ -11,7 +11,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-func (s *KeeperTestSuite) getBasicReputerPayload(
+func (s *MsgServerTestSuite) getBasicReputerPayload(
 	reputerAddr sdk.AccAddress,
 	workerAddr sdk.AccAddress,
 	block types.BlockHeight,
@@ -113,7 +113,7 @@ func (s *KeeperTestSuite) getBasicReputerPayload(
 	return reputerValueBundle, expectedInferences, expectedForecasts, topicId, reputerNonce, workerNonce
 }
 
-func (s *KeeperTestSuite) signValueBundle(reputerValueBundle *types.ValueBundle, privateKey secp256k1.PrivKey) []byte {
+func (s *MsgServerTestSuite) signValueBundle(reputerValueBundle *types.ValueBundle, privateKey secp256k1.PrivKey) []byte {
 	require := s.Require()
 	src := make([]byte, 0)
 	src, err := reputerValueBundle.XXX_Marshal(src, true)
@@ -125,7 +125,7 @@ func (s *KeeperTestSuite) signValueBundle(reputerValueBundle *types.ValueBundle,
 	return valueBundleSignature
 }
 
-func (s *KeeperTestSuite) constructAndInsertReputerPayload(
+func (s *MsgServerTestSuite) constructAndInsertReputerPayload(
 	reputerAddr sdk.AccAddress,
 	reputerPrivateKey secp256k1.PrivKey,
 	reputerPublicKeyBytes []byte,
@@ -158,7 +158,7 @@ func (s *KeeperTestSuite) constructAndInsertReputerPayload(
 	return err
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayload() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkReputerPayload() {
 	ctx := s.ctx
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -184,7 +184,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayload() {
 	require.NoError(err)
 }
 
-func (s *KeeperTestSuite) TestInsertingReputerPayloadWithMismatchedTopicIdsIsIgnored() {
+func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithMismatchedTopicIdsIsIgnored() {
 	ctx := s.ctx
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -223,7 +223,7 @@ func (s *KeeperTestSuite) TestInsertingReputerPayloadWithMismatchedTopicIdsIsIgn
 	require.ErrorIs(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestInsertingReputerPayloadWithMismatchedWorkerNonceIsIgnored() {
+func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithMismatchedWorkerNonceIsIgnored() {
 	ctx := s.ctx
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -262,7 +262,7 @@ func (s *KeeperTestSuite) TestInsertingReputerPayloadWithMismatchedWorkerNonceIs
 	require.ErrorIs(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestInsertingReputerPayloadWithMismatchedReputerNonceIsIgnored() {
+func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithMismatchedReputerNonceIsIgnored() {
 	ctx := s.ctx
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -301,7 +301,7 @@ func (s *KeeperTestSuite) TestInsertingReputerPayloadWithMismatchedReputerNonceI
 	require.ErrorIs(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestInsertingReputerPayloadWithUnregisteredReputerIsIgnored() {
+func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithUnregisteredReputerIsIgnored() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -347,7 +347,7 @@ func (s *KeeperTestSuite) TestInsertingReputerPayloadWithUnregisteredReputerIsIg
 	require.ErrorIs(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestInsertingReputerPayloadWithUnderstakeReputerIsIgnored() {
+func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithUnderstakeReputerIsIgnored() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -412,7 +412,7 @@ func (s *KeeperTestSuite) TestInsertingReputerPayloadWithUnderstakeReputerIsIgno
 	require.ErrorIs(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestInsertingReputerPayloadWithMissingInferencesIsIgnored() {
+func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithMissingInferencesIsIgnored() {
 	ctx := s.ctx
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -449,7 +449,7 @@ func (s *KeeperTestSuite) TestInsertingReputerPayloadWithMissingInferencesIsIgno
 	require.ErrorIs(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestInsertingReputerPayloadWithIncorrectBaseWorkerNonceIsIgnored() {
+func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithIncorrectBaseWorkerNonceIsIgnored() {
 	ctx := s.ctx
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -488,7 +488,7 @@ func (s *KeeperTestSuite) TestInsertingReputerPayloadWithIncorrectBaseWorkerNonc
 	require.ErrorIs(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayloadInvalid() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkReputerPayloadInvalid() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -636,7 +636,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkReputerPayloadInvalid() {
 	require.ErrorIs(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestMsgInsertHugeBulkReputerPayloadFails() {
+func (s *MsgServerTestSuite) TestMsgInsertHugeBulkReputerPayloadFails() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	keeper := s.emissionsKeeper

--- a/x/emissions/keeper/msgserver/msg_server_params_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_params_test.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *KeeperTestSuite) TestUpdateParams() {
+func (s *MsgServerTestSuite) TestUpdateParams() {
 	ctx, msgServer := s.ctx, s.msgServer
 	keeper := s.emissionsKeeper
 	require := s.Require()
@@ -44,7 +44,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	require.Equal(existingParams.Version, updatedParams.Version)
 }
 
-func (s *KeeperTestSuite) TestUpdateAllParams() {
+func (s *MsgServerTestSuite) TestUpdateAllParams() {
 	ctx, msgServer := s.ctx, s.msgServer
 	keeper := s.emissionsKeeper
 	require := s.Require()
@@ -147,7 +147,7 @@ func (s *KeeperTestSuite) TestUpdateAllParams() {
 	require.Equal(newParams.CNorm[0], updatedParams.CNorm)
 }
 
-func (s *KeeperTestSuite) TestUpdateParamsNonWhitelistedUser() {
+func (s *MsgServerTestSuite) TestUpdateParamsNonWhitelistedUser() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 

--- a/x/emissions/keeper/msgserver/msg_server_registrations_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations_test.go
@@ -14,7 +14,7 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
-func (s *KeeperTestSuite) TestMsgRegisterReputer() {
+func (s *MsgServerTestSuite) TestMsgRegisterReputer() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -59,7 +59,7 @@ func (s *KeeperTestSuite) TestMsgRegisterReputer() {
 	require.True(isReputerRegistered, "Reputer should be registered in topic")
 }
 
-func (s *KeeperTestSuite) TestMsgRemoveRegistration() {
+func (s *MsgServerTestSuite) TestMsgRemoveRegistration() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -113,7 +113,7 @@ func (s *KeeperTestSuite) TestMsgRemoveRegistration() {
 	require.False(isReputerRegistered, "Reputer should be registered in topic")
 }
 
-func (s *KeeperTestSuite) TestMsgRegisterWorker() {
+func (s *MsgServerTestSuite) TestMsgRegisterWorker() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -162,7 +162,7 @@ func (s *KeeperTestSuite) TestMsgRegisterWorker() {
 	require.True(isWorkerRegistered, "Worker should be registered in topic")
 }
 
-func (s *KeeperTestSuite) TestMsgRemoveRegistrationWorker() {
+func (s *MsgServerTestSuite) TestMsgRemoveRegistrationWorker() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -216,7 +216,7 @@ func (s *KeeperTestSuite) TestMsgRemoveRegistrationWorker() {
 	require.False(isWorkerRegistered, "Worker should be registered in topic")
 }
 
-func (s *KeeperTestSuite) TestMsgRegisterReputerInvalidLibP2PKey() {
+func (s *MsgServerTestSuite) TestMsgRegisterReputerInvalidLibP2PKey() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -238,7 +238,7 @@ func (s *KeeperTestSuite) TestMsgRegisterReputerInvalidLibP2PKey() {
 	require.ErrorIs(err, types.ErrLibP2PKeyRequired, "Register should return an error")
 }
 
-func (s *KeeperTestSuite) TestMsgRegisterReputerInsufficientBalance() {
+func (s *MsgServerTestSuite) TestMsgRegisterReputerInsufficientBalance() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	topicId := uint64(0)
@@ -263,7 +263,7 @@ func (s *KeeperTestSuite) TestMsgRegisterReputerInsufficientBalance() {
 	require.ErrorIs(types.ErrTopicRegistrantNotEnoughDenom, err, "Register should return an error")
 }
 
-func (s *KeeperTestSuite) TestMsgRegisterReputerInsufficientDenom() {
+func (s *MsgServerTestSuite) TestMsgRegisterReputerInsufficientDenom() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	topicId := s.CreateOneTopic()
@@ -289,7 +289,7 @@ func (s *KeeperTestSuite) TestMsgRegisterReputerInsufficientDenom() {
 	require.ErrorIs(err, types.ErrTopicRegistrantNotEnoughDenom, "Register should return an error")
 }
 
-func (s *KeeperTestSuite) TestBlocklistedAddressUnableToRegister() {
+func (s *MsgServerTestSuite) TestBlocklistedAddressUnableToRegister() {
 	// Reputer Addresses
 	reputer := s.addrs[2]
 	// Worker Addresses
@@ -363,7 +363,7 @@ func (s *KeeperTestSuite) TestBlocklistedAddressUnableToRegister() {
 	s.Require().ErrorIs(err, types.ErrTopicRegistrantNotEnoughDenom, "Register should return an error")
 }
 
-func (s *KeeperTestSuite) TestMsgRegisterReputerInvalidTopicNotExist() {
+func (s *MsgServerTestSuite) TestMsgRegisterReputerInvalidTopicNotExist() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 

--- a/x/emissions/keeper/msgserver/msg_server_stake.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake.go
@@ -79,13 +79,11 @@ func (ms msgServer) StartRemoveStake(ctx context.Context, msg *types.MsgStartRem
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	stakeToRemove := types.StakeRemoval{
+	stakeToRemove := types.StakePlacement{
 		BlockRemovalStarted: sdkCtx.BlockHeight(),
-		Placement: &types.StakePlacement{
-			TopicId: msg.TopicId,
-			Reputer: msg.Sender,
-			Amount:  msg.Amount,
-		},
+		TopicId:             msg.TopicId,
+		Reputer:             msg.Sender,
+		Amount:              msg.Amount,
 	}
 
 	// If no errors have occurred and the removal is valid, add the stake removal to the delayed queue
@@ -119,14 +117,19 @@ func (ms msgServer) ConfirmRemoveStake(ctx context.Context, msg *types.MsgConfir
 	// Check the module has enough funds to send back to the sender
 	// Bank module does this for us in module SendCoins / subUnlockedCoins so we don't need to check
 	// Send the funds
-	coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, stakeRemoval.Placement.Amount))
+	coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, stakeRemoval.Amount))
 	err = ms.k.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, msg.Sender, coins)
 	if err != nil {
 		return nil, err
 	}
 
 	// Update the stake data structures
-	err = ms.k.RemoveStake(ctx, stakeRemoval.Placement.TopicId, msg.Sender, stakeRemoval.Placement.Amount)
+	err = ms.k.RemoveStake(
+		ctx,
+		stakeRemoval.TopicId,
+		msg.Sender,
+		stakeRemoval.Amount,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -207,14 +210,12 @@ func (ms msgServer) StartRemoveDelegateStake(ctx context.Context, msg *types.Msg
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	stakeToRemove := types.DelegateStakeRemoval{
+	stakeToRemove := types.DelegateStakePlacement{
 		BlockRemovalStarted: sdkCtx.BlockHeight(),
-		Placement: &types.DelegateStakePlacement{
-			TopicId:   msg.TopicId,
-			Reputer:   msg.Reputer,
-			Delegator: msg.Sender,
-			Amount:    msg.Amount,
-		},
+		TopicId:             msg.TopicId,
+		Reputer:             msg.Reputer,
+		Delegator:           msg.Sender,
+		Amount:              msg.Amount,
 	}
 
 	// If no errors have occurred and the removal is valid, add the stake removal to the delayed queue
@@ -249,14 +250,14 @@ func (ms msgServer) ConfirmRemoveDelegateStake(ctx context.Context, msg *types.M
 	// Check the module has enough funds to send back to the sender
 	// Bank module does this for us in module SendCoins / subUnlockedCoins so we don't need to check
 	// Send the funds
-	coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, stakeRemoval.Placement.Amount))
+	coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, stakeRemoval.Amount))
 	err = ms.k.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, msg.Sender, coins)
 	if err != nil {
 		return nil, err
 	}
 
 	// Update the stake data structures
-	err = ms.k.RemoveDelegateStake(ctx, stakeRemoval.Placement.TopicId, msg.Sender, msg.Reputer, stakeRemoval.Placement.Amount)
+	err = ms.k.RemoveDelegateStake(ctx, stakeRemoval.TopicId, msg.Sender, msg.Reputer, stakeRemoval.Amount)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/msgserver/msg_server_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_test.go
@@ -54,7 +54,7 @@ var (
 	ValAddr = GeneratePrivateKeys(10)
 )
 
-type KeeperTestSuite struct {
+type MsgServerTestSuite struct {
 	suite.Suite
 
 	ctx             sdk.Context
@@ -71,11 +71,11 @@ type KeeperTestSuite struct {
 	addrsStr        []string
 }
 
-func TestKeeperTestSuite(t *testing.T) {
-	suite.Run(t, new(KeeperTestSuite))
+func TestMsgServerTestSuite(t *testing.T) {
+	suite.Run(t, new(MsgServerTestSuite))
 }
 
-func (s *KeeperTestSuite) SetupTest() {
+func (s *MsgServerTestSuite) SetupTest() {
 	key := storetypes.NewKVStoreKey("emissions")
 	storeService := runtime.NewKVStoreService(key)
 	s.storeService = storeService
@@ -165,19 +165,19 @@ func GeneratePrivateKeys(numKeys int) []ChainKey {
 	return testAddrs
 }
 
-func (s *KeeperTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
+func (s *MsgServerTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
 
 	s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
 	s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
 }
 
-func (s *KeeperTestSuite) MintTokensToModule(moduleName string, amount cosmosMath.Int) {
+func (s *MsgServerTestSuite) MintTokensToModule(moduleName string, amount cosmosMath.Int) {
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
 	s.bankKeeper.MintCoins(s.ctx, moduleName, creatorInitialBalanceCoins)
 }
 
-func (s *KeeperTestSuite) CreateOneTopic() uint64 {
+func (s *MsgServerTestSuite) CreateOneTopic() uint64 {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -208,7 +208,7 @@ func (s *KeeperTestSuite) CreateOneTopic() uint64 {
 	return result.TopicId
 }
 
-func (s *KeeperTestSuite) TestCreateSeveralTopics() {
+func (s *MsgServerTestSuite) TestCreateSeveralTopics() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	// Mock setup for metadata and validation steps

--- a/x/emissions/keeper/msgserver/msg_server_topics_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics_test.go
@@ -8,7 +8,7 @@ import (
 
 /// Topics tests
 
-func (s *KeeperTestSuite) TestMsgCreateNewTopic() {
+func (s *MsgServerTestSuite) TestMsgCreateNewTopic() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -51,7 +51,7 @@ func (s *KeeperTestSuite) TestMsgCreateNewTopic() {
 	require.False(found, "Added topic found in active topics")
 }
 
-func (s *KeeperTestSuite) TestUpdateTopicLossUpdateLastRan() {
+func (s *MsgServerTestSuite) TestUpdateTopicLossUpdateLastRan() {
 	ctx := s.ctx
 	require := s.Require()
 	topicId := s.CreateOneTopic()

--- a/x/emissions/keeper/msgserver/msg_server_whitelist_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_whitelist_test.go
@@ -5,7 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *KeeperTestSuite) TestAddWhitelistAdmin() {
+func (s *MsgServerTestSuite) TestAddWhitelistAdmin() {
 	ctx := s.ctx
 	require := s.Require()
 	msgServer := s.msgServer
@@ -33,7 +33,7 @@ func (s *KeeperTestSuite) TestAddWhitelistAdmin() {
 	require.True(isWhitelistAdmin, "newAdminAddr should be a whitelist admin")
 }
 
-func (s *KeeperTestSuite) TestAddWhitelistAdminInvalidUnauthorized() {
+func (s *MsgServerTestSuite) TestAddWhitelistAdminInvalidUnauthorized() {
 	ctx := s.ctx
 	require := s.Require()
 
@@ -50,7 +50,7 @@ func (s *KeeperTestSuite) TestAddWhitelistAdminInvalidUnauthorized() {
 	require.ErrorIs(err, types.ErrNotWhitelistAdmin, "Should fail due to unauthorized access")
 }
 
-func (s *KeeperTestSuite) TestRemoveWhitelistAdmin() {
+func (s *MsgServerTestSuite) TestRemoveWhitelistAdmin() {
 	ctx := s.ctx
 	require := s.Require()
 	msgServer := s.msgServer
@@ -73,7 +73,7 @@ func (s *KeeperTestSuite) TestRemoveWhitelistAdmin() {
 	require.False(isWhitelistAdmin, "adminToRemove should not be a whitelist admin anymore")
 }
 
-func (s *KeeperTestSuite) TestRemoveWhitelistAdminInvalidUnauthorized() {
+func (s *MsgServerTestSuite) TestRemoveWhitelistAdminInvalidUnauthorized() {
 	ctx := s.ctx
 	require := s.Require()
 

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
@@ -14,7 +14,7 @@ func getNewAddress() string {
 	return sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
 }
 
-func (s *KeeperTestSuite) setUpMsgInsertBulkWorkerPayload(
+func (s *MsgServerTestSuite) setUpMsgInsertBulkWorkerPayload(
 	workerPrivateKey secp256k1.PrivKey,
 
 ) (types.MsgInsertBulkWorkerPayload, uint64) {
@@ -87,7 +87,7 @@ func (s *KeeperTestSuite) setUpMsgInsertBulkWorkerPayload(
 	return workerMsg, topicId
 }
 
-func (s *KeeperTestSuite) signMsgInsertBulkWorkerPayload(workerMsg types.MsgInsertBulkWorkerPayload, workerPrivateKey secp256k1.PrivKey) types.MsgInsertBulkWorkerPayload {
+func (s *MsgServerTestSuite) signMsgInsertBulkWorkerPayload(workerMsg types.MsgInsertBulkWorkerPayload, workerPrivateKey secp256k1.PrivKey) types.MsgInsertBulkWorkerPayload {
 	require := s.Require()
 
 	workerPublicKeyBytes := workerPrivateKey.PubKey().Bytes()
@@ -104,7 +104,7 @@ func (s *KeeperTestSuite) signMsgInsertBulkWorkerPayload(workerMsg types.MsgInse
 	return workerMsg
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayload() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayload() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -127,7 +127,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayload() {
 	require.Equal(forecastsCount1, 1)
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithoutWorkerDataBundle() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithoutWorkerDataBundle() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -144,7 +144,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithoutWorkerDataBu
 	require.Error(err)
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithMismatchedTopicId() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithMismatchedTopicId() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -162,7 +162,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithMismatchedTopic
 	require.Error(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithUnregisteredInferer() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithUnregisteredInferer() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -190,7 +190,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithUnregisteredInf
 	require.Error(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) getCountForecastsAtBlock(topicId uint64, blockHeight int64) int {
+func (s *MsgServerTestSuite) getCountForecastsAtBlock(topicId uint64, blockHeight int64) int {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	forecastsAtBlock, err := keeper.GetForecastsAtBlock(ctx, topicId, blockHeight)
@@ -201,7 +201,7 @@ func (s *KeeperTestSuite) getCountForecastsAtBlock(topicId uint64, blockHeight i
 
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithMismatchedForecastTopicId() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithMismatchedForecastTopicId() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -229,7 +229,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithMismatchedForec
 	require.Equal(forecastsCount1, 0)
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithUnregisteredForecaster() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithUnregisteredForecaster() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -263,7 +263,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithUnregisteredFor
 	require.Equal(forecastsCount1, 0)
 }
 
-func (s *KeeperTestSuite) TestInsertingHugeBulkWorkerPayloadFails() {
+func (s *MsgServerTestSuite) TestInsertingHugeBulkWorkerPayloadFails() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -348,7 +348,7 @@ func (s *KeeperTestSuite) TestInsertingHugeBulkWorkerPayloadFails() {
 	require.Error(err, types.ErrQueryTooLarge)
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadVerifyFailed() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayloadVerifyFailed() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -430,7 +430,7 @@ func (s *KeeperTestSuite) TestMsgInsertBulkWorkerPayloadVerifyFailed() {
 	require.ErrorIs(err, types.ErrNoValidBundles)
 }
 
-func (s *KeeperTestSuite) TestMsgInsertBulkWorkerAlreadyFullfilledNonce() {
+func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerAlreadyFullfilledNonce() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	keeper := s.emissionsKeeper

--- a/x/emissions/proto/emissions/v1/stake.proto
+++ b/x/emissions/proto/emissions/v1/stake.proto
@@ -8,25 +8,9 @@ import "amino/amino.proto";
 import "gogoproto/gogo.proto";
 
 message StakePlacement {
-  uint64 topic_id = 1;
-  string reputer = 2;
-  string amount = 3 [
-    (cosmos_proto.scalar) = "cosmos.Int",
-    (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-}
-
-message StakeRemoval {
   int64 block_removal_started = 1;
-  StakePlacement placement = 2;
-}
-
-message DelegateStakePlacement {
-  uint64 topic_id = 1;
-  string reputer = 2;
-  string delegator = 3;
+  uint64 topic_id = 2;
+  string reputer = 3;
   string amount = 4 [
     (cosmos_proto.scalar) = "cosmos.Int",
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
@@ -35,9 +19,17 @@ message DelegateStakePlacement {
   ];
 }
 
-message DelegateStakeRemoval {
+message DelegateStakePlacement {
   int64 block_removal_started = 1;
-  DelegateStakePlacement placement = 2;
+  uint64 topic_id = 2;
+  string reputer = 3;
+  string delegator = 4;
+  string amount = 5 [
+    (cosmos_proto.scalar) = "cosmos.Int",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false,
+    (amino.dont_omitempty) = true
+  ];
 }
 
 message DelegatorInfo {

--- a/x/emissions/types/stake.pb.go
+++ b/x/emissions/types/stake.pb.go
@@ -28,9 +28,10 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type StakePlacement struct {
-	TopicId uint64                `protobuf:"varint,1,opt,name=topic_id,json=topicId,proto3" json:"topic_id,omitempty"`
-	Reputer string                `protobuf:"bytes,2,opt,name=reputer,proto3" json:"reputer,omitempty"`
-	Amount  cosmossdk_io_math.Int `protobuf:"bytes,3,opt,name=amount,proto3,customtype=cosmossdk.io/math.Int" json:"amount"`
+	BlockRemovalStarted int64                 `protobuf:"varint,1,opt,name=block_removal_started,json=blockRemovalStarted,proto3" json:"block_removal_started,omitempty"`
+	TopicId             uint64                `protobuf:"varint,2,opt,name=topic_id,json=topicId,proto3" json:"topic_id,omitempty"`
+	Reputer             string                `protobuf:"bytes,3,opt,name=reputer,proto3" json:"reputer,omitempty"`
+	Amount              cosmossdk_io_math.Int `protobuf:"bytes,4,opt,name=amount,proto3,customtype=cosmossdk.io/math.Int" json:"amount"`
 }
 
 func (m *StakePlacement) Reset()         { *m = StakePlacement{} }
@@ -66,6 +67,13 @@ func (m *StakePlacement) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_StakePlacement proto.InternalMessageInfo
 
+func (m *StakePlacement) GetBlockRemovalStarted() int64 {
+	if m != nil {
+		return m.BlockRemovalStarted
+	}
+	return 0
+}
+
 func (m *StakePlacement) GetTopicId() uint64 {
 	if m != nil {
 		return m.TopicId
@@ -80,70 +88,19 @@ func (m *StakePlacement) GetReputer() string {
 	return ""
 }
 
-type StakeRemoval struct {
-	BlockRemovalStarted int64           `protobuf:"varint,1,opt,name=block_removal_started,json=blockRemovalStarted,proto3" json:"block_removal_started,omitempty"`
-	Placement           *StakePlacement `protobuf:"bytes,2,opt,name=placement,proto3" json:"placement,omitempty"`
-}
-
-func (m *StakeRemoval) Reset()         { *m = StakeRemoval{} }
-func (m *StakeRemoval) String() string { return proto.CompactTextString(m) }
-func (*StakeRemoval) ProtoMessage()    {}
-func (*StakeRemoval) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f03692b073d250c3, []int{1}
-}
-func (m *StakeRemoval) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *StakeRemoval) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_StakeRemoval.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *StakeRemoval) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StakeRemoval.Merge(m, src)
-}
-func (m *StakeRemoval) XXX_Size() int {
-	return m.Size()
-}
-func (m *StakeRemoval) XXX_DiscardUnknown() {
-	xxx_messageInfo_StakeRemoval.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_StakeRemoval proto.InternalMessageInfo
-
-func (m *StakeRemoval) GetBlockRemovalStarted() int64 {
-	if m != nil {
-		return m.BlockRemovalStarted
-	}
-	return 0
-}
-
-func (m *StakeRemoval) GetPlacement() *StakePlacement {
-	if m != nil {
-		return m.Placement
-	}
-	return nil
-}
-
 type DelegateStakePlacement struct {
-	TopicId   uint64                `protobuf:"varint,1,opt,name=topic_id,json=topicId,proto3" json:"topic_id,omitempty"`
-	Reputer   string                `protobuf:"bytes,2,opt,name=reputer,proto3" json:"reputer,omitempty"`
-	Delegator string                `protobuf:"bytes,3,opt,name=delegator,proto3" json:"delegator,omitempty"`
-	Amount    cosmossdk_io_math.Int `protobuf:"bytes,4,opt,name=amount,proto3,customtype=cosmossdk.io/math.Int" json:"amount"`
+	BlockRemovalStarted int64                 `protobuf:"varint,1,opt,name=block_removal_started,json=blockRemovalStarted,proto3" json:"block_removal_started,omitempty"`
+	TopicId             uint64                `protobuf:"varint,2,opt,name=topic_id,json=topicId,proto3" json:"topic_id,omitempty"`
+	Reputer             string                `protobuf:"bytes,3,opt,name=reputer,proto3" json:"reputer,omitempty"`
+	Delegator           string                `protobuf:"bytes,4,opt,name=delegator,proto3" json:"delegator,omitempty"`
+	Amount              cosmossdk_io_math.Int `protobuf:"bytes,5,opt,name=amount,proto3,customtype=cosmossdk.io/math.Int" json:"amount"`
 }
 
 func (m *DelegateStakePlacement) Reset()         { *m = DelegateStakePlacement{} }
 func (m *DelegateStakePlacement) String() string { return proto.CompactTextString(m) }
 func (*DelegateStakePlacement) ProtoMessage()    {}
 func (*DelegateStakePlacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f03692b073d250c3, []int{2}
+	return fileDescriptor_f03692b073d250c3, []int{1}
 }
 func (m *DelegateStakePlacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -172,6 +129,13 @@ func (m *DelegateStakePlacement) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DelegateStakePlacement proto.InternalMessageInfo
 
+func (m *DelegateStakePlacement) GetBlockRemovalStarted() int64 {
+	if m != nil {
+		return m.BlockRemovalStarted
+	}
+	return 0
+}
+
 func (m *DelegateStakePlacement) GetTopicId() uint64 {
 	if m != nil {
 		return m.TopicId
@@ -193,58 +157,6 @@ func (m *DelegateStakePlacement) GetDelegator() string {
 	return ""
 }
 
-type DelegateStakeRemoval struct {
-	BlockRemovalStarted int64                   `protobuf:"varint,1,opt,name=block_removal_started,json=blockRemovalStarted,proto3" json:"block_removal_started,omitempty"`
-	Placement           *DelegateStakePlacement `protobuf:"bytes,2,opt,name=placement,proto3" json:"placement,omitempty"`
-}
-
-func (m *DelegateStakeRemoval) Reset()         { *m = DelegateStakeRemoval{} }
-func (m *DelegateStakeRemoval) String() string { return proto.CompactTextString(m) }
-func (*DelegateStakeRemoval) ProtoMessage()    {}
-func (*DelegateStakeRemoval) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f03692b073d250c3, []int{3}
-}
-func (m *DelegateStakeRemoval) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *DelegateStakeRemoval) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_DelegateStakeRemoval.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *DelegateStakeRemoval) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DelegateStakeRemoval.Merge(m, src)
-}
-func (m *DelegateStakeRemoval) XXX_Size() int {
-	return m.Size()
-}
-func (m *DelegateStakeRemoval) XXX_DiscardUnknown() {
-	xxx_messageInfo_DelegateStakeRemoval.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_DelegateStakeRemoval proto.InternalMessageInfo
-
-func (m *DelegateStakeRemoval) GetBlockRemovalStarted() int64 {
-	if m != nil {
-		return m.BlockRemovalStarted
-	}
-	return 0
-}
-
-func (m *DelegateStakeRemoval) GetPlacement() *DelegateStakePlacement {
-	if m != nil {
-		return m.Placement
-	}
-	return nil
-}
-
 type DelegatorInfo struct {
 	Amount     github_com_allora_network_allora_chain_math.Dec `protobuf:"bytes,1,opt,name=amount,proto3,customtype=github.com/allora-network/allora-chain/math.Dec" json:"amount"`
 	RewardDebt github_com_allora_network_allora_chain_math.Dec `protobuf:"bytes,2,opt,name=reward_debt,json=rewardDebt,proto3,customtype=github.com/allora-network/allora-chain/math.Dec" json:"reward_debt"`
@@ -254,7 +166,7 @@ func (m *DelegatorInfo) Reset()         { *m = DelegatorInfo{} }
 func (m *DelegatorInfo) String() string { return proto.CompactTextString(m) }
 func (*DelegatorInfo) ProtoMessage()    {}
 func (*DelegatorInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f03692b073d250c3, []int{4}
+	return fileDescriptor_f03692b073d250c3, []int{2}
 }
 func (m *DelegatorInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -285,45 +197,40 @@ var xxx_messageInfo_DelegatorInfo proto.InternalMessageInfo
 
 func init() {
 	proto.RegisterType((*StakePlacement)(nil), "emissions.v1.StakePlacement")
-	proto.RegisterType((*StakeRemoval)(nil), "emissions.v1.StakeRemoval")
 	proto.RegisterType((*DelegateStakePlacement)(nil), "emissions.v1.DelegateStakePlacement")
-	proto.RegisterType((*DelegateStakeRemoval)(nil), "emissions.v1.DelegateStakeRemoval")
 	proto.RegisterType((*DelegatorInfo)(nil), "emissions.v1.DelegatorInfo")
 }
 
 func init() { proto.RegisterFile("emissions/v1/stake.proto", fileDescriptor_f03692b073d250c3) }
 
 var fileDescriptor_f03692b073d250c3 = []byte{
-	// 465 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x93, 0x31, 0x6f, 0xd3, 0x40,
-	0x14, 0xc7, 0x73, 0xb4, 0x6a, 0xc9, 0xb5, 0x20, 0x61, 0x5a, 0xe4, 0x56, 0x95, 0x5b, 0x45, 0x0c,
-	0x15, 0x52, 0x6d, 0x5a, 0x06, 0x10, 0x63, 0x94, 0x81, 0x4c, 0x20, 0x77, 0x41, 0x2c, 0xd6, 0xd9,
-	0x7e, 0x24, 0x56, 0xec, 0x7b, 0xd6, 0xdd, 0x4b, 0x0a, 0x0b, 0x1f, 0x01, 0xf8, 0x18, 0x8c, 0x0c,
-	0xb0, 0xf0, 0x09, 0x3a, 0x56, 0x4c, 0x88, 0xa1, 0x42, 0xc9, 0xc0, 0xd7, 0x40, 0xb9, 0xb3, 0x9b,
-	0x44, 0x30, 0x20, 0xa5, 0x8b, 0xe5, 0xf7, 0xfe, 0xcf, 0xcf, 0xff, 0xff, 0x4f, 0x7a, 0xdc, 0x85,
-	0x22, 0xd3, 0x3a, 0x43, 0xa9, 0x83, 0xd1, 0x71, 0xa0, 0x49, 0x0c, 0xc0, 0x2f, 0x15, 0x12, 0x3a,
-	0x9b, 0x57, 0x8a, 0x3f, 0x3a, 0xde, 0xdd, 0x49, 0x50, 0x17, 0xa8, 0x23, 0xa3, 0x05, 0xb6, 0xb0,
-	0x83, 0xbb, 0x77, 0x44, 0x91, 0x49, 0x0c, 0xcc, 0xb3, 0x6a, 0x6d, 0xf5, 0xb0, 0x87, 0x76, 0x74,
-	0xfa, 0x66, 0xbb, 0xad, 0x0f, 0x8c, 0xdf, 0x3e, 0x9d, 0xfe, 0xe1, 0x45, 0x2e, 0x12, 0x28, 0x40,
-	0x92, 0xb3, 0xc3, 0x6f, 0x12, 0x96, 0x59, 0x12, 0x65, 0xa9, 0xcb, 0x0e, 0xd8, 0xe1, 0x6a, 0xb8,
-	0x6e, 0xea, 0x6e, 0xea, 0xb8, 0x7c, 0x5d, 0x41, 0x39, 0x24, 0x50, 0xee, 0x8d, 0x03, 0x76, 0xd8,
-	0x0c, 0xeb, 0xd2, 0x79, 0xc6, 0xd7, 0x44, 0x81, 0x43, 0x49, 0xee, 0xca, 0x54, 0x68, 0x3f, 0x3c,
-	0xbf, 0xdc, 0x6f, 0xfc, 0xbc, 0xdc, 0xdf, 0xb6, 0xb6, 0x74, 0x3a, 0xf0, 0x33, 0x0c, 0x0a, 0x41,
-	0x7d, 0xbf, 0x2b, 0xe9, 0xfb, 0x97, 0x23, 0x5e, 0xf9, 0xed, 0x4a, 0xfa, 0xf4, 0xfb, 0xf3, 0x03,
-	0x16, 0x56, 0xdf, 0xb7, 0xde, 0xf1, 0x4d, 0x63, 0x28, 0x84, 0x02, 0x47, 0x22, 0x77, 0x4e, 0xf8,
-	0x76, 0x9c, 0x63, 0x32, 0x88, 0x94, 0x6d, 0x44, 0x9a, 0x84, 0x22, 0xb0, 0xde, 0x56, 0xc2, 0xbb,
-	0x46, 0xac, 0x86, 0x4f, 0xad, 0xe4, 0x3c, 0xe5, 0xcd, 0xb2, 0xce, 0x63, 0x9c, 0x6e, 0x9c, 0xec,
-	0xf9, 0xf3, 0xec, 0xfc, 0xc5, 0xcc, 0xe1, 0x6c, 0xbc, 0xf5, 0x95, 0xf1, 0x7b, 0x1d, 0xc8, 0xa1,
-	0x27, 0x08, 0xae, 0x83, 0xcc, 0x1e, 0x6f, 0xa6, 0x76, 0x1d, 0x2a, 0x0b, 0x27, 0x9c, 0x35, 0xe6,
-	0xb8, 0xad, 0x2e, 0xc9, 0xed, 0x3d, 0xe3, 0x5b, 0x0b, 0xbe, 0x97, 0x01, 0xd8, 0xfe, 0x1b, 0xe0,
-	0xfd, 0x45, 0x80, 0xff, 0x46, 0x34, 0x0f, 0xf2, 0x1b, 0xe3, 0xb7, 0x3a, 0x75, 0xd0, 0xae, 0x7c,
-	0x8d, 0xce, 0xf3, 0xab, 0xb0, 0xcc, 0x84, 0x7d, 0x5c, 0x85, 0x0d, 0x7a, 0x19, 0xf5, 0x87, 0xb1,
-	0x9f, 0x60, 0x11, 0x88, 0x3c, 0x47, 0x25, 0x8e, 0x24, 0xd0, 0x19, 0xaa, 0x41, 0x5d, 0x26, 0x7d,
-	0x91, 0x49, 0x8b, 0xa1, 0x03, 0x49, 0x9d, 0xd9, 0x79, 0xc9, 0x37, 0x14, 0x9c, 0x09, 0x95, 0x46,
-	0x29, 0xc4, 0xd6, 0xe8, 0x12, 0x5b, 0xb9, 0xdd, 0xd5, 0x81, 0x98, 0xda, 0xe1, 0xf9, 0xd8, 0x63,
-	0x17, 0x63, 0x8f, 0xfd, 0x1a, 0x7b, 0xec, 0xe3, 0xc4, 0x6b, 0x5c, 0x4c, 0xbc, 0xc6, 0x8f, 0x89,
-	0xd7, 0x78, 0xf5, 0xe4, 0x3f, 0xd7, 0xbe, 0x09, 0x66, 0x67, 0x4c, 0x6f, 0x4b, 0xd0, 0xf1, 0x9a,
-	0x39, 0xb9, 0x47, 0x7f, 0x02, 0x00, 0x00, 0xff, 0xff, 0x25, 0xc3, 0xee, 0x36, 0xe0, 0x03, 0x00,
+	// 417 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x93, 0xbf, 0x6f, 0xd4, 0x30,
+	0x14, 0xc7, 0xcf, 0xb4, 0xb4, 0xd4, 0xfc, 0x90, 0x08, 0x14, 0xa5, 0x15, 0x4a, 0x4f, 0x9d, 0x4e,
+	0x48, 0x8d, 0x29, 0x0c, 0x30, 0x57, 0x37, 0x70, 0x13, 0x28, 0x5d, 0x10, 0x4b, 0xe4, 0x24, 0x8f,
+	0x9c, 0x95, 0xd8, 0x2f, 0xb2, 0xdf, 0x5d, 0xe1, 0xbf, 0xe0, 0xcf, 0x60, 0x64, 0x60, 0x62, 0x65,
+	0xe9, 0x58, 0x31, 0x21, 0x86, 0x0a, 0xdd, 0x0d, 0x88, 0xff, 0x02, 0x5d, 0x9c, 0xb4, 0x8c, 0x48,
+	0x1d, 0x58, 0xa2, 0x7c, 0xdf, 0xf7, 0xf9, 0xf3, 0xfc, 0xb5, 0x6c, 0x1e, 0x82, 0x56, 0xce, 0x29,
+	0x34, 0x4e, 0xcc, 0x0f, 0x85, 0x23, 0x59, 0x41, 0xdc, 0x58, 0x24, 0x0c, 0x6e, 0x5d, 0x38, 0xf1,
+	0xfc, 0x70, 0x77, 0x27, 0x47, 0xa7, 0xd1, 0xa5, 0xad, 0x27, 0xbc, 0xf0, 0x8d, 0xbb, 0x77, 0xa5,
+	0x56, 0x06, 0x45, 0xfb, 0xed, 0x4a, 0xf7, 0x4b, 0x2c, 0xd1, 0xb7, 0xae, 0xfe, 0x7c, 0x75, 0xff,
+	0x2b, 0xe3, 0x77, 0x8e, 0x57, 0x13, 0x5e, 0xd5, 0x32, 0x07, 0x0d, 0x86, 0x82, 0x27, 0x7c, 0x3b,
+	0xab, 0x31, 0xaf, 0x52, 0x0b, 0x1a, 0xe7, 0xb2, 0x4e, 0x1d, 0x49, 0x4b, 0x50, 0x84, 0x6c, 0xc8,
+	0x46, 0x6b, 0xc9, 0xbd, 0xd6, 0x4c, 0xbc, 0x77, 0xec, 0xad, 0x60, 0x87, 0xdf, 0x20, 0x6c, 0x54,
+	0x9e, 0xaa, 0x22, 0xbc, 0x36, 0x64, 0xa3, 0xf5, 0x64, 0xb3, 0xd5, 0x93, 0x22, 0x08, 0xf9, 0xa6,
+	0x85, 0x66, 0x46, 0x60, 0xc3, 0xb5, 0x21, 0x1b, 0x6d, 0x25, 0xbd, 0x0c, 0x5e, 0xf0, 0x0d, 0xa9,
+	0x71, 0x66, 0x28, 0x5c, 0x5f, 0x19, 0x47, 0x8f, 0x4f, 0xcf, 0xf7, 0x06, 0x3f, 0xce, 0xf7, 0xb6,
+	0x7d, 0x14, 0x57, 0x54, 0xb1, 0x42, 0xa1, 0x25, 0x4d, 0xe3, 0x89, 0xa1, 0x6f, 0x9f, 0x0f, 0x78,
+	0x97, 0x71, 0x62, 0xe8, 0xe3, 0xaf, 0x4f, 0x8f, 0x58, 0xd2, 0xad, 0xdf, 0xff, 0xcd, 0xf8, 0x83,
+	0x31, 0xd4, 0x50, 0x4a, 0x82, 0xff, 0x95, 0xe6, 0x21, 0xdf, 0x2a, 0xfc, 0x16, 0xd0, 0xfa, 0x40,
+	0xc9, 0x65, 0xe1, 0xaf, 0xac, 0xd7, 0xaf, 0x98, 0xf5, 0x0b, 0xe3, 0xb7, 0xc7, 0x3d, 0x77, 0x62,
+	0xde, 0x62, 0xf0, 0xf2, 0x82, 0xcd, 0x5a, 0xf6, 0xb3, 0x8e, 0x2d, 0x4a, 0x45, 0xd3, 0x59, 0x16,
+	0xe7, 0xa8, 0x85, 0xac, 0x6b, 0xb4, 0xf2, 0xc0, 0x00, 0x9d, 0xa0, 0xad, 0x7a, 0x99, 0x4f, 0xa5,
+	0x32, 0x7e, 0xea, 0x18, 0xf2, 0x7e, 0x44, 0xf0, 0x9a, 0xdf, 0xb4, 0x70, 0x22, 0x6d, 0x91, 0x16,
+	0x90, 0x51, 0x7b, 0x04, 0x57, 0xa0, 0x72, 0xcf, 0x1a, 0x43, 0x46, 0x47, 0xc9, 0xe9, 0x22, 0x62,
+	0x67, 0x8b, 0x88, 0xfd, 0x5c, 0x44, 0xec, 0xc3, 0x32, 0x1a, 0x9c, 0x2d, 0xa3, 0xc1, 0xf7, 0x65,
+	0x34, 0x78, 0xf3, 0xfc, 0x1f, 0xb1, 0xef, 0xc4, 0xe5, 0xeb, 0xa0, 0xf7, 0x0d, 0xb8, 0x6c, 0xa3,
+	0xbd, 0xc9, 0x4f, 0xff, 0x04, 0x00, 0x00, 0xff, 0xff, 0xed, 0x1d, 0xa3, 0xc6, 0x37, 0x03, 0x00,
 	0x00,
 }
 
@@ -356,53 +263,18 @@ func (m *StakePlacement) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i = encodeVarintStake(dAtA, i, uint64(size))
 	}
 	i--
-	dAtA[i] = 0x1a
+	dAtA[i] = 0x22
 	if len(m.Reputer) > 0 {
 		i -= len(m.Reputer)
 		copy(dAtA[i:], m.Reputer)
 		i = encodeVarintStake(dAtA, i, uint64(len(m.Reputer)))
 		i--
-		dAtA[i] = 0x12
+		dAtA[i] = 0x1a
 	}
 	if m.TopicId != 0 {
 		i = encodeVarintStake(dAtA, i, uint64(m.TopicId))
 		i--
-		dAtA[i] = 0x8
-	}
-	return len(dAtA) - i, nil
-}
-
-func (m *StakeRemoval) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *StakeRemoval) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *StakeRemoval) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	if m.Placement != nil {
-		{
-			size, err := m.Placement.MarshalToSizedBuffer(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = encodeVarintStake(dAtA, i, uint64(size))
-		}
-		i--
-		dAtA[i] = 0x12
+		dAtA[i] = 0x10
 	}
 	if m.BlockRemovalStarted != 0 {
 		i = encodeVarintStake(dAtA, i, uint64(m.BlockRemovalStarted))
@@ -441,60 +313,25 @@ func (m *DelegateStakePlacement) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 		i = encodeVarintStake(dAtA, i, uint64(size))
 	}
 	i--
-	dAtA[i] = 0x22
+	dAtA[i] = 0x2a
 	if len(m.Delegator) > 0 {
 		i -= len(m.Delegator)
 		copy(dAtA[i:], m.Delegator)
 		i = encodeVarintStake(dAtA, i, uint64(len(m.Delegator)))
 		i--
-		dAtA[i] = 0x1a
+		dAtA[i] = 0x22
 	}
 	if len(m.Reputer) > 0 {
 		i -= len(m.Reputer)
 		copy(dAtA[i:], m.Reputer)
 		i = encodeVarintStake(dAtA, i, uint64(len(m.Reputer)))
 		i--
-		dAtA[i] = 0x12
+		dAtA[i] = 0x1a
 	}
 	if m.TopicId != 0 {
 		i = encodeVarintStake(dAtA, i, uint64(m.TopicId))
 		i--
-		dAtA[i] = 0x8
-	}
-	return len(dAtA) - i, nil
-}
-
-func (m *DelegateStakeRemoval) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *DelegateStakeRemoval) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *DelegateStakeRemoval) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	if m.Placement != nil {
-		{
-			size, err := m.Placement.MarshalToSizedBuffer(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = encodeVarintStake(dAtA, i, uint64(size))
-		}
-		i--
-		dAtA[i] = 0x12
+		dAtA[i] = 0x10
 	}
 	if m.BlockRemovalStarted != 0 {
 		i = encodeVarintStake(dAtA, i, uint64(m.BlockRemovalStarted))
@@ -564,6 +401,9 @@ func (m *StakePlacement) Size() (n int) {
 	}
 	var l int
 	_ = l
+	if m.BlockRemovalStarted != 0 {
+		n += 1 + sovStake(uint64(m.BlockRemovalStarted))
+	}
 	if m.TopicId != 0 {
 		n += 1 + sovStake(uint64(m.TopicId))
 	}
@@ -576,7 +416,7 @@ func (m *StakePlacement) Size() (n int) {
 	return n
 }
 
-func (m *StakeRemoval) Size() (n int) {
+func (m *DelegateStakePlacement) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -585,19 +425,6 @@ func (m *StakeRemoval) Size() (n int) {
 	if m.BlockRemovalStarted != 0 {
 		n += 1 + sovStake(uint64(m.BlockRemovalStarted))
 	}
-	if m.Placement != nil {
-		l = m.Placement.Size()
-		n += 1 + l + sovStake(uint64(l))
-	}
-	return n
-}
-
-func (m *DelegateStakePlacement) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
 	if m.TopicId != 0 {
 		n += 1 + sovStake(uint64(m.TopicId))
 	}
@@ -611,22 +438,6 @@ func (m *DelegateStakePlacement) Size() (n int) {
 	}
 	l = m.Amount.Size()
 	n += 1 + l + sovStake(uint64(l))
-	return n
-}
-
-func (m *DelegateStakeRemoval) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	if m.BlockRemovalStarted != 0 {
-		n += 1 + sovStake(uint64(m.BlockRemovalStarted))
-	}
-	if m.Placement != nil {
-		l = m.Placement.Size()
-		n += 1 + l + sovStake(uint64(l))
-	}
 	return n
 }
 
@@ -680,141 +491,6 @@ func (m *StakePlacement) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
-			}
-			m.TopicId = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowStake
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.TopicId |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Reputer", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowStake
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthStake
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthStake
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Reputer = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowStake
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthStake
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthStake
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipStake(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if (skippy < 0) || (iNdEx+skippy) < 0 {
-				return ErrInvalidLengthStake
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *StakeRemoval) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowStake
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: StakeRemoval: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: StakeRemoval: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field BlockRemovalStarted", wireType)
 			}
 			m.BlockRemovalStarted = 0
@@ -833,92 +509,6 @@ func (m *StakeRemoval) Unmarshal(dAtA []byte) error {
 				}
 			}
 		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Placement", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowStake
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthStake
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthStake
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.Placement == nil {
-				m.Placement = &StakePlacement{}
-			}
-			if err := m.Placement.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipStake(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if (skippy < 0) || (iNdEx+skippy) < 0 {
-				return ErrInvalidLengthStake
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *DelegateStakePlacement) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowStake
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: DelegateStakePlacement: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: DelegateStakePlacement: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
 			}
@@ -937,7 +527,7 @@ func (m *DelegateStakePlacement) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Reputer", wireType)
 			}
@@ -968,38 +558,6 @@ func (m *DelegateStakePlacement) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Reputer = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Delegator", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowStake
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthStake
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthStake
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Delegator = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
@@ -1056,7 +614,7 @@ func (m *DelegateStakePlacement) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *DelegateStakeRemoval) Unmarshal(dAtA []byte) error {
+func (m *DelegateStakePlacement) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1079,10 +637,10 @@ func (m *DelegateStakeRemoval) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: DelegateStakeRemoval: wiretype end group for non-group")
+			return fmt.Errorf("proto: DelegateStakePlacement: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: DelegateStakeRemoval: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: DelegateStakePlacement: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -1105,10 +663,10 @@ func (m *DelegateStakeRemoval) Unmarshal(dAtA []byte) error {
 				}
 			}
 		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Placement", wireType)
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
 			}
-			var msglen int
+			m.TopicId = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowStake
@@ -1118,25 +676,106 @@ func (m *DelegateStakeRemoval) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= int(b&0x7F) << shift
+				m.TopicId |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			if msglen < 0 {
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Reputer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStake
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
 				return ErrInvalidLengthStake
 			}
-			postIndex := iNdEx + msglen
+			postIndex := iNdEx + intStringLen
 			if postIndex < 0 {
 				return ErrInvalidLengthStake
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Placement == nil {
-				m.Placement = &DelegateStakePlacement{}
+			m.Reputer = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Delegator", wireType)
 			}
-			if err := m.Placement.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStake
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthStake
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStake
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Delegator = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStake
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthStake
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStake
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex


### PR DESCRIPTION
This prevents an attacker from being able to withdraw stake multiple times after waiting the delay period once.