### PR TITLE
[ORA-1666] Fix get last network inference query

### DIFF
--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -151,3 +151,119 @@ func GetNetworkInferencesAtBlock(
 
 	return networkInferences, forecastImpliedInferencesByWorker, infererWeights, forecasterWeights, nil
 }
+
+func GetLatestNetworkInference(
+	ctx sdk.Context,
+	k keeper.Keeper,
+	topicId TopicId,
+) (
+	*emissions.ValueBundle,
+	map[string]*emissions.Inference,
+	map[string]alloraMath.Dec,
+	map[string]alloraMath.Dec,
+	error,
+) {
+	networkInferences := &emissions.ValueBundle{
+		TopicId:          topicId,
+		InfererValues:    make([]*emissions.WorkerAttributedValue, 0),
+		ForecasterValues: make([]*emissions.WorkerAttributedValue, 0),
+	}
+	forecastImpliedInferencesByWorker := make(map[string]*emissions.Inference, 0)
+	var infererWeights map[string]alloraMath.Dec
+	var forecasterWeights map[string]alloraMath.Dec
+
+	inferences, infBlockHeight, err := k.GetLatestTopicInferences(ctx, topicId)
+	if err != nil || len(inferences.Inferences) == 0 {
+		Logger(ctx).Warn("Error getting inferences: %s", err.Error())
+		return networkInferences, nil, infererWeights, forecasterWeights, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "no inferences found for topic %v", topicId)
+	}
+	forecasts, err := k.GetForecastsAtBlock(ctx, topicId, infBlockHeight)
+	if err != nil {
+		Logger(ctx).Warn("Error getting forecasts: %s", err.Error())
+		return networkInferences, nil, infererWeights, forecasterWeights, nil
+	}
+
+	if len(inferences.Inferences) > 1 {
+		moduleParams, err := k.GetParams(ctx)
+		if err != nil {
+			return networkInferences, nil, infererWeights, forecasterWeights, err
+		}
+		topic, err := k.GetTopic(ctx, topicId)
+		if err != nil {
+			Logger(ctx).Warn("Error getting topic: %s", err.Error())
+			return networkInferences, nil, infererWeights, forecasterWeights, nil
+		}
+		previousLossNonce := infBlockHeight - topic.EpochLength
+		reputerReportedLosses, err := k.GetReputerLossBundlesAtBlock(ctx, topicId, previousLossNonce)
+		if err != nil {
+			Logger(ctx).Warn(fmt.Sprintf("Error getting reputer losses: %s", err.Error()))
+			return networkInferences, nil, infererWeights, forecasterWeights, nil
+		}
+
+		// Map list of stakesOnTopic to map of stakesByReputer
+		stakesByReputer := make(map[string]cosmosMath.Int)
+		for _, bundle := range reputerReportedLosses.ReputerValueBundles {
+			stakeAmount, err := k.GetStakeOnReputerInTopic(ctx, topicId, bundle.ValueBundle.Reputer)
+			if err != nil {
+				Logger(ctx).Warn(fmt.Sprintf("Error getting stake on reputer: %s", err.Error()))
+				return networkInferences, nil, infererWeights, forecasterWeights, nil
+			}
+			stakesByReputer[bundle.ValueBundle.Reputer] = stakeAmount
+		}
+		networkCombinedLoss, err := CalcCombinedNetworkLoss(
+			stakesByReputer,
+			reputerReportedLosses,
+			moduleParams.Epsilon,
+		)
+		if err != nil {
+			Logger(ctx).Warn(fmt.Sprintf("Error calculating network combined loss: %s", err.Error()))
+			return networkInferences, nil, infererWeights, forecasterWeights, nil
+		}
+
+		networkInferenceBuilder, err := NewNetworkInferenceBuilderFromSynthRequest(
+			SynthRequest{
+				Ctx:                 ctx,
+				K:                   k,
+				TopicId:             topicId,
+				Inferences:          inferences,
+				Forecasts:           forecasts,
+				NetworkCombinedLoss: networkCombinedLoss,
+				Epsilon:             moduleParams.Epsilon,
+				FTolerance:          moduleParams.FTolerance,
+				PNorm:               topic.PNorm,
+				CNorm:               moduleParams.CNorm,
+			},
+		)
+		if err != nil {
+			Logger(ctx).Warn("Error constructing network inferences builder topic: %s", err.Error())
+			return networkInferences, nil, infererWeights, forecasterWeights, err
+		}
+		networkInferences = networkInferenceBuilder.CalcAndSetNetworkInferences().Build()
+
+		forecastImpliedInferencesByWorker = networkInferenceBuilder.palette.ForecastImpliedInferenceByWorker
+		infererWeights = networkInferenceBuilder.weights.inferers
+		forecasterWeights = networkInferenceBuilder.weights.forecasters
+	} else {
+		// If there is only one valid inference, then the network inference is the same as the single inference
+		// For the forecasts to be meaningful, there should be at least 2 inferences
+		singleInference := inferences.Inferences[0]
+
+		networkInferences = &emissions.ValueBundle{
+			TopicId:       topicId,
+			CombinedValue: singleInference.Value,
+			InfererValues: []*emissions.WorkerAttributedValue{
+				{
+					Worker: singleInference.Inferer,
+					Value:  singleInference.Value,
+				},
+			},
+			ForecasterValues:       []*emissions.WorkerAttributedValue{},
+			NaiveValue:             singleInference.Value,
+			OneOutInfererValues:    []*emissions.WithheldWorkerAttributedValue{},
+			OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{},
+			OneInForecasterValues:  []*emissions.WorkerAttributedValue{},
+		}
+	}
+
+	return networkInferences, forecastImpliedInferencesByWorker, infererWeights, forecasterWeights, nil
+}

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -194,6 +194,10 @@ func GetLatestNetworkInference(
 			return networkInferences, nil, infererWeights, forecasterWeights, nil
 		}
 		previousLossNonce := infBlockHeight - topic.EpochLength
+		if previousLossNonce < 0 {
+			Logger(ctx).Warn("Network inference is not available for the epoch yet")
+			return networkInferences, nil, infererWeights, forecasterWeights, nil
+		}
 		reputerReportedLosses, err := k.GetReputerLossBundlesAtBlock(ctx, topicId, previousLossNonce)
 		if err != nil {
 			Logger(ctx).Warn(fmt.Sprintf("Error getting reputer losses: %s", err.Error()))

--- a/x/emissions/keeper/inference_synthesis/network_inferences_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences_test.go
@@ -494,3 +494,423 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 		}
 	}
 }
+
+func (s *InferenceSynthesisTestSuite) TestGetLatestNetworkInference() {
+	s.SetupTest()
+	epochGet := GetSimulatedValuesGetterForEpochs()
+	epoch2Get := epochGet[2]
+	epoch3Get := epochGet[3]
+
+	require := s.Require()
+	keeper := s.emissionsKeeper
+
+	topicId := uint64(1)
+	blockHeightInferences := int64(300)
+	blockHeightPreviousLosses := int64(200)
+
+	simpleNonce := emissionstypes.Nonce{BlockHeight: blockHeightInferences}
+	reputerRequestNonce := &emissionstypes.ReputerRequestNonce{
+		ReputerNonce: &emissionstypes.Nonce{BlockHeight: blockHeightPreviousLosses},
+	}
+
+	err := s.emissionsKeeper.SetTopic(s.ctx, topicId, emissionstypes.Topic{
+		Id:              topicId,
+		Creator:         "creator",
+		Metadata:        "metadata",
+		LossLogic:       "losslogic",
+		LossMethod:      "lossmethod",
+		InferenceLogic:  "inferencelogic",
+		InferenceMethod: "inferencemethod",
+		EpochLastEnded:  0,
+		EpochLength:     100,
+		GroundTruthLag:  10,
+		DefaultArg:      "defaultarg",
+		PNorm:           alloraMath.NewDecFromInt64(3),
+		AlphaRegret:     alloraMath.MustNewDecFromString("0.1"),
+		AllowNegative:   false,
+	})
+	s.Require().NoError(err)
+
+	reputer0 := "allo1m5v6rgjtxh4xszrrzqacwjh4ve6r0za2gxx9qr"
+	reputer1 := "allo1e7cj9839ht2xm8urynqs5279hrvqd8neusvp2x"
+	reputer2 := "allo1k9ss0xfer54nyack5678frl36e5g3rj2yzxtfj"
+	reputer3 := "allo18ljxewge4vqrkk09tm5heldqg25yj8d9ekgkw5"
+	reputer4 := "allo1k36ljvn8z0u49sagdg46p75psgreh23kdjn3l0"
+
+	forecaster0 := "allo1pluvmvsmvecg2ccuqxa6ugzvc3a5udfyy0t76v"
+	forecaster1 := "allo1e92saykj94jw3z55g4d3lfz098ppk0suwzc03a"
+	forecaster2 := "allo1pk6mxny5p79t8zhkm23z7u3zmfuz2gn0snxkkt"
+
+	// Set Loss bundles
+	reputerLossBundles := emissionstypes.ReputerValueBundles{
+		ReputerValueBundles: []*emissionstypes.ReputerValueBundle{
+			{
+				ValueBundle: &emissionstypes.ValueBundle{
+					Reputer:             reputer0,
+					CombinedValue:       epoch2Get("reputer_0_loss_network_inference"),
+					ReputerRequestNonce: reputerRequestNonce,
+					TopicId:             topicId,
+				},
+			},
+			{
+				ValueBundle: &emissionstypes.ValueBundle{
+					Reputer:             reputer1,
+					CombinedValue:       epoch2Get("reputer_1_loss_network_inference"),
+					ReputerRequestNonce: reputerRequestNonce,
+					TopicId:             topicId,
+				},
+			},
+			{
+				ValueBundle: &emissionstypes.ValueBundle{
+					Reputer:             reputer2,
+					CombinedValue:       epoch2Get("reputer_2_loss_network_inference"),
+					ReputerRequestNonce: reputerRequestNonce,
+					TopicId:             topicId,
+				},
+			},
+			{
+				ValueBundle: &emissionstypes.ValueBundle{
+					Reputer:             reputer3,
+					CombinedValue:       epoch2Get("reputer_3_loss_network_inference"),
+					ReputerRequestNonce: reputerRequestNonce,
+					TopicId:             topicId,
+				},
+			},
+			{
+				ValueBundle: &emissionstypes.ValueBundle{
+					Reputer:             reputer4,
+					CombinedValue:       epoch2Get("reputer_4_loss_network_inference"),
+					ReputerRequestNonce: reputerRequestNonce,
+					TopicId:             topicId,
+				},
+			},
+		},
+	}
+
+	err = keeper.InsertReputerLossBundlesAtBlock(s.ctx, topicId, blockHeightPreviousLosses, reputerLossBundles)
+	require.NoError(err)
+
+	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
+
+	// Set Stake
+	stake1 := cosmosMath.NewInt(209884).Mul(cosmosOneE18)
+	err = keeper.AddStake(s.ctx, topicId, reputer0, stake1)
+	require.NoError(err)
+	stake2 := cosmosMath.NewInt(216051).Mul(cosmosOneE18)
+	err = keeper.AddStake(s.ctx, topicId, reputer1, stake2)
+	require.NoError(err)
+	stake3 := cosmosMath.NewInt(161259).Mul(cosmosOneE18)
+	err = keeper.AddStake(s.ctx, topicId, reputer2, stake3)
+	require.NoError(err)
+	stake4 := cosmosMath.NewInt(393670).Mul(cosmosOneE18)
+	err = keeper.AddStake(s.ctx, topicId, reputer3, stake4)
+	require.NoError(err)
+	stake5 := cosmosMath.NewInt(205385).Mul(cosmosOneE18)
+	err = keeper.AddStake(s.ctx, topicId, reputer4, stake5)
+	require.NoError(err)
+
+	reputerAddresses := []string{reputer0, reputer1, reputer2, reputer3, reputer4}
+	for workerIndex, reputer := range reputerAddresses {
+		stakeValue := epoch3Get("reputer_stake_" + strconv.Itoa(workerIndex))
+
+		stakeValueScaled, err := stakeValue.Mul(alloraMath.MustNewDecFromString("1e18"))
+		s.Require().NoError(err)
+
+		stakeValueFloored, err := stakeValueScaled.Floor()
+		s.Require().NoError(err)
+
+		stakeInt, ok := cosmosMath.NewIntFromString(stakeValueFloored.String())
+		s.Require().True(ok)
+
+		err = keeper.AddStake(s.ctx, topicId, reputer, stakeInt)
+		s.Require().NoError(err)
+	}
+
+	// Set Inferences
+	inferences := emissionstypes.Inferences{
+		Inferences: []*emissionstypes.Inference{
+			{
+				Inferer:     reputer0,
+				Value:       epoch3Get("inference_0"),
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+			},
+			{
+				Inferer:     reputer1,
+				Value:       epoch3Get("inference_1"),
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+			},
+			{
+				Inferer:     reputer2,
+				Value:       epoch3Get("inference_2"),
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+			},
+			{
+				Inferer:     reputer3,
+				Value:       epoch3Get("inference_3"),
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+			},
+			{
+				Inferer:     reputer4,
+				Value:       epoch3Get("inference_4"),
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+			},
+		},
+	}
+
+	err = keeper.InsertInferences(s.ctx, topicId, simpleNonce, inferences)
+	s.Require().NoError(err)
+
+	// Set Forecasts
+	forecasts := emissionstypes.Forecasts{
+		Forecasts: []*emissionstypes.Forecast{
+			{
+				Forecaster: forecaster0,
+				ForecastElements: []*emissionstypes.ForecastElement{
+					{
+						Inferer: reputer0,
+						Value:   epoch3Get("forecasted_loss_0_for_0"),
+					},
+					{
+						Inferer: reputer1,
+						Value:   epoch3Get("forecasted_loss_0_for_1"),
+					},
+					{
+						Inferer: reputer2,
+						Value:   epoch3Get("forecasted_loss_0_for_2"),
+					},
+					{
+						Inferer: reputer3,
+						Value:   epoch3Get("forecasted_loss_0_for_3"),
+					},
+					{
+						Inferer: reputer4,
+						Value:   epoch3Get("forecasted_loss_0_for_4"),
+					},
+				},
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+			},
+			{
+				Forecaster: forecaster1,
+				ForecastElements: []*emissionstypes.ForecastElement{
+					{
+						Inferer: reputer0,
+						Value:   epoch3Get("forecasted_loss_1_for_0"),
+					},
+					{
+						Inferer: reputer1,
+						Value:   epoch3Get("forecasted_loss_1_for_1"),
+					},
+					{
+						Inferer: reputer2,
+						Value:   epoch3Get("forecasted_loss_1_for_2"),
+					},
+					{
+						Inferer: reputer3,
+						Value:   epoch3Get("forecasted_loss_1_for_3"),
+					},
+					{
+						Inferer: reputer4,
+						Value:   epoch3Get("forecasted_loss_1_for_4"),
+					},
+				},
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+			},
+			{
+				Forecaster: forecaster2,
+				ForecastElements: []*emissionstypes.ForecastElement{
+					{
+						Inferer: reputer0,
+						Value:   epoch3Get("forecasted_loss_2_for_0"),
+					},
+					{
+						Inferer: reputer1,
+						Value:   epoch3Get("forecasted_loss_2_for_1"),
+					},
+					{
+						Inferer: reputer2,
+						Value:   epoch3Get("forecasted_loss_2_for_2"),
+					},
+					{
+						Inferer: reputer3,
+						Value:   epoch3Get("forecasted_loss_2_for_3"),
+					},
+					{
+						Inferer: reputer4,
+						Value:   epoch3Get("forecasted_loss_2_for_4"),
+					},
+				},
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+			},
+		},
+	}
+
+	err = keeper.InsertForecasts(s.ctx, topicId, simpleNonce, forecasts)
+	s.Require().NoError(err)
+
+	// Set inferer network regrets
+	infererNetworkRegrets := map[string]inferencesynthesis.Regret{
+		reputer0: epoch2Get("inference_regret_worker_0"),
+		reputer1: epoch2Get("inference_regret_worker_1"),
+		reputer2: epoch2Get("inference_regret_worker_2"),
+		reputer3: epoch2Get("inference_regret_worker_3"),
+		reputer4: epoch2Get("inference_regret_worker_4"),
+	}
+
+	for inferer, regret := range infererNetworkRegrets {
+		s.emissionsKeeper.SetInfererNetworkRegret(
+			s.ctx,
+			topicId,
+			inferer,
+			emissionstypes.TimestampedValue{BlockHeight: blockHeightInferences, Value: regret},
+		)
+	}
+
+	// Set forecaster network regrets
+	forecasterNetworkRegrets := map[string]inferencesynthesis.Regret{
+		forecaster0: epoch2Get("inference_regret_worker_5"),
+		forecaster1: epoch2Get("inference_regret_worker_6"),
+		forecaster2: epoch2Get("inference_regret_worker_7"),
+	}
+
+	for forecaster, regret := range forecasterNetworkRegrets {
+		s.emissionsKeeper.SetForecasterNetworkRegret(
+			s.ctx,
+			topicId,
+			forecaster,
+			emissionstypes.TimestampedValue{BlockHeight: blockHeightInferences, Value: regret},
+		)
+	}
+
+	// Set one in forecaster network regrets
+	setOneInForecasterNetworkRegret := func(forecaster string, inferer string, value string) {
+		keeper.SetOneInForecasterNetworkRegret(
+			s.ctx,
+			topicId,
+			forecaster,
+			inferer,
+			emissionstypes.TimestampedValue{
+				BlockHeight: blockHeightInferences,
+				Value:       alloraMath.MustNewDecFromString(value),
+			},
+		)
+	}
+
+	/// Epoch 3 values
+	setOneInForecasterNetworkRegret(forecaster0, reputer0, epoch2Get("inference_regret_worker_0_onein_0").String())
+	setOneInForecasterNetworkRegret(forecaster0, reputer1, epoch2Get("inference_regret_worker_1_onein_0").String())
+	setOneInForecasterNetworkRegret(forecaster0, reputer2, epoch2Get("inference_regret_worker_2_onein_0").String())
+	setOneInForecasterNetworkRegret(forecaster0, reputer3, epoch2Get("inference_regret_worker_3_onein_0").String())
+	setOneInForecasterNetworkRegret(forecaster0, reputer4, epoch2Get("inference_regret_worker_4_onein_0").String())
+
+	keeper.SetOneInForecasterSelfNetworkRegret(s.ctx, topicId, forecaster0, emissionstypes.TimestampedValue{
+		BlockHeight: blockHeightInferences,
+		Value:       epoch2Get("inference_regret_worker_5_onein_0"),
+	})
+
+	setOneInForecasterNetworkRegret(forecaster1, reputer0, epoch2Get("inference_regret_worker_0_onein_1").String())
+	setOneInForecasterNetworkRegret(forecaster1, reputer1, epoch2Get("inference_regret_worker_1_onein_1").String())
+	setOneInForecasterNetworkRegret(forecaster1, reputer2, epoch2Get("inference_regret_worker_2_onein_1").String())
+	setOneInForecasterNetworkRegret(forecaster1, reputer3, epoch2Get("inference_regret_worker_3_onein_1").String())
+	setOneInForecasterNetworkRegret(forecaster1, reputer4, epoch2Get("inference_regret_worker_4_onein_1").String())
+
+	keeper.SetOneInForecasterSelfNetworkRegret(s.ctx, topicId, forecaster1, emissionstypes.TimestampedValue{
+		BlockHeight: blockHeightInferences,
+		Value:       epoch2Get("inference_regret_worker_5_onein_1"),
+	})
+
+	setOneInForecasterNetworkRegret(forecaster2, reputer0, epoch2Get("inference_regret_worker_0_onein_2").String())
+	setOneInForecasterNetworkRegret(forecaster2, reputer1, epoch2Get("inference_regret_worker_1_onein_2").String())
+	setOneInForecasterNetworkRegret(forecaster2, reputer2, epoch2Get("inference_regret_worker_2_onein_2").String())
+	setOneInForecasterNetworkRegret(forecaster2, reputer3, epoch2Get("inference_regret_worker_3_onein_2").String())
+	setOneInForecasterNetworkRegret(forecaster2, reputer4, epoch2Get("inference_regret_worker_4_onein_2").String())
+
+	keeper.SetOneInForecasterSelfNetworkRegret(s.ctx, topicId, forecaster2, emissionstypes.TimestampedValue{
+		BlockHeight: blockHeightInferences,
+		Value:       epoch2Get("inference_regret_worker_5_onein_2"),
+	})
+
+	// Calculate
+	valueBundle, _, _, _, err :=
+		inferencesynthesis.GetLatestNetworkInference(
+			s.ctx,
+			s.emissionsKeeper,
+			topicId,
+		)
+	require.NoError(err)
+	testutil.InEpsilon2(s.T(), valueBundle.CombinedValue, epoch3Get("network_inference").String())
+	testutil.InEpsilon2(s.T(), valueBundle.NaiveValue, epoch3Get("network_naive_inference").String())
+
+	for _, inference := range inferences.Inferences {
+		found := false
+		for _, infererValue := range valueBundle.InfererValues {
+			if string(inference.Inferer) == infererValue.Worker {
+				found = true
+				require.Equal(inference.Value, infererValue.Value)
+			}
+		}
+		require.True(found, "Inference not found")
+	}
+	for _, forecasterValue := range valueBundle.ForecasterValues {
+		switch string(forecasterValue.Worker) {
+		case forecaster0:
+			testutil.InEpsilon2(s.T(), forecasterValue.Value, epoch3Get("forecast_implied_inference_0").String())
+		case forecaster1:
+			testutil.InEpsilon2(s.T(), forecasterValue.Value, epoch3Get("forecast_implied_inference_1").String())
+		case forecaster2:
+			testutil.InEpsilon2(s.T(), forecasterValue.Value, epoch3Get("forecast_implied_inference_2").String())
+		default:
+			require.Fail("Unexpected forecaster %v", forecasterValue.Worker)
+		}
+	}
+
+	for _, oneOutInfererValue := range valueBundle.OneOutInfererValues {
+		switch string(oneOutInfererValue.Worker) {
+		case reputer0:
+			testutil.InEpsilon2(s.T(), oneOutInfererValue.Value, epoch3Get("network_inference_oneout_0").String())
+		case reputer1:
+			testutil.InEpsilon2(s.T(), oneOutInfererValue.Value, epoch3Get("network_inference_oneout_1").String())
+		case reputer2:
+			testutil.InEpsilon2(s.T(), oneOutInfererValue.Value, epoch3Get("network_inference_oneout_2").String())
+		case reputer3:
+			testutil.InEpsilon2(s.T(), oneOutInfererValue.Value, epoch3Get("network_inference_oneout_3").String())
+		case reputer4:
+			testutil.InEpsilon2(s.T(), oneOutInfererValue.Value, epoch3Get("network_inference_oneout_4").String())
+		default:
+			require.Fail("Unexpected worker %v", oneOutInfererValue.Worker)
+		}
+	}
+
+	for _, oneOutForecasterValue := range valueBundle.OneOutForecasterValues {
+		switch string(oneOutForecasterValue.Worker) {
+		case forecaster0:
+			testutil.InEpsilon2(s.T(), oneOutForecasterValue.Value, epoch3Get("network_inference_oneout_5").String())
+		case forecaster1:
+			testutil.InEpsilon2(s.T(), oneOutForecasterValue.Value, epoch3Get("network_inference_oneout_6").String())
+		case forecaster2:
+			testutil.InEpsilon2(s.T(), oneOutForecasterValue.Value, epoch3Get("network_inference_oneout_7").String())
+		default:
+			require.Fail("Unexpected worker %v", oneOutForecasterValue.Worker)
+		}
+	}
+
+	for _, oneInForecasterValue := range valueBundle.OneInForecasterValues {
+		switch string(oneInForecasterValue.Worker) {
+		case forecaster0:
+			testutil.InEpsilon2(s.T(), oneInForecasterValue.Value, epoch3Get("network_naive_inference_onein_0").String())
+		case forecaster1:
+			testutil.InEpsilon2(s.T(), oneInForecasterValue.Value, epoch3Get("network_naive_inference_onein_1").String())
+		case forecaster2:
+			testutil.InEpsilon2(s.T(), oneInForecasterValue.Value, epoch3Get("network_naive_inference_onein_2").String())
+		default:
+			require.Fail("Unexpected worker %v", oneInForecasterValue.Worker)
+		}
+	}
+}

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -558,6 +558,29 @@ func (k *Keeper) GetInferencesAtBlock(ctx context.Context, topicId TopicId, bloc
 	return &inferences, nil
 }
 
+// GetLatestTopicInferences retrieves the latest topic inferences and its block height.
+func (k *Keeper) GetLatestTopicInferences(ctx context.Context, topicId TopicId) (*types.Inferences, BlockHeight, error) {
+	rng := collections.NewPrefixedPairRange[TopicId, BlockHeight](topicId).Descending()
+
+	iter, err := k.allInferences.Iterate(ctx, rng)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer iter.Close()
+
+	if iter.Valid() {
+		keyValue, err := iter.KeyValue()
+		if err != nil {
+			return nil, 0, err
+		}
+		return &keyValue.Value, keyValue.Key.K2(), nil
+	}
+
+	return &types.Inferences{
+		Inferences: make([]*types.Inference, 0),
+	}, 0, nil
+}
+
 func (k *Keeper) GetForecastsAtBlock(ctx context.Context, topicId TopicId, block BlockHeight) (*types.Forecasts, error) {
 	key := collections.Join(topicId, block)
 	forecasts, err := k.allForecasts.Get(ctx, key)

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -944,6 +944,59 @@ func (s *KeeperTestSuite) TestGetInferencesAtBlock() {
 	s.Require().Equal(&expectedInferences, actualInferences)
 }
 
+func (s *KeeperTestSuite) TestGetLatestTopicInferences() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+
+	topicId := uint64(1)
+
+	// Initially, there should be no inferences, so we expect an empty result
+	emptyInferences, emptyBlockHeight, err := keeper.GetLatestTopicInferences(ctx, topicId)
+	s.Require().NoError(err, "Retrieving latest inferences when none exist should not result in an error")
+	s.Require().Equal(&types.Inferences{Inferences: []*types.Inference{}}, emptyInferences, "Expected no inferences initially")
+	s.Require().Equal(types.BlockHeight(0), emptyBlockHeight, "Expected block height to be zero initially")
+
+	// Insert first set of inferences
+	blockHeight1 := types.BlockHeight(12345)
+	newInference1 := types.Inference{
+		TopicId:     uint64(topicId),
+		BlockHeight: blockHeight1,
+		Inferer:     "worker1",
+		Value:       alloraMath.MustNewDecFromString("10"),
+		ExtraData:   []byte("data1"),
+		Proof:       "proof1",
+	}
+	inferences1 := types.Inferences{
+		Inferences: []*types.Inference{&newInference1},
+	}
+	nonce1 := types.Nonce{BlockHeight: blockHeight1}
+	err = keeper.InsertInferences(ctx, topicId, nonce1, inferences1)
+	s.Require().NoError(err, "Inserting first set of inferences should not fail")
+
+	// Insert second set of inferences
+	blockHeight2 := types.BlockHeight(12346)
+	newInference2 := types.Inference{
+		TopicId:     uint64(topicId),
+		BlockHeight: blockHeight2,
+		Inferer:     "worker2",
+		Value:       alloraMath.MustNewDecFromString("20"),
+		ExtraData:   []byte("data2"),
+		Proof:       "proof2",
+	}
+	inferences2 := types.Inferences{
+		Inferences: []*types.Inference{&newInference2},
+	}
+	nonce2 := types.Nonce{BlockHeight: blockHeight2}
+	err = keeper.InsertInferences(ctx, topicId, nonce2, inferences2)
+	s.Require().NoError(err, "Inserting second set of inferences should not fail")
+
+	// Retrieve the latest inferences
+	latestInferences, latestBlockHeight, err := keeper.GetLatestTopicInferences(ctx, topicId)
+	s.Require().NoError(err, "Retrieving latest inferences should not fail")
+	s.Require().Equal(&inferences2, latestInferences, "Latest inferences should match the second inserted set")
+	s.Require().Equal(blockHeight2, latestBlockHeight, "Latest block height should match the second inserted set")
+}
+
 func (s *KeeperTestSuite) TestGetWorkerLatestInferenceByTopicId() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper

--- a/x/emissions/keeper/queryserver/query_server_inferences.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences.go
@@ -71,20 +71,11 @@ func (qs queryServer) GetLatestNetworkInference(
 	*types.QueryLatestNetworkInferencesAtBlockResponse,
 	error,
 ) {
-	topic, err := qs.k.GetTopic(ctx, req.TopicId)
-	if err != nil {
-		return nil, status.Errorf(codes.NotFound, "topic %v not found", req.TopicId)
-	}
-	if topic.EpochLastEnded == 0 {
-		return nil, status.Errorf(codes.NotFound, "network inference not available for topic %v", req.TopicId)
-	}
 
-	networkInferences, forecastImpliedInferenceByWorker, infererWeights, forecasterWeights, err := synth.GetNetworkInferencesAtBlock(
+	networkInferences, forecastImpliedInferenceByWorker, infererWeights, forecasterWeights, err := synth.GetLatestNetworkInference(
 		sdk.UnwrapSDKContext(ctx),
 		qs.k,
 		req.TopicId,
-		topic.EpochLastEnded,
-		topic.EpochLastEnded-topic.EpochLength,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- GetLastNetworkInference was using EpochLastEnded as a reference to query the network inference, which is not optimal since this property is updated before the worker sends the inferences.
- Getting the last inferences reported and its `blockHeight` -> then getting the topic `EpochLength` -> `blockHeight - EpochLength` should get the losses from the previous time step. If it exists, calculate and return the network inference.

Ticket: https://linear.app/upshot/issue/ORA-1666/debug-getlatestnetworkinference-returning-empty-values-on-edgenet