### PR TITLE
Limit Exposure of Internal Keepers inside Emissions Keeper

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server_registrations.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations.go
@@ -126,6 +126,6 @@ func (ms msgServer) CheckBalanceForRegistration(ctx context.Context, address str
 	if err != nil {
 		return false, fee, err
 	}
-	balance := ms.k.BankKeeper().GetBalance(ctx, accAddress, fee.Denom)
+	balance := ms.k.GetBankBalance(ctx, accAddress, fee.Denom)
 	return balance.IsGTE(fee), fee, nil
 }

--- a/x/emissions/keeper/msgserver/msg_server_topics.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics.go
@@ -83,6 +83,6 @@ func checkAddressHasBalanceForTopicCreationFee(ctx context.Context, ms msgServer
 	if err != nil {
 		return false, sdk.Coin{}, err
 	}
-	balance := ms.k.BankKeeper().GetBalance(ctx, accAddress, fee.Denom)
+	balance := ms.k.GetBankBalance(ctx, accAddress, fee.Denom)
 	return balance.IsGTE(fee), fee, nil
 }

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -444,15 +444,15 @@ func payoutRewards(
 
 			reputerAndDelegatorRewards = append(reputerAndDelegatorRewards, reward)
 		} else {
-			accAddress, err := sdk.AccAddressFromBech32(reward.Address)
+			_, err := sdk.AccAddressFromBech32(reward.Address)
 			if err != nil {
 				ret = append(ret, errors.Wrapf(err, "failed to decode payout address: %s", reward.Address))
 				continue
 			}
-			err = k.BankKeeper().SendCoinsFromModuleToAccount(
+			err = k.SendCoinsFromModuleToAccount(
 				ctx,
 				types.AlloraRewardsAccountName,
-				accAddress,
+				reward.Address,
 				coins,
 			)
 			if err != nil {


### PR DESCRIPTION
Removes public access from outside the keeper module to internal keepers e.g. bank and auth
Makes sure when you do "find all references on one of the keepers" you don't miss references because they're wrapped around a Get function
Makes sure that every `SendCoinsFromXToY` is injectible (e.g. for logging) from within the emissions keeper
Makes sure that if we need to edit flows related to coins we can do so in one place
