### PR TITLE
 Check Invariants Hold During Integration Testing

### DIFF
--- a/.github/workflows/format_and_test.yml
+++ b/.github/workflows/format_and_test.yml
@@ -51,6 +51,9 @@ jobs:
       with:
         go-version: 1.22.x
 
+    - name: Apply Invariants Patch
+      run: git apply ./test/invariant/invariants.patch
+
     - name: Run allora l1 chain
       run: bash ./test/local_testnet_l1.sh
 

--- a/test/invariant/invariants.patch
+++ b/test/invariant/invariants.patch
@@ -1,0 +1,43 @@
+diff --git a/x/emissions/module/abci.go b/x/emissions/module/abci.go
+index 1ca10a02..7a755bac 100644
+--- a/x/emissions/module/abci.go
++++ b/x/emissions/module/abci.go
+@@ -6,6 +6,7 @@ import (
+ 	"sync"
+ 
+ 	"cosmossdk.io/errors"
++	emissionskeeper "github.com/allora-network/allora-chain/x/emissions/keeper"
+ 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
+ 	"github.com/allora-network/allora-chain/x/emissions/types"
+ 	sdk "github.com/cosmos/cosmos-sdk/types"
+@@ -13,6 +14,10 @@ import (
+ 
+ func EndBlocker(ctx context.Context, am AppModule) error {
+ 	sdkCtx := sdk.UnwrapSDKContext(ctx)
++	invariantMessage, invariantFailed := emissionskeeper.AllInvariants(am.keeper)(sdkCtx)
++	if invariantFailed {
++		panic(fmt.Sprintf("Invariants broken: %s", invariantMessage))
++	}
+ 	blockHeight := sdkCtx.BlockHeight()
+ 	sdkCtx.Logger().Debug(
+ 		fmt.Sprintf("\n ---------------- Emissions EndBlock %d ------------------- \n",
+diff --git a/x/emissions/module/module.go b/x/emissions/module/module.go
+index 2cda57ab..3f619551 100644
+--- a/x/emissions/module/module.go
++++ b/x/emissions/module/module.go
+@@ -18,6 +18,15 @@ import (
+ 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+ )
+ 
++var (
++	_ module.HasInvariants = AppModule{}
++)
++
++// RegisterInvariants registers the emissions module invariants.
++func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
++	keeper.RegisterInvariants(ir, &am.keeper)
++}
++
+ var (
+ 	_ module.AppModuleBasic   = AppModule{}
+ 	_ module.HasGenesis       = AppModule{}

--- a/x/emissions/keeper/invariants.go
+++ b/x/emissions/keeper/invariants.go
@@ -1,0 +1,399 @@
+package keeper
+
+import (
+	"fmt"
+
+	"cosmossdk.io/collections"
+	cosmosMath "cosmossdk.io/math"
+	"github.com/allora-network/allora-chain/app/params"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// RegisterInvariants registers the emissions module invariants.
+func RegisterInvariants(ir sdk.InvariantRegistry, k *Keeper) {
+	ir.RegisterRoute(emissionstypes.ModuleName, "allora-staking-total-balance", StakingInvariantTotalStakeEqualAlloraStakingBankBalance(*k))
+	ir.RegisterRoute(emissionstypes.ModuleName, "allora-staking-total-topic-stake-equal-reputer-authority", StakingInvariantSumStakeFromStakeReputerAuthorityEqualTotalStakeAndTopicStake(*k))
+	ir.RegisterRoute(emissionstypes.ModuleName, "stake-removals-length-same", StakingInvariantLenStakeRemovalsSame(*k))
+	ir.RegisterRoute(emissionstypes.ModuleName, "stake-sum-delegated-stakes", StakingInvariantDelegatedStakes(*k))
+	ir.RegisterRoute(emissionstypes.ModuleName, "pending-reward-for-delegators-equal-reward-per-share-minus-reward-debt", StakingInvariantPendingRewardForDelegatorsEqualRewardPerShareMinusRewardDebt(*k))
+}
+
+// AllInvariants is a convience function to run all invariants in the emissions module.
+func AllInvariants(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		if res, stop := StakingInvariantTotalStakeEqualAlloraStakingBankBalance(k)(ctx); stop {
+			return res, stop
+		}
+		if res, stop := StakingInvariantSumStakeFromStakeReputerAuthorityEqualTotalStakeAndTopicStake(k)(ctx); stop {
+			return res, stop
+		}
+		if res, stop := StakingInvariantLenStakeRemovalsSame(k)(ctx); stop {
+			return res, stop
+		}
+		if res, stop := StakingInvariantDelegatedStakes(k)(ctx); stop {
+			return res, stop
+		}
+		if res, stop := StakingInvariantPendingRewardForDelegatorsEqualRewardPerShareMinusRewardDebt(k)(ctx); stop {
+			return res, stop
+		}
+		return "", false
+	}
+}
+
+// StakingInvariantTotalStakeEqualAlloraStakingBankBalance checks that
+// the total stake in the emissions module is equal to the balance
+// of the Allora staking bank account.
+func StakingInvariantTotalStakeEqualAlloraStakingBankBalance(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		totalStake, err := k.GetTotalStake(ctx)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get total stake: %v", err))
+		}
+		alloraStakingAddr := k.authKeeper.GetModuleAccount(ctx, emissionstypes.AlloraStakingAccountName).GetAddress()
+		alloraStakingBalance := k.bankKeeper.GetBalance(
+			ctx,
+			alloraStakingAddr,
+			params.DefaultBondDenom).Amount
+		broken := !totalStake.Equal(alloraStakingBalance)
+		return sdk.FormatInvariant(
+			emissionstypes.ModuleName,
+			"emissions module total stake equal allora staking bank balance",
+			fmt.Sprintf("TotalStake: %s | Allora Module Account Staking Balance: %s",
+				totalStake.String(),
+				alloraStakingBalance.String(),
+			),
+		), broken
+	}
+}
+
+// the number of values in the stakeRemovalsByBlock map
+// should always equal the number of values in the stakeRemovalsByActor map
+func StakingInvariantLenStakeRemovalsSame(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		iterByBlock, err := k.stakeRemovalsByBlock.Iterate(ctx, nil)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get stake removals iterator: %v", err))
+		}
+		valuesByBlock, err := iterByBlock.Values()
+		if err != nil {
+			panic(fmt.Sprintf("failed to get stake removals values: %v", err))
+		}
+		lenByBlock := len(valuesByBlock)
+		iterByActor, err := k.stakeRemovalsByActor.Iterate(ctx, nil)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get stake removals iterator: %v", err))
+		}
+		valuesByActor, err := iterByActor.Keys()
+		if err != nil {
+			panic(fmt.Sprintf("failed to get stake removals values: %v", err))
+		}
+		lenByActor := len(valuesByActor)
+
+		broken := lenByBlock != lenByActor
+		if broken {
+			return sdk.FormatInvariant(
+				emissionstypes.ModuleName,
+				"emissions module length of stake removals same",
+				fmt.Sprintf("Length of stake removals: %d | Length of stake removals: %d\n%v\n%v",
+					lenByBlock,
+					lenByActor,
+					valuesByBlock,
+					valuesByActor,
+				),
+			), broken
+		}
+		totalSumRemove := cosmosMath.ZeroInt()
+		topicSumsRemove := make(map[uint64]cosmosMath.Int)
+		for _, value := range valuesByBlock {
+			topicSumBefore, has := topicSumsRemove[value.TopicId]
+			if !has {
+				topicSumBefore = cosmosMath.ZeroInt()
+			}
+			topicSumsRemove[value.TopicId] = topicSumBefore.Add(value.Amount)
+			totalSumRemove = totalSumRemove.Add(value.Amount)
+		}
+		totalStake, err := k.totalStake.Get(ctx)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get total stake: %v", err))
+		}
+		broken = !totalStake.GTE(totalSumRemove)
+		if broken {
+			return sdk.FormatInvariant(
+				emissionstypes.ModuleName,
+				"emissions module total stake greater than or equal to total stake removals",
+				fmt.Sprintf("TotalStake: %s | TotalStakeRemove: %s",
+					totalStake.String(),
+					totalSumRemove.String(),
+				),
+			), broken
+		}
+		for topicId, topicSumRemove := range topicSumsRemove {
+			topicStake, err := k.GetTopicStake(ctx, topicId)
+			if err != nil {
+				panic(fmt.Sprintf("failed to get topic stake: %v", err))
+			}
+			broken = !topicStake.GTE(topicSumRemove)
+			if broken {
+				return sdk.FormatInvariant(
+					emissionstypes.ModuleName,
+					"emissions module topic stake greater than or equal to topic stake removals",
+					fmt.Sprintf("TopicId: %d | TopicStake: %s | TopicStakeRemove: %s",
+						topicId,
+						topicStake.String(),
+						topicSumRemove.String(),
+					),
+				), broken
+			}
+		}
+		return "", false
+	}
+}
+
+// stakeSumFromDelegator = Sum(delegatedStakes[topicid, delegator, all reputers])
+// stakeFromDelegatorsUponReputer = Sum(delegatedStakes[topicid, all delegators, reputer])
+func StakingInvariantDelegatedStakes(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		numTopics, err := k.GetNextTopicId(ctx)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get next topic id: %v", err))
+		}
+		for i := uint64(0); i < numTopics; i++ {
+			rng := collections.NewPrefixedTripleRange[uint64, string, string](i)
+			topicIter, err := k.delegatedStakes.Iterate(ctx, rng)
+			if err != nil {
+				panic(fmt.Sprintf("failed to get delegated stakes iterator: %v", err))
+			}
+			type ExpectedSumToComputedSum struct {
+				expected cosmosMath.Int
+				computed cosmosMath.Int
+			}
+			delegatorsToSumsMap := make(map[string]ExpectedSumToComputedSum)
+			reputersToSumsMap := make(map[string]ExpectedSumToComputedSum)
+			for ; topicIter.Valid(); topicIter.Next() {
+				delegatorInfo, err := topicIter.KeyValue()
+				if err != nil {
+					panic(fmt.Sprintf("failed to get delegator info: %v", err))
+				}
+				delegator := delegatorInfo.Key.K2()
+				reputer := delegatorInfo.Key.K3()
+				amount := delegatorInfo.Value.Amount.SdkIntTrim()
+				existingSumsDelegator, presentDelegator := delegatorsToSumsMap[delegator]
+				if !presentDelegator {
+					stakeSumForDelegator, err := k.stakeSumFromDelegator.Get(ctx, collections.Join(i, delegator))
+					if err != nil {
+						panic(fmt.Sprintf("failed to get stake sum from delegator: %v", err))
+					}
+					delegatorsToSumsMap[delegator] = ExpectedSumToComputedSum{
+						expected: stakeSumForDelegator,
+						computed: amount,
+					}
+				} else {
+					newSum := existingSumsDelegator.computed.Add(amount)
+					delegatorsToSumsMap[delegator] = ExpectedSumToComputedSum{
+						expected: existingSumsDelegator.expected,
+						computed: newSum,
+					}
+				}
+				existingSumsReputer, presentReputer := reputersToSumsMap[reputer]
+				if !presentReputer {
+					stakeSumForReputer, err := k.stakeFromDelegatorsUponReputer.Get(ctx, collections.Join(i, reputer))
+					if err != nil {
+						panic(fmt.Sprintf("failed to get delegator stake upon reputer: %v", err))
+					}
+					reputersToSumsMap[reputer] = ExpectedSumToComputedSum{
+						expected: stakeSumForReputer,
+						computed: amount,
+					}
+				} else {
+					newSum := existingSumsReputer.computed.Add(amount)
+					reputersToSumsMap[reputer] = ExpectedSumToComputedSum{
+						expected: existingSumsReputer.expected,
+						computed: newSum,
+					}
+				}
+			}
+			for delegator, sums := range delegatorsToSumsMap {
+				broken := !sums.expected.Equal(sums.computed)
+				if broken {
+					return sdk.FormatInvariant(
+						emissionstypes.ModuleName,
+						"emissions module stake sum from delegator equal sum of delegated stakes for that delegator",
+						fmt.Sprintf("Topic Id: %d | Delegator: %s | sum from stakeSumFromDelegator: %s | sum from delegatedStakes: %s",
+							i,
+							delegator,
+							sums.expected.String(),
+							sums.computed.String(),
+						),
+					), broken
+				}
+			}
+			for reputer, sums := range reputersToSumsMap {
+				broken := !sums.expected.Equal(sums.computed)
+				if broken {
+					return sdk.FormatInvariant(
+						emissionstypes.ModuleName,
+						"emissions module stake sum from delegator upon reputer equal sum delegatedStakes upon reputer",
+						fmt.Sprintf("Topic Id: %d | Reputer: %s | sum from stakeFromDelegatorsUponReputer: %s | sum from delegatedStakes: %s",
+							i,
+							reputer,
+							sums.expected.String(),
+							sums.computed.String(),
+						),
+					), broken
+				}
+			}
+		}
+		return "", false
+	}
+}
+
+func StakingInvariantSumStakeFromStakeReputerAuthorityEqualTotalStakeAndTopicStake(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		totalStake, err := k.GetTotalStake(ctx)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get total stake: %v", err))
+		}
+		numTopics, err := k.GetNextTopicId(ctx)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get next topic id: %v", err))
+		}
+		sumTopicStakes := cosmosMath.ZeroInt()
+		for i := uint64(0); i < numTopics; i++ {
+			topicStake, err := k.GetTopicStake(ctx, i)
+			if err != nil {
+				panic(fmt.Sprintf("failed to get topic stake: %v", err))
+			}
+			sumTopicStakes = sumTopicStakes.Add(topicStake)
+
+			sumReputersThisTopic := cosmosMath.ZeroInt()
+			rng := collections.NewPrefixedPairRange[uint64, string](i)
+			reputerAuthoritiesForTopicIter, err := k.stakeReputerAuthority.Iterate(ctx, rng)
+			if err != nil {
+				panic(fmt.Sprintf("failed to get reputer authorities iterator: %v", err))
+			}
+			for ; reputerAuthoritiesForTopicIter.Valid(); reputerAuthoritiesForTopicIter.Next() {
+				reputerAuthority, err := reputerAuthoritiesForTopicIter.Value()
+				if err != nil {
+					panic(fmt.Sprintf("failed to get reputer authority: %v", err))
+				}
+				sumReputersThisTopic = sumReputersThisTopic.Add(reputerAuthority)
+			}
+
+			broken := !sumReputersThisTopic.Equal(topicStake)
+			if broken {
+				return sdk.FormatInvariant(
+					emissionstypes.ModuleName,
+					"emissions module sum stake from stake reputer authority equal topic stake",
+					fmt.Sprintf("Sum of Stake from Stake Reputer Authority: %s | Topic Stake: %s | Topic ID: %d",
+						sumReputersThisTopic.String(),
+						topicStake.String(),
+						i,
+					),
+				), broken
+			}
+		}
+		broken := !totalStake.Equal(sumTopicStakes)
+		return sdk.FormatInvariant(
+			emissionstypes.ModuleName,
+			"emissions module total stake equal sum of all topic stakes",
+			fmt.Sprintf("TotalStake: %s | Sum of all Topic Stakes: %s | num topics :%d",
+				totalStake.String(),
+				sumTopicStakes.String(),
+				numTopics,
+			),
+		), broken
+	}
+}
+
+func StakingInvariantPendingRewardForDelegatorsEqualRewardPerShareMinusRewardDebt(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		// get the sum of all accumulated debts that happend to be staked upon a reputer
+		iter, err := k.delegatedStakes.Iterate(ctx, nil)
+		if err != nil {
+			panic("failed to get delegated stakes iterator")
+		}
+		type TopicAndReputer struct {
+			topicId uint64
+			reputer string
+		}
+		rewardDebtSums := make(map[TopicAndReputer]alloraMath.Dec)
+		reputerStakeSums := make(map[TopicAndReputer]alloraMath.Dec)
+		for ; iter.Valid(); iter.Next() {
+			keyValue, err := iter.KeyValue()
+			if err != nil {
+				panic("failed to get key value from delegatedStakes iterator")
+			}
+			topicAndReputer := TopicAndReputer{topicId: keyValue.Key.K1(), reputer: keyValue.Key.K3()}
+			rewardDebtSum, has := rewardDebtSums[topicAndReputer]
+			if !has {
+				rewardDebtSum = alloraMath.ZeroDec()
+			}
+			rewardDebtSumNew, err := rewardDebtSum.Add(keyValue.Value.RewardDebt)
+			if err != nil {
+				panic("failed to add reward debt sum")
+			}
+			rewardDebtSums[topicAndReputer] = rewardDebtSumNew
+			delegatedStakeSum, has := reputerStakeSums[topicAndReputer]
+			if !has {
+				delegatedStakeSum = alloraMath.ZeroDec()
+			}
+			delegatedStakeSumNew, err := delegatedStakeSum.Add(keyValue.Value.Amount)
+			if err != nil {
+				panic("failed to add stake sum")
+			}
+			reputerStakeSums[topicAndReputer] = delegatedStakeSumNew
+		}
+		// now for each reputer and topic, get the accumulated reward per share
+		// then multiply it by the stake sum of the reputer
+		iter2, err := k.delegateRewardPerShare.Iterate(ctx, nil)
+		if err != nil {
+			panic("failed to get delegate reward per share iterator")
+		}
+		accumulatedRewardsBeyondRewardDebt := alloraMath.ZeroDec()
+		for ; iter2.Valid(); iter2.Next() {
+			keyValue, err := iter2.KeyValue()
+			if err != nil {
+				panic("failed to get key value from delegateRewardPerShare iterator")
+			}
+			topicAndReputer := TopicAndReputer{topicId: keyValue.Key.K1(), reputer: keyValue.Key.K2()}
+			stakeSum := reputerStakeSums[topicAndReputer]
+			rewardDebt := rewardDebtSums[topicAndReputer]
+			stakeTimesRewardPerShare, err := stakeSum.Mul(keyValue.Value)
+			if err != nil {
+				panic("failed to multiply stake sum by reward per share")
+			}
+			stakeTimeRewardPerShareMinusRewardDebt, err := stakeTimesRewardPerShare.Sub(rewardDebt)
+			if err != nil {
+				panic("failed to subtract reward debt from stake times reward per share")
+			}
+			if stakeTimeRewardPerShareMinusRewardDebt.IsNegative() {
+				panic(fmt.Sprintf("reward per share minus reward debt negative: stakeSum: %s, rewardPerShare: %s, rewardDebt: %s",
+					stakeSum.String(), keyValue.Value.String(), rewardDebt.String(),
+				))
+			}
+			accumulatedRewardsBeyondRewardDebt, err = accumulatedRewardsBeyondRewardDebt.Add(stakeTimeRewardPerShareMinusRewardDebt)
+			if err != nil {
+				panic("failed to add stake times reward per share minus reward debt to accumulated rewards")
+			}
+		}
+
+		// now check the total pending rewards bank balance is equal to the accumulated rewards beyond reward debt
+		alloraPendingAddr := k.authKeeper.GetModuleAccount(ctx, emissionstypes.AlloraPendingRewardForDelegatorAccountName).GetAddress()
+		bal := k.GetBankBalance(ctx, alloraPendingAddr, params.DefaultBondDenom).Amount
+		rewards := accumulatedRewardsBeyondRewardDebt.SdkIntTrim()
+		broken := !bal.Equal(rewards)
+		if broken {
+			return sdk.FormatInvariant(
+				emissionstypes.ModuleName,
+				"emissions module pending reward for delegators equal reward per share minus reward debt",
+				fmt.Sprintf("Pending Reward For Delegators: %s | Accumulated Rewards Beyond Reward Debt: %s",
+					bal.String(),
+					rewards.String(),
+				),
+			), broken
+		}
+		return "", false
+	}
+}


### PR DESCRIPTION
Check the following invariants during the course of an integration test run:

* The balance of the totalStake in the emissions keeper should always equal the cosmos-sdk /x/bank balance of the "allorastaking" bank account
* The sum of all topicStake in every topic should always equal the totalStake
* The sum of all stakeReputerAuthority for a given topic should always equal the topic stake for that topic
* The sum of all stakeReputerAuthority should equal the total stake
* The stakeSumFromDelegator should always equal the sum of `delegatedStakes[topicid, delegator, all reputers for that delegator])`
* The stakeFromDelegatorsUponReputer should always equal the sum of `delegatedStakes[topicid, all delegators for that reputer, reputer]`
* The sum of all (delegateRewardsPerShare * delegated stake - reward debt) = the balance of the /x/bank AlloraPendingRewardForDelegatorAccountName module account
* The state of the stakeRemovalsByBlock and stakeRemovalsByActor should always be identical in terms of the number of keys in the map, and the content of those keys
* The sum of all stakeRemovals should always be less than or equal to the totalStake


The invariant checking lives in a file called invariants.go. The cosmos /x/invariants module apparently is not functional at this time so rather than rely on their module, we just edit the ABCI endBlock to check the invariants at the end of every block. This is not perfect, but better than nothing. The code to do that is stored in a patch that is applied in the github workflow via `git apply ./test/invariant/invariants.patch`