### PR TITLE
Parallelize Unit and Integration Testing Jobs

### DIFF
--- a/.github/workflows/format_and_test.yml
+++ b/.github/workflows/format_and_test.yml
@@ -3,29 +3,24 @@ name: Run Format, Unit Tests, and Integration Tests
 on: [pull_request]
 
 jobs:
-  build-and-format:
+  gofmt: 
+    name: "Go Format Check"
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.22.x
-
-    - name: Install Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '12'
-
+    - uses: actions/checkout@v4
     - name: Check code formatting using gofmt
       uses: Jerome1337/gofmt-action@v1.0.5
       with:
           gofmt-path: '.'
           gofmt-flags: '-l -d'
 
+  clang-format:
+    name: "Clang Format Protobuf Check"
+    runs-on: ubuntu-latest
+    needs: [gofmt]
+
+    steps:
+    - uses: actions/checkout@v4
     - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.11.0
       with:
@@ -34,19 +29,27 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [build-and-format]
     timeout-minutes: 10
-
     steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: 1.22.x
+
     - name: Test
       uses: robherley/go-test-action@v0.1.0
 
   integration-test:
     runs-on: ubuntu-latest
-    needs: [build-and-format]
     timeout-minutes: 25
 
     steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: 1.22.x
 
     - name: Apply Invariants Patch
       run: git apply ./test/invariant/invariants.patch

--- a/.github/workflows/format_and_test.yml
+++ b/.github/workflows/format_and_test.yml
@@ -3,7 +3,7 @@ name: Run Format, Unit Tests, and Integration Tests
 on: [pull_request]
 
 jobs:
-  test:
+  build-and-format:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,12 +20,6 @@ jobs:
       with:
         node-version: '12'
 
-    - name: Build Source
-      run: go build -v ./...
-
-    - name: Install allorad
-      run: make install
-
     - name: Check code formatting using gofmt
       uses: Jerome1337/gofmt-action@v1.0.5
       with:
@@ -38,8 +32,24 @@ jobs:
         clang-format-version: '17'
         include-regex: '^.*\.proto$'
 
+  test:
+    runs-on: ubuntu-latest
+    needs: [build-and-format]
+    timeout-minutes: 10
+
+    steps:
     - name: Test
       uses: robherley/go-test-action@v0.1.0
+
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: [build-and-format]
+    timeout-minutes: 25
+
+    steps:
+
+    - name: Apply Invariants Patch
+      run: git apply ./test/invariant/invariants.patch
 
     - name: Run allora l1 chain
       run: bash ./test/local_testnet_l1.sh

--- a/.github/workflows/format_and_test.yml
+++ b/.github/workflows/format_and_test.yml
@@ -51,9 +51,6 @@ jobs:
       with:
         go-version: 1.22.x
 
-    - name: Apply Invariants Patch
-      run: git apply ./test/invariant/invariants.patch
-
     - name: Run allora l1 chain
       run: bash ./test/local_testnet_l1.sh
 


### PR DESCRIPTION
In #290 I made all the integration and unit tests run on the same github VM in some weird goal of either making our github actions cheaper and or faster

I am now of the conclusion that it is definitely not faster

therefore, we use job dependencies to allow parallelizing the github action on multiple VMs. I used [this](https://medium.com/tradeling/how-to-achieve-parallel-execution-using-github-actions-d534404702fb) as a reference.