### PR TITLE
Functions create their own context.Ctx to call cosmosclient.Client

### DIFF
--- a/test/common/node_config.go
+++ b/test/common/node_config.go
@@ -1,7 +1,6 @@
 package testcommon
 
 import (
-	"context"
 	"testing"
 
 	upgrade "cosmossdk.io/x/upgrade"
@@ -21,7 +20,6 @@ import (
 // handle to various node data
 type TestConfig struct {
 	T              *testing.T
-	Ctx            context.Context
 	Client         Client                // a testcommon.Client which holds several cosmosclient.Client instances
 	AlloraHomeDir  string                // home directory for the allora keystore
 	FaucetAcc      cosmosaccount.Account // account info for the faucet
@@ -53,7 +51,6 @@ func NewTestConfig(
 	nodeConfig := TestConfig{}
 	var err error
 	nodeConfig.T = t
-	nodeConfig.Ctx = context.Background()
 	nodeConfig.AlloraHomeDir = alloraHomeDir
 	nodeConfig.Seed = seed
 	if rpcConnectionType == SingleRpc {

--- a/test/integration/create_topic_test.go
+++ b/test/integration/create_topic_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"context"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	testCommon "github.com/allora-network/allora-chain/test/common"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
@@ -9,8 +11,9 @@ import (
 
 // test that we can create topics and that the resultant topics are what we asked for
 func CreateTopic(m testCommon.TestConfig) (topicId uint64) {
+	ctx := context.Background()
 	topicIdStart, err := m.Client.QueryEmissions().GetNextTopicId(
-		m.Ctx,
+		ctx,
 		&emissionstypes.QueryNextTopicIdRequest{},
 	)
 	require.NoError(m.T, err)
@@ -30,9 +33,9 @@ func CreateTopic(m testCommon.TestConfig) (topicId uint64) {
 		AlphaRegret:     alloraMath.MustNewDecFromString("0.1"),
 		AllowNegative:   true,
 	}
-	txResp, err := m.Client.BroadcastTx(m.Ctx, m.AliceAcc, createTopicRequest)
+	txResp, err := m.Client.BroadcastTx(ctx, m.AliceAcc, createTopicRequest)
 	require.NoError(m.T, err)
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	require.NoError(m.T, err)
 	createTopicResponse := &emissionstypes.MsgCreateNewTopicResponse{}
 	err = txResp.Decode(createTopicResponse)
@@ -40,14 +43,14 @@ func CreateTopic(m testCommon.TestConfig) (topicId uint64) {
 	topicId = createTopicResponse.TopicId
 	require.Equal(m.T, topicIdStart.NextTopicId, topicId)
 	topicIdEnd, err := m.Client.QueryEmissions().GetNextTopicId(
-		m.Ctx,
+		ctx,
 		&emissionstypes.QueryNextTopicIdRequest{},
 	)
 	require.NoError(m.T, err)
 	require.Equal(m.T, topicIdEnd.NextTopicId, topicId+1)
 
 	storedTopicResponse, err := m.Client.QueryEmissions().GetTopic(
-		m.Ctx,
+		ctx,
 		&emissionstypes.QueryTopicRequest{
 			TopicId: topicId,
 		},

--- a/test/integration/distribution_test.go
+++ b/test/integration/distribution_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"os"
 	"strings"
@@ -63,9 +64,10 @@ func CheckValidatorBalancesIncreaseOnNewBlock(m testCommon.TestConfig) {
 
 	balancesBefore := make(map[string]*distributiontypes.QueryValidatorOutstandingRewardsResponse)
 
+	ctx := context.Background()
 	for _, addr := range validatorAddrs {
 		response, err := m.Client.QueryDistribution().ValidatorOutstandingRewards(
-			m.Ctx,
+			ctx,
 			&distributiontypes.QueryValidatorOutstandingRewardsRequest{
 				ValidatorAddress: addr,
 			},
@@ -74,14 +76,14 @@ func CheckValidatorBalancesIncreaseOnNewBlock(m testCommon.TestConfig) {
 		balancesBefore[addr] = response
 	}
 
-	err = m.Client.WaitForNextBlock(m.Ctx)
+	err = m.Client.WaitForNextBlock(ctx)
 	require.NoError(m.T, err)
 
 	balanceIncreased := false
 
 	for _, addr := range validatorAddrs {
 		balanceAfter, err := m.Client.QueryDistribution().ValidatorOutstandingRewards(
-			m.Ctx,
+			ctx,
 			&distributiontypes.QueryValidatorOutstandingRewardsRequest{
 				ValidatorAddress: addr,
 			},
@@ -107,8 +109,9 @@ func CheckValidatorBalancesIncreaseOnNewBlock(m testCommon.TestConfig) {
 // the mint module pays the ecosystem module account
 // as new blocks are produced.
 func CheckAlloraRewardsBalanceGoesUpOnNewBlock(m testCommon.TestConfig) {
+	ctx := context.Background()
 	alloraRewardsModuleAccResponse, err := m.Client.QueryAuth().ModuleAccountByName(
-		m.Ctx,
+		ctx,
 		&authtypes.QueryModuleAccountByNameRequest{
 			Name: emissionstypes.AlloraRewardsAccountName,
 		},
@@ -122,7 +125,7 @@ func CheckAlloraRewardsBalanceGoesUpOnNewBlock(m testCommon.TestConfig) {
 	require.NoError(m.T, err)
 
 	alloraRewardsBalanceBefore, err := m.Client.QueryBank().Balance(
-		m.Ctx,
+		ctx,
 		&banktypes.QueryBalanceRequest{
 			Address: alloraRewardsModuleAcc.Address,
 			Denom:   params.BaseCoinUnit,
@@ -130,18 +133,18 @@ func CheckAlloraRewardsBalanceGoesUpOnNewBlock(m testCommon.TestConfig) {
 	)
 	require.NoError(m.T, err)
 
-	blockHeight, err := m.Client.BlockHeight(m.Ctx)
+	blockHeight, err := m.Client.BlockHeight(ctx)
 	require.NoError(m.T, err)
-	err = m.Client.WaitForNextBlock(m.Ctx)
+	err = m.Client.WaitForNextBlock(ctx)
 	require.NoError(m.T, err)
-	err = m.Client.WaitForNextBlock(m.Ctx)
+	err = m.Client.WaitForNextBlock(ctx)
 	require.NoError(m.T, err)
-	blockHeight2, err := m.Client.BlockHeight(m.Ctx)
+	blockHeight2, err := m.Client.BlockHeight(ctx)
 	require.NoError(m.T, err)
 	require.Greater(m.T, blockHeight2, blockHeight)
 
 	alloraRewardsBalanceAfter, err := m.Client.QueryBank().Balance(
-		m.Ctx,
+		ctx,
 		&banktypes.QueryBalanceRequest{
 			Address: alloraRewardsModuleAcc.Address,
 			Denom:   params.BaseCoinUnit,

--- a/test/integration/fund_topic_test.go
+++ b/test/integration/fund_topic_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"context"
+
 	cosmosMath "cosmossdk.io/math"
 	testCommon "github.com/allora-network/allora-chain/test/common"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
@@ -8,8 +10,9 @@ import (
 )
 
 func FundTopic1(m testCommon.TestConfig) {
+	ctx := context.Background()
 	txResp, err := m.Client.BroadcastTx(
-		m.Ctx,
+		ctx,
 		m.BobAcc,
 		&emissionstypes.MsgFundTopic{
 			Sender:  m.BobAddr,
@@ -18,7 +21,7 @@ func FundTopic1(m testCommon.TestConfig) {
 		},
 	)
 	require.NoError(m.T, err)
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	require.NoError(m.T, err)
 	resp := &emissionstypes.MsgFundTopicResponse{}
 	err = txResp.Decode(resp)
@@ -26,6 +29,7 @@ func FundTopic1(m testCommon.TestConfig) {
 }
 
 func CheckTopic1Activated(m testCommon.TestConfig) {
+	ctx := context.Background()
 	// Fetch only active topics
 	pagi := &emissionstypes.QueryActiveTopicsRequest{
 		Pagination: &emissionstypes.SimpleCursorPaginationRequest{
@@ -33,7 +37,7 @@ func CheckTopic1Activated(m testCommon.TestConfig) {
 		},
 	}
 	activeTopics, err := m.Client.QueryEmissions().GetActiveTopics(
-		m.Ctx,
+		ctx,
 		pagi)
 	require.NoError(m.T, err, "Fetching active topics should not produce an error")
 

--- a/test/integration/params_test.go
+++ b/test/integration/params_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"context"
+
 	testCommon "github.com/allora-network/allora-chain/test/common"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	minttypes "github.com/allora-network/allora-chain/x/mint/types"
@@ -9,9 +11,10 @@ import (
 
 // get the emissions params from outside the chain
 func GetEmissionsParams(m testCommon.TestConfig) emissionstypes.Params {
+	ctx := context.Background()
 	paramsReq := &emissionstypes.QueryParamsRequest{}
 	p, err := m.Client.QueryEmissions().Params(
-		m.Ctx,
+		ctx,
 		paramsReq,
 	)
 	require.NoError(m.T, err)
@@ -21,9 +24,10 @@ func GetEmissionsParams(m testCommon.TestConfig) emissionstypes.Params {
 
 // get the mint params from outside the chain
 func GetMintParams(m testCommon.TestConfig) minttypes.Params {
+	ctx := context.Background()
 	paramsReq := &minttypes.QueryParamsRequest{}
 	p, err := m.Client.QueryMint().Params(
-		m.Ctx,
+		ctx,
 		paramsReq,
 	)
 	require.NoError(m.T, err)

--- a/test/integration/registration_test.go
+++ b/test/integration/registration_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"context"
+
 	testCommon "github.com/allora-network/allora-chain/test/common"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/stretchr/testify/require"
@@ -8,6 +10,7 @@ import (
 
 // register alice as a reputer in topic 1, then check success
 func RegisterAliceAsReputerTopic1(m testCommon.TestConfig) {
+	ctx := context.Background()
 	registerAliceRequest := &emissionstypes.MsgRegister{
 		Sender:       m.AliceAddr,
 		Owner:        m.AliceAddr,
@@ -16,9 +19,9 @@ func RegisterAliceAsReputerTopic1(m testCommon.TestConfig) {
 		TopicId:      1,
 		IsReputer:    true,
 	}
-	txResp, err := m.Client.BroadcastTx(m.Ctx, m.AliceAcc, registerAliceRequest)
+	txResp, err := m.Client.BroadcastTx(ctx, m.AliceAcc, registerAliceRequest)
 	require.NoError(m.T, err)
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	require.NoError(m.T, err)
 	registerAliceResponse := &emissionstypes.MsgRegisterResponse{}
 	err = txResp.Decode(registerAliceResponse)
@@ -28,7 +31,7 @@ func RegisterAliceAsReputerTopic1(m testCommon.TestConfig) {
 
 	// Check Alice registered as reputer
 	aliceRegistered, err := m.Client.QueryEmissions().IsReputerRegisteredInTopicId(
-		m.Ctx,
+		ctx,
 		&emissionstypes.QueryIsReputerRegisteredInTopicIdRequest{
 			TopicId: 1,
 			Address: m.AliceAddr,
@@ -39,7 +42,7 @@ func RegisterAliceAsReputerTopic1(m testCommon.TestConfig) {
 
 	// Check Alice not registered as worker
 	aliceNotRegisteredAsWorker, err := m.Client.QueryEmissions().IsWorkerRegisteredInTopicId(
-		m.Ctx,
+		ctx,
 		&emissionstypes.QueryIsWorkerRegisteredInTopicIdRequest{
 			TopicId: 1,
 			Address: m.AliceAddr,
@@ -51,6 +54,7 @@ func RegisterAliceAsReputerTopic1(m testCommon.TestConfig) {
 
 // register bob as worker in topic 1, then check sucess
 func RegisterBobAsWorkerTopic1(m testCommon.TestConfig) {
+	ctx := context.Background()
 	registerBobRequest := &emissionstypes.MsgRegister{
 		Sender:       m.BobAddr,
 		Owner:        m.BobAddr,
@@ -59,9 +63,9 @@ func RegisterBobAsWorkerTopic1(m testCommon.TestConfig) {
 		TopicId:      1,
 		IsReputer:    false,
 	}
-	txResp, err := m.Client.BroadcastTx(m.Ctx, m.BobAcc, registerBobRequest)
+	txResp, err := m.Client.BroadcastTx(ctx, m.BobAcc, registerBobRequest)
 	require.NoError(m.T, err)
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	require.NoError(m.T, err)
 	registerBobResponse := &emissionstypes.MsgRegisterResponse{}
 	err = txResp.Decode(registerBobResponse)
@@ -70,7 +74,7 @@ func RegisterBobAsWorkerTopic1(m testCommon.TestConfig) {
 	require.Equal(m.T, "Node successfully registered", registerBobResponse.Message)
 	// Check Bob registered as worker
 	bobRegistered, err := m.Client.QueryEmissions().IsWorkerRegisteredInTopicId(
-		m.Ctx,
+		ctx,
 		&emissionstypes.QueryIsWorkerRegisteredInTopicIdRequest{
 			TopicId: 1,
 			Address: m.BobAddr,
@@ -81,7 +85,7 @@ func RegisterBobAsWorkerTopic1(m testCommon.TestConfig) {
 
 	// Check Bob not registered as reputer
 	bobNotRegisteredAsWorker, err := m.Client.QueryEmissions().IsReputerRegisteredInTopicId(
-		m.Ctx,
+		ctx,
 		&emissionstypes.QueryIsReputerRegisteredInTopicIdRequest{
 			TopicId: 1,
 			Address: m.BobAddr,

--- a/test/integration/update_params_test.go
+++ b/test/integration/update_params_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"context"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	testCommon "github.com/allora-network/allora-chain/test/common"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
@@ -8,11 +10,12 @@ import (
 )
 
 func checkIfAdmin(m testCommon.TestConfig, address string) bool {
+	ctx := context.Background()
 	paramsReq := &emissionstypes.QueryIsWhitelistAdminRequest{
 		Address: address,
 	}
 	p, err := m.Client.QueryEmissions().IsWhitelistAdmin(
-		m.Ctx,
+		ctx,
 		paramsReq,
 	)
 	require.NoError(m.T, err)
@@ -22,6 +25,7 @@ func checkIfAdmin(m testCommon.TestConfig, address string) bool {
 
 // Test that whitelisted admin can successfully update params and others cannot
 func UpdateParamsChecks(m testCommon.TestConfig) {
+	ctx := context.Background()
 	// Ensure Alice is in the whitelist and Bob is not
 	require.True(m.T, checkIfAdmin(m, m.AliceAddr))
 	require.False(m.T, checkIfAdmin(m, m.BobAddr))
@@ -42,9 +46,9 @@ func UpdateParamsChecks(m testCommon.TestConfig) {
 			MinEpochLength:         []int64{1},
 		},
 	}
-	txResp, err := m.Client.BroadcastTx(m.Ctx, m.AliceAcc, updateParamRequest)
+	txResp, err := m.Client.BroadcastTx(ctx, m.AliceAcc, updateParamRequest)
 	require.NoError(m.T, err)
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	require.NoError(m.T, err)
 
 	// Should fail for Bob because he's not a whitelist admin
@@ -55,7 +59,7 @@ func UpdateParamsChecks(m testCommon.TestConfig) {
 			Epsilon: input,
 		},
 	}
-	_, err = m.Client.BroadcastTx(m.Ctx, m.BobAcc, updateParamRequest)
+	_, err = m.Client.BroadcastTx(ctx, m.BobAcc, updateParamRequest)
 	require.Error(m.T, err)
 	// Check that error is due to Bob not being a whitelist admin
 	require.Contains(m.T, err.Error(), "not whitelist admin")
@@ -72,8 +76,8 @@ func UpdateParamsChecks(m testCommon.TestConfig) {
 			Epsilon: input,
 		},
 	}
-	txResp, err = m.Client.BroadcastTx(m.Ctx, m.AliceAcc, updateParamRequest)
+	txResp, err = m.Client.BroadcastTx(ctx, m.AliceAcc, updateParamRequest)
 	require.NoError(m.T, err)
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	require.NoError(m.T, err)
 }

--- a/test/stress/create_topic_test.go
+++ b/test/stress/create_topic_test.go
@@ -1,6 +1,8 @@
 package stress_test
 
 import (
+	"context"
+
 	cosmosMath "cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	testCommon "github.com/allora-network/allora-chain/test/common"
@@ -14,6 +16,7 @@ func createTopic(
 	epochLength int64,
 	creator NameAccountAndAddress,
 ) (topicId uint64) {
+	ctx := context.Background()
 	createTopicRequest := &emissionstypes.MsgCreateNewTopic{
 		Creator:         creator.aa.addr,
 		Metadata:        "ETH 24h Prediction",
@@ -29,10 +32,10 @@ func createTopic(
 		AllowNegative:   true,
 	}
 
-	txResp, err := m.Client.BroadcastTx(m.Ctx, creator.aa.acc, createTopicRequest)
+	txResp, err := m.Client.BroadcastTx(ctx, creator.aa.acc, createTopicRequest)
 	require.NoError(m.T, err)
 
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	require.NoError(m.T, err)
 
 	createTopicResponse := &emissionstypes.MsgCreateNewTopicResponse{}
@@ -53,9 +56,10 @@ func fundTopic(
 	sender NameAccountAndAddress,
 	amount int64,
 ) error {
+	ctx := context.Background()
 	m.T.Log(topicLog(topicId, "funded topic with ", amount, "from", sender.name))
 	txResp, err := m.Client.BroadcastTx(
-		m.Ctx,
+		ctx,
 		sender.aa.acc,
 		&emissionstypes.MsgFundTopic{
 			Sender:  sender.aa.addr,
@@ -66,7 +70,7 @@ func fundTopic(
 	if err != nil {
 		return err
 	}
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	if err != nil {
 		return err
 	}

--- a/test/stress/funding_test.go
+++ b/test/stress/funding_test.go
@@ -1,6 +1,8 @@
 package stress_test
 
 import (
+	"context"
+
 	cosmossdk_io_math "cosmossdk.io/math"
 	"github.com/allora-network/allora-chain/app/params"
 	testCommon "github.com/allora-network/allora-chain/test/common"
@@ -76,7 +78,8 @@ func fundAccounts(
 		},
 		Outputs: outputs,
 	}
-	_, err := m.Client.BroadcastTx(m.Ctx, sender.aa.acc, sendMsg)
+	ctx := context.Background()
+	_, err := m.Client.BroadcastTx(ctx, sender.aa.acc, sendMsg)
 	if err != nil {
 		m.T.Log("Error worker address: ", err)
 		return err

--- a/test/stress/getters_helpers_test.go
+++ b/test/stress/getters_helpers_test.go
@@ -135,9 +135,10 @@ func getNonZeroTopicEpochLastRan(
 ) (*types.Topic, error) {
 	sleepingTimeBlocks := defaultEpochLength
 	// Retry loop for a maximum of 5 times
+	ctx := context.Background()
 	for retries := 0; retries < maxRetries; retries++ {
 		topicResponse, err := m.Client.QueryEmissions().GetTopic(
-			m.Ctx,
+			ctx,
 			&types.QueryTopicRequest{TopicId: topicId},
 		)
 		if err == nil {

--- a/test/stress/params_test.go
+++ b/test/stress/params_test.go
@@ -1,6 +1,8 @@
 package stress_test
 
 import (
+	"context"
+
 	testCommon "github.com/allora-network/allora-chain/test/common"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	minttypes "github.com/allora-network/allora-chain/x/mint/types"
@@ -9,9 +11,10 @@ import (
 
 // get the emissions params from outside the chain
 func GetEmissionsParams(m testCommon.TestConfig) emissionstypes.Params {
+	ctx := context.Background()
 	paramsReq := &emissionstypes.QueryParamsRequest{}
 	p, err := m.Client.QueryEmissions().Params(
-		m.Ctx,
+		ctx,
 		paramsReq,
 	)
 	require.NoError(m.T, err)
@@ -21,9 +24,10 @@ func GetEmissionsParams(m testCommon.TestConfig) emissionstypes.Params {
 
 // get the mint params from outside the chain
 func GetMintParams(m testCommon.TestConfig) minttypes.Params {
+	ctx := context.Background()
 	paramsReq := &minttypes.QueryParamsRequest{}
 	p, err := m.Client.QueryMint().Params(
-		m.Ctx,
+		ctx,
 		paramsReq,
 	)
 	require.NoError(m.T, err)

--- a/test/stress/registration_test.go
+++ b/test/stress/registration_test.go
@@ -1,6 +1,7 @@
 package stress_test
 
 import (
+	"context"
 	"math/rand"
 	"strconv"
 
@@ -14,6 +15,7 @@ func RegisterReputerForTopic(
 	reputer NameAccountAndAddress,
 	topicId uint64,
 ) error {
+	ctx := context.Background()
 
 	registerReputerRequest := &emissionstypes.MsgRegister{
 		Sender:       reputer.aa.addr,
@@ -23,11 +25,11 @@ func RegisterReputerForTopic(
 		TopicId:      topicId,
 		IsReputer:    true,
 	}
-	txResp, err := m.Client.BroadcastTx(m.Ctx, reputer.aa.acc, registerReputerRequest)
+	txResp, err := m.Client.BroadcastTx(ctx, reputer.aa.acc, registerReputerRequest)
 	if err != nil {
 		return err
 	}
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	if err != nil {
 		return err
 	}
@@ -46,6 +48,7 @@ func RegisterWorkerForTopic(
 	worker NameAccountAndAddress,
 	topicId uint64,
 ) error {
+	ctx := context.Background()
 	registerWorkerRequest := &emissionstypes.MsgRegister{
 		Sender:       worker.aa.addr,
 		Owner:        worker.aa.addr,
@@ -54,11 +57,11 @@ func RegisterWorkerForTopic(
 		TopicId:      topicId,
 		IsReputer:    false,
 	}
-	txResp, err := m.Client.BroadcastTx(m.Ctx, worker.aa.acc, registerWorkerRequest)
+	txResp, err := m.Client.BroadcastTx(ctx, worker.aa.acc, registerWorkerRequest)
 	if err != nil {
 		return err
 	}
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	if err != nil {
 		return err
 	}

--- a/test/stress/staking_test.go
+++ b/test/stress/staking_test.go
@@ -1,6 +1,8 @@
 package stress_test
 
 import (
+	"context"
+
 	cosmosMath "cosmossdk.io/math"
 	testCommon "github.com/allora-network/allora-chain/test/common"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
@@ -18,11 +20,12 @@ func stakeReputer(
 		TopicId: topicId,
 		Amount:  cosmosMath.NewIntFromUint64(stakeToAdd),
 	}
-	txResp, err := m.Client.BroadcastTx(m.Ctx, reputer.aa.acc, addStake)
+	ctx := context.Background()
+	txResp, err := m.Client.BroadcastTx(ctx, reputer.aa.acc, addStake)
 	if err != nil {
 		return err
 	}
-	_, err = m.Client.WaitForTx(m.Ctx, txResp.TxHash)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Remove global shared context from TestConfig struct

Every place in the test suite where `m.Ctx` was called, instead just call context.Background and create a new separate context object.

Not actually sure this works, just a test PR to test the idea