### PR TITLE
EpochLength changes + Using last commit at request time

### DIFF
--- a/app/topics_handler.go
+++ b/app/topics_handler.go
@@ -101,7 +101,6 @@ func (th *TopicsHandler) requestTopicReputers(ctx sdk.Context, topic emissionsty
 	lastCommit, err := th.emissionsKeeper.GetTopicLastCommit(ctx, topic.Id, emissionstypes.ActorType_REPUTER)
 	if err != nil {
 		Logger(ctx).Warn("Error getting reputer last commit: "+err.Error(), ", first reputer commit?")
-		lastCommit = nil
 	}
 	// iterate over all the reputer nonces to find if this is unfulfilled
 	for _, nonce := range topNReputerNonces {

--- a/x/emissions/keeper/inference_synthesis/nonce_mgmt.go
+++ b/x/emissions/keeper/inference_synthesis/nonce_mgmt.go
@@ -25,7 +25,7 @@ func SortByBlockHeight(r []*emissions.ReputerRequestNonce) {
 }
 
 // Select the top N latest reputer nonces
-func SelectTopNReputerNonces(reputerRequestNonces *emissions.ReputerRequestNonces, N int, currentBlockHeight int64, groundTruthLag int64) []*emissions.ReputerRequestNonce {
+func SelectTopNReputerNonces(reputerRequestNonces *emissions.ReputerRequestNonces, N int, currentBlockHeight, groundTruthLag, epochLength int64) []*emissions.ReputerRequestNonce {
 	topN := make([]*emissions.ReputerRequestNonce, 0)
 	// sort reputerRequestNonces by reputer block height
 
@@ -37,7 +37,8 @@ func SelectTopNReputerNonces(reputerRequestNonces *emissions.ReputerRequestNonce
 	// loop reputerRequestNonces
 	for _, nonce := range sortedSlice {
 		nonceCopy := nonce
-		if currentBlockHeight >= nonceCopy.ReputerNonce.BlockHeight+groundTruthLag {
+		// Only select when the ground truth is available.
+		if currentBlockHeight >= nonceCopy.ReputerNonce.BlockHeight+groundTruthLag+epochLength {
 			topN = append(topN, nonceCopy)
 		}
 		if len(topN) >= N {

--- a/x/emissions/keeper/inference_synthesis/nonce_mgmt_test.go
+++ b/x/emissions/keeper/inference_synthesis/nonce_mgmt_test.go
@@ -192,6 +192,7 @@ func TestSelectTopNReputerNonces(t *testing.T) {
 		expectedTopNReputerNonce []*emissionstypes.ReputerRequestNonce
 		currentBlockHeight       int64
 		groundTruthLag           int64
+		epochLength              int64
 	}{
 		{
 			name: "N greater than length of nonces, zero lag",
@@ -208,6 +209,7 @@ func TestSelectTopNReputerNonces(t *testing.T) {
 			},
 			currentBlockHeight: 10,
 			groundTruthLag:     0,
+			epochLength:        1,
 		},
 		{
 			name: "N less than length of nonces, zero lag",
@@ -225,6 +227,7 @@ func TestSelectTopNReputerNonces(t *testing.T) {
 			},
 			currentBlockHeight: 10,
 			groundTruthLag:     0,
+			epochLength:        1,
 		},
 		{
 			name: "Ground truth lag cutting selection midway",
@@ -241,7 +244,8 @@ func TestSelectTopNReputerNonces(t *testing.T) {
 				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 2}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 1}},
 			},
 			currentBlockHeight: 10,
-			groundTruthLag:     6,
+			groundTruthLag:     5,
+			epochLength:        1,
 		},
 		{
 			name: "Big Ground truth lag, not selecting any nonces",
@@ -256,6 +260,7 @@ func TestSelectTopNReputerNonces(t *testing.T) {
 			expectedTopNReputerNonce: []*emissionstypes.ReputerRequestNonce{},
 			currentBlockHeight:       10,
 			groundTruthLag:           10,
+			epochLength:              1,
 		},
 		{
 			name: "Small ground truth lag, selecting all nonces",
@@ -274,6 +279,7 @@ func TestSelectTopNReputerNonces(t *testing.T) {
 			},
 			currentBlockHeight: 10,
 			groundTruthLag:     2,
+			epochLength:        1,
 		},
 		{
 			name: "Mid ground truth lag, selecting some nonces",
@@ -290,14 +296,15 @@ func TestSelectTopNReputerNonces(t *testing.T) {
 				{ReputerNonce: &emissionstypes.Nonce{BlockHeight: 4}, WorkerNonce: &emissionstypes.Nonce{BlockHeight: 3}},
 			},
 			currentBlockHeight: 10,
-			groundTruthLag:     5,
+			groundTruthLag:     3,
+			epochLength:        2,
 		},
 	}
 
 	// Run test cases
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := inference_synthesis.SelectTopNReputerNonces(tc.reputerRequestNonces, tc.N, tc.currentBlockHeight, tc.groundTruthLag)
+			actual := inference_synthesis.SelectTopNReputerNonces(tc.reputerRequestNonces, tc.N, tc.currentBlockHeight, tc.groundTruthLag, tc.epochLength)
 			require.Equal(t, tc.expectedTopNReputerNonce, actual, "Reputer nonces do not match")
 		})
 	}

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -65,7 +65,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 					sdkCtx.Logger().Warn(fmt.Sprintf("Error updating last inference ran: %s", err.Error()))
 				}
 				// Add Worker Nonces
-				nextNonce := types.Nonce{BlockHeight: blockHeight + topic.EpochLength}
+				nextNonce := types.Nonce{BlockHeight: blockHeight}
 				err = am.keeper.AddWorkerNonce(sdkCtx, topic.Id, &nextNonce)
 				if err != nil {
 					sdkCtx.Logger().Warn(fmt.Sprintf("Error adding worker nonce: %s", err.Error()))
@@ -91,11 +91,11 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 					sdkCtx.Logger().Warn(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, blockHeight))
 					am.keeper.PruneReputerNonces(sdkCtx, topic.Id, reputerPruningBlock)
 
+					// Reputer nonces need to check worker nonces from one epoch before
 					workerPruningBlock := reputerPruningBlock - topic.EpochLength
 					if workerPruningBlock > 0 {
 						sdkCtx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
 						// Prune old worker nonces previous to current blockHeight to avoid inserting inferences after its time has passed
-						// Reputer nonces need to check worker nonces one epoch before the reputer nonces
 						am.keeper.PruneWorkerNonces(sdkCtx, topic.Id, workerPruningBlock)
 					}
 				}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

* Defines worker nonce as blockHeight, instead of blockheight + epochLength. Meaning is changed from "the block for when the inference should be made" to "the block when the request is made".
* In places where this is used, adjust adding epochLength where appropriate

* Use last reputer commit nonce as previousLosses value where applicable. Keep previous value (`reputerNonce - epochLength`) on first commit and as default if no losses are found.

## Testing and Verifying

*(Please pick one of the following options)*

This change added tests and can be verified as follows:

*(example:)*
  - *Modifies the topNonces tests that are failing due to the changes*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?


Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Allora documentation site `docs.allora.network` source code at: `https://github.com/allora-network/docs` 
  - [ ] Code comments?
  - [ X ] N/A

Will be documented as part of a larger change on nonces management.
