### PR TITLE
Adjustments on WorkerNonces - Use ReputerNonce

### DIFF
--- a/app/topics_handler.go
+++ b/app/topics_handler.go
@@ -112,7 +112,7 @@ func (th *TopicsHandler) requestTopicReputers(ctx sdk.Context, topic emissionsty
 			lastReputerCommitBlockHeight = lastCommit.Nonce.BlockHeight
 		}
 
-		Logger(ctx).Warn(fmt.Sprintf("Reputer block height found unfulfilled, requesting reputers for block: %v, worker: %v", nonceCopy.ReputerNonce.BlockHeight, nonceCopy.WorkerNonce.BlockHeight))
+		Logger(ctx).Warn(fmt.Sprintf("Reputer block height found unfulfilled, requesting reputers for block: %v", nonceCopy.ReputerNonce.BlockHeight))
 		reputerValueBundle, _, _, _, err := synth.GetNetworkInferencesAtBlock(
 			ctx,
 			th.emissionsKeeper,

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -404,10 +404,6 @@ func (k *Keeper) AddReputerNonce(ctx context.Context, topicId TopicId, nonce *ty
 		if n.ReputerNonce.BlockHeight == nonce.BlockHeight {
 			return nil
 		}
-		// Do nothing if the associated worker nonce is already in the list
-		if n.WorkerNonce.BlockHeight == associatedWorkerNonce.BlockHeight {
-			return nil
-		}
 	}
 	reputerRequestNonce := &types.ReputerRequestNonce{
 		ReputerNonce: nonce,

--- a/x/emissions/keeper/msgserver/msg_server_losses.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses.go
@@ -40,7 +40,7 @@ func (ms msgServer) InsertBulkReputerPayload(
 	/// All filters should be done in order of increasing computational complexity
 
 	// Check if the worker nonce is unfulfilled
-	workerNonceUnfulfilled, err := ms.k.IsWorkerNonceUnfulfilled(ctx, msg.TopicId, msg.ReputerRequestNonce.WorkerNonce)
+	workerNonceUnfulfilled, err := ms.k.IsWorkerNonceUnfulfilled(ctx, msg.TopicId, msg.ReputerRequestNonce.ReputerNonce)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +48,7 @@ func (ms msgServer) InsertBulkReputerPayload(
 	if workerNonceUnfulfilled {
 		return nil, errorsmod.Wrapf(
 			types.ErrNonceStillUnfulfilled,
-			"Reputer's worker nonce not yet fulfilled: %v  for reputer block: %v",
-			msg.ReputerRequestNonce.WorkerNonce.BlockHeight,
+			"Reputer's worker nonce not yet fulfilled for reputer block: %v",
 			msg.ReputerRequestNonce.ReputerNonce.BlockHeight,
 		)
 	}
@@ -90,9 +89,6 @@ func (ms msgServer) InsertBulkReputerPayload(
 			continue
 		}
 		// Check that the reputer's value bundle is for a nonce matching the leader's given nonce
-		if bundle.ValueBundle.ReputerRequestNonce.WorkerNonce.BlockHeight != msg.ReputerRequestNonce.WorkerNonce.BlockHeight {
-			continue
-		}
 		if bundle.ValueBundle.ReputerRequestNonce.ReputerNonce.BlockHeight != msg.ReputerRequestNonce.ReputerNonce.BlockHeight {
 			continue
 		}
@@ -232,7 +228,7 @@ func filterUnacceptedWorkersFromReputerValueBundle(
 	reputerValueBundle *types.ReputerValueBundle,
 ) (*types.ReputerValueBundle, error) {
 	// Get the accepted inferers of the associated worker response payload
-	inferences, err := ms.k.GetInferencesAtBlock(ctx, topicId, reputerRequestNonce.WorkerNonce.BlockHeight)
+	inferences, err := ms.k.GetInferencesAtBlock(ctx, topicId, reputerRequestNonce.ReputerNonce.BlockHeight)
 	if err != nil {
 		if errors.Is(err, collections.ErrNotFound) {
 			return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "no inferences found at block height")
@@ -246,7 +242,7 @@ func filterUnacceptedWorkersFromReputerValueBundle(
 	}
 
 	// Get the accepted forecasters of the associated worker response payload
-	forecasts, err := ms.k.GetForecastsAtBlock(ctx, topicId, reputerRequestNonce.WorkerNonce.BlockHeight)
+	forecasts, err := ms.k.GetForecastsAtBlock(ctx, topicId, reputerRequestNonce.ReputerNonce.BlockHeight)
 	if err != nil {
 		// If no forecasts, we'll just assume there are 0 forecasters
 		if errors.Is(err, collections.ErrNotFound) {

--- a/x/emissions/keeper/msgserver/msg_server_losses_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_losses_test.go
@@ -45,7 +45,7 @@ func (s *MsgServerTestSuite) getBasicReputerPayload(
 	s.Require().NoError(err)
 
 	reputerNonce = types.Nonce{
-		BlockHeight: block + 1,
+		BlockHeight: block,
 	}
 	workerNonce = types.Nonce{
 		BlockHeight: block,
@@ -205,45 +205,6 @@ func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithMismatchedTopicIdsIs
 	// END MODIFICATION
 
 	err := keeper.InsertForecasts(ctx, topicId, types.Nonce{BlockHeight: int64(block)}, expectedForecasts)
-	require.NoError(err)
-
-	err = keeper.InsertInferences(ctx, topicId, types.Nonce{BlockHeight: block}, expectedInferences)
-	require.NoError(err)
-
-	err = s.constructAndInsertReputerPayload(
-		reputerAddr,
-		reputerPrivateKey,
-		reputerPublicKeyBytes,
-		&reputerValueBundle,
-		topicId,
-		&reputerNonce,
-		&workerNonce,
-	)
-
-	require.ErrorIs(err, types.ErrNoValidBundles)
-}
-
-func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithMismatchedWorkerNonceIsIgnored() {
-	ctx := s.ctx
-	require := s.Require()
-	keeper := s.emissionsKeeper
-
-	block := types.BlockHeight(1)
-
-	reputerPrivateKey := secp256k1.GenPrivKey()
-	reputerPublicKeyBytes := reputerPrivateKey.PubKey().Bytes()
-	reputerAddr := sdk.AccAddress(reputerPrivateKey.PubKey().Address())
-
-	workerPrivateKey := secp256k1.GenPrivKey()
-	workerAddr := sdk.AccAddress(workerPrivateKey.PubKey().Address())
-
-	reputerValueBundle, expectedInferences, expectedForecasts, topicId, reputerNonce, workerNonce := s.getBasicReputerPayload(reputerAddr, workerAddr, block)
-
-	// BEGIN MODIFICATION
-	reputerValueBundle.ReputerRequestNonce.WorkerNonce.BlockHeight = 123
-	// END MODIFICATION
-
-	err := keeper.InsertForecasts(ctx, topicId, types.Nonce{BlockHeight: block}, expectedForecasts)
 	require.NoError(err)
 
 	err = keeper.InsertInferences(ctx, topicId, types.Nonce{BlockHeight: block}, expectedInferences)
@@ -461,7 +422,7 @@ func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithIncorrectBaseWorkerN
 	reputerValueBundle, expectedInferences, expectedForecasts, topicId, reputerNonce, workerNonce := s.getBasicReputerPayload(reputerAddr, workerAddr, block)
 
 	// BEGIN MODIFICATION
-	workerNonce.BlockHeight = block + 1
+	reputerNonce.BlockHeight = block + 1
 	// END MODIFICATION
 
 	err := keeper.InsertForecasts(ctx, topicId, types.Nonce{BlockHeight: int64(block)}, expectedForecasts)
@@ -480,7 +441,7 @@ func (s *MsgServerTestSuite) TestInsertingReputerPayloadWithIncorrectBaseWorkerN
 		&workerNonce,
 	)
 
-	require.ErrorIs(err, types.ErrNoValidBundles)
+	require.ErrorIs(err, types.ErrNonceAlreadyFulfilled)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertBulkReputerPayloadInvalid() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Uses ReputerRequestNonce.ReputerNonce instead of ReputerRequestNonce.WorkerNonce.

## Testing and Verifying

This change modifies tests. Some are removed because they no longer make sense or fail differently.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?


Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Allora documentation site `docs.allora.network` source code at: `https://github.com/allora-network/docs`
  - [ ] Code comments?
  - [ X] N/A

Documented rework needed on Nonces on Allora documentaiton site. Part of its parent ticket.