### PR TITLE
Remove `go func` parallelization in ABCI EndBlocker

### DIFF
--- a/test/invariant/invariants.patch
+++ b/test/invariant/invariants.patch
@@ -1,16 +1,17 @@
 diff --git a/x/emissions/module/abci.go b/x/emissions/module/abci.go
-index 1ca10a02..7a755bac 100644
+index 8d778144..523ac83f 100644
 --- a/x/emissions/module/abci.go
 +++ b/x/emissions/module/abci.go
-@@ -6,6 +6,7 @@ import (
- 	"sync"
+@@ -4,6 +4,8 @@ import (
+ 	"context"
+ 	"fmt"
  
- 	"cosmossdk.io/errors"
 +	emissionskeeper "github.com/allora-network/allora-chain/x/emissions/keeper"
++
+ 	"cosmossdk.io/errors"
  	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
- 	"github.com/allora-network/allora-chain/x/emissions/types"
  	sdk "github.com/cosmos/cosmos-sdk/types"
-@@ -13,6 +14,10 @@ import (
+@@ -11,6 +13,10 @@ import (
  
  func EndBlocker(ctx context.Context, am AppModule) error {
  	sdkCtx := sdk.UnwrapSDKContext(ctx)

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -3,11 +3,9 @@ package module
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"cosmossdk.io/errors"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
-	"github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -43,79 +41,17 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		return errors.Wrapf(err, "Resetting churn ready topics error")
 	}
 
-	// NONCE MGMT with Churnable weights
-	var wg sync.WaitGroup
-	// Loop over and run epochs on topics whose inferences are demanded enough to be served
-	fn := func(sdkCtx sdk.Context, topic *types.Topic) error {
-		// Parallelize nonce management and update of topic to be in a churn ready state
-		wg.Add(1)
-		go func(topic types.Topic) {
-			defer wg.Done()
-			// Check the cadence of inferences, and just in case also check multiples of epoch lengths
-			// to avoid potential situations where the block is missed
-			if am.keeper.CheckCadence(blockHeight, topic) {
-				sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Inference cadence met for topic: %v metadata: %s default arg: %s. \n",
-					topic.Id,
-					topic.Metadata,
-					topic.DefaultArg))
-
-				// Update the last inference ran
-				err = am.keeper.UpdateTopicEpochLastEnded(sdkCtx, topic.Id, blockHeight)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error updating last inference ran: %s", err.Error()))
-				}
-				// Add Worker Nonces
-				nextNonce := types.Nonce{BlockHeight: blockHeight}
-				err = am.keeper.AddWorkerNonce(sdkCtx, topic.Id, &nextNonce)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error adding worker nonce: %s", err.Error()))
-					return
-				}
-				sdkCtx.Logger().Debug(fmt.Sprintf("Added worker nonce for topic %d: %v \n", topic.Id, nextNonce.BlockHeight))
-				// To notify topic handler that the topic is ready for churn i.e. requests to be sent to workers and reputers
-				err = am.keeper.AddChurnableTopic(ctx, topic.Id)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error setting churn ready topic: %s", err.Error()))
-					return
-				}
-
-				MaxUnfulfilledReputerRequests := types.DefaultParams().MaxUnfulfilledReputerRequests
-				moduleParams, err := am.keeper.GetParams(ctx)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error getting max retries to fulfil nonces for worker requests (using default), err: %s", err.Error()))
-				} else {
-					MaxUnfulfilledReputerRequests = moduleParams.MaxUnfulfilledReputerRequests
-				}
-				// Adding one to cover for one extra epochLength
-				reputerPruningBlock := blockHeight - (int64(MaxUnfulfilledReputerRequests+1)*topic.EpochLength + topic.GroundTruthLag)
-				if reputerPruningBlock > 0 {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, blockHeight))
-					am.keeper.PruneReputerNonces(sdkCtx, topic.Id, reputerPruningBlock)
-
-					// Reputer nonces need to check worker nonces from one epoch before
-					workerPruningBlock := reputerPruningBlock - topic.EpochLength
-					if workerPruningBlock > 0 {
-						sdkCtx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
-						// Prune old worker nonces previous to current blockHeight to avoid inserting inferences after its time has passed
-						am.keeper.PruneWorkerNonces(sdkCtx, topic.Id, workerPruningBlock)
-					}
-				}
-			}
-		}(*topic)
-		return nil
-	}
-	err = rewards.IdentifyChurnableAmongActiveTopicsAndApplyFn(
+	// identify which topics are churnable from the list of active topics
+	err = rewards.PickChurnableActiveTopics(
 		sdkCtx,
 		am.keeper,
 		blockHeight,
-		fn,
 		weights,
 	)
 	if err != nil {
 		sdkCtx.Logger().Error("Error applying function on all rewardable topics: ", err)
 		return err
 	}
-	wg.Wait()
 
 	return nil
 }

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -98,11 +98,10 @@ func SafeApplyFuncOnAllActiveEpochEndingTopics(
 // "Churn-ready topic" is active, has an epoch that ended, and is in top N by weights, has non-zero weight.
 // We iterate through active topics, fetch their weight, skim the top N by weight (these are the churnable topics)
 // then finally apply a function on each of these churnable topics.
-func IdentifyChurnableAmongActiveTopicsAndApplyFn(
+func PickChurnableActiveTopics(
 	ctx sdk.Context,
 	k keeper.Keeper,
 	block BlockHeight,
-	fn func(ctx sdk.Context, topic *types.Topic) error,
 	weights map[TopicId]*alloraMath.Dec,
 ) error {
 	moduleParams, err := k.GetParams(ctx)
@@ -128,8 +127,57 @@ func IdentifyChurnableAmongActiveTopicsAndApplyFn(
 			Logger(ctx).Debug("Error getting topic: ", err)
 			continue
 		}
-		// Execute the function
-		err = fn(ctx, &topic)
+		// Loop over and run epochs on topics whose inferences are demanded enough to be served
+		// Check the cadence of inferences, and just in case also check multiples of epoch lengths
+		// to avoid potential situations where the block is missed
+		if k.CheckCadence(block, topic) {
+			ctx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Inference cadence met for topic: %v metadata: %s default arg: %s. \n",
+				topic.Id,
+				topic.Metadata,
+				topic.DefaultArg))
+
+			// Update the last inference ran
+			err = k.UpdateTopicEpochLastEnded(ctx, topic.Id, block)
+			if err != nil {
+				ctx.Logger().Warn(fmt.Sprintf("Error updating last inference ran: %s", err.Error()))
+			}
+			// Add Worker Nonces
+			nextNonce := types.Nonce{BlockHeight: block}
+			err = k.AddWorkerNonce(ctx, topic.Id, &nextNonce)
+			if err != nil {
+				ctx.Logger().Warn(fmt.Sprintf("Error adding worker nonce: %s", err.Error()))
+				continue
+			}
+			ctx.Logger().Debug(fmt.Sprintf("Added worker nonce for topic %d: %v \n", topic.Id, nextNonce.BlockHeight))
+			// To notify topic handler that the topic is ready for churn i.e. requests to be sent to workers and reputers
+			err = k.AddChurnableTopic(ctx, topic.Id)
+			if err != nil {
+				ctx.Logger().Warn(fmt.Sprintf("Error setting churn ready topic: %s", err.Error()))
+				continue
+			}
+
+			MaxUnfulfilledReputerRequests := types.DefaultParams().MaxUnfulfilledReputerRequests
+			moduleParams, err := k.GetParams(ctx)
+			if err != nil {
+				ctx.Logger().Warn(fmt.Sprintf("Error getting max retries to fulfil nonces for worker requests (using default), err: %s", err.Error()))
+			} else {
+				MaxUnfulfilledReputerRequests = moduleParams.MaxUnfulfilledReputerRequests
+			}
+			// Adding one to cover for one extra epochLength
+			reputerPruningBlock := block - (int64(MaxUnfulfilledReputerRequests+1)*topic.EpochLength + topic.GroundTruthLag)
+			if reputerPruningBlock > 0 {
+				ctx.Logger().Warn(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, block))
+				k.PruneReputerNonces(ctx, topic.Id, reputerPruningBlock)
+
+				// Reputer nonces need to check worker nonces from one epoch before
+				workerPruningBlock := reputerPruningBlock - topic.EpochLength
+				if workerPruningBlock > 0 {
+					ctx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
+					// Prune old worker nonces previous to current blockHeight to avoid inserting inferences after its time has passed
+					k.PruneWorkerNonces(ctx, topic.Id, workerPruningBlock)
+				}
+			}
+		}
 		if err != nil {
 			Logger(ctx).Debug("Error applying function on topic: ", err)
 			continue


### PR DESCRIPTION
## What is the purpose of the change

This change simplifies a hard-to-read and hard-to-reason about piece of code that parallelized the picking of churn ready topics from the active set. After this PR the code is easier to read and understand, and has less likelihood of causing non-determinism issues. The tradeoff is that the code may run slightly slower in serial.

## Testing and Verifying

This change is not trivial, however it is a small diff / refactor PR and our existing test cases should be able to cover the change.

## Documentation and Release Note

This PR does not have any implications for documentation.