### PR TITLE
Prevent calling RemoveStake/RemoveDelegateStake with negative amount

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server_stake.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake.go
@@ -62,6 +62,9 @@ func (ms msgServer) RemoveStake(ctx context.Context, msg *types.MsgRemoveStake) 
 	if msg.Amount.IsZero() {
 		return nil, types.ErrReceivedZeroAmount
 	}
+	if msg.Amount.IsNegative() {
+		return nil, types.ErrInvalidValue
+	}
 
 	// Check the sender has enough stake already placed on the topic to remove the stake
 	stakePlaced, err := ms.k.GetStakeReputerAuthority(ctx, msg.TopicId, msg.Sender)
@@ -174,6 +177,9 @@ func (ms msgServer) DelegateStake(ctx context.Context, msg *types.MsgDelegateSta
 func (ms msgServer) RemoveDelegateStake(ctx context.Context, msg *types.MsgRemoveDelegateStake) (*types.MsgRemoveDelegateStakeResponse, error) {
 	if msg.Amount.IsZero() {
 		return nil, types.ErrReceivedZeroAmount
+	}
+	if msg.Amount.IsNegative() {
+		return nil, types.ErrInvalidValue
 	}
 
 	// Check the delegator has enough stake already placed on the topic to remove the stake

--- a/x/emissions/keeper/msgserver/msg_server_stake.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	errorsmod "cosmossdk.io/errors"
+	cosmosMath "cosmossdk.io/math"
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
@@ -59,10 +60,7 @@ func (ms msgServer) AddStake(ctx context.Context, msg *types.MsgAddStake) (*type
 // once the withdrawal delay has passed then the ABCI endBlocker will automatically pay out the stake removal
 // if this function is called twice, it will overwrite the previous stake removal and the delay will reset.
 func (ms msgServer) RemoveStake(ctx context.Context, msg *types.MsgRemoveStake) (*types.MsgRemoveStakeResponse, error) {
-	if msg.Amount.IsZero() {
-		return nil, types.ErrReceivedZeroAmount
-	}
-	if msg.Amount.IsNegative() {
+	if msg.Amount.LTE(cosmosMath.ZeroInt()) {
 		return nil, types.ErrInvalidValue
 	}
 
@@ -175,10 +173,7 @@ func (ms msgServer) DelegateStake(ctx context.Context, msg *types.MsgDelegateSta
 // once the withdrawal delay has passed then the ABCI endBlocker will automatically pay out the stake removal
 // if this function is called twice, it will overwrite the previous stake removal and the delay will reset.
 func (ms msgServer) RemoveDelegateStake(ctx context.Context, msg *types.MsgRemoveDelegateStake) (*types.MsgRemoveDelegateStakeResponse, error) {
-	if msg.Amount.IsZero() {
-		return nil, types.ErrReceivedZeroAmount
-	}
-	if msg.Amount.IsNegative() {
+	if msg.Amount.LTE(cosmosMath.ZeroInt()) {
 		return nil, types.ErrInvalidValue
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a critical-severity issue that would allow any random person on the internet to denial of service the Allora chain, by sending a negative Coin amount to the RemoveDelegateStake function. The fix merely checks that the value is positive, thereby preventing an eventual panic and halt of the chain.

## Testing and Verifying

This change added tests that check that you cannot try to RemoveStake of negative amounts of coins.

## Documentation and Release Note

This PR has no implications on documentation.