### PR TITLE
Prevent potential race condition by making parallelized pass-by-copy rather than reference

### DIFF
--- a/app/topics_handler.go
+++ b/app/topics_handler.go
@@ -167,6 +167,7 @@ func (th *TopicsHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 		// Within each loop, execute the inference and weight cadence checks and trigger the inference and weight generation
 		for _, churnableTopicId := range churnableTopics {
 			wg.Add(1)
+			localTopicId := churnableTopicId
 			go func(topicId TopicId) {
 				defer wg.Done()
 				topic, err := th.emissionsKeeper.GetTopic(ctx, topicId)
@@ -176,7 +177,7 @@ func (th *TopicsHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 				}
 				th.requestTopicWorkers(ctx, topic)
 				th.requestTopicReputers(ctx, topic)
-			}(churnableTopicId)
+			}(localTopicId)
 		}
 		wg.Wait()
 		// Return the transactions as they came

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -49,6 +49,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 	fn := func(sdkCtx sdk.Context, topic *types.Topic) error {
 		// Parallelize nonce management and update of topic to be in a churn ready state
 		wg.Add(1)
+		localTopic := *topic
 		go func(topic types.Topic) {
 			defer wg.Done()
 			// Check the cadence of inferences, and just in case also check multiples of epoch lengths
@@ -101,7 +102,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 					}
 				}
 			}
-		}(*topic)
+		}(localTopic)
 		return nil
 	}
 	err = rewards.IdentifyChurnableAmongActiveTopicsAndApplyFn(


### PR DESCRIPTION
## What is the purpose of the change

This PR closes a subtle race condition bug that could potentially happen anywhere that for-loops are spawned with `go func` - the for loop operates on a reference which changes faster than the function call can potentially happen, causing a function to use the wrong parameter when referenced.

The solution is very simple, make a local copy of the variable and pass the resulting function by copy, rather than by reference - then there's no way the for loop can accidentally reference the wrong data. 

## Testing and Verifying

This change is hard to test, so we're not going to write a unit test to simulate it explicitly. The performance implicaitons of doing a pass-by-copy are trivial, therefore there is no reason to not do the safer thing. Our existing test suite should test that the change does not have correctness implications.

## Documentation and Release Note

This PR has no implications for documentation.