### PR TITLE
Add Genesis Import / Init / Export of full emissions module state

### DIFF
--- a/x/emissions/api/v1/genesis.pulsar.go
+++ b/x/emissions/api/v1/genesis.pulsar.go
@@ -3,6 +3,7 @@ package emissionsv1
 
 import (
 	fmt "fmt"
+	_ "github.com/cosmos/cosmos-proto"
 	runtime "github.com/cosmos/cosmos-proto/runtime"
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino"
 	_ "github.com/cosmos/gogoproto/gogoproto"
@@ -13,6 +14,2184 @@ import (
 	reflect "reflect"
 	sync "sync"
 )
+
+var _ protoreflect.List = (*_GenesisState_4_list)(nil)
+
+type _GenesisState_4_list struct {
+	list *[]*TopicIdAndTopic
+}
+
+func (x *_GenesisState_4_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_4_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_4_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndTopic)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_4_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndTopic)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_4_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdAndTopic)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_4_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_4_list) NewElement() protoreflect.Value {
+	v := new(TopicIdAndTopic)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_4_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_5_list)(nil)
+
+type _GenesisState_5_list struct {
+	list *[]uint64
+}
+
+func (x *_GenesisState_5_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_5_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfUint64((*x.list)[i])
+}
+
+func (x *_GenesisState_5_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Uint()
+	concreteValue := valueUnwrapped
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_5_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Uint()
+	concreteValue := valueUnwrapped
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_5_list) AppendMutable() protoreflect.Value {
+	panic(fmt.Errorf("AppendMutable can not be called on message GenesisState at list field ActiveTopics as it is not of Message kind"))
+}
+
+func (x *_GenesisState_5_list) Truncate(n int) {
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_5_list) NewElement() protoreflect.Value {
+	v := uint64(0)
+	return protoreflect.ValueOfUint64(v)
+}
+
+func (x *_GenesisState_5_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_6_list)(nil)
+
+type _GenesisState_6_list struct {
+	list *[]uint64
+}
+
+func (x *_GenesisState_6_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_6_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfUint64((*x.list)[i])
+}
+
+func (x *_GenesisState_6_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Uint()
+	concreteValue := valueUnwrapped
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_6_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Uint()
+	concreteValue := valueUnwrapped
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_6_list) AppendMutable() protoreflect.Value {
+	panic(fmt.Errorf("AppendMutable can not be called on message GenesisState at list field ChurnableTopics as it is not of Message kind"))
+}
+
+func (x *_GenesisState_6_list) Truncate(n int) {
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_6_list) NewElement() protoreflect.Value {
+	v := uint64(0)
+	return protoreflect.ValueOfUint64(v)
+}
+
+func (x *_GenesisState_6_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_7_list)(nil)
+
+type _GenesisState_7_list struct {
+	list *[]uint64
+}
+
+func (x *_GenesisState_7_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_7_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfUint64((*x.list)[i])
+}
+
+func (x *_GenesisState_7_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Uint()
+	concreteValue := valueUnwrapped
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_7_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Uint()
+	concreteValue := valueUnwrapped
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_7_list) AppendMutable() protoreflect.Value {
+	panic(fmt.Errorf("AppendMutable can not be called on message GenesisState at list field RewardableTopics as it is not of Message kind"))
+}
+
+func (x *_GenesisState_7_list) Truncate(n int) {
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_7_list) NewElement() protoreflect.Value {
+	v := uint64(0)
+	return protoreflect.ValueOfUint64(v)
+}
+
+func (x *_GenesisState_7_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_8_list)(nil)
+
+type _GenesisState_8_list struct {
+	list *[]*TopicAndActorId
+}
+
+func (x *_GenesisState_8_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_8_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_8_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicAndActorId)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_8_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicAndActorId)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_8_list) AppendMutable() protoreflect.Value {
+	v := new(TopicAndActorId)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_8_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_8_list) NewElement() protoreflect.Value {
+	v := new(TopicAndActorId)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_8_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_9_list)(nil)
+
+type _GenesisState_9_list struct {
+	list *[]*TopicAndActorId
+}
+
+func (x *_GenesisState_9_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_9_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_9_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicAndActorId)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_9_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicAndActorId)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_9_list) AppendMutable() protoreflect.Value {
+	v := new(TopicAndActorId)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_9_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_9_list) NewElement() protoreflect.Value {
+	v := new(TopicAndActorId)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_9_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_10_list)(nil)
+
+type _GenesisState_10_list struct {
+	list *[]*TopicIdAndBlockHeight
+}
+
+func (x *_GenesisState_10_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_10_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_10_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndBlockHeight)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_10_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndBlockHeight)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_10_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdAndBlockHeight)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_10_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_10_list) NewElement() protoreflect.Value {
+	v := new(TopicIdAndBlockHeight)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_10_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_11_list)(nil)
+
+type _GenesisState_11_list struct {
+	list *[]*TopicIdBlockHeightScores
+}
+
+func (x *_GenesisState_11_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_11_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_11_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightScores)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_11_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightScores)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_11_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdBlockHeightScores)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_11_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_11_list) NewElement() protoreflect.Value {
+	v := new(TopicIdBlockHeightScores)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_11_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_12_list)(nil)
+
+type _GenesisState_12_list struct {
+	list *[]*TopicIdBlockHeightScores
+}
+
+func (x *_GenesisState_12_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_12_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_12_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightScores)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_12_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightScores)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_12_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdBlockHeightScores)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_12_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_12_list) NewElement() protoreflect.Value {
+	v := new(TopicIdBlockHeightScores)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_12_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_13_list)(nil)
+
+type _GenesisState_13_list struct {
+	list *[]*TopicIdBlockHeightScores
+}
+
+func (x *_GenesisState_13_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_13_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_13_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightScores)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_13_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightScores)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_13_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdBlockHeightScores)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_13_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_13_list) NewElement() protoreflect.Value {
+	v := new(TopicIdBlockHeightScores)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_13_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_14_list)(nil)
+
+type _GenesisState_14_list struct {
+	list *[]*TopicIdActorIdScore
+}
+
+func (x *_GenesisState_14_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_14_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_14_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdScore)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_14_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdScore)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_14_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdScore)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_14_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_14_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdScore)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_14_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_15_list)(nil)
+
+type _GenesisState_15_list struct {
+	list *[]*TopicIdActorIdScore
+}
+
+func (x *_GenesisState_15_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_15_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_15_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdScore)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_15_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdScore)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_15_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdScore)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_15_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_15_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdScore)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_15_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_16_list)(nil)
+
+type _GenesisState_16_list struct {
+	list *[]*TopicIdActorIdScore
+}
+
+func (x *_GenesisState_16_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_16_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_16_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdScore)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_16_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdScore)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_16_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdScore)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_16_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_16_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdScore)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_16_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_17_list)(nil)
+
+type _GenesisState_17_list struct {
+	list *[]*TopicIdActorIdListeningCoefficient
+}
+
+func (x *_GenesisState_17_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_17_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_17_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdListeningCoefficient)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_17_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdListeningCoefficient)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_17_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdListeningCoefficient)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_17_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_17_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdListeningCoefficient)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_17_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_18_list)(nil)
+
+type _GenesisState_18_list struct {
+	list *[]*TopicIdActorIdDec
+}
+
+func (x *_GenesisState_18_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_18_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_18_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdDec)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_18_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdDec)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_18_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdDec)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_18_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_18_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdDec)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_18_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_19_list)(nil)
+
+type _GenesisState_19_list struct {
+	list *[]*TopicIdActorIdDec
+}
+
+func (x *_GenesisState_19_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_19_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_19_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdDec)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_19_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdDec)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_19_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdDec)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_19_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_19_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdDec)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_19_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_20_list)(nil)
+
+type _GenesisState_20_list struct {
+	list *[]*TopicIdActorIdDec
+}
+
+func (x *_GenesisState_20_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_20_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_20_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdDec)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_20_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdDec)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_20_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdDec)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_20_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_20_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdDec)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_20_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_22_list)(nil)
+
+type _GenesisState_22_list struct {
+	list *[]*TopicIdAndInt
+}
+
+func (x *_GenesisState_22_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_22_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_22_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndInt)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_22_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndInt)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_22_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdAndInt)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_22_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_22_list) NewElement() protoreflect.Value {
+	v := new(TopicIdAndInt)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_22_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_23_list)(nil)
+
+type _GenesisState_23_list struct {
+	list *[]*TopicIdActorIdInt
+}
+
+func (x *_GenesisState_23_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_23_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_23_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdInt)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_23_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdInt)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_23_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdInt)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_23_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_23_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdInt)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_23_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_24_list)(nil)
+
+type _GenesisState_24_list struct {
+	list *[]*TopicIdActorIdInt
+}
+
+func (x *_GenesisState_24_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_24_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_24_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdInt)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_24_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdInt)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_24_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdInt)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_24_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_24_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdInt)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_24_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_25_list)(nil)
+
+type _GenesisState_25_list struct {
+	list *[]*TopicIdDelegatorReputerDelegatorInfo
+}
+
+func (x *_GenesisState_25_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_25_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_25_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdDelegatorReputerDelegatorInfo)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_25_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdDelegatorReputerDelegatorInfo)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_25_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdDelegatorReputerDelegatorInfo)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_25_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_25_list) NewElement() protoreflect.Value {
+	v := new(TopicIdDelegatorReputerDelegatorInfo)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_25_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_26_list)(nil)
+
+type _GenesisState_26_list struct {
+	list *[]*TopicIdActorIdInt
+}
+
+func (x *_GenesisState_26_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_26_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_26_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdInt)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_26_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdInt)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_26_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdInt)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_26_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_26_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdInt)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_26_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_27_list)(nil)
+
+type _GenesisState_27_list struct {
+	list *[]*TopicIdActorIdDec
+}
+
+func (x *_GenesisState_27_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_27_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_27_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdDec)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_27_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdDec)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_27_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdDec)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_27_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_27_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdDec)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_27_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_28_list)(nil)
+
+type _GenesisState_28_list struct {
+	list *[]*BlockHeightTopicIdReputerStakeRemovalInfo
+}
+
+func (x *_GenesisState_28_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_28_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_28_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*BlockHeightTopicIdReputerStakeRemovalInfo)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_28_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*BlockHeightTopicIdReputerStakeRemovalInfo)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_28_list) AppendMutable() protoreflect.Value {
+	v := new(BlockHeightTopicIdReputerStakeRemovalInfo)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_28_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_28_list) NewElement() protoreflect.Value {
+	v := new(BlockHeightTopicIdReputerStakeRemovalInfo)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_28_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_29_list)(nil)
+
+type _GenesisState_29_list struct {
+	list *[]*ActorIdTopicIdBlockHeight
+}
+
+func (x *_GenesisState_29_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_29_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_29_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*ActorIdTopicIdBlockHeight)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_29_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*ActorIdTopicIdBlockHeight)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_29_list) AppendMutable() protoreflect.Value {
+	v := new(ActorIdTopicIdBlockHeight)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_29_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_29_list) NewElement() protoreflect.Value {
+	v := new(ActorIdTopicIdBlockHeight)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_29_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_30_list)(nil)
+
+type _GenesisState_30_list struct {
+	list *[]*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo
+}
+
+func (x *_GenesisState_30_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_30_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_30_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_30_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_30_list) AppendMutable() protoreflect.Value {
+	v := new(BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_30_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_30_list) NewElement() protoreflect.Value {
+	v := new(BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_30_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_31_list)(nil)
+
+type _GenesisState_31_list struct {
+	list *[]*DelegatorReputerTopicIdBlockHeight
+}
+
+func (x *_GenesisState_31_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_31_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_31_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*DelegatorReputerTopicIdBlockHeight)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_31_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*DelegatorReputerTopicIdBlockHeight)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_31_list) AppendMutable() protoreflect.Value {
+	v := new(DelegatorReputerTopicIdBlockHeight)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_31_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_31_list) NewElement() protoreflect.Value {
+	v := new(DelegatorReputerTopicIdBlockHeight)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_31_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_32_list)(nil)
+
+type _GenesisState_32_list struct {
+	list *[]*TopicIdActorIdInference
+}
+
+func (x *_GenesisState_32_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_32_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_32_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdInference)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_32_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdInference)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_32_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdInference)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_32_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_32_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdInference)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_32_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_33_list)(nil)
+
+type _GenesisState_33_list struct {
+	list *[]*TopicIdActorIdForecast
+}
+
+func (x *_GenesisState_33_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_33_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_33_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdForecast)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_33_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdForecast)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_33_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdForecast)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_33_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_33_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdForecast)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_33_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_34_list)(nil)
+
+type _GenesisState_34_list struct {
+	list *[]*LibP2PKeyAndOffchainNode
+}
+
+func (x *_GenesisState_34_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_34_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_34_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*LibP2PKeyAndOffchainNode)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_34_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*LibP2PKeyAndOffchainNode)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_34_list) AppendMutable() protoreflect.Value {
+	v := new(LibP2PKeyAndOffchainNode)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_34_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_34_list) NewElement() protoreflect.Value {
+	v := new(LibP2PKeyAndOffchainNode)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_34_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_35_list)(nil)
+
+type _GenesisState_35_list struct {
+	list *[]*LibP2PKeyAndOffchainNode
+}
+
+func (x *_GenesisState_35_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_35_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_35_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*LibP2PKeyAndOffchainNode)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_35_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*LibP2PKeyAndOffchainNode)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_35_list) AppendMutable() protoreflect.Value {
+	v := new(LibP2PKeyAndOffchainNode)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_35_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_35_list) NewElement() protoreflect.Value {
+	v := new(LibP2PKeyAndOffchainNode)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_35_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_36_list)(nil)
+
+type _GenesisState_36_list struct {
+	list *[]*TopicIdAndInt
+}
+
+func (x *_GenesisState_36_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_36_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_36_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndInt)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_36_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndInt)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_36_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdAndInt)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_36_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_36_list) NewElement() protoreflect.Value {
+	v := new(TopicIdAndInt)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_36_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_37_list)(nil)
+
+type _GenesisState_37_list struct {
+	list *[]*TopicIdAndDec
+}
+
+func (x *_GenesisState_37_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_37_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_37_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndDec)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_37_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndDec)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_37_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdAndDec)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_37_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_37_list) NewElement() protoreflect.Value {
+	v := new(TopicIdAndDec)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_37_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_38_list)(nil)
+
+type _GenesisState_38_list struct {
+	list *[]*TopicIdBlockHeightInferences
+}
+
+func (x *_GenesisState_38_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_38_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_38_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightInferences)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_38_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightInferences)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_38_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdBlockHeightInferences)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_38_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_38_list) NewElement() protoreflect.Value {
+	v := new(TopicIdBlockHeightInferences)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_38_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_39_list)(nil)
+
+type _GenesisState_39_list struct {
+	list *[]*TopicIdBlockHeightForecasts
+}
+
+func (x *_GenesisState_39_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_39_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_39_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightForecasts)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_39_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightForecasts)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_39_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdBlockHeightForecasts)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_39_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_39_list) NewElement() protoreflect.Value {
+	v := new(TopicIdBlockHeightForecasts)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_39_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_40_list)(nil)
+
+type _GenesisState_40_list struct {
+	list *[]*TopicIdBlockHeightReputerValueBundles
+}
+
+func (x *_GenesisState_40_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_40_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_40_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightReputerValueBundles)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_40_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightReputerValueBundles)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_40_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdBlockHeightReputerValueBundles)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_40_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_40_list) NewElement() protoreflect.Value {
+	v := new(TopicIdBlockHeightReputerValueBundles)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_40_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_41_list)(nil)
+
+type _GenesisState_41_list struct {
+	list *[]*TopicIdBlockHeightValueBundles
+}
+
+func (x *_GenesisState_41_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_41_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_41_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightValueBundles)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_41_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdBlockHeightValueBundles)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_41_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdBlockHeightValueBundles)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_41_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_41_list) NewElement() protoreflect.Value {
+	v := new(TopicIdBlockHeightValueBundles)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_41_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_43_list)(nil)
+
+type _GenesisState_43_list struct {
+	list *[]*TopicIdAndNonces
+}
+
+func (x *_GenesisState_43_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_43_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_43_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndNonces)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_43_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndNonces)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_43_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdAndNonces)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_43_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_43_list) NewElement() protoreflect.Value {
+	v := new(TopicIdAndNonces)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_43_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_44_list)(nil)
+
+type _GenesisState_44_list struct {
+	list *[]*TopicIdAndReputerRequestNonces
+}
+
+func (x *_GenesisState_44_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_44_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_44_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndReputerRequestNonces)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_44_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdAndReputerRequestNonces)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_44_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdAndReputerRequestNonces)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_44_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_44_list) NewElement() protoreflect.Value {
+	v := new(TopicIdAndReputerRequestNonces)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_44_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_45_list)(nil)
+
+type _GenesisState_45_list struct {
+	list *[]*TopicIdActorIdTimeStampedValue
+}
+
+func (x *_GenesisState_45_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_45_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_45_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdTimeStampedValue)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_45_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdTimeStampedValue)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_45_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdTimeStampedValue)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_45_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_45_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdTimeStampedValue)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_45_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_46_list)(nil)
+
+type _GenesisState_46_list struct {
+	list *[]*TopicIdActorIdTimeStampedValue
+}
+
+func (x *_GenesisState_46_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_46_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_46_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdTimeStampedValue)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_46_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdTimeStampedValue)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_46_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdTimeStampedValue)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_46_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_46_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdTimeStampedValue)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_46_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_47_list)(nil)
+
+type _GenesisState_47_list struct {
+	list *[]*TopicIdActorIdActorIdTimeStampedValue
+}
+
+func (x *_GenesisState_47_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_47_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_47_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdActorIdTimeStampedValue)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_47_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdActorIdTimeStampedValue)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_47_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdActorIdTimeStampedValue)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_47_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_47_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdActorIdTimeStampedValue)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_47_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_48_list)(nil)
+
+type _GenesisState_48_list struct {
+	list *[]*TopicIdActorIdTimeStampedValue
+}
+
+func (x *_GenesisState_48_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_48_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_48_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdTimeStampedValue)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_48_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdActorIdTimeStampedValue)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_48_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdActorIdTimeStampedValue)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_48_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_48_list) NewElement() protoreflect.Value {
+	v := new(TopicIdActorIdTimeStampedValue)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_48_list) IsValid() bool {
+	return x.list != nil
+}
 
 var _ protoreflect.List = (*_GenesisState_2_list)(nil)
 
@@ -60,17 +2239,321 @@ func (x *_GenesisState_2_list) IsValid() bool {
 	return x.list != nil
 }
 
+var _ protoreflect.List = (*_GenesisState_49_list)(nil)
+
+type _GenesisState_49_list struct {
+	list *[]*TopicIdTimestampedActorNonce
+}
+
+func (x *_GenesisState_49_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_49_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_49_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdTimestampedActorNonce)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_49_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdTimestampedActorNonce)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_49_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdTimestampedActorNonce)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_49_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_49_list) NewElement() protoreflect.Value {
+	v := new(TopicIdTimestampedActorNonce)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_49_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_50_list)(nil)
+
+type _GenesisState_50_list struct {
+	list *[]*TopicIdTimestampedActorNonce
+}
+
+func (x *_GenesisState_50_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_50_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_50_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdTimestampedActorNonce)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_50_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdTimestampedActorNonce)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_50_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdTimestampedActorNonce)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_50_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_50_list) NewElement() protoreflect.Value {
+	v := new(TopicIdTimestampedActorNonce)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_50_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_51_list)(nil)
+
+type _GenesisState_51_list struct {
+	list *[]*TopicIdTimestampedActorNonce
+}
+
+func (x *_GenesisState_51_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_51_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_51_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdTimestampedActorNonce)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_51_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdTimestampedActorNonce)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_51_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdTimestampedActorNonce)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_51_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_51_list) NewElement() protoreflect.Value {
+	v := new(TopicIdTimestampedActorNonce)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_51_list) IsValid() bool {
+	return x.list != nil
+}
+
+var _ protoreflect.List = (*_GenesisState_52_list)(nil)
+
+type _GenesisState_52_list struct {
+	list *[]*TopicIdTimestampedActorNonce
+}
+
+func (x *_GenesisState_52_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_GenesisState_52_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfMessage((*x.list)[i].ProtoReflect())
+}
+
+func (x *_GenesisState_52_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdTimestampedActorNonce)
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_GenesisState_52_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Message()
+	concreteValue := valueUnwrapped.Interface().(*TopicIdTimestampedActorNonce)
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_GenesisState_52_list) AppendMutable() protoreflect.Value {
+	v := new(TopicIdTimestampedActorNonce)
+	*x.list = append(*x.list, v)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_52_list) Truncate(n int) {
+	for i := n; i < len(*x.list); i++ {
+		(*x.list)[i] = nil
+	}
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_GenesisState_52_list) NewElement() protoreflect.Value {
+	v := new(TopicIdTimestampedActorNonce)
+	return protoreflect.ValueOfMessage(v.ProtoReflect())
+}
+
+func (x *_GenesisState_52_list) IsValid() bool {
+	return x.list != nil
+}
+
 var (
-	md_GenesisState                     protoreflect.MessageDescriptor
-	fd_GenesisState_params              protoreflect.FieldDescriptor
-	fd_GenesisState_core_team_addresses protoreflect.FieldDescriptor
+	md_GenesisState                                          protoreflect.MessageDescriptor
+	fd_GenesisState_params                                   protoreflect.FieldDescriptor
+	fd_GenesisState_nextTopicId                              protoreflect.FieldDescriptor
+	fd_GenesisState_topics                                   protoreflect.FieldDescriptor
+	fd_GenesisState_activeTopics                             protoreflect.FieldDescriptor
+	fd_GenesisState_churnableTopics                          protoreflect.FieldDescriptor
+	fd_GenesisState_rewardableTopics                         protoreflect.FieldDescriptor
+	fd_GenesisState_topicWorkers                             protoreflect.FieldDescriptor
+	fd_GenesisState_topicReputers                            protoreflect.FieldDescriptor
+	fd_GenesisState_topicRewardNonce                         protoreflect.FieldDescriptor
+	fd_GenesisState_infererScoresByBlock                     protoreflect.FieldDescriptor
+	fd_GenesisState_forecasterScoresByBlock                  protoreflect.FieldDescriptor
+	fd_GenesisState_reputerScoresByBlock                     protoreflect.FieldDescriptor
+	fd_GenesisState_latestInfererScoresByWorker              protoreflect.FieldDescriptor
+	fd_GenesisState_latestForecasterScoresByWorker           protoreflect.FieldDescriptor
+	fd_GenesisState_latestReputerScoresByReputer             protoreflect.FieldDescriptor
+	fd_GenesisState_reputerListeningCoefficient              protoreflect.FieldDescriptor
+	fd_GenesisState_previousReputerRewardFraction            protoreflect.FieldDescriptor
+	fd_GenesisState_previousInferenceRewardFraction          protoreflect.FieldDescriptor
+	fd_GenesisState_previousForecastRewardFraction           protoreflect.FieldDescriptor
+	fd_GenesisState_totalStake                               protoreflect.FieldDescriptor
+	fd_GenesisState_topicStake                               protoreflect.FieldDescriptor
+	fd_GenesisState_stakeReputerAuthority                    protoreflect.FieldDescriptor
+	fd_GenesisState_stakeSumFromDelegator                    protoreflect.FieldDescriptor
+	fd_GenesisState_delegatedStakes                          protoreflect.FieldDescriptor
+	fd_GenesisState_stakeFromDelegatorsUponReputer           protoreflect.FieldDescriptor
+	fd_GenesisState_delegateRewardPerShare                   protoreflect.FieldDescriptor
+	fd_GenesisState_stakeRemovalsByBlock                     protoreflect.FieldDescriptor
+	fd_GenesisState_stakeRemovalsByActor                     protoreflect.FieldDescriptor
+	fd_GenesisState_delegateStakeRemovalsByBlock             protoreflect.FieldDescriptor
+	fd_GenesisState_delegateStakeRemovalsByActor             protoreflect.FieldDescriptor
+	fd_GenesisState_inferences                               protoreflect.FieldDescriptor
+	fd_GenesisState_forecasts                                protoreflect.FieldDescriptor
+	fd_GenesisState_workers                                  protoreflect.FieldDescriptor
+	fd_GenesisState_reputers                                 protoreflect.FieldDescriptor
+	fd_GenesisState_topicFeeRevenue                          protoreflect.FieldDescriptor
+	fd_GenesisState_previousTopicWeight                      protoreflect.FieldDescriptor
+	fd_GenesisState_allInferences                            protoreflect.FieldDescriptor
+	fd_GenesisState_allForecasts                             protoreflect.FieldDescriptor
+	fd_GenesisState_allLossBundles                           protoreflect.FieldDescriptor
+	fd_GenesisState_networkLossBundles                       protoreflect.FieldDescriptor
+	fd_GenesisState_previousPercentageRewardToStakedReputers protoreflect.FieldDescriptor
+	fd_GenesisState_unfulfilledWorkerNonces                  protoreflect.FieldDescriptor
+	fd_GenesisState_unfulfilledReputerNonces                 protoreflect.FieldDescriptor
+	fd_GenesisState_latestInfererNetworkRegrets              protoreflect.FieldDescriptor
+	fd_GenesisState_latestForecasterNetworkRegrets           protoreflect.FieldDescriptor
+	fd_GenesisState_latestOneInForecasterNetworkRegrets      protoreflect.FieldDescriptor
+	fd_GenesisState_latestOneInForecasterSelfNetworkRegrets  protoreflect.FieldDescriptor
+	fd_GenesisState_core_team_addresses                      protoreflect.FieldDescriptor
+	fd_GenesisState_topicLastWorkerCommit                    protoreflect.FieldDescriptor
+	fd_GenesisState_topicLastReputerCommit                   protoreflect.FieldDescriptor
+	fd_GenesisState_topicLastWorkerPayload                   protoreflect.FieldDescriptor
+	fd_GenesisState_topicLastReputerPayload                  protoreflect.FieldDescriptor
 )
 
 func init() {
 	file_emissions_v1_genesis_proto_init()
 	md_GenesisState = File_emissions_v1_genesis_proto.Messages().ByName("GenesisState")
 	fd_GenesisState_params = md_GenesisState.Fields().ByName("params")
+	fd_GenesisState_nextTopicId = md_GenesisState.Fields().ByName("nextTopicId")
+	fd_GenesisState_topics = md_GenesisState.Fields().ByName("topics")
+	fd_GenesisState_activeTopics = md_GenesisState.Fields().ByName("activeTopics")
+	fd_GenesisState_churnableTopics = md_GenesisState.Fields().ByName("churnableTopics")
+	fd_GenesisState_rewardableTopics = md_GenesisState.Fields().ByName("rewardableTopics")
+	fd_GenesisState_topicWorkers = md_GenesisState.Fields().ByName("topicWorkers")
+	fd_GenesisState_topicReputers = md_GenesisState.Fields().ByName("topicReputers")
+	fd_GenesisState_topicRewardNonce = md_GenesisState.Fields().ByName("topicRewardNonce")
+	fd_GenesisState_infererScoresByBlock = md_GenesisState.Fields().ByName("infererScoresByBlock")
+	fd_GenesisState_forecasterScoresByBlock = md_GenesisState.Fields().ByName("forecasterScoresByBlock")
+	fd_GenesisState_reputerScoresByBlock = md_GenesisState.Fields().ByName("reputerScoresByBlock")
+	fd_GenesisState_latestInfererScoresByWorker = md_GenesisState.Fields().ByName("latestInfererScoresByWorker")
+	fd_GenesisState_latestForecasterScoresByWorker = md_GenesisState.Fields().ByName("latestForecasterScoresByWorker")
+	fd_GenesisState_latestReputerScoresByReputer = md_GenesisState.Fields().ByName("latestReputerScoresByReputer")
+	fd_GenesisState_reputerListeningCoefficient = md_GenesisState.Fields().ByName("reputerListeningCoefficient")
+	fd_GenesisState_previousReputerRewardFraction = md_GenesisState.Fields().ByName("previousReputerRewardFraction")
+	fd_GenesisState_previousInferenceRewardFraction = md_GenesisState.Fields().ByName("previousInferenceRewardFraction")
+	fd_GenesisState_previousForecastRewardFraction = md_GenesisState.Fields().ByName("previousForecastRewardFraction")
+	fd_GenesisState_totalStake = md_GenesisState.Fields().ByName("totalStake")
+	fd_GenesisState_topicStake = md_GenesisState.Fields().ByName("topicStake")
+	fd_GenesisState_stakeReputerAuthority = md_GenesisState.Fields().ByName("stakeReputerAuthority")
+	fd_GenesisState_stakeSumFromDelegator = md_GenesisState.Fields().ByName("stakeSumFromDelegator")
+	fd_GenesisState_delegatedStakes = md_GenesisState.Fields().ByName("delegatedStakes")
+	fd_GenesisState_stakeFromDelegatorsUponReputer = md_GenesisState.Fields().ByName("stakeFromDelegatorsUponReputer")
+	fd_GenesisState_delegateRewardPerShare = md_GenesisState.Fields().ByName("delegateRewardPerShare")
+	fd_GenesisState_stakeRemovalsByBlock = md_GenesisState.Fields().ByName("stakeRemovalsByBlock")
+	fd_GenesisState_stakeRemovalsByActor = md_GenesisState.Fields().ByName("stakeRemovalsByActor")
+	fd_GenesisState_delegateStakeRemovalsByBlock = md_GenesisState.Fields().ByName("delegateStakeRemovalsByBlock")
+	fd_GenesisState_delegateStakeRemovalsByActor = md_GenesisState.Fields().ByName("delegateStakeRemovalsByActor")
+	fd_GenesisState_inferences = md_GenesisState.Fields().ByName("inferences")
+	fd_GenesisState_forecasts = md_GenesisState.Fields().ByName("forecasts")
+	fd_GenesisState_workers = md_GenesisState.Fields().ByName("workers")
+	fd_GenesisState_reputers = md_GenesisState.Fields().ByName("reputers")
+	fd_GenesisState_topicFeeRevenue = md_GenesisState.Fields().ByName("topicFeeRevenue")
+	fd_GenesisState_previousTopicWeight = md_GenesisState.Fields().ByName("previousTopicWeight")
+	fd_GenesisState_allInferences = md_GenesisState.Fields().ByName("allInferences")
+	fd_GenesisState_allForecasts = md_GenesisState.Fields().ByName("allForecasts")
+	fd_GenesisState_allLossBundles = md_GenesisState.Fields().ByName("allLossBundles")
+	fd_GenesisState_networkLossBundles = md_GenesisState.Fields().ByName("networkLossBundles")
+	fd_GenesisState_previousPercentageRewardToStakedReputers = md_GenesisState.Fields().ByName("previousPercentageRewardToStakedReputers")
+	fd_GenesisState_unfulfilledWorkerNonces = md_GenesisState.Fields().ByName("unfulfilledWorkerNonces")
+	fd_GenesisState_unfulfilledReputerNonces = md_GenesisState.Fields().ByName("unfulfilledReputerNonces")
+	fd_GenesisState_latestInfererNetworkRegrets = md_GenesisState.Fields().ByName("latestInfererNetworkRegrets")
+	fd_GenesisState_latestForecasterNetworkRegrets = md_GenesisState.Fields().ByName("latestForecasterNetworkRegrets")
+	fd_GenesisState_latestOneInForecasterNetworkRegrets = md_GenesisState.Fields().ByName("latestOneInForecasterNetworkRegrets")
+	fd_GenesisState_latestOneInForecasterSelfNetworkRegrets = md_GenesisState.Fields().ByName("latestOneInForecasterSelfNetworkRegrets")
 	fd_GenesisState_core_team_addresses = md_GenesisState.Fields().ByName("core_team_addresses")
+	fd_GenesisState_topicLastWorkerCommit = md_GenesisState.Fields().ByName("topicLastWorkerCommit")
+	fd_GenesisState_topicLastReputerCommit = md_GenesisState.Fields().ByName("topicLastReputerCommit")
+	fd_GenesisState_topicLastWorkerPayload = md_GenesisState.Fields().ByName("topicLastWorkerPayload")
+	fd_GenesisState_topicLastReputerPayload = md_GenesisState.Fields().ByName("topicLastReputerPayload")
 }
 
 var _ protoreflect.Message = (*fastReflection_GenesisState)(nil)
@@ -144,9 +2627,309 @@ func (x *fastReflection_GenesisState) Range(f func(protoreflect.FieldDescriptor,
 			return
 		}
 	}
+	if x.NextTopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.NextTopicId)
+		if !f(fd_GenesisState_nextTopicId, value) {
+			return
+		}
+	}
+	if len(x.Topics) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_4_list{list: &x.Topics})
+		if !f(fd_GenesisState_topics, value) {
+			return
+		}
+	}
+	if len(x.ActiveTopics) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_5_list{list: &x.ActiveTopics})
+		if !f(fd_GenesisState_activeTopics, value) {
+			return
+		}
+	}
+	if len(x.ChurnableTopics) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_6_list{list: &x.ChurnableTopics})
+		if !f(fd_GenesisState_churnableTopics, value) {
+			return
+		}
+	}
+	if len(x.RewardableTopics) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_7_list{list: &x.RewardableTopics})
+		if !f(fd_GenesisState_rewardableTopics, value) {
+			return
+		}
+	}
+	if len(x.TopicWorkers) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_8_list{list: &x.TopicWorkers})
+		if !f(fd_GenesisState_topicWorkers, value) {
+			return
+		}
+	}
+	if len(x.TopicReputers) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_9_list{list: &x.TopicReputers})
+		if !f(fd_GenesisState_topicReputers, value) {
+			return
+		}
+	}
+	if len(x.TopicRewardNonce) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_10_list{list: &x.TopicRewardNonce})
+		if !f(fd_GenesisState_topicRewardNonce, value) {
+			return
+		}
+	}
+	if len(x.InfererScoresByBlock) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_11_list{list: &x.InfererScoresByBlock})
+		if !f(fd_GenesisState_infererScoresByBlock, value) {
+			return
+		}
+	}
+	if len(x.ForecasterScoresByBlock) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_12_list{list: &x.ForecasterScoresByBlock})
+		if !f(fd_GenesisState_forecasterScoresByBlock, value) {
+			return
+		}
+	}
+	if len(x.ReputerScoresByBlock) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_13_list{list: &x.ReputerScoresByBlock})
+		if !f(fd_GenesisState_reputerScoresByBlock, value) {
+			return
+		}
+	}
+	if len(x.LatestInfererScoresByWorker) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_14_list{list: &x.LatestInfererScoresByWorker})
+		if !f(fd_GenesisState_latestInfererScoresByWorker, value) {
+			return
+		}
+	}
+	if len(x.LatestForecasterScoresByWorker) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_15_list{list: &x.LatestForecasterScoresByWorker})
+		if !f(fd_GenesisState_latestForecasterScoresByWorker, value) {
+			return
+		}
+	}
+	if len(x.LatestReputerScoresByReputer) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_16_list{list: &x.LatestReputerScoresByReputer})
+		if !f(fd_GenesisState_latestReputerScoresByReputer, value) {
+			return
+		}
+	}
+	if len(x.ReputerListeningCoefficient) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_17_list{list: &x.ReputerListeningCoefficient})
+		if !f(fd_GenesisState_reputerListeningCoefficient, value) {
+			return
+		}
+	}
+	if len(x.PreviousReputerRewardFraction) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_18_list{list: &x.PreviousReputerRewardFraction})
+		if !f(fd_GenesisState_previousReputerRewardFraction, value) {
+			return
+		}
+	}
+	if len(x.PreviousInferenceRewardFraction) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_19_list{list: &x.PreviousInferenceRewardFraction})
+		if !f(fd_GenesisState_previousInferenceRewardFraction, value) {
+			return
+		}
+	}
+	if len(x.PreviousForecastRewardFraction) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_20_list{list: &x.PreviousForecastRewardFraction})
+		if !f(fd_GenesisState_previousForecastRewardFraction, value) {
+			return
+		}
+	}
+	if x.TotalStake != "" {
+		value := protoreflect.ValueOfString(x.TotalStake)
+		if !f(fd_GenesisState_totalStake, value) {
+			return
+		}
+	}
+	if len(x.TopicStake) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_22_list{list: &x.TopicStake})
+		if !f(fd_GenesisState_topicStake, value) {
+			return
+		}
+	}
+	if len(x.StakeReputerAuthority) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_23_list{list: &x.StakeReputerAuthority})
+		if !f(fd_GenesisState_stakeReputerAuthority, value) {
+			return
+		}
+	}
+	if len(x.StakeSumFromDelegator) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_24_list{list: &x.StakeSumFromDelegator})
+		if !f(fd_GenesisState_stakeSumFromDelegator, value) {
+			return
+		}
+	}
+	if len(x.DelegatedStakes) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_25_list{list: &x.DelegatedStakes})
+		if !f(fd_GenesisState_delegatedStakes, value) {
+			return
+		}
+	}
+	if len(x.StakeFromDelegatorsUponReputer) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_26_list{list: &x.StakeFromDelegatorsUponReputer})
+		if !f(fd_GenesisState_stakeFromDelegatorsUponReputer, value) {
+			return
+		}
+	}
+	if len(x.DelegateRewardPerShare) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_27_list{list: &x.DelegateRewardPerShare})
+		if !f(fd_GenesisState_delegateRewardPerShare, value) {
+			return
+		}
+	}
+	if len(x.StakeRemovalsByBlock) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_28_list{list: &x.StakeRemovalsByBlock})
+		if !f(fd_GenesisState_stakeRemovalsByBlock, value) {
+			return
+		}
+	}
+	if len(x.StakeRemovalsByActor) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_29_list{list: &x.StakeRemovalsByActor})
+		if !f(fd_GenesisState_stakeRemovalsByActor, value) {
+			return
+		}
+	}
+	if len(x.DelegateStakeRemovalsByBlock) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_30_list{list: &x.DelegateStakeRemovalsByBlock})
+		if !f(fd_GenesisState_delegateStakeRemovalsByBlock, value) {
+			return
+		}
+	}
+	if len(x.DelegateStakeRemovalsByActor) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_31_list{list: &x.DelegateStakeRemovalsByActor})
+		if !f(fd_GenesisState_delegateStakeRemovalsByActor, value) {
+			return
+		}
+	}
+	if len(x.Inferences) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_32_list{list: &x.Inferences})
+		if !f(fd_GenesisState_inferences, value) {
+			return
+		}
+	}
+	if len(x.Forecasts) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_33_list{list: &x.Forecasts})
+		if !f(fd_GenesisState_forecasts, value) {
+			return
+		}
+	}
+	if len(x.Workers) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_34_list{list: &x.Workers})
+		if !f(fd_GenesisState_workers, value) {
+			return
+		}
+	}
+	if len(x.Reputers) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_35_list{list: &x.Reputers})
+		if !f(fd_GenesisState_reputers, value) {
+			return
+		}
+	}
+	if len(x.TopicFeeRevenue) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_36_list{list: &x.TopicFeeRevenue})
+		if !f(fd_GenesisState_topicFeeRevenue, value) {
+			return
+		}
+	}
+	if len(x.PreviousTopicWeight) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_37_list{list: &x.PreviousTopicWeight})
+		if !f(fd_GenesisState_previousTopicWeight, value) {
+			return
+		}
+	}
+	if len(x.AllInferences) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_38_list{list: &x.AllInferences})
+		if !f(fd_GenesisState_allInferences, value) {
+			return
+		}
+	}
+	if len(x.AllForecasts) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_39_list{list: &x.AllForecasts})
+		if !f(fd_GenesisState_allForecasts, value) {
+			return
+		}
+	}
+	if len(x.AllLossBundles) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_40_list{list: &x.AllLossBundles})
+		if !f(fd_GenesisState_allLossBundles, value) {
+			return
+		}
+	}
+	if len(x.NetworkLossBundles) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_41_list{list: &x.NetworkLossBundles})
+		if !f(fd_GenesisState_networkLossBundles, value) {
+			return
+		}
+	}
+	if x.PreviousPercentageRewardToStakedReputers != "" {
+		value := protoreflect.ValueOfString(x.PreviousPercentageRewardToStakedReputers)
+		if !f(fd_GenesisState_previousPercentageRewardToStakedReputers, value) {
+			return
+		}
+	}
+	if len(x.UnfulfilledWorkerNonces) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_43_list{list: &x.UnfulfilledWorkerNonces})
+		if !f(fd_GenesisState_unfulfilledWorkerNonces, value) {
+			return
+		}
+	}
+	if len(x.UnfulfilledReputerNonces) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_44_list{list: &x.UnfulfilledReputerNonces})
+		if !f(fd_GenesisState_unfulfilledReputerNonces, value) {
+			return
+		}
+	}
+	if len(x.LatestInfererNetworkRegrets) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_45_list{list: &x.LatestInfererNetworkRegrets})
+		if !f(fd_GenesisState_latestInfererNetworkRegrets, value) {
+			return
+		}
+	}
+	if len(x.LatestForecasterNetworkRegrets) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_46_list{list: &x.LatestForecasterNetworkRegrets})
+		if !f(fd_GenesisState_latestForecasterNetworkRegrets, value) {
+			return
+		}
+	}
+	if len(x.LatestOneInForecasterNetworkRegrets) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_47_list{list: &x.LatestOneInForecasterNetworkRegrets})
+		if !f(fd_GenesisState_latestOneInForecasterNetworkRegrets, value) {
+			return
+		}
+	}
+	if len(x.LatestOneInForecasterSelfNetworkRegrets) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_48_list{list: &x.LatestOneInForecasterSelfNetworkRegrets})
+		if !f(fd_GenesisState_latestOneInForecasterSelfNetworkRegrets, value) {
+			return
+		}
+	}
 	if len(x.CoreTeamAddresses) != 0 {
 		value := protoreflect.ValueOfList(&_GenesisState_2_list{list: &x.CoreTeamAddresses})
 		if !f(fd_GenesisState_core_team_addresses, value) {
+			return
+		}
+	}
+	if len(x.TopicLastWorkerCommit) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_49_list{list: &x.TopicLastWorkerCommit})
+		if !f(fd_GenesisState_topicLastWorkerCommit, value) {
+			return
+		}
+	}
+	if len(x.TopicLastReputerCommit) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_50_list{list: &x.TopicLastReputerCommit})
+		if !f(fd_GenesisState_topicLastReputerCommit, value) {
+			return
+		}
+	}
+	if len(x.TopicLastWorkerPayload) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_51_list{list: &x.TopicLastWorkerPayload})
+		if !f(fd_GenesisState_topicLastWorkerPayload, value) {
+			return
+		}
+	}
+	if len(x.TopicLastReputerPayload) != 0 {
+		value := protoreflect.ValueOfList(&_GenesisState_52_list{list: &x.TopicLastReputerPayload})
+		if !f(fd_GenesisState_topicLastReputerPayload, value) {
 			return
 		}
 	}
@@ -167,8 +2950,108 @@ func (x *fastReflection_GenesisState) Has(fd protoreflect.FieldDescriptor) bool 
 	switch fd.FullName() {
 	case "emissions.v1.GenesisState.params":
 		return x.Params != nil
+	case "emissions.v1.GenesisState.nextTopicId":
+		return x.NextTopicId != uint64(0)
+	case "emissions.v1.GenesisState.topics":
+		return len(x.Topics) != 0
+	case "emissions.v1.GenesisState.activeTopics":
+		return len(x.ActiveTopics) != 0
+	case "emissions.v1.GenesisState.churnableTopics":
+		return len(x.ChurnableTopics) != 0
+	case "emissions.v1.GenesisState.rewardableTopics":
+		return len(x.RewardableTopics) != 0
+	case "emissions.v1.GenesisState.topicWorkers":
+		return len(x.TopicWorkers) != 0
+	case "emissions.v1.GenesisState.topicReputers":
+		return len(x.TopicReputers) != 0
+	case "emissions.v1.GenesisState.topicRewardNonce":
+		return len(x.TopicRewardNonce) != 0
+	case "emissions.v1.GenesisState.infererScoresByBlock":
+		return len(x.InfererScoresByBlock) != 0
+	case "emissions.v1.GenesisState.forecasterScoresByBlock":
+		return len(x.ForecasterScoresByBlock) != 0
+	case "emissions.v1.GenesisState.reputerScoresByBlock":
+		return len(x.ReputerScoresByBlock) != 0
+	case "emissions.v1.GenesisState.latestInfererScoresByWorker":
+		return len(x.LatestInfererScoresByWorker) != 0
+	case "emissions.v1.GenesisState.latestForecasterScoresByWorker":
+		return len(x.LatestForecasterScoresByWorker) != 0
+	case "emissions.v1.GenesisState.latestReputerScoresByReputer":
+		return len(x.LatestReputerScoresByReputer) != 0
+	case "emissions.v1.GenesisState.reputerListeningCoefficient":
+		return len(x.ReputerListeningCoefficient) != 0
+	case "emissions.v1.GenesisState.previousReputerRewardFraction":
+		return len(x.PreviousReputerRewardFraction) != 0
+	case "emissions.v1.GenesisState.previousInferenceRewardFraction":
+		return len(x.PreviousInferenceRewardFraction) != 0
+	case "emissions.v1.GenesisState.previousForecastRewardFraction":
+		return len(x.PreviousForecastRewardFraction) != 0
+	case "emissions.v1.GenesisState.totalStake":
+		return x.TotalStake != ""
+	case "emissions.v1.GenesisState.topicStake":
+		return len(x.TopicStake) != 0
+	case "emissions.v1.GenesisState.stakeReputerAuthority":
+		return len(x.StakeReputerAuthority) != 0
+	case "emissions.v1.GenesisState.stakeSumFromDelegator":
+		return len(x.StakeSumFromDelegator) != 0
+	case "emissions.v1.GenesisState.delegatedStakes":
+		return len(x.DelegatedStakes) != 0
+	case "emissions.v1.GenesisState.stakeFromDelegatorsUponReputer":
+		return len(x.StakeFromDelegatorsUponReputer) != 0
+	case "emissions.v1.GenesisState.delegateRewardPerShare":
+		return len(x.DelegateRewardPerShare) != 0
+	case "emissions.v1.GenesisState.stakeRemovalsByBlock":
+		return len(x.StakeRemovalsByBlock) != 0
+	case "emissions.v1.GenesisState.stakeRemovalsByActor":
+		return len(x.StakeRemovalsByActor) != 0
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByBlock":
+		return len(x.DelegateStakeRemovalsByBlock) != 0
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByActor":
+		return len(x.DelegateStakeRemovalsByActor) != 0
+	case "emissions.v1.GenesisState.inferences":
+		return len(x.Inferences) != 0
+	case "emissions.v1.GenesisState.forecasts":
+		return len(x.Forecasts) != 0
+	case "emissions.v1.GenesisState.workers":
+		return len(x.Workers) != 0
+	case "emissions.v1.GenesisState.reputers":
+		return len(x.Reputers) != 0
+	case "emissions.v1.GenesisState.topicFeeRevenue":
+		return len(x.TopicFeeRevenue) != 0
+	case "emissions.v1.GenesisState.previousTopicWeight":
+		return len(x.PreviousTopicWeight) != 0
+	case "emissions.v1.GenesisState.allInferences":
+		return len(x.AllInferences) != 0
+	case "emissions.v1.GenesisState.allForecasts":
+		return len(x.AllForecasts) != 0
+	case "emissions.v1.GenesisState.allLossBundles":
+		return len(x.AllLossBundles) != 0
+	case "emissions.v1.GenesisState.networkLossBundles":
+		return len(x.NetworkLossBundles) != 0
+	case "emissions.v1.GenesisState.previousPercentageRewardToStakedReputers":
+		return x.PreviousPercentageRewardToStakedReputers != ""
+	case "emissions.v1.GenesisState.unfulfilledWorkerNonces":
+		return len(x.UnfulfilledWorkerNonces) != 0
+	case "emissions.v1.GenesisState.unfulfilledReputerNonces":
+		return len(x.UnfulfilledReputerNonces) != 0
+	case "emissions.v1.GenesisState.latestInfererNetworkRegrets":
+		return len(x.LatestInfererNetworkRegrets) != 0
+	case "emissions.v1.GenesisState.latestForecasterNetworkRegrets":
+		return len(x.LatestForecasterNetworkRegrets) != 0
+	case "emissions.v1.GenesisState.latestOneInForecasterNetworkRegrets":
+		return len(x.LatestOneInForecasterNetworkRegrets) != 0
+	case "emissions.v1.GenesisState.latestOneInForecasterSelfNetworkRegrets":
+		return len(x.LatestOneInForecasterSelfNetworkRegrets) != 0
 	case "emissions.v1.GenesisState.core_team_addresses":
 		return len(x.CoreTeamAddresses) != 0
+	case "emissions.v1.GenesisState.topicLastWorkerCommit":
+		return len(x.TopicLastWorkerCommit) != 0
+	case "emissions.v1.GenesisState.topicLastReputerCommit":
+		return len(x.TopicLastReputerCommit) != 0
+	case "emissions.v1.GenesisState.topicLastWorkerPayload":
+		return len(x.TopicLastWorkerPayload) != 0
+	case "emissions.v1.GenesisState.topicLastReputerPayload":
+		return len(x.TopicLastReputerPayload) != 0
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.GenesisState"))
@@ -187,8 +3070,108 @@ func (x *fastReflection_GenesisState) Clear(fd protoreflect.FieldDescriptor) {
 	switch fd.FullName() {
 	case "emissions.v1.GenesisState.params":
 		x.Params = nil
+	case "emissions.v1.GenesisState.nextTopicId":
+		x.NextTopicId = uint64(0)
+	case "emissions.v1.GenesisState.topics":
+		x.Topics = nil
+	case "emissions.v1.GenesisState.activeTopics":
+		x.ActiveTopics = nil
+	case "emissions.v1.GenesisState.churnableTopics":
+		x.ChurnableTopics = nil
+	case "emissions.v1.GenesisState.rewardableTopics":
+		x.RewardableTopics = nil
+	case "emissions.v1.GenesisState.topicWorkers":
+		x.TopicWorkers = nil
+	case "emissions.v1.GenesisState.topicReputers":
+		x.TopicReputers = nil
+	case "emissions.v1.GenesisState.topicRewardNonce":
+		x.TopicRewardNonce = nil
+	case "emissions.v1.GenesisState.infererScoresByBlock":
+		x.InfererScoresByBlock = nil
+	case "emissions.v1.GenesisState.forecasterScoresByBlock":
+		x.ForecasterScoresByBlock = nil
+	case "emissions.v1.GenesisState.reputerScoresByBlock":
+		x.ReputerScoresByBlock = nil
+	case "emissions.v1.GenesisState.latestInfererScoresByWorker":
+		x.LatestInfererScoresByWorker = nil
+	case "emissions.v1.GenesisState.latestForecasterScoresByWorker":
+		x.LatestForecasterScoresByWorker = nil
+	case "emissions.v1.GenesisState.latestReputerScoresByReputer":
+		x.LatestReputerScoresByReputer = nil
+	case "emissions.v1.GenesisState.reputerListeningCoefficient":
+		x.ReputerListeningCoefficient = nil
+	case "emissions.v1.GenesisState.previousReputerRewardFraction":
+		x.PreviousReputerRewardFraction = nil
+	case "emissions.v1.GenesisState.previousInferenceRewardFraction":
+		x.PreviousInferenceRewardFraction = nil
+	case "emissions.v1.GenesisState.previousForecastRewardFraction":
+		x.PreviousForecastRewardFraction = nil
+	case "emissions.v1.GenesisState.totalStake":
+		x.TotalStake = ""
+	case "emissions.v1.GenesisState.topicStake":
+		x.TopicStake = nil
+	case "emissions.v1.GenesisState.stakeReputerAuthority":
+		x.StakeReputerAuthority = nil
+	case "emissions.v1.GenesisState.stakeSumFromDelegator":
+		x.StakeSumFromDelegator = nil
+	case "emissions.v1.GenesisState.delegatedStakes":
+		x.DelegatedStakes = nil
+	case "emissions.v1.GenesisState.stakeFromDelegatorsUponReputer":
+		x.StakeFromDelegatorsUponReputer = nil
+	case "emissions.v1.GenesisState.delegateRewardPerShare":
+		x.DelegateRewardPerShare = nil
+	case "emissions.v1.GenesisState.stakeRemovalsByBlock":
+		x.StakeRemovalsByBlock = nil
+	case "emissions.v1.GenesisState.stakeRemovalsByActor":
+		x.StakeRemovalsByActor = nil
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByBlock":
+		x.DelegateStakeRemovalsByBlock = nil
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByActor":
+		x.DelegateStakeRemovalsByActor = nil
+	case "emissions.v1.GenesisState.inferences":
+		x.Inferences = nil
+	case "emissions.v1.GenesisState.forecasts":
+		x.Forecasts = nil
+	case "emissions.v1.GenesisState.workers":
+		x.Workers = nil
+	case "emissions.v1.GenesisState.reputers":
+		x.Reputers = nil
+	case "emissions.v1.GenesisState.topicFeeRevenue":
+		x.TopicFeeRevenue = nil
+	case "emissions.v1.GenesisState.previousTopicWeight":
+		x.PreviousTopicWeight = nil
+	case "emissions.v1.GenesisState.allInferences":
+		x.AllInferences = nil
+	case "emissions.v1.GenesisState.allForecasts":
+		x.AllForecasts = nil
+	case "emissions.v1.GenesisState.allLossBundles":
+		x.AllLossBundles = nil
+	case "emissions.v1.GenesisState.networkLossBundles":
+		x.NetworkLossBundles = nil
+	case "emissions.v1.GenesisState.previousPercentageRewardToStakedReputers":
+		x.PreviousPercentageRewardToStakedReputers = ""
+	case "emissions.v1.GenesisState.unfulfilledWorkerNonces":
+		x.UnfulfilledWorkerNonces = nil
+	case "emissions.v1.GenesisState.unfulfilledReputerNonces":
+		x.UnfulfilledReputerNonces = nil
+	case "emissions.v1.GenesisState.latestInfererNetworkRegrets":
+		x.LatestInfererNetworkRegrets = nil
+	case "emissions.v1.GenesisState.latestForecasterNetworkRegrets":
+		x.LatestForecasterNetworkRegrets = nil
+	case "emissions.v1.GenesisState.latestOneInForecasterNetworkRegrets":
+		x.LatestOneInForecasterNetworkRegrets = nil
+	case "emissions.v1.GenesisState.latestOneInForecasterSelfNetworkRegrets":
+		x.LatestOneInForecasterSelfNetworkRegrets = nil
 	case "emissions.v1.GenesisState.core_team_addresses":
 		x.CoreTeamAddresses = nil
+	case "emissions.v1.GenesisState.topicLastWorkerCommit":
+		x.TopicLastWorkerCommit = nil
+	case "emissions.v1.GenesisState.topicLastReputerCommit":
+		x.TopicLastReputerCommit = nil
+	case "emissions.v1.GenesisState.topicLastWorkerPayload":
+		x.TopicLastWorkerPayload = nil
+	case "emissions.v1.GenesisState.topicLastReputerPayload":
+		x.TopicLastReputerPayload = nil
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.GenesisState"))
@@ -208,11 +3191,302 @@ func (x *fastReflection_GenesisState) Get(descriptor protoreflect.FieldDescripto
 	case "emissions.v1.GenesisState.params":
 		value := x.Params
 		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	case "emissions.v1.GenesisState.nextTopicId":
+		value := x.NextTopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.GenesisState.topics":
+		if len(x.Topics) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_4_list{})
+		}
+		listValue := &_GenesisState_4_list{list: &x.Topics}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.activeTopics":
+		if len(x.ActiveTopics) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_5_list{})
+		}
+		listValue := &_GenesisState_5_list{list: &x.ActiveTopics}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.churnableTopics":
+		if len(x.ChurnableTopics) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_6_list{})
+		}
+		listValue := &_GenesisState_6_list{list: &x.ChurnableTopics}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.rewardableTopics":
+		if len(x.RewardableTopics) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_7_list{})
+		}
+		listValue := &_GenesisState_7_list{list: &x.RewardableTopics}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.topicWorkers":
+		if len(x.TopicWorkers) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_8_list{})
+		}
+		listValue := &_GenesisState_8_list{list: &x.TopicWorkers}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.topicReputers":
+		if len(x.TopicReputers) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_9_list{})
+		}
+		listValue := &_GenesisState_9_list{list: &x.TopicReputers}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.topicRewardNonce":
+		if len(x.TopicRewardNonce) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_10_list{})
+		}
+		listValue := &_GenesisState_10_list{list: &x.TopicRewardNonce}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.infererScoresByBlock":
+		if len(x.InfererScoresByBlock) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_11_list{})
+		}
+		listValue := &_GenesisState_11_list{list: &x.InfererScoresByBlock}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.forecasterScoresByBlock":
+		if len(x.ForecasterScoresByBlock) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_12_list{})
+		}
+		listValue := &_GenesisState_12_list{list: &x.ForecasterScoresByBlock}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.reputerScoresByBlock":
+		if len(x.ReputerScoresByBlock) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_13_list{})
+		}
+		listValue := &_GenesisState_13_list{list: &x.ReputerScoresByBlock}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.latestInfererScoresByWorker":
+		if len(x.LatestInfererScoresByWorker) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_14_list{})
+		}
+		listValue := &_GenesisState_14_list{list: &x.LatestInfererScoresByWorker}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.latestForecasterScoresByWorker":
+		if len(x.LatestForecasterScoresByWorker) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_15_list{})
+		}
+		listValue := &_GenesisState_15_list{list: &x.LatestForecasterScoresByWorker}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.latestReputerScoresByReputer":
+		if len(x.LatestReputerScoresByReputer) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_16_list{})
+		}
+		listValue := &_GenesisState_16_list{list: &x.LatestReputerScoresByReputer}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.reputerListeningCoefficient":
+		if len(x.ReputerListeningCoefficient) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_17_list{})
+		}
+		listValue := &_GenesisState_17_list{list: &x.ReputerListeningCoefficient}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.previousReputerRewardFraction":
+		if len(x.PreviousReputerRewardFraction) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_18_list{})
+		}
+		listValue := &_GenesisState_18_list{list: &x.PreviousReputerRewardFraction}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.previousInferenceRewardFraction":
+		if len(x.PreviousInferenceRewardFraction) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_19_list{})
+		}
+		listValue := &_GenesisState_19_list{list: &x.PreviousInferenceRewardFraction}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.previousForecastRewardFraction":
+		if len(x.PreviousForecastRewardFraction) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_20_list{})
+		}
+		listValue := &_GenesisState_20_list{list: &x.PreviousForecastRewardFraction}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.totalStake":
+		value := x.TotalStake
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.GenesisState.topicStake":
+		if len(x.TopicStake) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_22_list{})
+		}
+		listValue := &_GenesisState_22_list{list: &x.TopicStake}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.stakeReputerAuthority":
+		if len(x.StakeReputerAuthority) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_23_list{})
+		}
+		listValue := &_GenesisState_23_list{list: &x.StakeReputerAuthority}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.stakeSumFromDelegator":
+		if len(x.StakeSumFromDelegator) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_24_list{})
+		}
+		listValue := &_GenesisState_24_list{list: &x.StakeSumFromDelegator}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.delegatedStakes":
+		if len(x.DelegatedStakes) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_25_list{})
+		}
+		listValue := &_GenesisState_25_list{list: &x.DelegatedStakes}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.stakeFromDelegatorsUponReputer":
+		if len(x.StakeFromDelegatorsUponReputer) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_26_list{})
+		}
+		listValue := &_GenesisState_26_list{list: &x.StakeFromDelegatorsUponReputer}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.delegateRewardPerShare":
+		if len(x.DelegateRewardPerShare) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_27_list{})
+		}
+		listValue := &_GenesisState_27_list{list: &x.DelegateRewardPerShare}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.stakeRemovalsByBlock":
+		if len(x.StakeRemovalsByBlock) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_28_list{})
+		}
+		listValue := &_GenesisState_28_list{list: &x.StakeRemovalsByBlock}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.stakeRemovalsByActor":
+		if len(x.StakeRemovalsByActor) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_29_list{})
+		}
+		listValue := &_GenesisState_29_list{list: &x.StakeRemovalsByActor}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByBlock":
+		if len(x.DelegateStakeRemovalsByBlock) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_30_list{})
+		}
+		listValue := &_GenesisState_30_list{list: &x.DelegateStakeRemovalsByBlock}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByActor":
+		if len(x.DelegateStakeRemovalsByActor) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_31_list{})
+		}
+		listValue := &_GenesisState_31_list{list: &x.DelegateStakeRemovalsByActor}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.inferences":
+		if len(x.Inferences) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_32_list{})
+		}
+		listValue := &_GenesisState_32_list{list: &x.Inferences}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.forecasts":
+		if len(x.Forecasts) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_33_list{})
+		}
+		listValue := &_GenesisState_33_list{list: &x.Forecasts}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.workers":
+		if len(x.Workers) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_34_list{})
+		}
+		listValue := &_GenesisState_34_list{list: &x.Workers}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.reputers":
+		if len(x.Reputers) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_35_list{})
+		}
+		listValue := &_GenesisState_35_list{list: &x.Reputers}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.topicFeeRevenue":
+		if len(x.TopicFeeRevenue) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_36_list{})
+		}
+		listValue := &_GenesisState_36_list{list: &x.TopicFeeRevenue}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.previousTopicWeight":
+		if len(x.PreviousTopicWeight) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_37_list{})
+		}
+		listValue := &_GenesisState_37_list{list: &x.PreviousTopicWeight}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.allInferences":
+		if len(x.AllInferences) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_38_list{})
+		}
+		listValue := &_GenesisState_38_list{list: &x.AllInferences}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.allForecasts":
+		if len(x.AllForecasts) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_39_list{})
+		}
+		listValue := &_GenesisState_39_list{list: &x.AllForecasts}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.allLossBundles":
+		if len(x.AllLossBundles) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_40_list{})
+		}
+		listValue := &_GenesisState_40_list{list: &x.AllLossBundles}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.networkLossBundles":
+		if len(x.NetworkLossBundles) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_41_list{})
+		}
+		listValue := &_GenesisState_41_list{list: &x.NetworkLossBundles}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.previousPercentageRewardToStakedReputers":
+		value := x.PreviousPercentageRewardToStakedReputers
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.GenesisState.unfulfilledWorkerNonces":
+		if len(x.UnfulfilledWorkerNonces) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_43_list{})
+		}
+		listValue := &_GenesisState_43_list{list: &x.UnfulfilledWorkerNonces}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.unfulfilledReputerNonces":
+		if len(x.UnfulfilledReputerNonces) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_44_list{})
+		}
+		listValue := &_GenesisState_44_list{list: &x.UnfulfilledReputerNonces}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.latestInfererNetworkRegrets":
+		if len(x.LatestInfererNetworkRegrets) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_45_list{})
+		}
+		listValue := &_GenesisState_45_list{list: &x.LatestInfererNetworkRegrets}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.latestForecasterNetworkRegrets":
+		if len(x.LatestForecasterNetworkRegrets) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_46_list{})
+		}
+		listValue := &_GenesisState_46_list{list: &x.LatestForecasterNetworkRegrets}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.latestOneInForecasterNetworkRegrets":
+		if len(x.LatestOneInForecasterNetworkRegrets) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_47_list{})
+		}
+		listValue := &_GenesisState_47_list{list: &x.LatestOneInForecasterNetworkRegrets}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.latestOneInForecasterSelfNetworkRegrets":
+		if len(x.LatestOneInForecasterSelfNetworkRegrets) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_48_list{})
+		}
+		listValue := &_GenesisState_48_list{list: &x.LatestOneInForecasterSelfNetworkRegrets}
+		return protoreflect.ValueOfList(listValue)
 	case "emissions.v1.GenesisState.core_team_addresses":
 		if len(x.CoreTeamAddresses) == 0 {
 			return protoreflect.ValueOfList(&_GenesisState_2_list{})
 		}
 		listValue := &_GenesisState_2_list{list: &x.CoreTeamAddresses}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.topicLastWorkerCommit":
+		if len(x.TopicLastWorkerCommit) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_49_list{})
+		}
+		listValue := &_GenesisState_49_list{list: &x.TopicLastWorkerCommit}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.topicLastReputerCommit":
+		if len(x.TopicLastReputerCommit) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_50_list{})
+		}
+		listValue := &_GenesisState_50_list{list: &x.TopicLastReputerCommit}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.topicLastWorkerPayload":
+		if len(x.TopicLastWorkerPayload) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_51_list{})
+		}
+		listValue := &_GenesisState_51_list{list: &x.TopicLastWorkerPayload}
+		return protoreflect.ValueOfList(listValue)
+	case "emissions.v1.GenesisState.topicLastReputerPayload":
+		if len(x.TopicLastReputerPayload) == 0 {
+			return protoreflect.ValueOfList(&_GenesisState_52_list{})
+		}
+		listValue := &_GenesisState_52_list{list: &x.TopicLastReputerPayload}
 		return protoreflect.ValueOfList(listValue)
 	default:
 		if descriptor.IsExtension() {
@@ -236,10 +3510,204 @@ func (x *fastReflection_GenesisState) Set(fd protoreflect.FieldDescriptor, value
 	switch fd.FullName() {
 	case "emissions.v1.GenesisState.params":
 		x.Params = value.Message().Interface().(*Params)
+	case "emissions.v1.GenesisState.nextTopicId":
+		x.NextTopicId = value.Uint()
+	case "emissions.v1.GenesisState.topics":
+		lv := value.List()
+		clv := lv.(*_GenesisState_4_list)
+		x.Topics = *clv.list
+	case "emissions.v1.GenesisState.activeTopics":
+		lv := value.List()
+		clv := lv.(*_GenesisState_5_list)
+		x.ActiveTopics = *clv.list
+	case "emissions.v1.GenesisState.churnableTopics":
+		lv := value.List()
+		clv := lv.(*_GenesisState_6_list)
+		x.ChurnableTopics = *clv.list
+	case "emissions.v1.GenesisState.rewardableTopics":
+		lv := value.List()
+		clv := lv.(*_GenesisState_7_list)
+		x.RewardableTopics = *clv.list
+	case "emissions.v1.GenesisState.topicWorkers":
+		lv := value.List()
+		clv := lv.(*_GenesisState_8_list)
+		x.TopicWorkers = *clv.list
+	case "emissions.v1.GenesisState.topicReputers":
+		lv := value.List()
+		clv := lv.(*_GenesisState_9_list)
+		x.TopicReputers = *clv.list
+	case "emissions.v1.GenesisState.topicRewardNonce":
+		lv := value.List()
+		clv := lv.(*_GenesisState_10_list)
+		x.TopicRewardNonce = *clv.list
+	case "emissions.v1.GenesisState.infererScoresByBlock":
+		lv := value.List()
+		clv := lv.(*_GenesisState_11_list)
+		x.InfererScoresByBlock = *clv.list
+	case "emissions.v1.GenesisState.forecasterScoresByBlock":
+		lv := value.List()
+		clv := lv.(*_GenesisState_12_list)
+		x.ForecasterScoresByBlock = *clv.list
+	case "emissions.v1.GenesisState.reputerScoresByBlock":
+		lv := value.List()
+		clv := lv.(*_GenesisState_13_list)
+		x.ReputerScoresByBlock = *clv.list
+	case "emissions.v1.GenesisState.latestInfererScoresByWorker":
+		lv := value.List()
+		clv := lv.(*_GenesisState_14_list)
+		x.LatestInfererScoresByWorker = *clv.list
+	case "emissions.v1.GenesisState.latestForecasterScoresByWorker":
+		lv := value.List()
+		clv := lv.(*_GenesisState_15_list)
+		x.LatestForecasterScoresByWorker = *clv.list
+	case "emissions.v1.GenesisState.latestReputerScoresByReputer":
+		lv := value.List()
+		clv := lv.(*_GenesisState_16_list)
+		x.LatestReputerScoresByReputer = *clv.list
+	case "emissions.v1.GenesisState.reputerListeningCoefficient":
+		lv := value.List()
+		clv := lv.(*_GenesisState_17_list)
+		x.ReputerListeningCoefficient = *clv.list
+	case "emissions.v1.GenesisState.previousReputerRewardFraction":
+		lv := value.List()
+		clv := lv.(*_GenesisState_18_list)
+		x.PreviousReputerRewardFraction = *clv.list
+	case "emissions.v1.GenesisState.previousInferenceRewardFraction":
+		lv := value.List()
+		clv := lv.(*_GenesisState_19_list)
+		x.PreviousInferenceRewardFraction = *clv.list
+	case "emissions.v1.GenesisState.previousForecastRewardFraction":
+		lv := value.List()
+		clv := lv.(*_GenesisState_20_list)
+		x.PreviousForecastRewardFraction = *clv.list
+	case "emissions.v1.GenesisState.totalStake":
+		x.TotalStake = value.Interface().(string)
+	case "emissions.v1.GenesisState.topicStake":
+		lv := value.List()
+		clv := lv.(*_GenesisState_22_list)
+		x.TopicStake = *clv.list
+	case "emissions.v1.GenesisState.stakeReputerAuthority":
+		lv := value.List()
+		clv := lv.(*_GenesisState_23_list)
+		x.StakeReputerAuthority = *clv.list
+	case "emissions.v1.GenesisState.stakeSumFromDelegator":
+		lv := value.List()
+		clv := lv.(*_GenesisState_24_list)
+		x.StakeSumFromDelegator = *clv.list
+	case "emissions.v1.GenesisState.delegatedStakes":
+		lv := value.List()
+		clv := lv.(*_GenesisState_25_list)
+		x.DelegatedStakes = *clv.list
+	case "emissions.v1.GenesisState.stakeFromDelegatorsUponReputer":
+		lv := value.List()
+		clv := lv.(*_GenesisState_26_list)
+		x.StakeFromDelegatorsUponReputer = *clv.list
+	case "emissions.v1.GenesisState.delegateRewardPerShare":
+		lv := value.List()
+		clv := lv.(*_GenesisState_27_list)
+		x.DelegateRewardPerShare = *clv.list
+	case "emissions.v1.GenesisState.stakeRemovalsByBlock":
+		lv := value.List()
+		clv := lv.(*_GenesisState_28_list)
+		x.StakeRemovalsByBlock = *clv.list
+	case "emissions.v1.GenesisState.stakeRemovalsByActor":
+		lv := value.List()
+		clv := lv.(*_GenesisState_29_list)
+		x.StakeRemovalsByActor = *clv.list
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByBlock":
+		lv := value.List()
+		clv := lv.(*_GenesisState_30_list)
+		x.DelegateStakeRemovalsByBlock = *clv.list
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByActor":
+		lv := value.List()
+		clv := lv.(*_GenesisState_31_list)
+		x.DelegateStakeRemovalsByActor = *clv.list
+	case "emissions.v1.GenesisState.inferences":
+		lv := value.List()
+		clv := lv.(*_GenesisState_32_list)
+		x.Inferences = *clv.list
+	case "emissions.v1.GenesisState.forecasts":
+		lv := value.List()
+		clv := lv.(*_GenesisState_33_list)
+		x.Forecasts = *clv.list
+	case "emissions.v1.GenesisState.workers":
+		lv := value.List()
+		clv := lv.(*_GenesisState_34_list)
+		x.Workers = *clv.list
+	case "emissions.v1.GenesisState.reputers":
+		lv := value.List()
+		clv := lv.(*_GenesisState_35_list)
+		x.Reputers = *clv.list
+	case "emissions.v1.GenesisState.topicFeeRevenue":
+		lv := value.List()
+		clv := lv.(*_GenesisState_36_list)
+		x.TopicFeeRevenue = *clv.list
+	case "emissions.v1.GenesisState.previousTopicWeight":
+		lv := value.List()
+		clv := lv.(*_GenesisState_37_list)
+		x.PreviousTopicWeight = *clv.list
+	case "emissions.v1.GenesisState.allInferences":
+		lv := value.List()
+		clv := lv.(*_GenesisState_38_list)
+		x.AllInferences = *clv.list
+	case "emissions.v1.GenesisState.allForecasts":
+		lv := value.List()
+		clv := lv.(*_GenesisState_39_list)
+		x.AllForecasts = *clv.list
+	case "emissions.v1.GenesisState.allLossBundles":
+		lv := value.List()
+		clv := lv.(*_GenesisState_40_list)
+		x.AllLossBundles = *clv.list
+	case "emissions.v1.GenesisState.networkLossBundles":
+		lv := value.List()
+		clv := lv.(*_GenesisState_41_list)
+		x.NetworkLossBundles = *clv.list
+	case "emissions.v1.GenesisState.previousPercentageRewardToStakedReputers":
+		x.PreviousPercentageRewardToStakedReputers = value.Interface().(string)
+	case "emissions.v1.GenesisState.unfulfilledWorkerNonces":
+		lv := value.List()
+		clv := lv.(*_GenesisState_43_list)
+		x.UnfulfilledWorkerNonces = *clv.list
+	case "emissions.v1.GenesisState.unfulfilledReputerNonces":
+		lv := value.List()
+		clv := lv.(*_GenesisState_44_list)
+		x.UnfulfilledReputerNonces = *clv.list
+	case "emissions.v1.GenesisState.latestInfererNetworkRegrets":
+		lv := value.List()
+		clv := lv.(*_GenesisState_45_list)
+		x.LatestInfererNetworkRegrets = *clv.list
+	case "emissions.v1.GenesisState.latestForecasterNetworkRegrets":
+		lv := value.List()
+		clv := lv.(*_GenesisState_46_list)
+		x.LatestForecasterNetworkRegrets = *clv.list
+	case "emissions.v1.GenesisState.latestOneInForecasterNetworkRegrets":
+		lv := value.List()
+		clv := lv.(*_GenesisState_47_list)
+		x.LatestOneInForecasterNetworkRegrets = *clv.list
+	case "emissions.v1.GenesisState.latestOneInForecasterSelfNetworkRegrets":
+		lv := value.List()
+		clv := lv.(*_GenesisState_48_list)
+		x.LatestOneInForecasterSelfNetworkRegrets = *clv.list
 	case "emissions.v1.GenesisState.core_team_addresses":
 		lv := value.List()
 		clv := lv.(*_GenesisState_2_list)
 		x.CoreTeamAddresses = *clv.list
+	case "emissions.v1.GenesisState.topicLastWorkerCommit":
+		lv := value.List()
+		clv := lv.(*_GenesisState_49_list)
+		x.TopicLastWorkerCommit = *clv.list
+	case "emissions.v1.GenesisState.topicLastReputerCommit":
+		lv := value.List()
+		clv := lv.(*_GenesisState_50_list)
+		x.TopicLastReputerCommit = *clv.list
+	case "emissions.v1.GenesisState.topicLastWorkerPayload":
+		lv := value.List()
+		clv := lv.(*_GenesisState_51_list)
+		x.TopicLastWorkerPayload = *clv.list
+	case "emissions.v1.GenesisState.topicLastReputerPayload":
+		lv := value.List()
+		clv := lv.(*_GenesisState_52_list)
+		x.TopicLastReputerPayload = *clv.list
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.GenesisState"))
@@ -265,12 +3733,300 @@ func (x *fastReflection_GenesisState) Mutable(fd protoreflect.FieldDescriptor) p
 			x.Params = new(Params)
 		}
 		return protoreflect.ValueOfMessage(x.Params.ProtoReflect())
+	case "emissions.v1.GenesisState.topics":
+		if x.Topics == nil {
+			x.Topics = []*TopicIdAndTopic{}
+		}
+		value := &_GenesisState_4_list{list: &x.Topics}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.activeTopics":
+		if x.ActiveTopics == nil {
+			x.ActiveTopics = []uint64{}
+		}
+		value := &_GenesisState_5_list{list: &x.ActiveTopics}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.churnableTopics":
+		if x.ChurnableTopics == nil {
+			x.ChurnableTopics = []uint64{}
+		}
+		value := &_GenesisState_6_list{list: &x.ChurnableTopics}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.rewardableTopics":
+		if x.RewardableTopics == nil {
+			x.RewardableTopics = []uint64{}
+		}
+		value := &_GenesisState_7_list{list: &x.RewardableTopics}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.topicWorkers":
+		if x.TopicWorkers == nil {
+			x.TopicWorkers = []*TopicAndActorId{}
+		}
+		value := &_GenesisState_8_list{list: &x.TopicWorkers}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.topicReputers":
+		if x.TopicReputers == nil {
+			x.TopicReputers = []*TopicAndActorId{}
+		}
+		value := &_GenesisState_9_list{list: &x.TopicReputers}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.topicRewardNonce":
+		if x.TopicRewardNonce == nil {
+			x.TopicRewardNonce = []*TopicIdAndBlockHeight{}
+		}
+		value := &_GenesisState_10_list{list: &x.TopicRewardNonce}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.infererScoresByBlock":
+		if x.InfererScoresByBlock == nil {
+			x.InfererScoresByBlock = []*TopicIdBlockHeightScores{}
+		}
+		value := &_GenesisState_11_list{list: &x.InfererScoresByBlock}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.forecasterScoresByBlock":
+		if x.ForecasterScoresByBlock == nil {
+			x.ForecasterScoresByBlock = []*TopicIdBlockHeightScores{}
+		}
+		value := &_GenesisState_12_list{list: &x.ForecasterScoresByBlock}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.reputerScoresByBlock":
+		if x.ReputerScoresByBlock == nil {
+			x.ReputerScoresByBlock = []*TopicIdBlockHeightScores{}
+		}
+		value := &_GenesisState_13_list{list: &x.ReputerScoresByBlock}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.latestInfererScoresByWorker":
+		if x.LatestInfererScoresByWorker == nil {
+			x.LatestInfererScoresByWorker = []*TopicIdActorIdScore{}
+		}
+		value := &_GenesisState_14_list{list: &x.LatestInfererScoresByWorker}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.latestForecasterScoresByWorker":
+		if x.LatestForecasterScoresByWorker == nil {
+			x.LatestForecasterScoresByWorker = []*TopicIdActorIdScore{}
+		}
+		value := &_GenesisState_15_list{list: &x.LatestForecasterScoresByWorker}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.latestReputerScoresByReputer":
+		if x.LatestReputerScoresByReputer == nil {
+			x.LatestReputerScoresByReputer = []*TopicIdActorIdScore{}
+		}
+		value := &_GenesisState_16_list{list: &x.LatestReputerScoresByReputer}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.reputerListeningCoefficient":
+		if x.ReputerListeningCoefficient == nil {
+			x.ReputerListeningCoefficient = []*TopicIdActorIdListeningCoefficient{}
+		}
+		value := &_GenesisState_17_list{list: &x.ReputerListeningCoefficient}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.previousReputerRewardFraction":
+		if x.PreviousReputerRewardFraction == nil {
+			x.PreviousReputerRewardFraction = []*TopicIdActorIdDec{}
+		}
+		value := &_GenesisState_18_list{list: &x.PreviousReputerRewardFraction}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.previousInferenceRewardFraction":
+		if x.PreviousInferenceRewardFraction == nil {
+			x.PreviousInferenceRewardFraction = []*TopicIdActorIdDec{}
+		}
+		value := &_GenesisState_19_list{list: &x.PreviousInferenceRewardFraction}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.previousForecastRewardFraction":
+		if x.PreviousForecastRewardFraction == nil {
+			x.PreviousForecastRewardFraction = []*TopicIdActorIdDec{}
+		}
+		value := &_GenesisState_20_list{list: &x.PreviousForecastRewardFraction}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.topicStake":
+		if x.TopicStake == nil {
+			x.TopicStake = []*TopicIdAndInt{}
+		}
+		value := &_GenesisState_22_list{list: &x.TopicStake}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.stakeReputerAuthority":
+		if x.StakeReputerAuthority == nil {
+			x.StakeReputerAuthority = []*TopicIdActorIdInt{}
+		}
+		value := &_GenesisState_23_list{list: &x.StakeReputerAuthority}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.stakeSumFromDelegator":
+		if x.StakeSumFromDelegator == nil {
+			x.StakeSumFromDelegator = []*TopicIdActorIdInt{}
+		}
+		value := &_GenesisState_24_list{list: &x.StakeSumFromDelegator}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.delegatedStakes":
+		if x.DelegatedStakes == nil {
+			x.DelegatedStakes = []*TopicIdDelegatorReputerDelegatorInfo{}
+		}
+		value := &_GenesisState_25_list{list: &x.DelegatedStakes}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.stakeFromDelegatorsUponReputer":
+		if x.StakeFromDelegatorsUponReputer == nil {
+			x.StakeFromDelegatorsUponReputer = []*TopicIdActorIdInt{}
+		}
+		value := &_GenesisState_26_list{list: &x.StakeFromDelegatorsUponReputer}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.delegateRewardPerShare":
+		if x.DelegateRewardPerShare == nil {
+			x.DelegateRewardPerShare = []*TopicIdActorIdDec{}
+		}
+		value := &_GenesisState_27_list{list: &x.DelegateRewardPerShare}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.stakeRemovalsByBlock":
+		if x.StakeRemovalsByBlock == nil {
+			x.StakeRemovalsByBlock = []*BlockHeightTopicIdReputerStakeRemovalInfo{}
+		}
+		value := &_GenesisState_28_list{list: &x.StakeRemovalsByBlock}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.stakeRemovalsByActor":
+		if x.StakeRemovalsByActor == nil {
+			x.StakeRemovalsByActor = []*ActorIdTopicIdBlockHeight{}
+		}
+		value := &_GenesisState_29_list{list: &x.StakeRemovalsByActor}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByBlock":
+		if x.DelegateStakeRemovalsByBlock == nil {
+			x.DelegateStakeRemovalsByBlock = []*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo{}
+		}
+		value := &_GenesisState_30_list{list: &x.DelegateStakeRemovalsByBlock}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByActor":
+		if x.DelegateStakeRemovalsByActor == nil {
+			x.DelegateStakeRemovalsByActor = []*DelegatorReputerTopicIdBlockHeight{}
+		}
+		value := &_GenesisState_31_list{list: &x.DelegateStakeRemovalsByActor}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.inferences":
+		if x.Inferences == nil {
+			x.Inferences = []*TopicIdActorIdInference{}
+		}
+		value := &_GenesisState_32_list{list: &x.Inferences}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.forecasts":
+		if x.Forecasts == nil {
+			x.Forecasts = []*TopicIdActorIdForecast{}
+		}
+		value := &_GenesisState_33_list{list: &x.Forecasts}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.workers":
+		if x.Workers == nil {
+			x.Workers = []*LibP2PKeyAndOffchainNode{}
+		}
+		value := &_GenesisState_34_list{list: &x.Workers}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.reputers":
+		if x.Reputers == nil {
+			x.Reputers = []*LibP2PKeyAndOffchainNode{}
+		}
+		value := &_GenesisState_35_list{list: &x.Reputers}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.topicFeeRevenue":
+		if x.TopicFeeRevenue == nil {
+			x.TopicFeeRevenue = []*TopicIdAndInt{}
+		}
+		value := &_GenesisState_36_list{list: &x.TopicFeeRevenue}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.previousTopicWeight":
+		if x.PreviousTopicWeight == nil {
+			x.PreviousTopicWeight = []*TopicIdAndDec{}
+		}
+		value := &_GenesisState_37_list{list: &x.PreviousTopicWeight}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.allInferences":
+		if x.AllInferences == nil {
+			x.AllInferences = []*TopicIdBlockHeightInferences{}
+		}
+		value := &_GenesisState_38_list{list: &x.AllInferences}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.allForecasts":
+		if x.AllForecasts == nil {
+			x.AllForecasts = []*TopicIdBlockHeightForecasts{}
+		}
+		value := &_GenesisState_39_list{list: &x.AllForecasts}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.allLossBundles":
+		if x.AllLossBundles == nil {
+			x.AllLossBundles = []*TopicIdBlockHeightReputerValueBundles{}
+		}
+		value := &_GenesisState_40_list{list: &x.AllLossBundles}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.networkLossBundles":
+		if x.NetworkLossBundles == nil {
+			x.NetworkLossBundles = []*TopicIdBlockHeightValueBundles{}
+		}
+		value := &_GenesisState_41_list{list: &x.NetworkLossBundles}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.unfulfilledWorkerNonces":
+		if x.UnfulfilledWorkerNonces == nil {
+			x.UnfulfilledWorkerNonces = []*TopicIdAndNonces{}
+		}
+		value := &_GenesisState_43_list{list: &x.UnfulfilledWorkerNonces}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.unfulfilledReputerNonces":
+		if x.UnfulfilledReputerNonces == nil {
+			x.UnfulfilledReputerNonces = []*TopicIdAndReputerRequestNonces{}
+		}
+		value := &_GenesisState_44_list{list: &x.UnfulfilledReputerNonces}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.latestInfererNetworkRegrets":
+		if x.LatestInfererNetworkRegrets == nil {
+			x.LatestInfererNetworkRegrets = []*TopicIdActorIdTimeStampedValue{}
+		}
+		value := &_GenesisState_45_list{list: &x.LatestInfererNetworkRegrets}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.latestForecasterNetworkRegrets":
+		if x.LatestForecasterNetworkRegrets == nil {
+			x.LatestForecasterNetworkRegrets = []*TopicIdActorIdTimeStampedValue{}
+		}
+		value := &_GenesisState_46_list{list: &x.LatestForecasterNetworkRegrets}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.latestOneInForecasterNetworkRegrets":
+		if x.LatestOneInForecasterNetworkRegrets == nil {
+			x.LatestOneInForecasterNetworkRegrets = []*TopicIdActorIdActorIdTimeStampedValue{}
+		}
+		value := &_GenesisState_47_list{list: &x.LatestOneInForecasterNetworkRegrets}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.latestOneInForecasterSelfNetworkRegrets":
+		if x.LatestOneInForecasterSelfNetworkRegrets == nil {
+			x.LatestOneInForecasterSelfNetworkRegrets = []*TopicIdActorIdTimeStampedValue{}
+		}
+		value := &_GenesisState_48_list{list: &x.LatestOneInForecasterSelfNetworkRegrets}
+		return protoreflect.ValueOfList(value)
 	case "emissions.v1.GenesisState.core_team_addresses":
 		if x.CoreTeamAddresses == nil {
 			x.CoreTeamAddresses = []string{}
 		}
 		value := &_GenesisState_2_list{list: &x.CoreTeamAddresses}
 		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.topicLastWorkerCommit":
+		if x.TopicLastWorkerCommit == nil {
+			x.TopicLastWorkerCommit = []*TopicIdTimestampedActorNonce{}
+		}
+		value := &_GenesisState_49_list{list: &x.TopicLastWorkerCommit}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.topicLastReputerCommit":
+		if x.TopicLastReputerCommit == nil {
+			x.TopicLastReputerCommit = []*TopicIdTimestampedActorNonce{}
+		}
+		value := &_GenesisState_50_list{list: &x.TopicLastReputerCommit}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.topicLastWorkerPayload":
+		if x.TopicLastWorkerPayload == nil {
+			x.TopicLastWorkerPayload = []*TopicIdTimestampedActorNonce{}
+		}
+		value := &_GenesisState_51_list{list: &x.TopicLastWorkerPayload}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.topicLastReputerPayload":
+		if x.TopicLastReputerPayload == nil {
+			x.TopicLastReputerPayload = []*TopicIdTimestampedActorNonce{}
+		}
+		value := &_GenesisState_52_list{list: &x.TopicLastReputerPayload}
+		return protoreflect.ValueOfList(value)
+	case "emissions.v1.GenesisState.nextTopicId":
+		panic(fmt.Errorf("field nextTopicId of message emissions.v1.GenesisState is not mutable"))
+	case "emissions.v1.GenesisState.totalStake":
+		panic(fmt.Errorf("field totalStake of message emissions.v1.GenesisState is not mutable"))
+	case "emissions.v1.GenesisState.previousPercentageRewardToStakedReputers":
+		panic(fmt.Errorf("field previousPercentageRewardToStakedReputers of message emissions.v1.GenesisState is not mutable"))
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.GenesisState"))
@@ -287,9 +4043,156 @@ func (x *fastReflection_GenesisState) NewField(fd protoreflect.FieldDescriptor) 
 	case "emissions.v1.GenesisState.params":
 		m := new(Params)
 		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	case "emissions.v1.GenesisState.nextTopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.GenesisState.topics":
+		list := []*TopicIdAndTopic{}
+		return protoreflect.ValueOfList(&_GenesisState_4_list{list: &list})
+	case "emissions.v1.GenesisState.activeTopics":
+		list := []uint64{}
+		return protoreflect.ValueOfList(&_GenesisState_5_list{list: &list})
+	case "emissions.v1.GenesisState.churnableTopics":
+		list := []uint64{}
+		return protoreflect.ValueOfList(&_GenesisState_6_list{list: &list})
+	case "emissions.v1.GenesisState.rewardableTopics":
+		list := []uint64{}
+		return protoreflect.ValueOfList(&_GenesisState_7_list{list: &list})
+	case "emissions.v1.GenesisState.topicWorkers":
+		list := []*TopicAndActorId{}
+		return protoreflect.ValueOfList(&_GenesisState_8_list{list: &list})
+	case "emissions.v1.GenesisState.topicReputers":
+		list := []*TopicAndActorId{}
+		return protoreflect.ValueOfList(&_GenesisState_9_list{list: &list})
+	case "emissions.v1.GenesisState.topicRewardNonce":
+		list := []*TopicIdAndBlockHeight{}
+		return protoreflect.ValueOfList(&_GenesisState_10_list{list: &list})
+	case "emissions.v1.GenesisState.infererScoresByBlock":
+		list := []*TopicIdBlockHeightScores{}
+		return protoreflect.ValueOfList(&_GenesisState_11_list{list: &list})
+	case "emissions.v1.GenesisState.forecasterScoresByBlock":
+		list := []*TopicIdBlockHeightScores{}
+		return protoreflect.ValueOfList(&_GenesisState_12_list{list: &list})
+	case "emissions.v1.GenesisState.reputerScoresByBlock":
+		list := []*TopicIdBlockHeightScores{}
+		return protoreflect.ValueOfList(&_GenesisState_13_list{list: &list})
+	case "emissions.v1.GenesisState.latestInfererScoresByWorker":
+		list := []*TopicIdActorIdScore{}
+		return protoreflect.ValueOfList(&_GenesisState_14_list{list: &list})
+	case "emissions.v1.GenesisState.latestForecasterScoresByWorker":
+		list := []*TopicIdActorIdScore{}
+		return protoreflect.ValueOfList(&_GenesisState_15_list{list: &list})
+	case "emissions.v1.GenesisState.latestReputerScoresByReputer":
+		list := []*TopicIdActorIdScore{}
+		return protoreflect.ValueOfList(&_GenesisState_16_list{list: &list})
+	case "emissions.v1.GenesisState.reputerListeningCoefficient":
+		list := []*TopicIdActorIdListeningCoefficient{}
+		return protoreflect.ValueOfList(&_GenesisState_17_list{list: &list})
+	case "emissions.v1.GenesisState.previousReputerRewardFraction":
+		list := []*TopicIdActorIdDec{}
+		return protoreflect.ValueOfList(&_GenesisState_18_list{list: &list})
+	case "emissions.v1.GenesisState.previousInferenceRewardFraction":
+		list := []*TopicIdActorIdDec{}
+		return protoreflect.ValueOfList(&_GenesisState_19_list{list: &list})
+	case "emissions.v1.GenesisState.previousForecastRewardFraction":
+		list := []*TopicIdActorIdDec{}
+		return protoreflect.ValueOfList(&_GenesisState_20_list{list: &list})
+	case "emissions.v1.GenesisState.totalStake":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.GenesisState.topicStake":
+		list := []*TopicIdAndInt{}
+		return protoreflect.ValueOfList(&_GenesisState_22_list{list: &list})
+	case "emissions.v1.GenesisState.stakeReputerAuthority":
+		list := []*TopicIdActorIdInt{}
+		return protoreflect.ValueOfList(&_GenesisState_23_list{list: &list})
+	case "emissions.v1.GenesisState.stakeSumFromDelegator":
+		list := []*TopicIdActorIdInt{}
+		return protoreflect.ValueOfList(&_GenesisState_24_list{list: &list})
+	case "emissions.v1.GenesisState.delegatedStakes":
+		list := []*TopicIdDelegatorReputerDelegatorInfo{}
+		return protoreflect.ValueOfList(&_GenesisState_25_list{list: &list})
+	case "emissions.v1.GenesisState.stakeFromDelegatorsUponReputer":
+		list := []*TopicIdActorIdInt{}
+		return protoreflect.ValueOfList(&_GenesisState_26_list{list: &list})
+	case "emissions.v1.GenesisState.delegateRewardPerShare":
+		list := []*TopicIdActorIdDec{}
+		return protoreflect.ValueOfList(&_GenesisState_27_list{list: &list})
+	case "emissions.v1.GenesisState.stakeRemovalsByBlock":
+		list := []*BlockHeightTopicIdReputerStakeRemovalInfo{}
+		return protoreflect.ValueOfList(&_GenesisState_28_list{list: &list})
+	case "emissions.v1.GenesisState.stakeRemovalsByActor":
+		list := []*ActorIdTopicIdBlockHeight{}
+		return protoreflect.ValueOfList(&_GenesisState_29_list{list: &list})
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByBlock":
+		list := []*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo{}
+		return protoreflect.ValueOfList(&_GenesisState_30_list{list: &list})
+	case "emissions.v1.GenesisState.delegateStakeRemovalsByActor":
+		list := []*DelegatorReputerTopicIdBlockHeight{}
+		return protoreflect.ValueOfList(&_GenesisState_31_list{list: &list})
+	case "emissions.v1.GenesisState.inferences":
+		list := []*TopicIdActorIdInference{}
+		return protoreflect.ValueOfList(&_GenesisState_32_list{list: &list})
+	case "emissions.v1.GenesisState.forecasts":
+		list := []*TopicIdActorIdForecast{}
+		return protoreflect.ValueOfList(&_GenesisState_33_list{list: &list})
+	case "emissions.v1.GenesisState.workers":
+		list := []*LibP2PKeyAndOffchainNode{}
+		return protoreflect.ValueOfList(&_GenesisState_34_list{list: &list})
+	case "emissions.v1.GenesisState.reputers":
+		list := []*LibP2PKeyAndOffchainNode{}
+		return protoreflect.ValueOfList(&_GenesisState_35_list{list: &list})
+	case "emissions.v1.GenesisState.topicFeeRevenue":
+		list := []*TopicIdAndInt{}
+		return protoreflect.ValueOfList(&_GenesisState_36_list{list: &list})
+	case "emissions.v1.GenesisState.previousTopicWeight":
+		list := []*TopicIdAndDec{}
+		return protoreflect.ValueOfList(&_GenesisState_37_list{list: &list})
+	case "emissions.v1.GenesisState.allInferences":
+		list := []*TopicIdBlockHeightInferences{}
+		return protoreflect.ValueOfList(&_GenesisState_38_list{list: &list})
+	case "emissions.v1.GenesisState.allForecasts":
+		list := []*TopicIdBlockHeightForecasts{}
+		return protoreflect.ValueOfList(&_GenesisState_39_list{list: &list})
+	case "emissions.v1.GenesisState.allLossBundles":
+		list := []*TopicIdBlockHeightReputerValueBundles{}
+		return protoreflect.ValueOfList(&_GenesisState_40_list{list: &list})
+	case "emissions.v1.GenesisState.networkLossBundles":
+		list := []*TopicIdBlockHeightValueBundles{}
+		return protoreflect.ValueOfList(&_GenesisState_41_list{list: &list})
+	case "emissions.v1.GenesisState.previousPercentageRewardToStakedReputers":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.GenesisState.unfulfilledWorkerNonces":
+		list := []*TopicIdAndNonces{}
+		return protoreflect.ValueOfList(&_GenesisState_43_list{list: &list})
+	case "emissions.v1.GenesisState.unfulfilledReputerNonces":
+		list := []*TopicIdAndReputerRequestNonces{}
+		return protoreflect.ValueOfList(&_GenesisState_44_list{list: &list})
+	case "emissions.v1.GenesisState.latestInfererNetworkRegrets":
+		list := []*TopicIdActorIdTimeStampedValue{}
+		return protoreflect.ValueOfList(&_GenesisState_45_list{list: &list})
+	case "emissions.v1.GenesisState.latestForecasterNetworkRegrets":
+		list := []*TopicIdActorIdTimeStampedValue{}
+		return protoreflect.ValueOfList(&_GenesisState_46_list{list: &list})
+	case "emissions.v1.GenesisState.latestOneInForecasterNetworkRegrets":
+		list := []*TopicIdActorIdActorIdTimeStampedValue{}
+		return protoreflect.ValueOfList(&_GenesisState_47_list{list: &list})
+	case "emissions.v1.GenesisState.latestOneInForecasterSelfNetworkRegrets":
+		list := []*TopicIdActorIdTimeStampedValue{}
+		return protoreflect.ValueOfList(&_GenesisState_48_list{list: &list})
 	case "emissions.v1.GenesisState.core_team_addresses":
 		list := []string{}
 		return protoreflect.ValueOfList(&_GenesisState_2_list{list: &list})
+	case "emissions.v1.GenesisState.topicLastWorkerCommit":
+		list := []*TopicIdTimestampedActorNonce{}
+		return protoreflect.ValueOfList(&_GenesisState_49_list{list: &list})
+	case "emissions.v1.GenesisState.topicLastReputerCommit":
+		list := []*TopicIdTimestampedActorNonce{}
+		return protoreflect.ValueOfList(&_GenesisState_50_list{list: &list})
+	case "emissions.v1.GenesisState.topicLastWorkerPayload":
+		list := []*TopicIdTimestampedActorNonce{}
+		return protoreflect.ValueOfList(&_GenesisState_51_list{list: &list})
+	case "emissions.v1.GenesisState.topicLastReputerPayload":
+		list := []*TopicIdTimestampedActorNonce{}
+		return protoreflect.ValueOfList(&_GenesisState_52_list{list: &list})
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.GenesisState"))
@@ -363,10 +4266,306 @@ func (x *fastReflection_GenesisState) ProtoMethods() *protoiface.Methods {
 			l = options.Size(x.Params)
 			n += 1 + l + runtime.Sov(uint64(l))
 		}
+		if x.NextTopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.NextTopicId))
+		}
+		if len(x.Topics) > 0 {
+			for _, e := range x.Topics {
+				l = options.Size(e)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.ActiveTopics) > 0 {
+			l = 0
+			for _, e := range x.ActiveTopics {
+				l += runtime.Sov(uint64(e))
+			}
+			n += 1 + runtime.Sov(uint64(l)) + l
+		}
+		if len(x.ChurnableTopics) > 0 {
+			l = 0
+			for _, e := range x.ChurnableTopics {
+				l += runtime.Sov(uint64(e))
+			}
+			n += 1 + runtime.Sov(uint64(l)) + l
+		}
+		if len(x.RewardableTopics) > 0 {
+			l = 0
+			for _, e := range x.RewardableTopics {
+				l += runtime.Sov(uint64(e))
+			}
+			n += 1 + runtime.Sov(uint64(l)) + l
+		}
+		if len(x.TopicWorkers) > 0 {
+			for _, e := range x.TopicWorkers {
+				l = options.Size(e)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.TopicReputers) > 0 {
+			for _, e := range x.TopicReputers {
+				l = options.Size(e)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.TopicRewardNonce) > 0 {
+			for _, e := range x.TopicRewardNonce {
+				l = options.Size(e)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.InfererScoresByBlock) > 0 {
+			for _, e := range x.InfererScoresByBlock {
+				l = options.Size(e)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.ForecasterScoresByBlock) > 0 {
+			for _, e := range x.ForecasterScoresByBlock {
+				l = options.Size(e)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.ReputerScoresByBlock) > 0 {
+			for _, e := range x.ReputerScoresByBlock {
+				l = options.Size(e)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.LatestInfererScoresByWorker) > 0 {
+			for _, e := range x.LatestInfererScoresByWorker {
+				l = options.Size(e)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.LatestForecasterScoresByWorker) > 0 {
+			for _, e := range x.LatestForecasterScoresByWorker {
+				l = options.Size(e)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.LatestReputerScoresByReputer) > 0 {
+			for _, e := range x.LatestReputerScoresByReputer {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.ReputerListeningCoefficient) > 0 {
+			for _, e := range x.ReputerListeningCoefficient {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.PreviousReputerRewardFraction) > 0 {
+			for _, e := range x.PreviousReputerRewardFraction {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.PreviousInferenceRewardFraction) > 0 {
+			for _, e := range x.PreviousInferenceRewardFraction {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.PreviousForecastRewardFraction) > 0 {
+			for _, e := range x.PreviousForecastRewardFraction {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		l = len(x.TotalStake)
+		if l > 0 {
+			n += 2 + l + runtime.Sov(uint64(l))
+		}
+		if len(x.TopicStake) > 0 {
+			for _, e := range x.TopicStake {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.StakeReputerAuthority) > 0 {
+			for _, e := range x.StakeReputerAuthority {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.StakeSumFromDelegator) > 0 {
+			for _, e := range x.StakeSumFromDelegator {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.DelegatedStakes) > 0 {
+			for _, e := range x.DelegatedStakes {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.StakeFromDelegatorsUponReputer) > 0 {
+			for _, e := range x.StakeFromDelegatorsUponReputer {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.DelegateRewardPerShare) > 0 {
+			for _, e := range x.DelegateRewardPerShare {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.StakeRemovalsByBlock) > 0 {
+			for _, e := range x.StakeRemovalsByBlock {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.StakeRemovalsByActor) > 0 {
+			for _, e := range x.StakeRemovalsByActor {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.DelegateStakeRemovalsByBlock) > 0 {
+			for _, e := range x.DelegateStakeRemovalsByBlock {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.DelegateStakeRemovalsByActor) > 0 {
+			for _, e := range x.DelegateStakeRemovalsByActor {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.Inferences) > 0 {
+			for _, e := range x.Inferences {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.Forecasts) > 0 {
+			for _, e := range x.Forecasts {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.Workers) > 0 {
+			for _, e := range x.Workers {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.Reputers) > 0 {
+			for _, e := range x.Reputers {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.TopicFeeRevenue) > 0 {
+			for _, e := range x.TopicFeeRevenue {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.PreviousTopicWeight) > 0 {
+			for _, e := range x.PreviousTopicWeight {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.AllInferences) > 0 {
+			for _, e := range x.AllInferences {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.AllForecasts) > 0 {
+			for _, e := range x.AllForecasts {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.AllLossBundles) > 0 {
+			for _, e := range x.AllLossBundles {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.NetworkLossBundles) > 0 {
+			for _, e := range x.NetworkLossBundles {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		l = len(x.PreviousPercentageRewardToStakedReputers)
+		if l > 0 {
+			n += 2 + l + runtime.Sov(uint64(l))
+		}
+		if len(x.UnfulfilledWorkerNonces) > 0 {
+			for _, e := range x.UnfulfilledWorkerNonces {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.UnfulfilledReputerNonces) > 0 {
+			for _, e := range x.UnfulfilledReputerNonces {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.LatestInfererNetworkRegrets) > 0 {
+			for _, e := range x.LatestInfererNetworkRegrets {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.LatestForecasterNetworkRegrets) > 0 {
+			for _, e := range x.LatestForecasterNetworkRegrets {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.LatestOneInForecasterNetworkRegrets) > 0 {
+			for _, e := range x.LatestOneInForecasterNetworkRegrets {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.LatestOneInForecasterSelfNetworkRegrets) > 0 {
+			for _, e := range x.LatestOneInForecasterSelfNetworkRegrets {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
 		if len(x.CoreTeamAddresses) > 0 {
 			for _, s := range x.CoreTeamAddresses {
 				l = len(s)
 				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.TopicLastWorkerCommit) > 0 {
+			for _, e := range x.TopicLastWorkerCommit {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.TopicLastReputerCommit) > 0 {
+			for _, e := range x.TopicLastReputerCommit {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.TopicLastWorkerPayload) > 0 {
+			for _, e := range x.TopicLastWorkerPayload {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if len(x.TopicLastReputerPayload) > 0 {
+			for _, e := range x.TopicLastReputerPayload {
+				l = options.Size(e)
+				n += 2 + l + runtime.Sov(uint64(l))
 			}
 		}
 		if x.unknownFields != nil {
@@ -397,6 +4596,863 @@ func (x *fastReflection_GenesisState) ProtoMethods() *protoiface.Methods {
 		if x.unknownFields != nil {
 			i -= len(x.unknownFields)
 			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.TopicLastReputerPayload) > 0 {
+			for iNdEx := len(x.TopicLastReputerPayload) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.TopicLastReputerPayload[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x3
+				i--
+				dAtA[i] = 0xa2
+			}
+		}
+		if len(x.TopicLastWorkerPayload) > 0 {
+			for iNdEx := len(x.TopicLastWorkerPayload) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.TopicLastWorkerPayload[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x3
+				i--
+				dAtA[i] = 0x9a
+			}
+		}
+		if len(x.TopicLastReputerCommit) > 0 {
+			for iNdEx := len(x.TopicLastReputerCommit) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.TopicLastReputerCommit[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x3
+				i--
+				dAtA[i] = 0x92
+			}
+		}
+		if len(x.TopicLastWorkerCommit) > 0 {
+			for iNdEx := len(x.TopicLastWorkerCommit) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.TopicLastWorkerCommit[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x3
+				i--
+				dAtA[i] = 0x8a
+			}
+		}
+		if len(x.LatestOneInForecasterSelfNetworkRegrets) > 0 {
+			for iNdEx := len(x.LatestOneInForecasterSelfNetworkRegrets) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.LatestOneInForecasterSelfNetworkRegrets[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x3
+				i--
+				dAtA[i] = 0x82
+			}
+		}
+		if len(x.LatestOneInForecasterNetworkRegrets) > 0 {
+			for iNdEx := len(x.LatestOneInForecasterNetworkRegrets) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.LatestOneInForecasterNetworkRegrets[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xfa
+			}
+		}
+		if len(x.LatestForecasterNetworkRegrets) > 0 {
+			for iNdEx := len(x.LatestForecasterNetworkRegrets) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.LatestForecasterNetworkRegrets[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xf2
+			}
+		}
+		if len(x.LatestInfererNetworkRegrets) > 0 {
+			for iNdEx := len(x.LatestInfererNetworkRegrets) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.LatestInfererNetworkRegrets[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xea
+			}
+		}
+		if len(x.UnfulfilledReputerNonces) > 0 {
+			for iNdEx := len(x.UnfulfilledReputerNonces) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.UnfulfilledReputerNonces[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xe2
+			}
+		}
+		if len(x.UnfulfilledWorkerNonces) > 0 {
+			for iNdEx := len(x.UnfulfilledWorkerNonces) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.UnfulfilledWorkerNonces[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xda
+			}
+		}
+		if len(x.PreviousPercentageRewardToStakedReputers) > 0 {
+			i -= len(x.PreviousPercentageRewardToStakedReputers)
+			copy(dAtA[i:], x.PreviousPercentageRewardToStakedReputers)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.PreviousPercentageRewardToStakedReputers)))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xd2
+		}
+		if len(x.NetworkLossBundles) > 0 {
+			for iNdEx := len(x.NetworkLossBundles) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.NetworkLossBundles[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xca
+			}
+		}
+		if len(x.AllLossBundles) > 0 {
+			for iNdEx := len(x.AllLossBundles) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.AllLossBundles[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xc2
+			}
+		}
+		if len(x.AllForecasts) > 0 {
+			for iNdEx := len(x.AllForecasts) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.AllForecasts[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xba
+			}
+		}
+		if len(x.AllInferences) > 0 {
+			for iNdEx := len(x.AllInferences) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.AllInferences[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xb2
+			}
+		}
+		if len(x.PreviousTopicWeight) > 0 {
+			for iNdEx := len(x.PreviousTopicWeight) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.PreviousTopicWeight[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xaa
+			}
+		}
+		if len(x.TopicFeeRevenue) > 0 {
+			for iNdEx := len(x.TopicFeeRevenue) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.TopicFeeRevenue[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0xa2
+			}
+		}
+		if len(x.Reputers) > 0 {
+			for iNdEx := len(x.Reputers) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.Reputers[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0x9a
+			}
+		}
+		if len(x.Workers) > 0 {
+			for iNdEx := len(x.Workers) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.Workers[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0x92
+			}
+		}
+		if len(x.Forecasts) > 0 {
+			for iNdEx := len(x.Forecasts) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.Forecasts[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0x8a
+			}
+		}
+		if len(x.Inferences) > 0 {
+			for iNdEx := len(x.Inferences) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.Inferences[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x2
+				i--
+				dAtA[i] = 0x82
+			}
+		}
+		if len(x.DelegateStakeRemovalsByActor) > 0 {
+			for iNdEx := len(x.DelegateStakeRemovalsByActor) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.DelegateStakeRemovalsByActor[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xfa
+			}
+		}
+		if len(x.DelegateStakeRemovalsByBlock) > 0 {
+			for iNdEx := len(x.DelegateStakeRemovalsByBlock) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.DelegateStakeRemovalsByBlock[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xf2
+			}
+		}
+		if len(x.StakeRemovalsByActor) > 0 {
+			for iNdEx := len(x.StakeRemovalsByActor) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.StakeRemovalsByActor[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xea
+			}
+		}
+		if len(x.StakeRemovalsByBlock) > 0 {
+			for iNdEx := len(x.StakeRemovalsByBlock) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.StakeRemovalsByBlock[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xe2
+			}
+		}
+		if len(x.DelegateRewardPerShare) > 0 {
+			for iNdEx := len(x.DelegateRewardPerShare) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.DelegateRewardPerShare[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xda
+			}
+		}
+		if len(x.StakeFromDelegatorsUponReputer) > 0 {
+			for iNdEx := len(x.StakeFromDelegatorsUponReputer) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.StakeFromDelegatorsUponReputer[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xd2
+			}
+		}
+		if len(x.DelegatedStakes) > 0 {
+			for iNdEx := len(x.DelegatedStakes) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.DelegatedStakes[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xca
+			}
+		}
+		if len(x.StakeSumFromDelegator) > 0 {
+			for iNdEx := len(x.StakeSumFromDelegator) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.StakeSumFromDelegator[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xc2
+			}
+		}
+		if len(x.StakeReputerAuthority) > 0 {
+			for iNdEx := len(x.StakeReputerAuthority) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.StakeReputerAuthority[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xba
+			}
+		}
+		if len(x.TopicStake) > 0 {
+			for iNdEx := len(x.TopicStake) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.TopicStake[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xb2
+			}
+		}
+		if len(x.TotalStake) > 0 {
+			i -= len(x.TotalStake)
+			copy(dAtA[i:], x.TotalStake)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.TotalStake)))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xaa
+		}
+		if len(x.PreviousForecastRewardFraction) > 0 {
+			for iNdEx := len(x.PreviousForecastRewardFraction) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.PreviousForecastRewardFraction[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0xa2
+			}
+		}
+		if len(x.PreviousInferenceRewardFraction) > 0 {
+			for iNdEx := len(x.PreviousInferenceRewardFraction) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.PreviousInferenceRewardFraction[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0x9a
+			}
+		}
+		if len(x.PreviousReputerRewardFraction) > 0 {
+			for iNdEx := len(x.PreviousReputerRewardFraction) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.PreviousReputerRewardFraction[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0x92
+			}
+		}
+		if len(x.ReputerListeningCoefficient) > 0 {
+			for iNdEx := len(x.ReputerListeningCoefficient) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.ReputerListeningCoefficient[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0x8a
+			}
+		}
+		if len(x.LatestReputerScoresByReputer) > 0 {
+			for iNdEx := len(x.LatestReputerScoresByReputer) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.LatestReputerScoresByReputer[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x1
+				i--
+				dAtA[i] = 0x82
+			}
+		}
+		if len(x.LatestForecasterScoresByWorker) > 0 {
+			for iNdEx := len(x.LatestForecasterScoresByWorker) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.LatestForecasterScoresByWorker[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x7a
+			}
+		}
+		if len(x.LatestInfererScoresByWorker) > 0 {
+			for iNdEx := len(x.LatestInfererScoresByWorker) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.LatestInfererScoresByWorker[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x72
+			}
+		}
+		if len(x.ReputerScoresByBlock) > 0 {
+			for iNdEx := len(x.ReputerScoresByBlock) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.ReputerScoresByBlock[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x6a
+			}
+		}
+		if len(x.ForecasterScoresByBlock) > 0 {
+			for iNdEx := len(x.ForecasterScoresByBlock) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.ForecasterScoresByBlock[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x62
+			}
+		}
+		if len(x.InfererScoresByBlock) > 0 {
+			for iNdEx := len(x.InfererScoresByBlock) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.InfererScoresByBlock[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x5a
+			}
+		}
+		if len(x.TopicRewardNonce) > 0 {
+			for iNdEx := len(x.TopicRewardNonce) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.TopicRewardNonce[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x52
+			}
+		}
+		if len(x.TopicReputers) > 0 {
+			for iNdEx := len(x.TopicReputers) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.TopicReputers[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x4a
+			}
+		}
+		if len(x.TopicWorkers) > 0 {
+			for iNdEx := len(x.TopicWorkers) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.TopicWorkers[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x42
+			}
+		}
+		if len(x.RewardableTopics) > 0 {
+			var pksize2 int
+			for _, num := range x.RewardableTopics {
+				pksize2 += runtime.Sov(uint64(num))
+			}
+			i -= pksize2
+			j1 := i
+			for _, num := range x.RewardableTopics {
+				for num >= 1<<7 {
+					dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+					num >>= 7
+					j1++
+				}
+				dAtA[j1] = uint8(num)
+				j1++
+			}
+			i = runtime.EncodeVarint(dAtA, i, uint64(pksize2))
+			i--
+			dAtA[i] = 0x3a
+		}
+		if len(x.ChurnableTopics) > 0 {
+			var pksize4 int
+			for _, num := range x.ChurnableTopics {
+				pksize4 += runtime.Sov(uint64(num))
+			}
+			i -= pksize4
+			j3 := i
+			for _, num := range x.ChurnableTopics {
+				for num >= 1<<7 {
+					dAtA[j3] = uint8(uint64(num)&0x7f | 0x80)
+					num >>= 7
+					j3++
+				}
+				dAtA[j3] = uint8(num)
+				j3++
+			}
+			i = runtime.EncodeVarint(dAtA, i, uint64(pksize4))
+			i--
+			dAtA[i] = 0x32
+		}
+		if len(x.ActiveTopics) > 0 {
+			var pksize6 int
+			for _, num := range x.ActiveTopics {
+				pksize6 += runtime.Sov(uint64(num))
+			}
+			i -= pksize6
+			j5 := i
+			for _, num := range x.ActiveTopics {
+				for num >= 1<<7 {
+					dAtA[j5] = uint8(uint64(num)&0x7f | 0x80)
+					num >>= 7
+					j5++
+				}
+				dAtA[j5] = uint8(num)
+				j5++
+			}
+			i = runtime.EncodeVarint(dAtA, i, uint64(pksize6))
+			i--
+			dAtA[i] = 0x2a
+		}
+		if len(x.Topics) > 0 {
+			for iNdEx := len(x.Topics) - 1; iNdEx >= 0; iNdEx-- {
+				encoded, err := options.Marshal(x.Topics[iNdEx])
+				if err != nil {
+					return protoiface.MarshalOutput{
+						NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+						Buf:               input.Buf,
+					}, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+				i--
+				dAtA[i] = 0x22
+			}
+		}
+		if x.NextTopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.NextTopicId))
+			i--
+			dAtA[i] = 0x18
 		}
 		if len(x.CoreTeamAddresses) > 0 {
 			for iNdEx := len(x.CoreTeamAddresses) - 1; iNdEx >= 0; iNdEx-- {
@@ -506,6 +5562,1677 @@ func (x *fastReflection_GenesisState) ProtoMethods() *protoiface.Methods {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
 				}
 				iNdEx = postIndex
+			case 3:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field NextTopicId", wireType)
+				}
+				x.NextTopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.NextTopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 4:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Topics", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Topics = append(x.Topics, &TopicIdAndTopic{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Topics[len(x.Topics)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 5:
+				if wireType == 0 {
+					var v uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					x.ActiveTopics = append(x.ActiveTopics, v)
+				} else if wireType == 2 {
+					var packedLen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						packedLen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if packedLen < 0 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+					}
+					postIndex := iNdEx + packedLen
+					if postIndex < 0 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+					}
+					if postIndex > l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					var elementCount int
+					var count int
+					for _, integer := range dAtA[iNdEx:postIndex] {
+						if integer < 128 {
+							count++
+						}
+					}
+					elementCount = count
+					if elementCount != 0 && len(x.ActiveTopics) == 0 {
+						x.ActiveTopics = make([]uint64, 0, elementCount)
+					}
+					for iNdEx < postIndex {
+						var v uint64
+						for shift := uint(0); ; shift += 7 {
+							if shift >= 64 {
+								return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+							}
+							if iNdEx >= l {
+								return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+							}
+							b := dAtA[iNdEx]
+							iNdEx++
+							v |= uint64(b&0x7F) << shift
+							if b < 0x80 {
+								break
+							}
+						}
+						x.ActiveTopics = append(x.ActiveTopics, v)
+					}
+				} else {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActiveTopics", wireType)
+				}
+			case 6:
+				if wireType == 0 {
+					var v uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					x.ChurnableTopics = append(x.ChurnableTopics, v)
+				} else if wireType == 2 {
+					var packedLen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						packedLen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if packedLen < 0 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+					}
+					postIndex := iNdEx + packedLen
+					if postIndex < 0 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+					}
+					if postIndex > l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					var elementCount int
+					var count int
+					for _, integer := range dAtA[iNdEx:postIndex] {
+						if integer < 128 {
+							count++
+						}
+					}
+					elementCount = count
+					if elementCount != 0 && len(x.ChurnableTopics) == 0 {
+						x.ChurnableTopics = make([]uint64, 0, elementCount)
+					}
+					for iNdEx < postIndex {
+						var v uint64
+						for shift := uint(0); ; shift += 7 {
+							if shift >= 64 {
+								return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+							}
+							if iNdEx >= l {
+								return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+							}
+							b := dAtA[iNdEx]
+							iNdEx++
+							v |= uint64(b&0x7F) << shift
+							if b < 0x80 {
+								break
+							}
+						}
+						x.ChurnableTopics = append(x.ChurnableTopics, v)
+					}
+				} else {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ChurnableTopics", wireType)
+				}
+			case 7:
+				if wireType == 0 {
+					var v uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					x.RewardableTopics = append(x.RewardableTopics, v)
+				} else if wireType == 2 {
+					var packedLen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						packedLen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if packedLen < 0 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+					}
+					postIndex := iNdEx + packedLen
+					if postIndex < 0 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+					}
+					if postIndex > l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					var elementCount int
+					var count int
+					for _, integer := range dAtA[iNdEx:postIndex] {
+						if integer < 128 {
+							count++
+						}
+					}
+					elementCount = count
+					if elementCount != 0 && len(x.RewardableTopics) == 0 {
+						x.RewardableTopics = make([]uint64, 0, elementCount)
+					}
+					for iNdEx < postIndex {
+						var v uint64
+						for shift := uint(0); ; shift += 7 {
+							if shift >= 64 {
+								return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+							}
+							if iNdEx >= l {
+								return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+							}
+							b := dAtA[iNdEx]
+							iNdEx++
+							v |= uint64(b&0x7F) << shift
+							if b < 0x80 {
+								break
+							}
+						}
+						x.RewardableTopics = append(x.RewardableTopics, v)
+					}
+				} else {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field RewardableTopics", wireType)
+				}
+			case 8:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicWorkers", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TopicWorkers = append(x.TopicWorkers, &TopicAndActorId{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TopicWorkers[len(x.TopicWorkers)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 9:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicReputers", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TopicReputers = append(x.TopicReputers, &TopicAndActorId{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TopicReputers[len(x.TopicReputers)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 10:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicRewardNonce", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TopicRewardNonce = append(x.TopicRewardNonce, &TopicIdAndBlockHeight{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TopicRewardNonce[len(x.TopicRewardNonce)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 11:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field InfererScoresByBlock", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.InfererScoresByBlock = append(x.InfererScoresByBlock, &TopicIdBlockHeightScores{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.InfererScoresByBlock[len(x.InfererScoresByBlock)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 12:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ForecasterScoresByBlock", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ForecasterScoresByBlock = append(x.ForecasterScoresByBlock, &TopicIdBlockHeightScores{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.ForecasterScoresByBlock[len(x.ForecasterScoresByBlock)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 13:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ReputerScoresByBlock", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ReputerScoresByBlock = append(x.ReputerScoresByBlock, &TopicIdBlockHeightScores{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.ReputerScoresByBlock[len(x.ReputerScoresByBlock)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 14:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field LatestInfererScoresByWorker", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.LatestInfererScoresByWorker = append(x.LatestInfererScoresByWorker, &TopicIdActorIdScore{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.LatestInfererScoresByWorker[len(x.LatestInfererScoresByWorker)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 15:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field LatestForecasterScoresByWorker", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.LatestForecasterScoresByWorker = append(x.LatestForecasterScoresByWorker, &TopicIdActorIdScore{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.LatestForecasterScoresByWorker[len(x.LatestForecasterScoresByWorker)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 16:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field LatestReputerScoresByReputer", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.LatestReputerScoresByReputer = append(x.LatestReputerScoresByReputer, &TopicIdActorIdScore{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.LatestReputerScoresByReputer[len(x.LatestReputerScoresByReputer)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 17:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ReputerListeningCoefficient", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ReputerListeningCoefficient = append(x.ReputerListeningCoefficient, &TopicIdActorIdListeningCoefficient{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.ReputerListeningCoefficient[len(x.ReputerListeningCoefficient)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 18:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field PreviousReputerRewardFraction", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.PreviousReputerRewardFraction = append(x.PreviousReputerRewardFraction, &TopicIdActorIdDec{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.PreviousReputerRewardFraction[len(x.PreviousReputerRewardFraction)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 19:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field PreviousInferenceRewardFraction", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.PreviousInferenceRewardFraction = append(x.PreviousInferenceRewardFraction, &TopicIdActorIdDec{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.PreviousInferenceRewardFraction[len(x.PreviousInferenceRewardFraction)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 20:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field PreviousForecastRewardFraction", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.PreviousForecastRewardFraction = append(x.PreviousForecastRewardFraction, &TopicIdActorIdDec{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.PreviousForecastRewardFraction[len(x.PreviousForecastRewardFraction)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 21:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TotalStake", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TotalStake = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 22:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicStake", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TopicStake = append(x.TopicStake, &TopicIdAndInt{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TopicStake[len(x.TopicStake)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 23:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field StakeReputerAuthority", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.StakeReputerAuthority = append(x.StakeReputerAuthority, &TopicIdActorIdInt{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.StakeReputerAuthority[len(x.StakeReputerAuthority)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 24:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field StakeSumFromDelegator", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.StakeSumFromDelegator = append(x.StakeSumFromDelegator, &TopicIdActorIdInt{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.StakeSumFromDelegator[len(x.StakeSumFromDelegator)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 25:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field DelegatedStakes", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.DelegatedStakes = append(x.DelegatedStakes, &TopicIdDelegatorReputerDelegatorInfo{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.DelegatedStakes[len(x.DelegatedStakes)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 26:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field StakeFromDelegatorsUponReputer", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.StakeFromDelegatorsUponReputer = append(x.StakeFromDelegatorsUponReputer, &TopicIdActorIdInt{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.StakeFromDelegatorsUponReputer[len(x.StakeFromDelegatorsUponReputer)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 27:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field DelegateRewardPerShare", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.DelegateRewardPerShare = append(x.DelegateRewardPerShare, &TopicIdActorIdDec{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.DelegateRewardPerShare[len(x.DelegateRewardPerShare)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 28:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field StakeRemovalsByBlock", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.StakeRemovalsByBlock = append(x.StakeRemovalsByBlock, &BlockHeightTopicIdReputerStakeRemovalInfo{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.StakeRemovalsByBlock[len(x.StakeRemovalsByBlock)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 29:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field StakeRemovalsByActor", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.StakeRemovalsByActor = append(x.StakeRemovalsByActor, &ActorIdTopicIdBlockHeight{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.StakeRemovalsByActor[len(x.StakeRemovalsByActor)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 30:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field DelegateStakeRemovalsByBlock", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.DelegateStakeRemovalsByBlock = append(x.DelegateStakeRemovalsByBlock, &BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.DelegateStakeRemovalsByBlock[len(x.DelegateStakeRemovalsByBlock)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 31:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field DelegateStakeRemovalsByActor", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.DelegateStakeRemovalsByActor = append(x.DelegateStakeRemovalsByActor, &DelegatorReputerTopicIdBlockHeight{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.DelegateStakeRemovalsByActor[len(x.DelegateStakeRemovalsByActor)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 32:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Inferences", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Inferences = append(x.Inferences, &TopicIdActorIdInference{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Inferences[len(x.Inferences)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 33:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Forecasts", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Forecasts = append(x.Forecasts, &TopicIdActorIdForecast{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Forecasts[len(x.Forecasts)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 34:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Workers", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Workers = append(x.Workers, &LibP2PKeyAndOffchainNode{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Workers[len(x.Workers)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 35:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Reputers", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Reputers = append(x.Reputers, &LibP2PKeyAndOffchainNode{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Reputers[len(x.Reputers)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 36:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicFeeRevenue", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TopicFeeRevenue = append(x.TopicFeeRevenue, &TopicIdAndInt{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TopicFeeRevenue[len(x.TopicFeeRevenue)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 37:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field PreviousTopicWeight", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.PreviousTopicWeight = append(x.PreviousTopicWeight, &TopicIdAndDec{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.PreviousTopicWeight[len(x.PreviousTopicWeight)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 38:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field AllInferences", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.AllInferences = append(x.AllInferences, &TopicIdBlockHeightInferences{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.AllInferences[len(x.AllInferences)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 39:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field AllForecasts", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.AllForecasts = append(x.AllForecasts, &TopicIdBlockHeightForecasts{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.AllForecasts[len(x.AllForecasts)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 40:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field AllLossBundles", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.AllLossBundles = append(x.AllLossBundles, &TopicIdBlockHeightReputerValueBundles{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.AllLossBundles[len(x.AllLossBundles)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 41:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field NetworkLossBundles", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.NetworkLossBundles = append(x.NetworkLossBundles, &TopicIdBlockHeightValueBundles{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.NetworkLossBundles[len(x.NetworkLossBundles)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 42:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field PreviousPercentageRewardToStakedReputers", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.PreviousPercentageRewardToStakedReputers = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 43:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field UnfulfilledWorkerNonces", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.UnfulfilledWorkerNonces = append(x.UnfulfilledWorkerNonces, &TopicIdAndNonces{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.UnfulfilledWorkerNonces[len(x.UnfulfilledWorkerNonces)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 44:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field UnfulfilledReputerNonces", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.UnfulfilledReputerNonces = append(x.UnfulfilledReputerNonces, &TopicIdAndReputerRequestNonces{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.UnfulfilledReputerNonces[len(x.UnfulfilledReputerNonces)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 45:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field LatestInfererNetworkRegrets", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.LatestInfererNetworkRegrets = append(x.LatestInfererNetworkRegrets, &TopicIdActorIdTimeStampedValue{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.LatestInfererNetworkRegrets[len(x.LatestInfererNetworkRegrets)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 46:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field LatestForecasterNetworkRegrets", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.LatestForecasterNetworkRegrets = append(x.LatestForecasterNetworkRegrets, &TopicIdActorIdTimeStampedValue{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.LatestForecasterNetworkRegrets[len(x.LatestForecasterNetworkRegrets)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 47:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field LatestOneInForecasterNetworkRegrets", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.LatestOneInForecasterNetworkRegrets = append(x.LatestOneInForecasterNetworkRegrets, &TopicIdActorIdActorIdTimeStampedValue{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.LatestOneInForecasterNetworkRegrets[len(x.LatestOneInForecasterNetworkRegrets)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 48:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field LatestOneInForecasterSelfNetworkRegrets", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.LatestOneInForecasterSelfNetworkRegrets = append(x.LatestOneInForecasterSelfNetworkRegrets, &TopicIdActorIdTimeStampedValue{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.LatestOneInForecasterSelfNetworkRegrets[len(x.LatestOneInForecasterSelfNetworkRegrets)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
 			case 2:
 				if wireType != 2 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field CoreTeamAddresses", wireType)
@@ -537,6 +7264,14455 @@ func (x *fastReflection_GenesisState) ProtoMethods() *protoiface.Methods {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
 				}
 				x.CoreTeamAddresses = append(x.CoreTeamAddresses, string(dAtA[iNdEx:postIndex]))
+				iNdEx = postIndex
+			case 49:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicLastWorkerCommit", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TopicLastWorkerCommit = append(x.TopicLastWorkerCommit, &TopicIdTimestampedActorNonce{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TopicLastWorkerCommit[len(x.TopicLastWorkerCommit)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 50:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicLastReputerCommit", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TopicLastReputerCommit = append(x.TopicLastReputerCommit, &TopicIdTimestampedActorNonce{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TopicLastReputerCommit[len(x.TopicLastReputerCommit)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 51:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicLastWorkerPayload", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TopicLastWorkerPayload = append(x.TopicLastWorkerPayload, &TopicIdTimestampedActorNonce{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TopicLastWorkerPayload[len(x.TopicLastWorkerPayload)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			case 52:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicLastReputerPayload", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.TopicLastReputerPayload = append(x.TopicLastReputerPayload, &TopicIdTimestampedActorNonce{})
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TopicLastReputerPayload[len(x.TopicLastReputerPayload)-1]); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdAndTopic         protoreflect.MessageDescriptor
+	fd_TopicIdAndTopic_TopicId protoreflect.FieldDescriptor
+	fd_TopicIdAndTopic_Topic   protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdAndTopic = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdAndTopic")
+	fd_TopicIdAndTopic_TopicId = md_TopicIdAndTopic.Fields().ByName("TopicId")
+	fd_TopicIdAndTopic_Topic = md_TopicIdAndTopic.Fields().ByName("Topic")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdAndTopic)(nil)
+
+type fastReflection_TopicIdAndTopic TopicIdAndTopic
+
+func (x *TopicIdAndTopic) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdAndTopic)(x)
+}
+
+func (x *TopicIdAndTopic) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[1]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdAndTopic_messageType fastReflection_TopicIdAndTopic_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdAndTopic_messageType{}
+
+type fastReflection_TopicIdAndTopic_messageType struct{}
+
+func (x fastReflection_TopicIdAndTopic_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdAndTopic)(nil)
+}
+func (x fastReflection_TopicIdAndTopic_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndTopic)
+}
+func (x fastReflection_TopicIdAndTopic_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndTopic
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdAndTopic) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndTopic
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdAndTopic) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdAndTopic_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdAndTopic) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndTopic)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdAndTopic) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdAndTopic)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdAndTopic) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdAndTopic_TopicId, value) {
+			return
+		}
+	}
+	if x.Topic != nil {
+		value := protoreflect.ValueOfMessage(x.Topic.ProtoReflect())
+		if !f(fd_TopicIdAndTopic_Topic, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdAndTopic) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndTopic.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdAndTopic.Topic":
+		return x.Topic != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndTopic"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndTopic does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndTopic) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndTopic.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdAndTopic.Topic":
+		x.Topic = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndTopic"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndTopic does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdAndTopic) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdAndTopic.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdAndTopic.Topic":
+		value := x.Topic
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndTopic"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndTopic does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndTopic) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndTopic.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdAndTopic.Topic":
+		x.Topic = value.Message().Interface().(*Topic)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndTopic"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndTopic does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndTopic) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndTopic.Topic":
+		if x.Topic == nil {
+			x.Topic = new(Topic)
+		}
+		return protoreflect.ValueOfMessage(x.Topic.ProtoReflect())
+	case "emissions.v1.TopicIdAndTopic.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdAndTopic is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndTopic"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndTopic does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdAndTopic) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndTopic.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdAndTopic.Topic":
+		m := new(Topic)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndTopic"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndTopic does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdAndTopic) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdAndTopic", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdAndTopic) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndTopic) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdAndTopic) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdAndTopic) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdAndTopic)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.Topic != nil {
+			l = options.Size(x.Topic)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndTopic)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.Topic != nil {
+			encoded, err := options.Marshal(x.Topic)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndTopic)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndTopic: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndTopic: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Topic", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.Topic == nil {
+					x.Topic = &Topic{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Topic); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicAndActorId         protoreflect.MessageDescriptor
+	fd_TopicAndActorId_TopicId protoreflect.FieldDescriptor
+	fd_TopicAndActorId_ActorId protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicAndActorId = File_emissions_v1_genesis_proto.Messages().ByName("TopicAndActorId")
+	fd_TopicAndActorId_TopicId = md_TopicAndActorId.Fields().ByName("TopicId")
+	fd_TopicAndActorId_ActorId = md_TopicAndActorId.Fields().ByName("ActorId")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicAndActorId)(nil)
+
+type fastReflection_TopicAndActorId TopicAndActorId
+
+func (x *TopicAndActorId) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicAndActorId)(x)
+}
+
+func (x *TopicAndActorId) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[2]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicAndActorId_messageType fastReflection_TopicAndActorId_messageType
+var _ protoreflect.MessageType = fastReflection_TopicAndActorId_messageType{}
+
+type fastReflection_TopicAndActorId_messageType struct{}
+
+func (x fastReflection_TopicAndActorId_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicAndActorId)(nil)
+}
+func (x fastReflection_TopicAndActorId_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicAndActorId)
+}
+func (x fastReflection_TopicAndActorId_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicAndActorId
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicAndActorId) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicAndActorId
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicAndActorId) Type() protoreflect.MessageType {
+	return _fastReflection_TopicAndActorId_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicAndActorId) New() protoreflect.Message {
+	return new(fastReflection_TopicAndActorId)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicAndActorId) Interface() protoreflect.ProtoMessage {
+	return (*TopicAndActorId)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicAndActorId) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicAndActorId_TopicId, value) {
+			return
+		}
+	}
+	if x.ActorId != "" {
+		value := protoreflect.ValueOfString(x.ActorId)
+		if !f(fd_TopicAndActorId_ActorId, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicAndActorId) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicAndActorId.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicAndActorId.ActorId":
+		return x.ActorId != ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicAndActorId"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicAndActorId does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicAndActorId) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicAndActorId.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicAndActorId.ActorId":
+		x.ActorId = ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicAndActorId"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicAndActorId does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicAndActorId) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicAndActorId.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicAndActorId.ActorId":
+		value := x.ActorId
+		return protoreflect.ValueOfString(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicAndActorId"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicAndActorId does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicAndActorId) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicAndActorId.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicAndActorId.ActorId":
+		x.ActorId = value.Interface().(string)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicAndActorId"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicAndActorId does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicAndActorId) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicAndActorId.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicAndActorId is not mutable"))
+	case "emissions.v1.TopicAndActorId.ActorId":
+		panic(fmt.Errorf("field ActorId of message emissions.v1.TopicAndActorId is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicAndActorId"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicAndActorId does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicAndActorId) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicAndActorId.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicAndActorId.ActorId":
+		return protoreflect.ValueOfString("")
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicAndActorId"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicAndActorId does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicAndActorId) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicAndActorId", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicAndActorId) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicAndActorId) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicAndActorId) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicAndActorId) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicAndActorId)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.ActorId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicAndActorId)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.ActorId) > 0 {
+			i -= len(x.ActorId)
+			copy(dAtA[i:], x.ActorId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicAndActorId)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicAndActorId: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicAndActorId: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdAndBlockHeight             protoreflect.MessageDescriptor
+	fd_TopicIdAndBlockHeight_TopicId     protoreflect.FieldDescriptor
+	fd_TopicIdAndBlockHeight_BlockHeight protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdAndBlockHeight = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdAndBlockHeight")
+	fd_TopicIdAndBlockHeight_TopicId = md_TopicIdAndBlockHeight.Fields().ByName("TopicId")
+	fd_TopicIdAndBlockHeight_BlockHeight = md_TopicIdAndBlockHeight.Fields().ByName("BlockHeight")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdAndBlockHeight)(nil)
+
+type fastReflection_TopicIdAndBlockHeight TopicIdAndBlockHeight
+
+func (x *TopicIdAndBlockHeight) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdAndBlockHeight)(x)
+}
+
+func (x *TopicIdAndBlockHeight) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdAndBlockHeight_messageType fastReflection_TopicIdAndBlockHeight_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdAndBlockHeight_messageType{}
+
+type fastReflection_TopicIdAndBlockHeight_messageType struct{}
+
+func (x fastReflection_TopicIdAndBlockHeight_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdAndBlockHeight)(nil)
+}
+func (x fastReflection_TopicIdAndBlockHeight_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndBlockHeight)
+}
+func (x fastReflection_TopicIdAndBlockHeight_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndBlockHeight
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdAndBlockHeight) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndBlockHeight
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdAndBlockHeight) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdAndBlockHeight_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdAndBlockHeight) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndBlockHeight)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdAndBlockHeight) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdAndBlockHeight)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdAndBlockHeight) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdAndBlockHeight_TopicId, value) {
+			return
+		}
+	}
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_TopicIdAndBlockHeight_BlockHeight, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdAndBlockHeight) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndBlockHeight.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdAndBlockHeight.BlockHeight":
+		return x.BlockHeight != int64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndBlockHeight) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndBlockHeight.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdAndBlockHeight.BlockHeight":
+		x.BlockHeight = int64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdAndBlockHeight) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdAndBlockHeight.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdAndBlockHeight.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndBlockHeight does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndBlockHeight) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndBlockHeight.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdAndBlockHeight.BlockHeight":
+		x.BlockHeight = value.Int()
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndBlockHeight) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndBlockHeight.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdAndBlockHeight is not mutable"))
+	case "emissions.v1.TopicIdAndBlockHeight.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.TopicIdAndBlockHeight is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdAndBlockHeight) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndBlockHeight.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdAndBlockHeight.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdAndBlockHeight) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdAndBlockHeight", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdAndBlockHeight) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndBlockHeight) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdAndBlockHeight) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdAndBlockHeight) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdAndBlockHeight)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndBlockHeight)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndBlockHeight)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndBlockHeight: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndBlockHeight: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdBlockHeightScores             protoreflect.MessageDescriptor
+	fd_TopicIdBlockHeightScores_TopicId     protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightScores_BlockHeight protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightScores_Scores      protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdBlockHeightScores = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdBlockHeightScores")
+	fd_TopicIdBlockHeightScores_TopicId = md_TopicIdBlockHeightScores.Fields().ByName("TopicId")
+	fd_TopicIdBlockHeightScores_BlockHeight = md_TopicIdBlockHeightScores.Fields().ByName("BlockHeight")
+	fd_TopicIdBlockHeightScores_Scores = md_TopicIdBlockHeightScores.Fields().ByName("Scores")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdBlockHeightScores)(nil)
+
+type fastReflection_TopicIdBlockHeightScores TopicIdBlockHeightScores
+
+func (x *TopicIdBlockHeightScores) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightScores)(x)
+}
+
+func (x *TopicIdBlockHeightScores) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[4]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdBlockHeightScores_messageType fastReflection_TopicIdBlockHeightScores_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdBlockHeightScores_messageType{}
+
+type fastReflection_TopicIdBlockHeightScores_messageType struct{}
+
+func (x fastReflection_TopicIdBlockHeightScores_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightScores)(nil)
+}
+func (x fastReflection_TopicIdBlockHeightScores_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightScores)
+}
+func (x fastReflection_TopicIdBlockHeightScores_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightScores
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdBlockHeightScores) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightScores
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdBlockHeightScores) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdBlockHeightScores_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdBlockHeightScores) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightScores)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdBlockHeightScores) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdBlockHeightScores)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdBlockHeightScores) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdBlockHeightScores_TopicId, value) {
+			return
+		}
+	}
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_TopicIdBlockHeightScores_BlockHeight, value) {
+			return
+		}
+	}
+	if x.Scores != nil {
+		value := protoreflect.ValueOfMessage(x.Scores.ProtoReflect())
+		if !f(fd_TopicIdBlockHeightScores_Scores, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdBlockHeightScores) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightScores.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdBlockHeightScores.BlockHeight":
+		return x.BlockHeight != int64(0)
+	case "emissions.v1.TopicIdBlockHeightScores.Scores":
+		return x.Scores != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightScores"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightScores does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightScores) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightScores.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdBlockHeightScores.BlockHeight":
+		x.BlockHeight = int64(0)
+	case "emissions.v1.TopicIdBlockHeightScores.Scores":
+		x.Scores = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightScores"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightScores does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdBlockHeightScores) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdBlockHeightScores.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdBlockHeightScores.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	case "emissions.v1.TopicIdBlockHeightScores.Scores":
+		value := x.Scores
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightScores"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightScores does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightScores) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightScores.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdBlockHeightScores.BlockHeight":
+		x.BlockHeight = value.Int()
+	case "emissions.v1.TopicIdBlockHeightScores.Scores":
+		x.Scores = value.Message().Interface().(*Scores)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightScores"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightScores does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightScores) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightScores.Scores":
+		if x.Scores == nil {
+			x.Scores = new(Scores)
+		}
+		return protoreflect.ValueOfMessage(x.Scores.ProtoReflect())
+	case "emissions.v1.TopicIdBlockHeightScores.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdBlockHeightScores is not mutable"))
+	case "emissions.v1.TopicIdBlockHeightScores.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.TopicIdBlockHeightScores is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightScores"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightScores does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdBlockHeightScores) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightScores.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdBlockHeightScores.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	case "emissions.v1.TopicIdBlockHeightScores.Scores":
+		m := new(Scores)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightScores"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightScores does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdBlockHeightScores) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdBlockHeightScores", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdBlockHeightScores) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightScores) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdBlockHeightScores) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdBlockHeightScores) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdBlockHeightScores)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.Scores != nil {
+			l = options.Size(x.Scores)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightScores)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.Scores != nil {
+			encoded, err := options.Marshal(x.Scores)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightScores)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightScores: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightScores: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Scores", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.Scores == nil {
+					x.Scores = &Scores{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Scores); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdActorIdScore         protoreflect.MessageDescriptor
+	fd_TopicIdActorIdScore_TopicId protoreflect.FieldDescriptor
+	fd_TopicIdActorIdScore_ActorId protoreflect.FieldDescriptor
+	fd_TopicIdActorIdScore_Score   protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdActorIdScore = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdActorIdScore")
+	fd_TopicIdActorIdScore_TopicId = md_TopicIdActorIdScore.Fields().ByName("TopicId")
+	fd_TopicIdActorIdScore_ActorId = md_TopicIdActorIdScore.Fields().ByName("ActorId")
+	fd_TopicIdActorIdScore_Score = md_TopicIdActorIdScore.Fields().ByName("Score")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdActorIdScore)(nil)
+
+type fastReflection_TopicIdActorIdScore TopicIdActorIdScore
+
+func (x *TopicIdActorIdScore) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdScore)(x)
+}
+
+func (x *TopicIdActorIdScore) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[5]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdActorIdScore_messageType fastReflection_TopicIdActorIdScore_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdActorIdScore_messageType{}
+
+type fastReflection_TopicIdActorIdScore_messageType struct{}
+
+func (x fastReflection_TopicIdActorIdScore_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdScore)(nil)
+}
+func (x fastReflection_TopicIdActorIdScore_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdScore)
+}
+func (x fastReflection_TopicIdActorIdScore_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdScore
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdActorIdScore) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdScore
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdActorIdScore) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdActorIdScore_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdActorIdScore) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdScore)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdActorIdScore) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdActorIdScore)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdActorIdScore) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdActorIdScore_TopicId, value) {
+			return
+		}
+	}
+	if x.ActorId != "" {
+		value := protoreflect.ValueOfString(x.ActorId)
+		if !f(fd_TopicIdActorIdScore_ActorId, value) {
+			return
+		}
+	}
+	if x.Score != nil {
+		value := protoreflect.ValueOfMessage(x.Score.ProtoReflect())
+		if !f(fd_TopicIdActorIdScore_Score, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdActorIdScore) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdScore.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdActorIdScore.ActorId":
+		return x.ActorId != ""
+	case "emissions.v1.TopicIdActorIdScore.Score":
+		return x.Score != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdScore"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdScore does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdScore) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdScore.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdActorIdScore.ActorId":
+		x.ActorId = ""
+	case "emissions.v1.TopicIdActorIdScore.Score":
+		x.Score = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdScore"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdScore does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdActorIdScore) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdActorIdScore.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdActorIdScore.ActorId":
+		value := x.ActorId
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdActorIdScore.Score":
+		value := x.Score
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdScore"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdScore does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdScore) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdScore.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdActorIdScore.ActorId":
+		x.ActorId = value.Interface().(string)
+	case "emissions.v1.TopicIdActorIdScore.Score":
+		x.Score = value.Message().Interface().(*Score)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdScore"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdScore does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdScore) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdScore.Score":
+		if x.Score == nil {
+			x.Score = new(Score)
+		}
+		return protoreflect.ValueOfMessage(x.Score.ProtoReflect())
+	case "emissions.v1.TopicIdActorIdScore.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdActorIdScore is not mutable"))
+	case "emissions.v1.TopicIdActorIdScore.ActorId":
+		panic(fmt.Errorf("field ActorId of message emissions.v1.TopicIdActorIdScore is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdScore"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdScore does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdActorIdScore) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdScore.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdActorIdScore.ActorId":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdActorIdScore.Score":
+		m := new(Score)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdScore"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdScore does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdActorIdScore) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdActorIdScore", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdActorIdScore) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdScore) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdActorIdScore) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdActorIdScore) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdActorIdScore)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.ActorId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.Score != nil {
+			l = options.Size(x.Score)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdScore)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.Score != nil {
+			encoded, err := options.Marshal(x.Score)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.ActorId) > 0 {
+			i -= len(x.ActorId)
+			copy(dAtA[i:], x.ActorId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdScore)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdScore: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdScore: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Score", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.Score == nil {
+					x.Score = &Score{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Score); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdActorIdListeningCoefficient                      protoreflect.MessageDescriptor
+	fd_TopicIdActorIdListeningCoefficient_TopicId              protoreflect.FieldDescriptor
+	fd_TopicIdActorIdListeningCoefficient_ActorId              protoreflect.FieldDescriptor
+	fd_TopicIdActorIdListeningCoefficient_ListeningCoefficient protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdActorIdListeningCoefficient = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdActorIdListeningCoefficient")
+	fd_TopicIdActorIdListeningCoefficient_TopicId = md_TopicIdActorIdListeningCoefficient.Fields().ByName("TopicId")
+	fd_TopicIdActorIdListeningCoefficient_ActorId = md_TopicIdActorIdListeningCoefficient.Fields().ByName("ActorId")
+	fd_TopicIdActorIdListeningCoefficient_ListeningCoefficient = md_TopicIdActorIdListeningCoefficient.Fields().ByName("ListeningCoefficient")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdActorIdListeningCoefficient)(nil)
+
+type fastReflection_TopicIdActorIdListeningCoefficient TopicIdActorIdListeningCoefficient
+
+func (x *TopicIdActorIdListeningCoefficient) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdListeningCoefficient)(x)
+}
+
+func (x *TopicIdActorIdListeningCoefficient) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[6]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdActorIdListeningCoefficient_messageType fastReflection_TopicIdActorIdListeningCoefficient_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdActorIdListeningCoefficient_messageType{}
+
+type fastReflection_TopicIdActorIdListeningCoefficient_messageType struct{}
+
+func (x fastReflection_TopicIdActorIdListeningCoefficient_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdListeningCoefficient)(nil)
+}
+func (x fastReflection_TopicIdActorIdListeningCoefficient_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdListeningCoefficient)
+}
+func (x fastReflection_TopicIdActorIdListeningCoefficient_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdListeningCoefficient
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdListeningCoefficient
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdActorIdListeningCoefficient_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdListeningCoefficient)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdActorIdListeningCoefficient)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdActorIdListeningCoefficient_TopicId, value) {
+			return
+		}
+	}
+	if x.ActorId != "" {
+		value := protoreflect.ValueOfString(x.ActorId)
+		if !f(fd_TopicIdActorIdListeningCoefficient_ActorId, value) {
+			return
+		}
+	}
+	if x.ListeningCoefficient != nil {
+		value := protoreflect.ValueOfMessage(x.ListeningCoefficient.ProtoReflect())
+		if !f(fd_TopicIdActorIdListeningCoefficient_ListeningCoefficient, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ActorId":
+		return x.ActorId != ""
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ListeningCoefficient":
+		return x.ListeningCoefficient != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdListeningCoefficient"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdListeningCoefficient does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ActorId":
+		x.ActorId = ""
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ListeningCoefficient":
+		x.ListeningCoefficient = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdListeningCoefficient"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdListeningCoefficient does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ActorId":
+		value := x.ActorId
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ListeningCoefficient":
+		value := x.ListeningCoefficient
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdListeningCoefficient"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdListeningCoefficient does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ActorId":
+		x.ActorId = value.Interface().(string)
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ListeningCoefficient":
+		x.ListeningCoefficient = value.Message().Interface().(*ListeningCoefficient)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdListeningCoefficient"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdListeningCoefficient does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ListeningCoefficient":
+		if x.ListeningCoefficient == nil {
+			x.ListeningCoefficient = new(ListeningCoefficient)
+		}
+		return protoreflect.ValueOfMessage(x.ListeningCoefficient.ProtoReflect())
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdActorIdListeningCoefficient is not mutable"))
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ActorId":
+		panic(fmt.Errorf("field ActorId of message emissions.v1.TopicIdActorIdListeningCoefficient is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdListeningCoefficient"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdListeningCoefficient does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ActorId":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdActorIdListeningCoefficient.ListeningCoefficient":
+		m := new(ListeningCoefficient)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdListeningCoefficient"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdListeningCoefficient does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdActorIdListeningCoefficient", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdActorIdListeningCoefficient) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdActorIdListeningCoefficient)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.ActorId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.ListeningCoefficient != nil {
+			l = options.Size(x.ListeningCoefficient)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdListeningCoefficient)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.ListeningCoefficient != nil {
+			encoded, err := options.Marshal(x.ListeningCoefficient)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.ActorId) > 0 {
+			i -= len(x.ActorId)
+			copy(dAtA[i:], x.ActorId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdListeningCoefficient)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdListeningCoefficient: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdListeningCoefficient: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ListeningCoefficient", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.ListeningCoefficient == nil {
+					x.ListeningCoefficient = &ListeningCoefficient{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.ListeningCoefficient); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdActorIdDec         protoreflect.MessageDescriptor
+	fd_TopicIdActorIdDec_TopicId protoreflect.FieldDescriptor
+	fd_TopicIdActorIdDec_ActorId protoreflect.FieldDescriptor
+	fd_TopicIdActorIdDec_Dec     protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdActorIdDec = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdActorIdDec")
+	fd_TopicIdActorIdDec_TopicId = md_TopicIdActorIdDec.Fields().ByName("TopicId")
+	fd_TopicIdActorIdDec_ActorId = md_TopicIdActorIdDec.Fields().ByName("ActorId")
+	fd_TopicIdActorIdDec_Dec = md_TopicIdActorIdDec.Fields().ByName("Dec")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdActorIdDec)(nil)
+
+type fastReflection_TopicIdActorIdDec TopicIdActorIdDec
+
+func (x *TopicIdActorIdDec) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdDec)(x)
+}
+
+func (x *TopicIdActorIdDec) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[7]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdActorIdDec_messageType fastReflection_TopicIdActorIdDec_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdActorIdDec_messageType{}
+
+type fastReflection_TopicIdActorIdDec_messageType struct{}
+
+func (x fastReflection_TopicIdActorIdDec_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdDec)(nil)
+}
+func (x fastReflection_TopicIdActorIdDec_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdDec)
+}
+func (x fastReflection_TopicIdActorIdDec_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdDec
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdActorIdDec) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdDec
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdActorIdDec) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdActorIdDec_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdActorIdDec) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdDec)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdActorIdDec) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdActorIdDec)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdActorIdDec) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdActorIdDec_TopicId, value) {
+			return
+		}
+	}
+	if x.ActorId != "" {
+		value := protoreflect.ValueOfString(x.ActorId)
+		if !f(fd_TopicIdActorIdDec_ActorId, value) {
+			return
+		}
+	}
+	if x.Dec != "" {
+		value := protoreflect.ValueOfString(x.Dec)
+		if !f(fd_TopicIdActorIdDec_Dec, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdActorIdDec) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdDec.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdActorIdDec.ActorId":
+		return x.ActorId != ""
+	case "emissions.v1.TopicIdActorIdDec.Dec":
+		return x.Dec != ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdDec) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdDec.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdActorIdDec.ActorId":
+		x.ActorId = ""
+	case "emissions.v1.TopicIdActorIdDec.Dec":
+		x.Dec = ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdActorIdDec) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdActorIdDec.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdActorIdDec.ActorId":
+		value := x.ActorId
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdActorIdDec.Dec":
+		value := x.Dec
+		return protoreflect.ValueOfString(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdDec does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdDec) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdDec.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdActorIdDec.ActorId":
+		x.ActorId = value.Interface().(string)
+	case "emissions.v1.TopicIdActorIdDec.Dec":
+		x.Dec = value.Interface().(string)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdDec) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdDec.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdActorIdDec is not mutable"))
+	case "emissions.v1.TopicIdActorIdDec.ActorId":
+		panic(fmt.Errorf("field ActorId of message emissions.v1.TopicIdActorIdDec is not mutable"))
+	case "emissions.v1.TopicIdActorIdDec.Dec":
+		panic(fmt.Errorf("field Dec of message emissions.v1.TopicIdActorIdDec is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdActorIdDec) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdDec.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdActorIdDec.ActorId":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdActorIdDec.Dec":
+		return protoreflect.ValueOfString("")
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdActorIdDec) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdActorIdDec", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdActorIdDec) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdDec) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdActorIdDec) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdActorIdDec) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdActorIdDec)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.ActorId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.Dec)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdDec)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.Dec) > 0 {
+			i -= len(x.Dec)
+			copy(dAtA[i:], x.Dec)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Dec)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.ActorId) > 0 {
+			i -= len(x.ActorId)
+			copy(dAtA[i:], x.ActorId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdDec)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdDec: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdDec: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Dec", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Dec = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdAndInt         protoreflect.MessageDescriptor
+	fd_TopicIdAndInt_TopicId protoreflect.FieldDescriptor
+	fd_TopicIdAndInt_Int     protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdAndInt = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdAndInt")
+	fd_TopicIdAndInt_TopicId = md_TopicIdAndInt.Fields().ByName("TopicId")
+	fd_TopicIdAndInt_Int = md_TopicIdAndInt.Fields().ByName("Int")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdAndInt)(nil)
+
+type fastReflection_TopicIdAndInt TopicIdAndInt
+
+func (x *TopicIdAndInt) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdAndInt)(x)
+}
+
+func (x *TopicIdAndInt) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[8]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdAndInt_messageType fastReflection_TopicIdAndInt_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdAndInt_messageType{}
+
+type fastReflection_TopicIdAndInt_messageType struct{}
+
+func (x fastReflection_TopicIdAndInt_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdAndInt)(nil)
+}
+func (x fastReflection_TopicIdAndInt_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndInt)
+}
+func (x fastReflection_TopicIdAndInt_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndInt
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdAndInt) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndInt
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdAndInt) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdAndInt_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdAndInt) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndInt)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdAndInt) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdAndInt)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdAndInt) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdAndInt_TopicId, value) {
+			return
+		}
+	}
+	if x.Int != "" {
+		value := protoreflect.ValueOfString(x.Int)
+		if !f(fd_TopicIdAndInt_Int, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdAndInt) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndInt.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdAndInt.Int":
+		return x.Int != ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndInt) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndInt.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdAndInt.Int":
+		x.Int = ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdAndInt) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdAndInt.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdAndInt.Int":
+		value := x.Int
+		return protoreflect.ValueOfString(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndInt does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndInt) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndInt.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdAndInt.Int":
+		x.Int = value.Interface().(string)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndInt) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndInt.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdAndInt is not mutable"))
+	case "emissions.v1.TopicIdAndInt.Int":
+		panic(fmt.Errorf("field Int of message emissions.v1.TopicIdAndInt is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdAndInt) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndInt.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdAndInt.Int":
+		return protoreflect.ValueOfString("")
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdAndInt) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdAndInt", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdAndInt) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndInt) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdAndInt) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdAndInt) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdAndInt)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.Int)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndInt)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.Int) > 0 {
+			i -= len(x.Int)
+			copy(dAtA[i:], x.Int)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Int)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndInt)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndInt: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndInt: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Int", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Int = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdActorIdInt         protoreflect.MessageDescriptor
+	fd_TopicIdActorIdInt_TopicId protoreflect.FieldDescriptor
+	fd_TopicIdActorIdInt_ActorId protoreflect.FieldDescriptor
+	fd_TopicIdActorIdInt_Int     protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdActorIdInt = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdActorIdInt")
+	fd_TopicIdActorIdInt_TopicId = md_TopicIdActorIdInt.Fields().ByName("TopicId")
+	fd_TopicIdActorIdInt_ActorId = md_TopicIdActorIdInt.Fields().ByName("ActorId")
+	fd_TopicIdActorIdInt_Int = md_TopicIdActorIdInt.Fields().ByName("Int")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdActorIdInt)(nil)
+
+type fastReflection_TopicIdActorIdInt TopicIdActorIdInt
+
+func (x *TopicIdActorIdInt) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdInt)(x)
+}
+
+func (x *TopicIdActorIdInt) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[9]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdActorIdInt_messageType fastReflection_TopicIdActorIdInt_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdActorIdInt_messageType{}
+
+type fastReflection_TopicIdActorIdInt_messageType struct{}
+
+func (x fastReflection_TopicIdActorIdInt_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdInt)(nil)
+}
+func (x fastReflection_TopicIdActorIdInt_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdInt)
+}
+func (x fastReflection_TopicIdActorIdInt_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdInt
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdActorIdInt) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdInt
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdActorIdInt) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdActorIdInt_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdActorIdInt) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdInt)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdActorIdInt) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdActorIdInt)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdActorIdInt) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdActorIdInt_TopicId, value) {
+			return
+		}
+	}
+	if x.ActorId != "" {
+		value := protoreflect.ValueOfString(x.ActorId)
+		if !f(fd_TopicIdActorIdInt_ActorId, value) {
+			return
+		}
+	}
+	if x.Int != "" {
+		value := protoreflect.ValueOfString(x.Int)
+		if !f(fd_TopicIdActorIdInt_Int, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdActorIdInt) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInt.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdActorIdInt.ActorId":
+		return x.ActorId != ""
+	case "emissions.v1.TopicIdActorIdInt.Int":
+		return x.Int != ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdInt) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInt.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdActorIdInt.ActorId":
+		x.ActorId = ""
+	case "emissions.v1.TopicIdActorIdInt.Int":
+		x.Int = ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdActorIdInt) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdActorIdInt.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdActorIdInt.ActorId":
+		value := x.ActorId
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdActorIdInt.Int":
+		value := x.Int
+		return protoreflect.ValueOfString(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInt does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdInt) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInt.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdActorIdInt.ActorId":
+		x.ActorId = value.Interface().(string)
+	case "emissions.v1.TopicIdActorIdInt.Int":
+		x.Int = value.Interface().(string)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdInt) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInt.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdActorIdInt is not mutable"))
+	case "emissions.v1.TopicIdActorIdInt.ActorId":
+		panic(fmt.Errorf("field ActorId of message emissions.v1.TopicIdActorIdInt is not mutable"))
+	case "emissions.v1.TopicIdActorIdInt.Int":
+		panic(fmt.Errorf("field Int of message emissions.v1.TopicIdActorIdInt is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdActorIdInt) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInt.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdActorIdInt.ActorId":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdActorIdInt.Int":
+		return protoreflect.ValueOfString("")
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInt"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInt does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdActorIdInt) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdActorIdInt", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdActorIdInt) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdInt) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdActorIdInt) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdActorIdInt) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdActorIdInt)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.ActorId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.Int)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdInt)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.Int) > 0 {
+			i -= len(x.Int)
+			copy(dAtA[i:], x.Int)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Int)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.ActorId) > 0 {
+			i -= len(x.ActorId)
+			copy(dAtA[i:], x.ActorId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdInt)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdInt: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdInt: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Int", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Int = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdDelegatorReputerDelegatorInfo               protoreflect.MessageDescriptor
+	fd_TopicIdDelegatorReputerDelegatorInfo_TopicId       protoreflect.FieldDescriptor
+	fd_TopicIdDelegatorReputerDelegatorInfo_Delegator     protoreflect.FieldDescriptor
+	fd_TopicIdDelegatorReputerDelegatorInfo_Reputer       protoreflect.FieldDescriptor
+	fd_TopicIdDelegatorReputerDelegatorInfo_DelegatorInfo protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdDelegatorReputerDelegatorInfo = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdDelegatorReputerDelegatorInfo")
+	fd_TopicIdDelegatorReputerDelegatorInfo_TopicId = md_TopicIdDelegatorReputerDelegatorInfo.Fields().ByName("TopicId")
+	fd_TopicIdDelegatorReputerDelegatorInfo_Delegator = md_TopicIdDelegatorReputerDelegatorInfo.Fields().ByName("Delegator")
+	fd_TopicIdDelegatorReputerDelegatorInfo_Reputer = md_TopicIdDelegatorReputerDelegatorInfo.Fields().ByName("Reputer")
+	fd_TopicIdDelegatorReputerDelegatorInfo_DelegatorInfo = md_TopicIdDelegatorReputerDelegatorInfo.Fields().ByName("DelegatorInfo")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdDelegatorReputerDelegatorInfo)(nil)
+
+type fastReflection_TopicIdDelegatorReputerDelegatorInfo TopicIdDelegatorReputerDelegatorInfo
+
+func (x *TopicIdDelegatorReputerDelegatorInfo) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdDelegatorReputerDelegatorInfo)(x)
+}
+
+func (x *TopicIdDelegatorReputerDelegatorInfo) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[10]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdDelegatorReputerDelegatorInfo_messageType fastReflection_TopicIdDelegatorReputerDelegatorInfo_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdDelegatorReputerDelegatorInfo_messageType{}
+
+type fastReflection_TopicIdDelegatorReputerDelegatorInfo_messageType struct{}
+
+func (x fastReflection_TopicIdDelegatorReputerDelegatorInfo_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdDelegatorReputerDelegatorInfo)(nil)
+}
+func (x fastReflection_TopicIdDelegatorReputerDelegatorInfo_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdDelegatorReputerDelegatorInfo)
+}
+func (x fastReflection_TopicIdDelegatorReputerDelegatorInfo_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdDelegatorReputerDelegatorInfo
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdDelegatorReputerDelegatorInfo
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdDelegatorReputerDelegatorInfo_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) New() protoreflect.Message {
+	return new(fastReflection_TopicIdDelegatorReputerDelegatorInfo)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdDelegatorReputerDelegatorInfo)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdDelegatorReputerDelegatorInfo_TopicId, value) {
+			return
+		}
+	}
+	if x.Delegator != "" {
+		value := protoreflect.ValueOfString(x.Delegator)
+		if !f(fd_TopicIdDelegatorReputerDelegatorInfo_Delegator, value) {
+			return
+		}
+	}
+	if x.Reputer != "" {
+		value := protoreflect.ValueOfString(x.Reputer)
+		if !f(fd_TopicIdDelegatorReputerDelegatorInfo_Reputer, value) {
+			return
+		}
+	}
+	if x.DelegatorInfo != nil {
+		value := protoreflect.ValueOfMessage(x.DelegatorInfo.ProtoReflect())
+		if !f(fd_TopicIdDelegatorReputerDelegatorInfo_DelegatorInfo, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Delegator":
+		return x.Delegator != ""
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Reputer":
+		return x.Reputer != ""
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.DelegatorInfo":
+		return x.DelegatorInfo != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdDelegatorReputerDelegatorInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdDelegatorReputerDelegatorInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Delegator":
+		x.Delegator = ""
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Reputer":
+		x.Reputer = ""
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.DelegatorInfo":
+		x.DelegatorInfo = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdDelegatorReputerDelegatorInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdDelegatorReputerDelegatorInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Delegator":
+		value := x.Delegator
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Reputer":
+		value := x.Reputer
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.DelegatorInfo":
+		value := x.DelegatorInfo
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdDelegatorReputerDelegatorInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdDelegatorReputerDelegatorInfo does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Delegator":
+		x.Delegator = value.Interface().(string)
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Reputer":
+		x.Reputer = value.Interface().(string)
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.DelegatorInfo":
+		x.DelegatorInfo = value.Message().Interface().(*DelegatorInfo)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdDelegatorReputerDelegatorInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdDelegatorReputerDelegatorInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.DelegatorInfo":
+		if x.DelegatorInfo == nil {
+			x.DelegatorInfo = new(DelegatorInfo)
+		}
+		return protoreflect.ValueOfMessage(x.DelegatorInfo.ProtoReflect())
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdDelegatorReputerDelegatorInfo is not mutable"))
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Delegator":
+		panic(fmt.Errorf("field Delegator of message emissions.v1.TopicIdDelegatorReputerDelegatorInfo is not mutable"))
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Reputer":
+		panic(fmt.Errorf("field Reputer of message emissions.v1.TopicIdDelegatorReputerDelegatorInfo is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdDelegatorReputerDelegatorInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdDelegatorReputerDelegatorInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Delegator":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.Reputer":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdDelegatorReputerDelegatorInfo.DelegatorInfo":
+		m := new(DelegatorInfo)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdDelegatorReputerDelegatorInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdDelegatorReputerDelegatorInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdDelegatorReputerDelegatorInfo", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdDelegatorReputerDelegatorInfo) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdDelegatorReputerDelegatorInfo)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.Delegator)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.Reputer)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.DelegatorInfo != nil {
+			l = options.Size(x.DelegatorInfo)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdDelegatorReputerDelegatorInfo)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.DelegatorInfo != nil {
+			encoded, err := options.Marshal(x.DelegatorInfo)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x22
+		}
+		if len(x.Reputer) > 0 {
+			i -= len(x.Reputer)
+			copy(dAtA[i:], x.Reputer)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Reputer)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.Delegator) > 0 {
+			i -= len(x.Delegator)
+			copy(dAtA[i:], x.Delegator)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Delegator)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdDelegatorReputerDelegatorInfo)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdDelegatorReputerDelegatorInfo: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdDelegatorReputerDelegatorInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Delegator", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Delegator = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Reputer", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Reputer = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 4:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field DelegatorInfo", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.DelegatorInfo == nil {
+					x.DelegatorInfo = &DelegatorInfo{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.DelegatorInfo); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_BlockHeightTopicIdReputerStakeRemovalInfo                  protoreflect.MessageDescriptor
+	fd_BlockHeightTopicIdReputerStakeRemovalInfo_BlockHeight      protoreflect.FieldDescriptor
+	fd_BlockHeightTopicIdReputerStakeRemovalInfo_TopicId          protoreflect.FieldDescriptor
+	fd_BlockHeightTopicIdReputerStakeRemovalInfo_Reputer          protoreflect.FieldDescriptor
+	fd_BlockHeightTopicIdReputerStakeRemovalInfo_StakeRemovalInfo protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_BlockHeightTopicIdReputerStakeRemovalInfo = File_emissions_v1_genesis_proto.Messages().ByName("BlockHeightTopicIdReputerStakeRemovalInfo")
+	fd_BlockHeightTopicIdReputerStakeRemovalInfo_BlockHeight = md_BlockHeightTopicIdReputerStakeRemovalInfo.Fields().ByName("BlockHeight")
+	fd_BlockHeightTopicIdReputerStakeRemovalInfo_TopicId = md_BlockHeightTopicIdReputerStakeRemovalInfo.Fields().ByName("TopicId")
+	fd_BlockHeightTopicIdReputerStakeRemovalInfo_Reputer = md_BlockHeightTopicIdReputerStakeRemovalInfo.Fields().ByName("Reputer")
+	fd_BlockHeightTopicIdReputerStakeRemovalInfo_StakeRemovalInfo = md_BlockHeightTopicIdReputerStakeRemovalInfo.Fields().ByName("StakeRemovalInfo")
+}
+
+var _ protoreflect.Message = (*fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo)(nil)
+
+type fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo BlockHeightTopicIdReputerStakeRemovalInfo
+
+func (x *BlockHeightTopicIdReputerStakeRemovalInfo) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo)(x)
+}
+
+func (x *BlockHeightTopicIdReputerStakeRemovalInfo) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[11]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo_messageType fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo_messageType
+var _ protoreflect.MessageType = fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo_messageType{}
+
+type fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo_messageType struct{}
+
+func (x fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo)(nil)
+}
+func (x fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo_messageType) New() protoreflect.Message {
+	return new(fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo)
+}
+func (x fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_BlockHeightTopicIdReputerStakeRemovalInfo
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) Descriptor() protoreflect.MessageDescriptor {
+	return md_BlockHeightTopicIdReputerStakeRemovalInfo
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) Type() protoreflect.MessageType {
+	return _fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) New() protoreflect.Message {
+	return new(fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) Interface() protoreflect.ProtoMessage {
+	return (*BlockHeightTopicIdReputerStakeRemovalInfo)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_BlockHeightTopicIdReputerStakeRemovalInfo_BlockHeight, value) {
+			return
+		}
+	}
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_BlockHeightTopicIdReputerStakeRemovalInfo_TopicId, value) {
+			return
+		}
+	}
+	if x.Reputer != "" {
+		value := protoreflect.ValueOfString(x.Reputer)
+		if !f(fd_BlockHeightTopicIdReputerStakeRemovalInfo_Reputer, value) {
+			return
+		}
+	}
+	if x.StakeRemovalInfo != nil {
+		value := protoreflect.ValueOfMessage(x.StakeRemovalInfo.ProtoReflect())
+		if !f(fd_BlockHeightTopicIdReputerStakeRemovalInfo_StakeRemovalInfo, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.BlockHeight":
+		return x.BlockHeight != int64(0)
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.Reputer":
+		return x.Reputer != ""
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.StakeRemovalInfo":
+		return x.StakeRemovalInfo != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.BlockHeight":
+		x.BlockHeight = int64(0)
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.Reputer":
+		x.Reputer = ""
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.StakeRemovalInfo":
+		x.StakeRemovalInfo = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.Reputer":
+		value := x.Reputer
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.StakeRemovalInfo":
+		value := x.StakeRemovalInfo
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.BlockHeight":
+		x.BlockHeight = value.Int()
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.Reputer":
+		x.Reputer = value.Interface().(string)
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.StakeRemovalInfo":
+		x.StakeRemovalInfo = value.Message().Interface().(*StakeRemovalInfo)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.StakeRemovalInfo":
+		if x.StakeRemovalInfo == nil {
+			x.StakeRemovalInfo = new(StakeRemovalInfo)
+		}
+		return protoreflect.ValueOfMessage(x.StakeRemovalInfo.ProtoReflect())
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo is not mutable"))
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo is not mutable"))
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.Reputer":
+		panic(fmt.Errorf("field Reputer of message emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.Reputer":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.StakeRemovalInfo":
+		m := new(StakeRemovalInfo)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_BlockHeightTopicIdReputerStakeRemovalInfo) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*BlockHeightTopicIdReputerStakeRemovalInfo)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.Reputer)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.StakeRemovalInfo != nil {
+			l = options.Size(x.StakeRemovalInfo)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*BlockHeightTopicIdReputerStakeRemovalInfo)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.StakeRemovalInfo != nil {
+			encoded, err := options.Marshal(x.StakeRemovalInfo)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x22
+		}
+		if len(x.Reputer) > 0 {
+			i -= len(x.Reputer)
+			copy(dAtA[i:], x.Reputer)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Reputer)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*BlockHeightTopicIdReputerStakeRemovalInfo)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: BlockHeightTopicIdReputerStakeRemovalInfo: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: BlockHeightTopicIdReputerStakeRemovalInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Reputer", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Reputer = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 4:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field StakeRemovalInfo", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.StakeRemovalInfo == nil {
+					x.StakeRemovalInfo = &StakeRemovalInfo{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.StakeRemovalInfo); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_ActorIdTopicIdBlockHeight             protoreflect.MessageDescriptor
+	fd_ActorIdTopicIdBlockHeight_ActorId     protoreflect.FieldDescriptor
+	fd_ActorIdTopicIdBlockHeight_TopicId     protoreflect.FieldDescriptor
+	fd_ActorIdTopicIdBlockHeight_BlockHeight protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_ActorIdTopicIdBlockHeight = File_emissions_v1_genesis_proto.Messages().ByName("ActorIdTopicIdBlockHeight")
+	fd_ActorIdTopicIdBlockHeight_ActorId = md_ActorIdTopicIdBlockHeight.Fields().ByName("ActorId")
+	fd_ActorIdTopicIdBlockHeight_TopicId = md_ActorIdTopicIdBlockHeight.Fields().ByName("TopicId")
+	fd_ActorIdTopicIdBlockHeight_BlockHeight = md_ActorIdTopicIdBlockHeight.Fields().ByName("BlockHeight")
+}
+
+var _ protoreflect.Message = (*fastReflection_ActorIdTopicIdBlockHeight)(nil)
+
+type fastReflection_ActorIdTopicIdBlockHeight ActorIdTopicIdBlockHeight
+
+func (x *ActorIdTopicIdBlockHeight) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_ActorIdTopicIdBlockHeight)(x)
+}
+
+func (x *ActorIdTopicIdBlockHeight) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[12]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_ActorIdTopicIdBlockHeight_messageType fastReflection_ActorIdTopicIdBlockHeight_messageType
+var _ protoreflect.MessageType = fastReflection_ActorIdTopicIdBlockHeight_messageType{}
+
+type fastReflection_ActorIdTopicIdBlockHeight_messageType struct{}
+
+func (x fastReflection_ActorIdTopicIdBlockHeight_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_ActorIdTopicIdBlockHeight)(nil)
+}
+func (x fastReflection_ActorIdTopicIdBlockHeight_messageType) New() protoreflect.Message {
+	return new(fastReflection_ActorIdTopicIdBlockHeight)
+}
+func (x fastReflection_ActorIdTopicIdBlockHeight_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_ActorIdTopicIdBlockHeight
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) Descriptor() protoreflect.MessageDescriptor {
+	return md_ActorIdTopicIdBlockHeight
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) Type() protoreflect.MessageType {
+	return _fastReflection_ActorIdTopicIdBlockHeight_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) New() protoreflect.Message {
+	return new(fastReflection_ActorIdTopicIdBlockHeight)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) Interface() protoreflect.ProtoMessage {
+	return (*ActorIdTopicIdBlockHeight)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.ActorId != "" {
+		value := protoreflect.ValueOfString(x.ActorId)
+		if !f(fd_ActorIdTopicIdBlockHeight_ActorId, value) {
+			return
+		}
+	}
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_ActorIdTopicIdBlockHeight_TopicId, value) {
+			return
+		}
+	}
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_ActorIdTopicIdBlockHeight_BlockHeight, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.ActorIdTopicIdBlockHeight.ActorId":
+		return x.ActorId != ""
+	case "emissions.v1.ActorIdTopicIdBlockHeight.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.ActorIdTopicIdBlockHeight.BlockHeight":
+		return x.BlockHeight != int64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.ActorIdTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.ActorIdTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.ActorIdTopicIdBlockHeight.ActorId":
+		x.ActorId = ""
+	case "emissions.v1.ActorIdTopicIdBlockHeight.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.ActorIdTopicIdBlockHeight.BlockHeight":
+		x.BlockHeight = int64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.ActorIdTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.ActorIdTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.ActorIdTopicIdBlockHeight.ActorId":
+		value := x.ActorId
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.ActorIdTopicIdBlockHeight.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.ActorIdTopicIdBlockHeight.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.ActorIdTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.ActorIdTopicIdBlockHeight does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.ActorIdTopicIdBlockHeight.ActorId":
+		x.ActorId = value.Interface().(string)
+	case "emissions.v1.ActorIdTopicIdBlockHeight.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.ActorIdTopicIdBlockHeight.BlockHeight":
+		x.BlockHeight = value.Int()
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.ActorIdTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.ActorIdTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.ActorIdTopicIdBlockHeight.ActorId":
+		panic(fmt.Errorf("field ActorId of message emissions.v1.ActorIdTopicIdBlockHeight is not mutable"))
+	case "emissions.v1.ActorIdTopicIdBlockHeight.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.ActorIdTopicIdBlockHeight is not mutable"))
+	case "emissions.v1.ActorIdTopicIdBlockHeight.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.ActorIdTopicIdBlockHeight is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.ActorIdTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.ActorIdTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.ActorIdTopicIdBlockHeight.ActorId":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.ActorIdTopicIdBlockHeight.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.ActorIdTopicIdBlockHeight.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.ActorIdTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.ActorIdTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.ActorIdTopicIdBlockHeight", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_ActorIdTopicIdBlockHeight) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*ActorIdTopicIdBlockHeight)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		l = len(x.ActorId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*ActorIdTopicIdBlockHeight)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x18
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x10
+		}
+		if len(x.ActorId) > 0 {
+			i -= len(x.ActorId)
+			copy(dAtA[i:], x.ActorId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId)))
+			i--
+			dAtA[i] = 0xa
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*ActorIdTopicIdBlockHeight)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: ActorIdTopicIdBlockHeight: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: ActorIdTopicIdBlockHeight: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 2:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 3:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo                          protoreflect.MessageDescriptor
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_BlockHeight              protoreflect.FieldDescriptor
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_TopicId                  protoreflect.FieldDescriptor
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_Delegator                protoreflect.FieldDescriptor
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_Reputer                  protoreflect.FieldDescriptor
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_DelegateStakeRemovalInfo protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo = File_emissions_v1_genesis_proto.Messages().ByName("BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo")
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_BlockHeight = md_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Fields().ByName("BlockHeight")
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_TopicId = md_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Fields().ByName("TopicId")
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_Delegator = md_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Fields().ByName("Delegator")
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_Reputer = md_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Fields().ByName("Reputer")
+	fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_DelegateStakeRemovalInfo = md_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Fields().ByName("DelegateStakeRemovalInfo")
+}
+
+var _ protoreflect.Message = (*fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)(nil)
+
+type fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo
+
+func (x *BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)(x)
+}
+
+func (x *BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[13]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_messageType fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_messageType
+var _ protoreflect.MessageType = fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_messageType{}
+
+type fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_messageType struct{}
+
+func (x fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)(nil)
+}
+func (x fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_messageType) New() protoreflect.Message {
+	return new(fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+}
+func (x fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Descriptor() protoreflect.MessageDescriptor {
+	return md_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Type() protoreflect.MessageType {
+	return _fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) New() protoreflect.Message {
+	return new(fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Interface() protoreflect.ProtoMessage {
+	return (*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_BlockHeight, value) {
+			return
+		}
+	}
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_TopicId, value) {
+			return
+		}
+	}
+	if x.Delegator != "" {
+		value := protoreflect.ValueOfString(x.Delegator)
+		if !f(fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_Delegator, value) {
+			return
+		}
+	}
+	if x.Reputer != "" {
+		value := protoreflect.ValueOfString(x.Reputer)
+		if !f(fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_Reputer, value) {
+			return
+		}
+	}
+	if x.DelegateStakeRemovalInfo != nil {
+		value := protoreflect.ValueOfMessage(x.DelegateStakeRemovalInfo.ProtoReflect())
+		if !f(fd_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo_DelegateStakeRemovalInfo, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.BlockHeight":
+		return x.BlockHeight != int64(0)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Delegator":
+		return x.Delegator != ""
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Reputer":
+		return x.Reputer != ""
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.DelegateStakeRemovalInfo":
+		return x.DelegateStakeRemovalInfo != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.BlockHeight":
+		x.BlockHeight = int64(0)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Delegator":
+		x.Delegator = ""
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Reputer":
+		x.Reputer = ""
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.DelegateStakeRemovalInfo":
+		x.DelegateStakeRemovalInfo = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Delegator":
+		value := x.Delegator
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Reputer":
+		value := x.Reputer
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.DelegateStakeRemovalInfo":
+		value := x.DelegateStakeRemovalInfo
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.BlockHeight":
+		x.BlockHeight = value.Int()
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Delegator":
+		x.Delegator = value.Interface().(string)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Reputer":
+		x.Reputer = value.Interface().(string)
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.DelegateStakeRemovalInfo":
+		x.DelegateStakeRemovalInfo = value.Message().Interface().(*DelegateStakeRemovalInfo)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.DelegateStakeRemovalInfo":
+		if x.DelegateStakeRemovalInfo == nil {
+			x.DelegateStakeRemovalInfo = new(DelegateStakeRemovalInfo)
+		}
+		return protoreflect.ValueOfMessage(x.DelegateStakeRemovalInfo.ProtoReflect())
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo is not mutable"))
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo is not mutable"))
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Delegator":
+		panic(fmt.Errorf("field Delegator of message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo is not mutable"))
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Reputer":
+		panic(fmt.Errorf("field Reputer of message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Delegator":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Reputer":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.DelegateStakeRemovalInfo":
+		m := new(DelegateStakeRemovalInfo)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo"))
+		}
+		panic(fmt.Errorf("message emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.Delegator)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.Reputer)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.DelegateStakeRemovalInfo != nil {
+			l = options.Size(x.DelegateStakeRemovalInfo)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.DelegateStakeRemovalInfo != nil {
+			encoded, err := options.Marshal(x.DelegateStakeRemovalInfo)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x2a
+		}
+		if len(x.Reputer) > 0 {
+			i -= len(x.Reputer)
+			copy(dAtA[i:], x.Reputer)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Reputer)))
+			i--
+			dAtA[i] = 0x22
+		}
+		if len(x.Delegator) > 0 {
+			i -= len(x.Delegator)
+			copy(dAtA[i:], x.Delegator)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Delegator)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Delegator", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Delegator = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 4:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Reputer", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Reputer = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 5:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field DelegateStakeRemovalInfo", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.DelegateStakeRemovalInfo == nil {
+					x.DelegateStakeRemovalInfo = &DelegateStakeRemovalInfo{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.DelegateStakeRemovalInfo); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_DelegatorReputerTopicIdBlockHeight             protoreflect.MessageDescriptor
+	fd_DelegatorReputerTopicIdBlockHeight_Delegator   protoreflect.FieldDescriptor
+	fd_DelegatorReputerTopicIdBlockHeight_Reputer     protoreflect.FieldDescriptor
+	fd_DelegatorReputerTopicIdBlockHeight_TopicId     protoreflect.FieldDescriptor
+	fd_DelegatorReputerTopicIdBlockHeight_BlockHeight protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_DelegatorReputerTopicIdBlockHeight = File_emissions_v1_genesis_proto.Messages().ByName("DelegatorReputerTopicIdBlockHeight")
+	fd_DelegatorReputerTopicIdBlockHeight_Delegator = md_DelegatorReputerTopicIdBlockHeight.Fields().ByName("Delegator")
+	fd_DelegatorReputerTopicIdBlockHeight_Reputer = md_DelegatorReputerTopicIdBlockHeight.Fields().ByName("Reputer")
+	fd_DelegatorReputerTopicIdBlockHeight_TopicId = md_DelegatorReputerTopicIdBlockHeight.Fields().ByName("TopicId")
+	fd_DelegatorReputerTopicIdBlockHeight_BlockHeight = md_DelegatorReputerTopicIdBlockHeight.Fields().ByName("BlockHeight")
+}
+
+var _ protoreflect.Message = (*fastReflection_DelegatorReputerTopicIdBlockHeight)(nil)
+
+type fastReflection_DelegatorReputerTopicIdBlockHeight DelegatorReputerTopicIdBlockHeight
+
+func (x *DelegatorReputerTopicIdBlockHeight) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_DelegatorReputerTopicIdBlockHeight)(x)
+}
+
+func (x *DelegatorReputerTopicIdBlockHeight) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[14]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_DelegatorReputerTopicIdBlockHeight_messageType fastReflection_DelegatorReputerTopicIdBlockHeight_messageType
+var _ protoreflect.MessageType = fastReflection_DelegatorReputerTopicIdBlockHeight_messageType{}
+
+type fastReflection_DelegatorReputerTopicIdBlockHeight_messageType struct{}
+
+func (x fastReflection_DelegatorReputerTopicIdBlockHeight_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_DelegatorReputerTopicIdBlockHeight)(nil)
+}
+func (x fastReflection_DelegatorReputerTopicIdBlockHeight_messageType) New() protoreflect.Message {
+	return new(fastReflection_DelegatorReputerTopicIdBlockHeight)
+}
+func (x fastReflection_DelegatorReputerTopicIdBlockHeight_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_DelegatorReputerTopicIdBlockHeight
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) Descriptor() protoreflect.MessageDescriptor {
+	return md_DelegatorReputerTopicIdBlockHeight
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) Type() protoreflect.MessageType {
+	return _fastReflection_DelegatorReputerTopicIdBlockHeight_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) New() protoreflect.Message {
+	return new(fastReflection_DelegatorReputerTopicIdBlockHeight)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) Interface() protoreflect.ProtoMessage {
+	return (*DelegatorReputerTopicIdBlockHeight)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.Delegator != "" {
+		value := protoreflect.ValueOfString(x.Delegator)
+		if !f(fd_DelegatorReputerTopicIdBlockHeight_Delegator, value) {
+			return
+		}
+	}
+	if x.Reputer != "" {
+		value := protoreflect.ValueOfString(x.Reputer)
+		if !f(fd_DelegatorReputerTopicIdBlockHeight_Reputer, value) {
+			return
+		}
+	}
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_DelegatorReputerTopicIdBlockHeight_TopicId, value) {
+			return
+		}
+	}
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_DelegatorReputerTopicIdBlockHeight_BlockHeight, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Delegator":
+		return x.Delegator != ""
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Reputer":
+		return x.Reputer != ""
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.BlockHeight":
+		return x.BlockHeight != int64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegatorReputerTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.DelegatorReputerTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Delegator":
+		x.Delegator = ""
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Reputer":
+		x.Reputer = ""
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.BlockHeight":
+		x.BlockHeight = int64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegatorReputerTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.DelegatorReputerTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Delegator":
+		value := x.Delegator
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Reputer":
+		value := x.Reputer
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegatorReputerTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.DelegatorReputerTopicIdBlockHeight does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Delegator":
+		x.Delegator = value.Interface().(string)
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Reputer":
+		x.Reputer = value.Interface().(string)
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.BlockHeight":
+		x.BlockHeight = value.Int()
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegatorReputerTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.DelegatorReputerTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Delegator":
+		panic(fmt.Errorf("field Delegator of message emissions.v1.DelegatorReputerTopicIdBlockHeight is not mutable"))
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Reputer":
+		panic(fmt.Errorf("field Reputer of message emissions.v1.DelegatorReputerTopicIdBlockHeight is not mutable"))
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.DelegatorReputerTopicIdBlockHeight is not mutable"))
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.DelegatorReputerTopicIdBlockHeight is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegatorReputerTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.DelegatorReputerTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Delegator":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.Reputer":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.DelegatorReputerTopicIdBlockHeight.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.DelegatorReputerTopicIdBlockHeight"))
+		}
+		panic(fmt.Errorf("message emissions.v1.DelegatorReputerTopicIdBlockHeight does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.DelegatorReputerTopicIdBlockHeight", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_DelegatorReputerTopicIdBlockHeight) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*DelegatorReputerTopicIdBlockHeight)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		l = len(x.Delegator)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.Reputer)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*DelegatorReputerTopicIdBlockHeight)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x20
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x18
+		}
+		if len(x.Reputer) > 0 {
+			i -= len(x.Reputer)
+			copy(dAtA[i:], x.Reputer)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Reputer)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if len(x.Delegator) > 0 {
+			i -= len(x.Delegator)
+			copy(dAtA[i:], x.Delegator)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Delegator)))
+			i--
+			dAtA[i] = 0xa
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*DelegatorReputerTopicIdBlockHeight)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: DelegatorReputerTopicIdBlockHeight: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: DelegatorReputerTopicIdBlockHeight: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Delegator", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Delegator = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Reputer", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Reputer = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 4:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdActorIdInference           protoreflect.MessageDescriptor
+	fd_TopicIdActorIdInference_TopicId   protoreflect.FieldDescriptor
+	fd_TopicIdActorIdInference_ActorId   protoreflect.FieldDescriptor
+	fd_TopicIdActorIdInference_Inference protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdActorIdInference = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdActorIdInference")
+	fd_TopicIdActorIdInference_TopicId = md_TopicIdActorIdInference.Fields().ByName("TopicId")
+	fd_TopicIdActorIdInference_ActorId = md_TopicIdActorIdInference.Fields().ByName("ActorId")
+	fd_TopicIdActorIdInference_Inference = md_TopicIdActorIdInference.Fields().ByName("Inference")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdActorIdInference)(nil)
+
+type fastReflection_TopicIdActorIdInference TopicIdActorIdInference
+
+func (x *TopicIdActorIdInference) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdInference)(x)
+}
+
+func (x *TopicIdActorIdInference) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[15]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdActorIdInference_messageType fastReflection_TopicIdActorIdInference_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdActorIdInference_messageType{}
+
+type fastReflection_TopicIdActorIdInference_messageType struct{}
+
+func (x fastReflection_TopicIdActorIdInference_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdInference)(nil)
+}
+func (x fastReflection_TopicIdActorIdInference_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdInference)
+}
+func (x fastReflection_TopicIdActorIdInference_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdInference
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdActorIdInference) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdInference
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdActorIdInference) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdActorIdInference_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdActorIdInference) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdInference)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdActorIdInference) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdActorIdInference)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdActorIdInference) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdActorIdInference_TopicId, value) {
+			return
+		}
+	}
+	if x.ActorId != "" {
+		value := protoreflect.ValueOfString(x.ActorId)
+		if !f(fd_TopicIdActorIdInference_ActorId, value) {
+			return
+		}
+	}
+	if x.Inference != nil {
+		value := protoreflect.ValueOfMessage(x.Inference.ProtoReflect())
+		if !f(fd_TopicIdActorIdInference_Inference, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdActorIdInference) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInference.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdActorIdInference.ActorId":
+		return x.ActorId != ""
+	case "emissions.v1.TopicIdActorIdInference.Inference":
+		return x.Inference != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInference"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInference does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdInference) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInference.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdActorIdInference.ActorId":
+		x.ActorId = ""
+	case "emissions.v1.TopicIdActorIdInference.Inference":
+		x.Inference = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInference"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInference does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdActorIdInference) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdActorIdInference.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdActorIdInference.ActorId":
+		value := x.ActorId
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdActorIdInference.Inference":
+		value := x.Inference
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInference"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInference does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdInference) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInference.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdActorIdInference.ActorId":
+		x.ActorId = value.Interface().(string)
+	case "emissions.v1.TopicIdActorIdInference.Inference":
+		x.Inference = value.Message().Interface().(*Inference)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInference"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInference does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdInference) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInference.Inference":
+		if x.Inference == nil {
+			x.Inference = new(Inference)
+		}
+		return protoreflect.ValueOfMessage(x.Inference.ProtoReflect())
+	case "emissions.v1.TopicIdActorIdInference.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdActorIdInference is not mutable"))
+	case "emissions.v1.TopicIdActorIdInference.ActorId":
+		panic(fmt.Errorf("field ActorId of message emissions.v1.TopicIdActorIdInference is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInference"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInference does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdActorIdInference) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdInference.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdActorIdInference.ActorId":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdActorIdInference.Inference":
+		m := new(Inference)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdInference"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdInference does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdActorIdInference) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdActorIdInference", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdActorIdInference) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdInference) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdActorIdInference) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdActorIdInference) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdActorIdInference)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.ActorId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.Inference != nil {
+			l = options.Size(x.Inference)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdInference)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.Inference != nil {
+			encoded, err := options.Marshal(x.Inference)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.ActorId) > 0 {
+			i -= len(x.ActorId)
+			copy(dAtA[i:], x.ActorId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdInference)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdInference: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdInference: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Inference", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.Inference == nil {
+					x.Inference = &Inference{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Inference); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdActorIdForecast          protoreflect.MessageDescriptor
+	fd_TopicIdActorIdForecast_TopicId  protoreflect.FieldDescriptor
+	fd_TopicIdActorIdForecast_ActorId  protoreflect.FieldDescriptor
+	fd_TopicIdActorIdForecast_Forecast protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdActorIdForecast = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdActorIdForecast")
+	fd_TopicIdActorIdForecast_TopicId = md_TopicIdActorIdForecast.Fields().ByName("TopicId")
+	fd_TopicIdActorIdForecast_ActorId = md_TopicIdActorIdForecast.Fields().ByName("ActorId")
+	fd_TopicIdActorIdForecast_Forecast = md_TopicIdActorIdForecast.Fields().ByName("Forecast")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdActorIdForecast)(nil)
+
+type fastReflection_TopicIdActorIdForecast TopicIdActorIdForecast
+
+func (x *TopicIdActorIdForecast) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdForecast)(x)
+}
+
+func (x *TopicIdActorIdForecast) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[16]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdActorIdForecast_messageType fastReflection_TopicIdActorIdForecast_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdActorIdForecast_messageType{}
+
+type fastReflection_TopicIdActorIdForecast_messageType struct{}
+
+func (x fastReflection_TopicIdActorIdForecast_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdForecast)(nil)
+}
+func (x fastReflection_TopicIdActorIdForecast_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdForecast)
+}
+func (x fastReflection_TopicIdActorIdForecast_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdForecast
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdActorIdForecast) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdForecast
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdActorIdForecast) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdActorIdForecast_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdActorIdForecast) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdForecast)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdActorIdForecast) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdActorIdForecast)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdActorIdForecast) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdActorIdForecast_TopicId, value) {
+			return
+		}
+	}
+	if x.ActorId != "" {
+		value := protoreflect.ValueOfString(x.ActorId)
+		if !f(fd_TopicIdActorIdForecast_ActorId, value) {
+			return
+		}
+	}
+	if x.Forecast != nil {
+		value := protoreflect.ValueOfMessage(x.Forecast.ProtoReflect())
+		if !f(fd_TopicIdActorIdForecast_Forecast, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdActorIdForecast) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdForecast.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdActorIdForecast.ActorId":
+		return x.ActorId != ""
+	case "emissions.v1.TopicIdActorIdForecast.Forecast":
+		return x.Forecast != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdForecast"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdForecast does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdForecast) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdForecast.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdActorIdForecast.ActorId":
+		x.ActorId = ""
+	case "emissions.v1.TopicIdActorIdForecast.Forecast":
+		x.Forecast = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdForecast"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdForecast does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdActorIdForecast) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdActorIdForecast.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdActorIdForecast.ActorId":
+		value := x.ActorId
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdActorIdForecast.Forecast":
+		value := x.Forecast
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdForecast"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdForecast does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdForecast) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdForecast.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdActorIdForecast.ActorId":
+		x.ActorId = value.Interface().(string)
+	case "emissions.v1.TopicIdActorIdForecast.Forecast":
+		x.Forecast = value.Message().Interface().(*Forecast)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdForecast"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdForecast does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdForecast) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdForecast.Forecast":
+		if x.Forecast == nil {
+			x.Forecast = new(Forecast)
+		}
+		return protoreflect.ValueOfMessage(x.Forecast.ProtoReflect())
+	case "emissions.v1.TopicIdActorIdForecast.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdActorIdForecast is not mutable"))
+	case "emissions.v1.TopicIdActorIdForecast.ActorId":
+		panic(fmt.Errorf("field ActorId of message emissions.v1.TopicIdActorIdForecast is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdForecast"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdForecast does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdActorIdForecast) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdForecast.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdActorIdForecast.ActorId":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdActorIdForecast.Forecast":
+		m := new(Forecast)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdForecast"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdForecast does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdActorIdForecast) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdActorIdForecast", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdActorIdForecast) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdForecast) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdActorIdForecast) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdActorIdForecast) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdActorIdForecast)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.ActorId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.Forecast != nil {
+			l = options.Size(x.Forecast)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdForecast)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.Forecast != nil {
+			encoded, err := options.Marshal(x.Forecast)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.ActorId) > 0 {
+			i -= len(x.ActorId)
+			copy(dAtA[i:], x.ActorId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdForecast)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdForecast: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdForecast: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Forecast", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.Forecast == nil {
+					x.Forecast = &Forecast{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Forecast); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_LibP2PKeyAndOffchainNode              protoreflect.MessageDescriptor
+	fd_LibP2PKeyAndOffchainNode_LibP2pKey    protoreflect.FieldDescriptor
+	fd_LibP2PKeyAndOffchainNode_OffchainNode protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_LibP2PKeyAndOffchainNode = File_emissions_v1_genesis_proto.Messages().ByName("LibP2pKeyAndOffchainNode")
+	fd_LibP2PKeyAndOffchainNode_LibP2pKey = md_LibP2PKeyAndOffchainNode.Fields().ByName("LibP2pKey")
+	fd_LibP2PKeyAndOffchainNode_OffchainNode = md_LibP2PKeyAndOffchainNode.Fields().ByName("OffchainNode")
+}
+
+var _ protoreflect.Message = (*fastReflection_LibP2PKeyAndOffchainNode)(nil)
+
+type fastReflection_LibP2PKeyAndOffchainNode LibP2PKeyAndOffchainNode
+
+func (x *LibP2PKeyAndOffchainNode) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_LibP2PKeyAndOffchainNode)(x)
+}
+
+func (x *LibP2PKeyAndOffchainNode) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[17]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_LibP2PKeyAndOffchainNode_messageType fastReflection_LibP2PKeyAndOffchainNode_messageType
+var _ protoreflect.MessageType = fastReflection_LibP2PKeyAndOffchainNode_messageType{}
+
+type fastReflection_LibP2PKeyAndOffchainNode_messageType struct{}
+
+func (x fastReflection_LibP2PKeyAndOffchainNode_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_LibP2PKeyAndOffchainNode)(nil)
+}
+func (x fastReflection_LibP2PKeyAndOffchainNode_messageType) New() protoreflect.Message {
+	return new(fastReflection_LibP2PKeyAndOffchainNode)
+}
+func (x fastReflection_LibP2PKeyAndOffchainNode_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_LibP2PKeyAndOffchainNode
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) Descriptor() protoreflect.MessageDescriptor {
+	return md_LibP2PKeyAndOffchainNode
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) Type() protoreflect.MessageType {
+	return _fastReflection_LibP2PKeyAndOffchainNode_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) New() protoreflect.Message {
+	return new(fastReflection_LibP2PKeyAndOffchainNode)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) Interface() protoreflect.ProtoMessage {
+	return (*LibP2PKeyAndOffchainNode)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.LibP2PKey != "" {
+		value := protoreflect.ValueOfString(x.LibP2PKey)
+		if !f(fd_LibP2PKeyAndOffchainNode_LibP2pKey, value) {
+			return
+		}
+	}
+	if x.OffchainNode != nil {
+		value := protoreflect.ValueOfMessage(x.OffchainNode.ProtoReflect())
+		if !f(fd_LibP2PKeyAndOffchainNode_OffchainNode, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.LibP2pKeyAndOffchainNode.LibP2pKey":
+		return x.LibP2PKey != ""
+	case "emissions.v1.LibP2pKeyAndOffchainNode.OffchainNode":
+		return x.OffchainNode != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.LibP2pKeyAndOffchainNode"))
+		}
+		panic(fmt.Errorf("message emissions.v1.LibP2pKeyAndOffchainNode does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.LibP2pKeyAndOffchainNode.LibP2pKey":
+		x.LibP2PKey = ""
+	case "emissions.v1.LibP2pKeyAndOffchainNode.OffchainNode":
+		x.OffchainNode = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.LibP2pKeyAndOffchainNode"))
+		}
+		panic(fmt.Errorf("message emissions.v1.LibP2pKeyAndOffchainNode does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.LibP2pKeyAndOffchainNode.LibP2pKey":
+		value := x.LibP2PKey
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.LibP2pKeyAndOffchainNode.OffchainNode":
+		value := x.OffchainNode
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.LibP2pKeyAndOffchainNode"))
+		}
+		panic(fmt.Errorf("message emissions.v1.LibP2pKeyAndOffchainNode does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.LibP2pKeyAndOffchainNode.LibP2pKey":
+		x.LibP2PKey = value.Interface().(string)
+	case "emissions.v1.LibP2pKeyAndOffchainNode.OffchainNode":
+		x.OffchainNode = value.Message().Interface().(*OffchainNode)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.LibP2pKeyAndOffchainNode"))
+		}
+		panic(fmt.Errorf("message emissions.v1.LibP2pKeyAndOffchainNode does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.LibP2pKeyAndOffchainNode.OffchainNode":
+		if x.OffchainNode == nil {
+			x.OffchainNode = new(OffchainNode)
+		}
+		return protoreflect.ValueOfMessage(x.OffchainNode.ProtoReflect())
+	case "emissions.v1.LibP2pKeyAndOffchainNode.LibP2pKey":
+		panic(fmt.Errorf("field LibP2pKey of message emissions.v1.LibP2pKeyAndOffchainNode is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.LibP2pKeyAndOffchainNode"))
+		}
+		panic(fmt.Errorf("message emissions.v1.LibP2pKeyAndOffchainNode does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.LibP2pKeyAndOffchainNode.LibP2pKey":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.LibP2pKeyAndOffchainNode.OffchainNode":
+		m := new(OffchainNode)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.LibP2pKeyAndOffchainNode"))
+		}
+		panic(fmt.Errorf("message emissions.v1.LibP2pKeyAndOffchainNode does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.LibP2pKeyAndOffchainNode", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_LibP2PKeyAndOffchainNode) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*LibP2PKeyAndOffchainNode)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		l = len(x.LibP2PKey)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.OffchainNode != nil {
+			l = options.Size(x.OffchainNode)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*LibP2PKeyAndOffchainNode)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.OffchainNode != nil {
+			encoded, err := options.Marshal(x.OffchainNode)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if len(x.LibP2PKey) > 0 {
+			i -= len(x.LibP2PKey)
+			copy(dAtA[i:], x.LibP2PKey)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.LibP2PKey)))
+			i--
+			dAtA[i] = 0xa
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*LibP2PKeyAndOffchainNode)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: LibP2PKeyAndOffchainNode: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: LibP2PKeyAndOffchainNode: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field LibP2PKey", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.LibP2PKey = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field OffchainNode", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.OffchainNode == nil {
+					x.OffchainNode = &OffchainNode{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.OffchainNode); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdAndDec         protoreflect.MessageDescriptor
+	fd_TopicIdAndDec_TopicId protoreflect.FieldDescriptor
+	fd_TopicIdAndDec_Dec     protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdAndDec = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdAndDec")
+	fd_TopicIdAndDec_TopicId = md_TopicIdAndDec.Fields().ByName("TopicId")
+	fd_TopicIdAndDec_Dec = md_TopicIdAndDec.Fields().ByName("Dec")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdAndDec)(nil)
+
+type fastReflection_TopicIdAndDec TopicIdAndDec
+
+func (x *TopicIdAndDec) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdAndDec)(x)
+}
+
+func (x *TopicIdAndDec) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[18]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdAndDec_messageType fastReflection_TopicIdAndDec_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdAndDec_messageType{}
+
+type fastReflection_TopicIdAndDec_messageType struct{}
+
+func (x fastReflection_TopicIdAndDec_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdAndDec)(nil)
+}
+func (x fastReflection_TopicIdAndDec_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndDec)
+}
+func (x fastReflection_TopicIdAndDec_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndDec
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdAndDec) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndDec
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdAndDec) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdAndDec_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdAndDec) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndDec)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdAndDec) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdAndDec)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdAndDec) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdAndDec_TopicId, value) {
+			return
+		}
+	}
+	if x.Dec != "" {
+		value := protoreflect.ValueOfString(x.Dec)
+		if !f(fd_TopicIdAndDec_Dec, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdAndDec) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndDec.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdAndDec.Dec":
+		return x.Dec != ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndDec) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndDec.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdAndDec.Dec":
+		x.Dec = ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdAndDec) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdAndDec.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdAndDec.Dec":
+		value := x.Dec
+		return protoreflect.ValueOfString(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndDec does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndDec) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndDec.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdAndDec.Dec":
+		x.Dec = value.Interface().(string)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndDec) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndDec.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdAndDec is not mutable"))
+	case "emissions.v1.TopicIdAndDec.Dec":
+		panic(fmt.Errorf("field Dec of message emissions.v1.TopicIdAndDec is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdAndDec) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndDec.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdAndDec.Dec":
+		return protoreflect.ValueOfString("")
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndDec"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndDec does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdAndDec) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdAndDec", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdAndDec) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndDec) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdAndDec) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdAndDec) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdAndDec)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.Dec)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndDec)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.Dec) > 0 {
+			i -= len(x.Dec)
+			copy(dAtA[i:], x.Dec)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Dec)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndDec)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndDec: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndDec: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Dec", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Dec = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdBlockHeightInferences             protoreflect.MessageDescriptor
+	fd_TopicIdBlockHeightInferences_TopicId     protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightInferences_BlockHeight protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightInferences_Inferences  protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdBlockHeightInferences = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdBlockHeightInferences")
+	fd_TopicIdBlockHeightInferences_TopicId = md_TopicIdBlockHeightInferences.Fields().ByName("TopicId")
+	fd_TopicIdBlockHeightInferences_BlockHeight = md_TopicIdBlockHeightInferences.Fields().ByName("BlockHeight")
+	fd_TopicIdBlockHeightInferences_Inferences = md_TopicIdBlockHeightInferences.Fields().ByName("Inferences")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdBlockHeightInferences)(nil)
+
+type fastReflection_TopicIdBlockHeightInferences TopicIdBlockHeightInferences
+
+func (x *TopicIdBlockHeightInferences) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightInferences)(x)
+}
+
+func (x *TopicIdBlockHeightInferences) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[19]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdBlockHeightInferences_messageType fastReflection_TopicIdBlockHeightInferences_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdBlockHeightInferences_messageType{}
+
+type fastReflection_TopicIdBlockHeightInferences_messageType struct{}
+
+func (x fastReflection_TopicIdBlockHeightInferences_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightInferences)(nil)
+}
+func (x fastReflection_TopicIdBlockHeightInferences_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightInferences)
+}
+func (x fastReflection_TopicIdBlockHeightInferences_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightInferences
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdBlockHeightInferences) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightInferences
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdBlockHeightInferences) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdBlockHeightInferences_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdBlockHeightInferences) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightInferences)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdBlockHeightInferences) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdBlockHeightInferences)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdBlockHeightInferences) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdBlockHeightInferences_TopicId, value) {
+			return
+		}
+	}
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_TopicIdBlockHeightInferences_BlockHeight, value) {
+			return
+		}
+	}
+	if x.Inferences != nil {
+		value := protoreflect.ValueOfMessage(x.Inferences.ProtoReflect())
+		if !f(fd_TopicIdBlockHeightInferences_Inferences, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdBlockHeightInferences) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightInferences.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdBlockHeightInferences.BlockHeight":
+		return x.BlockHeight != int64(0)
+	case "emissions.v1.TopicIdBlockHeightInferences.Inferences":
+		return x.Inferences != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightInferences"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightInferences does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightInferences) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightInferences.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdBlockHeightInferences.BlockHeight":
+		x.BlockHeight = int64(0)
+	case "emissions.v1.TopicIdBlockHeightInferences.Inferences":
+		x.Inferences = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightInferences"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightInferences does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdBlockHeightInferences) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdBlockHeightInferences.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdBlockHeightInferences.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	case "emissions.v1.TopicIdBlockHeightInferences.Inferences":
+		value := x.Inferences
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightInferences"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightInferences does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightInferences) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightInferences.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdBlockHeightInferences.BlockHeight":
+		x.BlockHeight = value.Int()
+	case "emissions.v1.TopicIdBlockHeightInferences.Inferences":
+		x.Inferences = value.Message().Interface().(*Inferences)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightInferences"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightInferences does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightInferences) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightInferences.Inferences":
+		if x.Inferences == nil {
+			x.Inferences = new(Inferences)
+		}
+		return protoreflect.ValueOfMessage(x.Inferences.ProtoReflect())
+	case "emissions.v1.TopicIdBlockHeightInferences.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdBlockHeightInferences is not mutable"))
+	case "emissions.v1.TopicIdBlockHeightInferences.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.TopicIdBlockHeightInferences is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightInferences"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightInferences does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdBlockHeightInferences) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightInferences.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdBlockHeightInferences.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	case "emissions.v1.TopicIdBlockHeightInferences.Inferences":
+		m := new(Inferences)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightInferences"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightInferences does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdBlockHeightInferences) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdBlockHeightInferences", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdBlockHeightInferences) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightInferences) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdBlockHeightInferences) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdBlockHeightInferences) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdBlockHeightInferences)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.Inferences != nil {
+			l = options.Size(x.Inferences)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightInferences)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.Inferences != nil {
+			encoded, err := options.Marshal(x.Inferences)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightInferences)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightInferences: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightInferences: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Inferences", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.Inferences == nil {
+					x.Inferences = &Inferences{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Inferences); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdBlockHeightForecasts             protoreflect.MessageDescriptor
+	fd_TopicIdBlockHeightForecasts_TopicId     protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightForecasts_BlockHeight protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightForecasts_Forecasts   protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdBlockHeightForecasts = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdBlockHeightForecasts")
+	fd_TopicIdBlockHeightForecasts_TopicId = md_TopicIdBlockHeightForecasts.Fields().ByName("TopicId")
+	fd_TopicIdBlockHeightForecasts_BlockHeight = md_TopicIdBlockHeightForecasts.Fields().ByName("BlockHeight")
+	fd_TopicIdBlockHeightForecasts_Forecasts = md_TopicIdBlockHeightForecasts.Fields().ByName("Forecasts")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdBlockHeightForecasts)(nil)
+
+type fastReflection_TopicIdBlockHeightForecasts TopicIdBlockHeightForecasts
+
+func (x *TopicIdBlockHeightForecasts) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightForecasts)(x)
+}
+
+func (x *TopicIdBlockHeightForecasts) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[20]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdBlockHeightForecasts_messageType fastReflection_TopicIdBlockHeightForecasts_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdBlockHeightForecasts_messageType{}
+
+type fastReflection_TopicIdBlockHeightForecasts_messageType struct{}
+
+func (x fastReflection_TopicIdBlockHeightForecasts_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightForecasts)(nil)
+}
+func (x fastReflection_TopicIdBlockHeightForecasts_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightForecasts)
+}
+func (x fastReflection_TopicIdBlockHeightForecasts_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightForecasts
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdBlockHeightForecasts) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightForecasts
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdBlockHeightForecasts) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdBlockHeightForecasts_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdBlockHeightForecasts) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightForecasts)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdBlockHeightForecasts) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdBlockHeightForecasts)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdBlockHeightForecasts) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdBlockHeightForecasts_TopicId, value) {
+			return
+		}
+	}
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_TopicIdBlockHeightForecasts_BlockHeight, value) {
+			return
+		}
+	}
+	if x.Forecasts != nil {
+		value := protoreflect.ValueOfMessage(x.Forecasts.ProtoReflect())
+		if !f(fd_TopicIdBlockHeightForecasts_Forecasts, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdBlockHeightForecasts) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightForecasts.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdBlockHeightForecasts.BlockHeight":
+		return x.BlockHeight != int64(0)
+	case "emissions.v1.TopicIdBlockHeightForecasts.Forecasts":
+		return x.Forecasts != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightForecasts"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightForecasts does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightForecasts) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightForecasts.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdBlockHeightForecasts.BlockHeight":
+		x.BlockHeight = int64(0)
+	case "emissions.v1.TopicIdBlockHeightForecasts.Forecasts":
+		x.Forecasts = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightForecasts"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightForecasts does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdBlockHeightForecasts) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdBlockHeightForecasts.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdBlockHeightForecasts.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	case "emissions.v1.TopicIdBlockHeightForecasts.Forecasts":
+		value := x.Forecasts
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightForecasts"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightForecasts does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightForecasts) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightForecasts.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdBlockHeightForecasts.BlockHeight":
+		x.BlockHeight = value.Int()
+	case "emissions.v1.TopicIdBlockHeightForecasts.Forecasts":
+		x.Forecasts = value.Message().Interface().(*Forecasts)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightForecasts"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightForecasts does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightForecasts) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightForecasts.Forecasts":
+		if x.Forecasts == nil {
+			x.Forecasts = new(Forecasts)
+		}
+		return protoreflect.ValueOfMessage(x.Forecasts.ProtoReflect())
+	case "emissions.v1.TopicIdBlockHeightForecasts.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdBlockHeightForecasts is not mutable"))
+	case "emissions.v1.TopicIdBlockHeightForecasts.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.TopicIdBlockHeightForecasts is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightForecasts"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightForecasts does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdBlockHeightForecasts) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightForecasts.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdBlockHeightForecasts.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	case "emissions.v1.TopicIdBlockHeightForecasts.Forecasts":
+		m := new(Forecasts)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightForecasts"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightForecasts does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdBlockHeightForecasts) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdBlockHeightForecasts", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdBlockHeightForecasts) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightForecasts) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdBlockHeightForecasts) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdBlockHeightForecasts) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdBlockHeightForecasts)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.Forecasts != nil {
+			l = options.Size(x.Forecasts)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightForecasts)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.Forecasts != nil {
+			encoded, err := options.Marshal(x.Forecasts)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightForecasts)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightForecasts: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightForecasts: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Forecasts", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.Forecasts == nil {
+					x.Forecasts = &Forecasts{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Forecasts); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdBlockHeightReputerValueBundles                     protoreflect.MessageDescriptor
+	fd_TopicIdBlockHeightReputerValueBundles_TopicId             protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightReputerValueBundles_BlockHeight         protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightReputerValueBundles_ReputerValueBundles protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdBlockHeightReputerValueBundles = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdBlockHeightReputerValueBundles")
+	fd_TopicIdBlockHeightReputerValueBundles_TopicId = md_TopicIdBlockHeightReputerValueBundles.Fields().ByName("TopicId")
+	fd_TopicIdBlockHeightReputerValueBundles_BlockHeight = md_TopicIdBlockHeightReputerValueBundles.Fields().ByName("BlockHeight")
+	fd_TopicIdBlockHeightReputerValueBundles_ReputerValueBundles = md_TopicIdBlockHeightReputerValueBundles.Fields().ByName("ReputerValueBundles")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdBlockHeightReputerValueBundles)(nil)
+
+type fastReflection_TopicIdBlockHeightReputerValueBundles TopicIdBlockHeightReputerValueBundles
+
+func (x *TopicIdBlockHeightReputerValueBundles) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightReputerValueBundles)(x)
+}
+
+func (x *TopicIdBlockHeightReputerValueBundles) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[21]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdBlockHeightReputerValueBundles_messageType fastReflection_TopicIdBlockHeightReputerValueBundles_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdBlockHeightReputerValueBundles_messageType{}
+
+type fastReflection_TopicIdBlockHeightReputerValueBundles_messageType struct{}
+
+func (x fastReflection_TopicIdBlockHeightReputerValueBundles_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightReputerValueBundles)(nil)
+}
+func (x fastReflection_TopicIdBlockHeightReputerValueBundles_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightReputerValueBundles)
+}
+func (x fastReflection_TopicIdBlockHeightReputerValueBundles_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightReputerValueBundles
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightReputerValueBundles
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdBlockHeightReputerValueBundles_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightReputerValueBundles)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdBlockHeightReputerValueBundles)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdBlockHeightReputerValueBundles_TopicId, value) {
+			return
+		}
+	}
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_TopicIdBlockHeightReputerValueBundles_BlockHeight, value) {
+			return
+		}
+	}
+	if x.ReputerValueBundles != nil {
+		value := protoreflect.ValueOfMessage(x.ReputerValueBundles.ProtoReflect())
+		if !f(fd_TopicIdBlockHeightReputerValueBundles_ReputerValueBundles, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.BlockHeight":
+		return x.BlockHeight != int64(0)
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.ReputerValueBundles":
+		return x.ReputerValueBundles != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightReputerValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightReputerValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.BlockHeight":
+		x.BlockHeight = int64(0)
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.ReputerValueBundles":
+		x.ReputerValueBundles = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightReputerValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightReputerValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.ReputerValueBundles":
+		value := x.ReputerValueBundles
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightReputerValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightReputerValueBundles does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.BlockHeight":
+		x.BlockHeight = value.Int()
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.ReputerValueBundles":
+		x.ReputerValueBundles = value.Message().Interface().(*ReputerValueBundles)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightReputerValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightReputerValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.ReputerValueBundles":
+		if x.ReputerValueBundles == nil {
+			x.ReputerValueBundles = new(ReputerValueBundles)
+		}
+		return protoreflect.ValueOfMessage(x.ReputerValueBundles.ProtoReflect())
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdBlockHeightReputerValueBundles is not mutable"))
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.TopicIdBlockHeightReputerValueBundles is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightReputerValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightReputerValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	case "emissions.v1.TopicIdBlockHeightReputerValueBundles.ReputerValueBundles":
+		m := new(ReputerValueBundles)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightReputerValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightReputerValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdBlockHeightReputerValueBundles", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdBlockHeightReputerValueBundles) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdBlockHeightReputerValueBundles)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.ReputerValueBundles != nil {
+			l = options.Size(x.ReputerValueBundles)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightReputerValueBundles)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.ReputerValueBundles != nil {
+			encoded, err := options.Marshal(x.ReputerValueBundles)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightReputerValueBundles)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightReputerValueBundles: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightReputerValueBundles: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ReputerValueBundles", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.ReputerValueBundles == nil {
+					x.ReputerValueBundles = &ReputerValueBundles{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.ReputerValueBundles); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdBlockHeightValueBundles             protoreflect.MessageDescriptor
+	fd_TopicIdBlockHeightValueBundles_TopicId     protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightValueBundles_BlockHeight protoreflect.FieldDescriptor
+	fd_TopicIdBlockHeightValueBundles_ValueBundle protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdBlockHeightValueBundles = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdBlockHeightValueBundles")
+	fd_TopicIdBlockHeightValueBundles_TopicId = md_TopicIdBlockHeightValueBundles.Fields().ByName("TopicId")
+	fd_TopicIdBlockHeightValueBundles_BlockHeight = md_TopicIdBlockHeightValueBundles.Fields().ByName("BlockHeight")
+	fd_TopicIdBlockHeightValueBundles_ValueBundle = md_TopicIdBlockHeightValueBundles.Fields().ByName("ValueBundle")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdBlockHeightValueBundles)(nil)
+
+type fastReflection_TopicIdBlockHeightValueBundles TopicIdBlockHeightValueBundles
+
+func (x *TopicIdBlockHeightValueBundles) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightValueBundles)(x)
+}
+
+func (x *TopicIdBlockHeightValueBundles) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[22]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdBlockHeightValueBundles_messageType fastReflection_TopicIdBlockHeightValueBundles_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdBlockHeightValueBundles_messageType{}
+
+type fastReflection_TopicIdBlockHeightValueBundles_messageType struct{}
+
+func (x fastReflection_TopicIdBlockHeightValueBundles_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdBlockHeightValueBundles)(nil)
+}
+func (x fastReflection_TopicIdBlockHeightValueBundles_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightValueBundles)
+}
+func (x fastReflection_TopicIdBlockHeightValueBundles_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightValueBundles
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdBlockHeightValueBundles
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdBlockHeightValueBundles_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) New() protoreflect.Message {
+	return new(fastReflection_TopicIdBlockHeightValueBundles)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdBlockHeightValueBundles)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdBlockHeightValueBundles_TopicId, value) {
+			return
+		}
+	}
+	if x.BlockHeight != int64(0) {
+		value := protoreflect.ValueOfInt64(x.BlockHeight)
+		if !f(fd_TopicIdBlockHeightValueBundles_BlockHeight, value) {
+			return
+		}
+	}
+	if x.ValueBundle != nil {
+		value := protoreflect.ValueOfMessage(x.ValueBundle.ProtoReflect())
+		if !f(fd_TopicIdBlockHeightValueBundles_ValueBundle, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightValueBundles.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdBlockHeightValueBundles.BlockHeight":
+		return x.BlockHeight != int64(0)
+	case "emissions.v1.TopicIdBlockHeightValueBundles.ValueBundle":
+		return x.ValueBundle != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightValueBundles.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdBlockHeightValueBundles.BlockHeight":
+		x.BlockHeight = int64(0)
+	case "emissions.v1.TopicIdBlockHeightValueBundles.ValueBundle":
+		x.ValueBundle = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdBlockHeightValueBundles.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdBlockHeightValueBundles.BlockHeight":
+		value := x.BlockHeight
+		return protoreflect.ValueOfInt64(value)
+	case "emissions.v1.TopicIdBlockHeightValueBundles.ValueBundle":
+		value := x.ValueBundle
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightValueBundles does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightValueBundles.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdBlockHeightValueBundles.BlockHeight":
+		x.BlockHeight = value.Int()
+	case "emissions.v1.TopicIdBlockHeightValueBundles.ValueBundle":
+		x.ValueBundle = value.Message().Interface().(*ValueBundle)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightValueBundles.ValueBundle":
+		if x.ValueBundle == nil {
+			x.ValueBundle = new(ValueBundle)
+		}
+		return protoreflect.ValueOfMessage(x.ValueBundle.ProtoReflect())
+	case "emissions.v1.TopicIdBlockHeightValueBundles.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdBlockHeightValueBundles is not mutable"))
+	case "emissions.v1.TopicIdBlockHeightValueBundles.BlockHeight":
+		panic(fmt.Errorf("field BlockHeight of message emissions.v1.TopicIdBlockHeightValueBundles is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdBlockHeightValueBundles.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdBlockHeightValueBundles.BlockHeight":
+		return protoreflect.ValueOfInt64(int64(0))
+	case "emissions.v1.TopicIdBlockHeightValueBundles.ValueBundle":
+		m := new(ValueBundle)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdBlockHeightValueBundles"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdBlockHeightValueBundles does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdBlockHeightValueBundles", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdBlockHeightValueBundles) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdBlockHeightValueBundles)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.BlockHeight != 0 {
+			n += 1 + runtime.Sov(uint64(x.BlockHeight))
+		}
+		if x.ValueBundle != nil {
+			l = options.Size(x.ValueBundle)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightValueBundles)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.ValueBundle != nil {
+			encoded, err := options.Marshal(x.ValueBundle)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if x.BlockHeight != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BlockHeight))
+			i--
+			dAtA[i] = 0x10
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdBlockHeightValueBundles)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightValueBundles: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdBlockHeightValueBundles: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+				}
+				x.BlockHeight = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BlockHeight |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ValueBundle", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.ValueBundle == nil {
+					x.ValueBundle = &ValueBundle{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.ValueBundle); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdAndNonces         protoreflect.MessageDescriptor
+	fd_TopicIdAndNonces_TopicId protoreflect.FieldDescriptor
+	fd_TopicIdAndNonces_Nonces  protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdAndNonces = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdAndNonces")
+	fd_TopicIdAndNonces_TopicId = md_TopicIdAndNonces.Fields().ByName("TopicId")
+	fd_TopicIdAndNonces_Nonces = md_TopicIdAndNonces.Fields().ByName("Nonces")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdAndNonces)(nil)
+
+type fastReflection_TopicIdAndNonces TopicIdAndNonces
+
+func (x *TopicIdAndNonces) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdAndNonces)(x)
+}
+
+func (x *TopicIdAndNonces) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[23]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdAndNonces_messageType fastReflection_TopicIdAndNonces_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdAndNonces_messageType{}
+
+type fastReflection_TopicIdAndNonces_messageType struct{}
+
+func (x fastReflection_TopicIdAndNonces_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdAndNonces)(nil)
+}
+func (x fastReflection_TopicIdAndNonces_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndNonces)
+}
+func (x fastReflection_TopicIdAndNonces_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndNonces
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdAndNonces) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndNonces
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdAndNonces) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdAndNonces_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdAndNonces) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndNonces)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdAndNonces) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdAndNonces)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdAndNonces) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdAndNonces_TopicId, value) {
+			return
+		}
+	}
+	if x.Nonces != nil {
+		value := protoreflect.ValueOfMessage(x.Nonces.ProtoReflect())
+		if !f(fd_TopicIdAndNonces_Nonces, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdAndNonces) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndNonces.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdAndNonces.Nonces":
+		return x.Nonces != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndNonces) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndNonces.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdAndNonces.Nonces":
+		x.Nonces = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdAndNonces) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdAndNonces.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdAndNonces.Nonces":
+		value := x.Nonces
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndNonces does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndNonces) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndNonces.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdAndNonces.Nonces":
+		x.Nonces = value.Message().Interface().(*Nonces)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndNonces) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndNonces.Nonces":
+		if x.Nonces == nil {
+			x.Nonces = new(Nonces)
+		}
+		return protoreflect.ValueOfMessage(x.Nonces.ProtoReflect())
+	case "emissions.v1.TopicIdAndNonces.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdAndNonces is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdAndNonces) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndNonces.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdAndNonces.Nonces":
+		m := new(Nonces)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdAndNonces) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdAndNonces", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdAndNonces) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndNonces) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdAndNonces) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdAndNonces) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdAndNonces)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.Nonces != nil {
+			l = options.Size(x.Nonces)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndNonces)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.Nonces != nil {
+			encoded, err := options.Marshal(x.Nonces)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndNonces)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndNonces: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndNonces: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Nonces", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.Nonces == nil {
+					x.Nonces = &Nonces{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.Nonces); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdAndReputerRequestNonces                      protoreflect.MessageDescriptor
+	fd_TopicIdAndReputerRequestNonces_TopicId              protoreflect.FieldDescriptor
+	fd_TopicIdAndReputerRequestNonces_ReputerRequestNonces protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdAndReputerRequestNonces = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdAndReputerRequestNonces")
+	fd_TopicIdAndReputerRequestNonces_TopicId = md_TopicIdAndReputerRequestNonces.Fields().ByName("TopicId")
+	fd_TopicIdAndReputerRequestNonces_ReputerRequestNonces = md_TopicIdAndReputerRequestNonces.Fields().ByName("ReputerRequestNonces")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdAndReputerRequestNonces)(nil)
+
+type fastReflection_TopicIdAndReputerRequestNonces TopicIdAndReputerRequestNonces
+
+func (x *TopicIdAndReputerRequestNonces) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdAndReputerRequestNonces)(x)
+}
+
+func (x *TopicIdAndReputerRequestNonces) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[24]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdAndReputerRequestNonces_messageType fastReflection_TopicIdAndReputerRequestNonces_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdAndReputerRequestNonces_messageType{}
+
+type fastReflection_TopicIdAndReputerRequestNonces_messageType struct{}
+
+func (x fastReflection_TopicIdAndReputerRequestNonces_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdAndReputerRequestNonces)(nil)
+}
+func (x fastReflection_TopicIdAndReputerRequestNonces_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndReputerRequestNonces)
+}
+func (x fastReflection_TopicIdAndReputerRequestNonces_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndReputerRequestNonces
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdAndReputerRequestNonces
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdAndReputerRequestNonces_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) New() protoreflect.Message {
+	return new(fastReflection_TopicIdAndReputerRequestNonces)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdAndReputerRequestNonces)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdAndReputerRequestNonces_TopicId, value) {
+			return
+		}
+	}
+	if x.ReputerRequestNonces != nil {
+		value := protoreflect.ValueOfMessage(x.ReputerRequestNonces.ProtoReflect())
+		if !f(fd_TopicIdAndReputerRequestNonces_ReputerRequestNonces, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndReputerRequestNonces.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdAndReputerRequestNonces.ReputerRequestNonces":
+		return x.ReputerRequestNonces != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndReputerRequestNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndReputerRequestNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndReputerRequestNonces.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdAndReputerRequestNonces.ReputerRequestNonces":
+		x.ReputerRequestNonces = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndReputerRequestNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndReputerRequestNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdAndReputerRequestNonces.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdAndReputerRequestNonces.ReputerRequestNonces":
+		value := x.ReputerRequestNonces
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndReputerRequestNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndReputerRequestNonces does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndReputerRequestNonces.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdAndReputerRequestNonces.ReputerRequestNonces":
+		x.ReputerRequestNonces = value.Message().Interface().(*ReputerRequestNonces)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndReputerRequestNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndReputerRequestNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndReputerRequestNonces.ReputerRequestNonces":
+		if x.ReputerRequestNonces == nil {
+			x.ReputerRequestNonces = new(ReputerRequestNonces)
+		}
+		return protoreflect.ValueOfMessage(x.ReputerRequestNonces.ProtoReflect())
+	case "emissions.v1.TopicIdAndReputerRequestNonces.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdAndReputerRequestNonces is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndReputerRequestNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndReputerRequestNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdAndReputerRequestNonces.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdAndReputerRequestNonces.ReputerRequestNonces":
+		m := new(ReputerRequestNonces)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdAndReputerRequestNonces"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdAndReputerRequestNonces does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdAndReputerRequestNonces", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdAndReputerRequestNonces) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdAndReputerRequestNonces)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.ReputerRequestNonces != nil {
+			l = options.Size(x.ReputerRequestNonces)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndReputerRequestNonces)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.ReputerRequestNonces != nil {
+			encoded, err := options.Marshal(x.ReputerRequestNonces)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdAndReputerRequestNonces)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndReputerRequestNonces: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdAndReputerRequestNonces: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ReputerRequestNonces", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.ReputerRequestNonces == nil {
+					x.ReputerRequestNonces = &ReputerRequestNonces{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.ReputerRequestNonces); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdActorIdTimeStampedValue                  protoreflect.MessageDescriptor
+	fd_TopicIdActorIdTimeStampedValue_TopicId          protoreflect.FieldDescriptor
+	fd_TopicIdActorIdTimeStampedValue_ActorId          protoreflect.FieldDescriptor
+	fd_TopicIdActorIdTimeStampedValue_TimestampedValue protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdActorIdTimeStampedValue = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdActorIdTimeStampedValue")
+	fd_TopicIdActorIdTimeStampedValue_TopicId = md_TopicIdActorIdTimeStampedValue.Fields().ByName("TopicId")
+	fd_TopicIdActorIdTimeStampedValue_ActorId = md_TopicIdActorIdTimeStampedValue.Fields().ByName("ActorId")
+	fd_TopicIdActorIdTimeStampedValue_TimestampedValue = md_TopicIdActorIdTimeStampedValue.Fields().ByName("TimestampedValue")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdActorIdTimeStampedValue)(nil)
+
+type fastReflection_TopicIdActorIdTimeStampedValue TopicIdActorIdTimeStampedValue
+
+func (x *TopicIdActorIdTimeStampedValue) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdTimeStampedValue)(x)
+}
+
+func (x *TopicIdActorIdTimeStampedValue) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[25]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdActorIdTimeStampedValue_messageType fastReflection_TopicIdActorIdTimeStampedValue_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdActorIdTimeStampedValue_messageType{}
+
+type fastReflection_TopicIdActorIdTimeStampedValue_messageType struct{}
+
+func (x fastReflection_TopicIdActorIdTimeStampedValue_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdTimeStampedValue)(nil)
+}
+func (x fastReflection_TopicIdActorIdTimeStampedValue_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdTimeStampedValue)
+}
+func (x fastReflection_TopicIdActorIdTimeStampedValue_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdTimeStampedValue
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdTimeStampedValue
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdActorIdTimeStampedValue_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdTimeStampedValue)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdActorIdTimeStampedValue)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdActorIdTimeStampedValue_TopicId, value) {
+			return
+		}
+	}
+	if x.ActorId != "" {
+		value := protoreflect.ValueOfString(x.ActorId)
+		if !f(fd_TopicIdActorIdTimeStampedValue_ActorId, value) {
+			return
+		}
+	}
+	if x.TimestampedValue != nil {
+		value := protoreflect.ValueOfMessage(x.TimestampedValue.ProtoReflect())
+		if !f(fd_TopicIdActorIdTimeStampedValue_TimestampedValue, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.ActorId":
+		return x.ActorId != ""
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TimestampedValue":
+		return x.TimestampedValue != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.ActorId":
+		x.ActorId = ""
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TimestampedValue":
+		x.TimestampedValue = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.ActorId":
+		value := x.ActorId
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TimestampedValue":
+		value := x.TimestampedValue
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdTimeStampedValue does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.ActorId":
+		x.ActorId = value.Interface().(string)
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TimestampedValue":
+		x.TimestampedValue = value.Message().Interface().(*TimestampedValue)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TimestampedValue":
+		if x.TimestampedValue == nil {
+			x.TimestampedValue = new(TimestampedValue)
+		}
+		return protoreflect.ValueOfMessage(x.TimestampedValue.ProtoReflect())
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdActorIdTimeStampedValue is not mutable"))
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.ActorId":
+		panic(fmt.Errorf("field ActorId of message emissions.v1.TopicIdActorIdTimeStampedValue is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.ActorId":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdActorIdTimeStampedValue.TimestampedValue":
+		m := new(TimestampedValue)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdActorIdTimeStampedValue", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdActorIdTimeStampedValue) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdActorIdTimeStampedValue)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.ActorId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.TimestampedValue != nil {
+			l = options.Size(x.TimestampedValue)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdTimeStampedValue)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.TimestampedValue != nil {
+			encoded, err := options.Marshal(x.TimestampedValue)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.ActorId) > 0 {
+			i -= len(x.ActorId)
+			copy(dAtA[i:], x.ActorId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdTimeStampedValue)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdTimeStampedValue: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdTimeStampedValue: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TimestampedValue", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.TimestampedValue == nil {
+					x.TimestampedValue = &TimestampedValue{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TimestampedValue); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdActorIdActorIdTimeStampedValue                  protoreflect.MessageDescriptor
+	fd_TopicIdActorIdActorIdTimeStampedValue_TopicId          protoreflect.FieldDescriptor
+	fd_TopicIdActorIdActorIdTimeStampedValue_ActorId1         protoreflect.FieldDescriptor
+	fd_TopicIdActorIdActorIdTimeStampedValue_ActorId2         protoreflect.FieldDescriptor
+	fd_TopicIdActorIdActorIdTimeStampedValue_TimestampedValue protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdActorIdActorIdTimeStampedValue = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdActorIdActorIdTimeStampedValue")
+	fd_TopicIdActorIdActorIdTimeStampedValue_TopicId = md_TopicIdActorIdActorIdTimeStampedValue.Fields().ByName("TopicId")
+	fd_TopicIdActorIdActorIdTimeStampedValue_ActorId1 = md_TopicIdActorIdActorIdTimeStampedValue.Fields().ByName("ActorId1")
+	fd_TopicIdActorIdActorIdTimeStampedValue_ActorId2 = md_TopicIdActorIdActorIdTimeStampedValue.Fields().ByName("ActorId2")
+	fd_TopicIdActorIdActorIdTimeStampedValue_TimestampedValue = md_TopicIdActorIdActorIdTimeStampedValue.Fields().ByName("TimestampedValue")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdActorIdActorIdTimeStampedValue)(nil)
+
+type fastReflection_TopicIdActorIdActorIdTimeStampedValue TopicIdActorIdActorIdTimeStampedValue
+
+func (x *TopicIdActorIdActorIdTimeStampedValue) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdActorIdTimeStampedValue)(x)
+}
+
+func (x *TopicIdActorIdActorIdTimeStampedValue) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[26]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdActorIdActorIdTimeStampedValue_messageType fastReflection_TopicIdActorIdActorIdTimeStampedValue_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdActorIdActorIdTimeStampedValue_messageType{}
+
+type fastReflection_TopicIdActorIdActorIdTimeStampedValue_messageType struct{}
+
+func (x fastReflection_TopicIdActorIdActorIdTimeStampedValue_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdActorIdActorIdTimeStampedValue)(nil)
+}
+func (x fastReflection_TopicIdActorIdActorIdTimeStampedValue_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdActorIdTimeStampedValue)
+}
+func (x fastReflection_TopicIdActorIdActorIdTimeStampedValue_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdActorIdTimeStampedValue
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdActorIdActorIdTimeStampedValue
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdActorIdActorIdTimeStampedValue_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) New() protoreflect.Message {
+	return new(fastReflection_TopicIdActorIdActorIdTimeStampedValue)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdActorIdActorIdTimeStampedValue)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdActorIdActorIdTimeStampedValue_TopicId, value) {
+			return
+		}
+	}
+	if x.ActorId1 != "" {
+		value := protoreflect.ValueOfString(x.ActorId1)
+		if !f(fd_TopicIdActorIdActorIdTimeStampedValue_ActorId1, value) {
+			return
+		}
+	}
+	if x.ActorId2 != "" {
+		value := protoreflect.ValueOfString(x.ActorId2)
+		if !f(fd_TopicIdActorIdActorIdTimeStampedValue_ActorId2, value) {
+			return
+		}
+	}
+	if x.TimestampedValue != nil {
+		value := protoreflect.ValueOfMessage(x.TimestampedValue.ProtoReflect())
+		if !f(fd_TopicIdActorIdActorIdTimeStampedValue_TimestampedValue, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId1":
+		return x.ActorId1 != ""
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId2":
+		return x.ActorId2 != ""
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TimestampedValue":
+		return x.TimestampedValue != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId1":
+		x.ActorId1 = ""
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId2":
+		x.ActorId2 = ""
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TimestampedValue":
+		x.TimestampedValue = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId1":
+		value := x.ActorId1
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId2":
+		value := x.ActorId2
+		return protoreflect.ValueOfString(value)
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TimestampedValue":
+		value := x.TimestampedValue
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdActorIdTimeStampedValue does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId1":
+		x.ActorId1 = value.Interface().(string)
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId2":
+		x.ActorId2 = value.Interface().(string)
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TimestampedValue":
+		x.TimestampedValue = value.Message().Interface().(*TimestampedValue)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TimestampedValue":
+		if x.TimestampedValue == nil {
+			x.TimestampedValue = new(TimestampedValue)
+		}
+		return protoreflect.ValueOfMessage(x.TimestampedValue.ProtoReflect())
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdActorIdActorIdTimeStampedValue is not mutable"))
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId1":
+		panic(fmt.Errorf("field ActorId1 of message emissions.v1.TopicIdActorIdActorIdTimeStampedValue is not mutable"))
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId2":
+		panic(fmt.Errorf("field ActorId2 of message emissions.v1.TopicIdActorIdActorIdTimeStampedValue is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId1":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.ActorId2":
+		return protoreflect.ValueOfString("")
+	case "emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TimestampedValue":
+		m := new(TimestampedValue)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdActorIdActorIdTimeStampedValue"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdActorIdActorIdTimeStampedValue does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdActorIdActorIdTimeStampedValue", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdActorIdActorIdTimeStampedValue) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdActorIdActorIdTimeStampedValue)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		l = len(x.ActorId1)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.ActorId2)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.TimestampedValue != nil {
+			l = options.Size(x.TimestampedValue)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdActorIdTimeStampedValue)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.TimestampedValue != nil {
+			encoded, err := options.Marshal(x.TimestampedValue)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x22
+		}
+		if len(x.ActorId2) > 0 {
+			i -= len(x.ActorId2)
+			copy(dAtA[i:], x.ActorId2)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId2)))
+			i--
+			dAtA[i] = 0x1a
+		}
+		if len(x.ActorId1) > 0 {
+			i -= len(x.ActorId1)
+			copy(dAtA[i:], x.ActorId1)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ActorId1)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdActorIdActorIdTimeStampedValue)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdActorIdTimeStampedValue: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdActorIdActorIdTimeStampedValue: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId1", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId1 = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ActorId2", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ActorId2 = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 4:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TimestampedValue", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.TimestampedValue == nil {
+					x.TimestampedValue = &TimestampedValue{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TimestampedValue); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_TopicIdTimestampedActorNonce                       protoreflect.MessageDescriptor
+	fd_TopicIdTimestampedActorNonce_TopicId               protoreflect.FieldDescriptor
+	fd_TopicIdTimestampedActorNonce_TimestampedActorNonce protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_emissions_v1_genesis_proto_init()
+	md_TopicIdTimestampedActorNonce = File_emissions_v1_genesis_proto.Messages().ByName("TopicIdTimestampedActorNonce")
+	fd_TopicIdTimestampedActorNonce_TopicId = md_TopicIdTimestampedActorNonce.Fields().ByName("TopicId")
+	fd_TopicIdTimestampedActorNonce_TimestampedActorNonce = md_TopicIdTimestampedActorNonce.Fields().ByName("TimestampedActorNonce")
+}
+
+var _ protoreflect.Message = (*fastReflection_TopicIdTimestampedActorNonce)(nil)
+
+type fastReflection_TopicIdTimestampedActorNonce TopicIdTimestampedActorNonce
+
+func (x *TopicIdTimestampedActorNonce) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_TopicIdTimestampedActorNonce)(x)
+}
+
+func (x *TopicIdTimestampedActorNonce) slowProtoReflect() protoreflect.Message {
+	mi := &file_emissions_v1_genesis_proto_msgTypes[27]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_TopicIdTimestampedActorNonce_messageType fastReflection_TopicIdTimestampedActorNonce_messageType
+var _ protoreflect.MessageType = fastReflection_TopicIdTimestampedActorNonce_messageType{}
+
+type fastReflection_TopicIdTimestampedActorNonce_messageType struct{}
+
+func (x fastReflection_TopicIdTimestampedActorNonce_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_TopicIdTimestampedActorNonce)(nil)
+}
+func (x fastReflection_TopicIdTimestampedActorNonce_messageType) New() protoreflect.Message {
+	return new(fastReflection_TopicIdTimestampedActorNonce)
+}
+func (x fastReflection_TopicIdTimestampedActorNonce_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdTimestampedActorNonce
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_TopicIdTimestampedActorNonce) Descriptor() protoreflect.MessageDescriptor {
+	return md_TopicIdTimestampedActorNonce
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_TopicIdTimestampedActorNonce) Type() protoreflect.MessageType {
+	return _fastReflection_TopicIdTimestampedActorNonce_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_TopicIdTimestampedActorNonce) New() protoreflect.Message {
+	return new(fastReflection_TopicIdTimestampedActorNonce)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_TopicIdTimestampedActorNonce) Interface() protoreflect.ProtoMessage {
+	return (*TopicIdTimestampedActorNonce)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_TopicIdTimestampedActorNonce) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.TopicId != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.TopicId)
+		if !f(fd_TopicIdTimestampedActorNonce_TopicId, value) {
+			return
+		}
+	}
+	if x.TimestampedActorNonce != nil {
+		value := protoreflect.ValueOfMessage(x.TimestampedActorNonce.ProtoReflect())
+		if !f(fd_TopicIdTimestampedActorNonce_TimestampedActorNonce, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_TopicIdTimestampedActorNonce) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdTimestampedActorNonce.TopicId":
+		return x.TopicId != uint64(0)
+	case "emissions.v1.TopicIdTimestampedActorNonce.TimestampedActorNonce":
+		return x.TimestampedActorNonce != nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdTimestampedActorNonce"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdTimestampedActorNonce does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdTimestampedActorNonce) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdTimestampedActorNonce.TopicId":
+		x.TopicId = uint64(0)
+	case "emissions.v1.TopicIdTimestampedActorNonce.TimestampedActorNonce":
+		x.TimestampedActorNonce = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdTimestampedActorNonce"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdTimestampedActorNonce does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_TopicIdTimestampedActorNonce) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "emissions.v1.TopicIdTimestampedActorNonce.TopicId":
+		value := x.TopicId
+		return protoreflect.ValueOfUint64(value)
+	case "emissions.v1.TopicIdTimestampedActorNonce.TimestampedActorNonce":
+		value := x.TimestampedActorNonce
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdTimestampedActorNonce"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdTimestampedActorNonce does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdTimestampedActorNonce) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdTimestampedActorNonce.TopicId":
+		x.TopicId = value.Uint()
+	case "emissions.v1.TopicIdTimestampedActorNonce.TimestampedActorNonce":
+		x.TimestampedActorNonce = value.Message().Interface().(*TimestampedActorNonce)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdTimestampedActorNonce"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdTimestampedActorNonce does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdTimestampedActorNonce) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdTimestampedActorNonce.TimestampedActorNonce":
+		if x.TimestampedActorNonce == nil {
+			x.TimestampedActorNonce = new(TimestampedActorNonce)
+		}
+		return protoreflect.ValueOfMessage(x.TimestampedActorNonce.ProtoReflect())
+	case "emissions.v1.TopicIdTimestampedActorNonce.TopicId":
+		panic(fmt.Errorf("field TopicId of message emissions.v1.TopicIdTimestampedActorNonce is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdTimestampedActorNonce"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdTimestampedActorNonce does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_TopicIdTimestampedActorNonce) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "emissions.v1.TopicIdTimestampedActorNonce.TopicId":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "emissions.v1.TopicIdTimestampedActorNonce.TimestampedActorNonce":
+		m := new(TimestampedActorNonce)
+		return protoreflect.ValueOfMessage(m.ProtoReflect())
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: emissions.v1.TopicIdTimestampedActorNonce"))
+		}
+		panic(fmt.Errorf("message emissions.v1.TopicIdTimestampedActorNonce does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_TopicIdTimestampedActorNonce) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in emissions.v1.TopicIdTimestampedActorNonce", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_TopicIdTimestampedActorNonce) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_TopicIdTimestampedActorNonce) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_TopicIdTimestampedActorNonce) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_TopicIdTimestampedActorNonce) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*TopicIdTimestampedActorNonce)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.TopicId != 0 {
+			n += 1 + runtime.Sov(uint64(x.TopicId))
+		}
+		if x.TimestampedActorNonce != nil {
+			l = options.Size(x.TimestampedActorNonce)
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdTimestampedActorNonce)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.TimestampedActorNonce != nil {
+			encoded, err := options.Marshal(x.TimestampedActorNonce)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if x.TopicId != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.TopicId))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*TopicIdTimestampedActorNonce)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdTimestampedActorNonce: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: TopicIdTimestampedActorNonce: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TopicId", wireType)
+				}
+				x.TopicId = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.TopicId |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field TimestampedActorNonce", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if x.TimestampedActorNonce == nil {
+					x.TimestampedActorNonce = &TimestampedActorNonce{}
+				}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], x.TimestampedActorNonce); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
 				iNdEx = postIndex
 			default:
 				iNdEx = preIndex
@@ -593,8 +21769,116 @@ type GenesisState struct {
 	unknownFields protoimpl.UnknownFields
 
 	// params defines all the parameters of the module.
-	Params            *Params  `protobuf:"bytes,1,opt,name=params,proto3" json:"params,omitempty"`
+	Params *Params `protobuf:"bytes,1,opt,name=params,proto3" json:"params,omitempty"`
+	// / TOPIC
+	// the next topic id to be used, equal to the number of topics that have been created
+	NextTopicId uint64 `protobuf:"varint,3,opt,name=nextTopicId,proto3" json:"nextTopicId,omitempty"`
+	// every topic that has been created indexed by their topicId starting from 1 (0 is reserved for the root network)
+	Topics       []*TopicIdAndTopic `protobuf:"bytes,4,rep,name=topics,proto3" json:"topics,omitempty"`
+	ActiveTopics []uint64           `protobuf:"varint,5,rep,packed,name=activeTopics,proto3" json:"activeTopics,omitempty"`
+	// every topic that is ready to request inferences and possible also losses
+	ChurnableTopics []uint64 `protobuf:"varint,6,rep,packed,name=churnableTopics,proto3" json:"churnableTopics,omitempty"`
+	// every topic that has been churned and ready to be rewarded i.e. reputer losses have been committed
+	RewardableTopics []uint64 `protobuf:"varint,7,rep,packed,name=rewardableTopics,proto3" json:"rewardableTopics,omitempty"`
+	// for a topic, what is every worker node that has registered to it?
+	TopicWorkers []*TopicAndActorId `protobuf:"bytes,8,rep,name=topicWorkers,proto3" json:"topicWorkers,omitempty"`
+	// for a topic, what is every reputer node that has registered to it?
+	TopicReputers []*TopicAndActorId `protobuf:"bytes,9,rep,name=topicReputers,proto3" json:"topicReputers,omitempty"`
+	// map of (topic) -> nonce/block height
+	TopicRewardNonce []*TopicIdAndBlockHeight `protobuf:"bytes,10,rep,name=topicRewardNonce,proto3" json:"topicRewardNonce,omitempty"`
+	// / SCORES
+	// map of (topic, block_height, worker) -> score
+	InfererScoresByBlock []*TopicIdBlockHeightScores `protobuf:"bytes,11,rep,name=infererScoresByBlock,proto3" json:"infererScoresByBlock,omitempty"`
+	// map of (topic, block_height, worker) -> score
+	ForecasterScoresByBlock []*TopicIdBlockHeightScores `protobuf:"bytes,12,rep,name=forecasterScoresByBlock,proto3" json:"forecasterScoresByBlock,omitempty"`
+	// map of (topic, block_height, reputer) -> score
+	ReputerScoresByBlock []*TopicIdBlockHeightScores `protobuf:"bytes,13,rep,name=reputerScoresByBlock,proto3" json:"reputerScoresByBlock,omitempty"`
+	// map of (topic, block_height, worker) -> score
+	LatestInfererScoresByWorker []*TopicIdActorIdScore `protobuf:"bytes,14,rep,name=latestInfererScoresByWorker,proto3" json:"latestInfererScoresByWorker,omitempty"`
+	// map of (topic, block_height, worker) -> score
+	LatestForecasterScoresByWorker []*TopicIdActorIdScore `protobuf:"bytes,15,rep,name=latestForecasterScoresByWorker,proto3" json:"latestForecasterScoresByWorker,omitempty"`
+	// map of (topic, block_height, reputer) -> score
+	LatestReputerScoresByReputer []*TopicIdActorIdScore `protobuf:"bytes,16,rep,name=latestReputerScoresByReputer,proto3" json:"latestReputerScoresByReputer,omitempty"`
+	// map of (topic, reputer) -> listening coefficient
+	ReputerListeningCoefficient []*TopicIdActorIdListeningCoefficient `protobuf:"bytes,17,rep,name=reputerListeningCoefficient,proto3" json:"reputerListeningCoefficient,omitempty"`
+	// map of (topic, reputer) -> previous reward (used for EMA)
+	PreviousReputerRewardFraction []*TopicIdActorIdDec `protobuf:"bytes,18,rep,name=previousReputerRewardFraction,proto3" json:"previousReputerRewardFraction,omitempty"`
+	// map of (topic, worker) -> previous reward for inference (used for EMA)
+	PreviousInferenceRewardFraction []*TopicIdActorIdDec `protobuf:"bytes,19,rep,name=previousInferenceRewardFraction,proto3" json:"previousInferenceRewardFraction,omitempty"`
+	// map of (topic, worker) -> previous reward for forecast (used for EMA)
+	PreviousForecastRewardFraction []*TopicIdActorIdDec `protobuf:"bytes,20,rep,name=previousForecastRewardFraction,proto3" json:"previousForecastRewardFraction,omitempty"`
+	// total sum stake of all stakers on the network
+	TotalStake string `protobuf:"bytes,21,opt,name=totalStake,proto3" json:"totalStake,omitempty"`
+	// for every topic, how much total stake does that topic have accumulated?
+	TopicStake []*TopicIdAndInt `protobuf:"bytes,22,rep,name=topicStake,proto3" json:"topicStake,omitempty"`
+	// stake reputer placed in topic + delegate stake placed in them,
+	// signalling their total authority on the topic
+	// (topic Id, reputer) -> stake from reputer on self + stakeFromDelegatorsUponReputer
+	StakeReputerAuthority []*TopicIdActorIdInt `protobuf:"bytes,23,rep,name=stakeReputerAuthority,proto3" json:"stakeReputerAuthority,omitempty"`
+	// map of (topic id, delegator) -> total amount of stake in that topic placed by that delegator
+	StakeSumFromDelegator []*TopicIdActorIdInt `protobuf:"bytes,24,rep,name=stakeSumFromDelegator,proto3" json:"stakeSumFromDelegator,omitempty"`
+	// map of (topic id, delegator, reputer) -> amount of stake that has been placed by that delegator on that target
+	DelegatedStakes []*TopicIdDelegatorReputerDelegatorInfo `protobuf:"bytes,25,rep,name=delegatedStakes,proto3" json:"delegatedStakes,omitempty"`
+	// map of (topic id, reputer) -> total amount of stake that has been placed on that reputer by delegators
+	StakeFromDelegatorsUponReputer []*TopicIdActorIdInt `protobuf:"bytes,26,rep,name=stakeFromDelegatorsUponReputer,proto3" json:"stakeFromDelegatorsUponReputer,omitempty"`
+	// map of (topicId, reputer) -> share of delegate reward
+	DelegateRewardPerShare []*TopicIdActorIdDec `protobuf:"bytes,27,rep,name=delegateRewardPerShare,proto3" json:"delegateRewardPerShare,omitempty"`
+	// stake removals are double indexed to avoid O(n) lookups when removing stake
+	// map of (blockHeight, topic, reputer) -> removal information for that reputer
+	StakeRemovalsByBlock []*BlockHeightTopicIdReputerStakeRemovalInfo `protobuf:"bytes,28,rep,name=stakeRemovalsByBlock,proto3" json:"stakeRemovalsByBlock,omitempty"`
+	// key set of (reputer, topic, blockHeight) to existence of a removal in the forwards map
+	StakeRemovalsByActor []*ActorIdTopicIdBlockHeight `protobuf:"bytes,29,rep,name=stakeRemovalsByActor,proto3" json:"stakeRemovalsByActor,omitempty"`
+	// delegate stake removals are double indexed to avoid O(n) lookups when removing stake
+	// map of (blockHeight, topic, delegator, reputer staked upon) -> (list of reputers delegated upon and info) to have
+	// stake removed at that block
+	DelegateStakeRemovalsByBlock []*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo `protobuf:"bytes,30,rep,name=delegateStakeRemovalsByBlock,proto3" json:"delegateStakeRemovalsByBlock,omitempty"`
+	// key set of (delegator, reputer, topicId, blockHeight) to existence of a removal in the forwards map
+	DelegateStakeRemovalsByActor []*DelegatorReputerTopicIdBlockHeight `protobuf:"bytes,31,rep,name=delegateStakeRemovalsByActor,proto3" json:"delegateStakeRemovalsByActor,omitempty"`
+	// / MISC GLOBAL STATE
+	// map of (topic, worker) -> inference
+	Inferences []*TopicIdActorIdInference `protobuf:"bytes,32,rep,name=inferences,proto3" json:"inferences,omitempty"`
+	// map of (topic, worker) -> forecast[]
+	Forecasts []*TopicIdActorIdForecast `protobuf:"bytes,33,rep,name=forecasts,proto3" json:"forecasts,omitempty"`
+	// map of worker id to node data about that worker
+	Workers []*LibP2PKeyAndOffchainNode `protobuf:"bytes,34,rep,name=workers,proto3" json:"workers,omitempty"`
+	// map of reputer id to node data about that reputer
+	Reputers []*LibP2PKeyAndOffchainNode `protobuf:"bytes,35,rep,name=reputers,proto3" json:"reputers,omitempty"`
+	// fee revenue collected by a topic over the course of the last reward cadence
+	TopicFeeRevenue []*TopicIdAndInt `protobuf:"bytes,36,rep,name=topicFeeRevenue,proto3" json:"topicFeeRevenue,omitempty"`
+	// store previous weights for exponential moving average in rewards calc
+	PreviousTopicWeight []*TopicIdAndDec `protobuf:"bytes,37,rep,name=previousTopicWeight,proto3" json:"previousTopicWeight,omitempty"`
+	// map of (topic, block_height) -> Inference
+	AllInferences []*TopicIdBlockHeightInferences `protobuf:"bytes,38,rep,name=allInferences,proto3" json:"allInferences,omitempty"`
+	// map of (topic, block_height) -> Forecast
+	AllForecasts []*TopicIdBlockHeightForecasts `protobuf:"bytes,39,rep,name=allForecasts,proto3" json:"allForecasts,omitempty"`
+	// map of (topic, block_height) -> ReputerValueBundles (1 per reputer active at that time)
+	AllLossBundles []*TopicIdBlockHeightReputerValueBundles `protobuf:"bytes,40,rep,name=allLossBundles,proto3" json:"allLossBundles,omitempty"`
+	// map of (topic, block_height) -> ValueBundle (1 network wide bundle per timestep)
+	NetworkLossBundles []*TopicIdBlockHeightValueBundles `protobuf:"bytes,41,rep,name=networkLossBundles,proto3" json:"networkLossBundles,omitempty"`
+	// Percentage of all rewards, paid out to staked reputers, during the previous reward cadence. Used by mint module
+	PreviousPercentageRewardToStakedReputers string `protobuf:"bytes,42,opt,name=previousPercentageRewardToStakedReputers,proto3" json:"previousPercentageRewardToStakedReputers,omitempty"`
+	// / NONCES
+	// map of (topic) -> unfulfilled nonces
+	UnfulfilledWorkerNonces []*TopicIdAndNonces `protobuf:"bytes,43,rep,name=unfulfilledWorkerNonces,proto3" json:"unfulfilledWorkerNonces,omitempty"`
+	// map of (topic) -> unfulfilled nonces
+	UnfulfilledReputerNonces []*TopicIdAndReputerRequestNonces `protobuf:"bytes,44,rep,name=unfulfilledReputerNonces,proto3" json:"unfulfilledReputerNonces,omitempty"`
+	// / REGRETS
+	// map of (topic, worker) -> regret of worker from comparing loss of worker relative to loss of other inferers
+	LatestInfererNetworkRegrets []*TopicIdActorIdTimeStampedValue `protobuf:"bytes,45,rep,name=latestInfererNetworkRegrets,proto3" json:"latestInfererNetworkRegrets,omitempty"`
+	// map of (topic, worker) -> regret of worker from comparing loss of worker relative to loss of other forecasters
+	LatestForecasterNetworkRegrets []*TopicIdActorIdTimeStampedValue `protobuf:"bytes,46,rep,name=latestForecasterNetworkRegrets,proto3" json:"latestForecasterNetworkRegrets,omitempty"`
+	// map of (topic, forecaster, inferer) -> R^+_{ij_kk} regret of forecaster loss from comparing one-in loss with
+	// all network inferer (3rd index) regrets L_ij made under the regime of the one-in forecaster (2nd index)
+	LatestOneInForecasterNetworkRegrets []*TopicIdActorIdActorIdTimeStampedValue `protobuf:"bytes,47,rep,name=latestOneInForecasterNetworkRegrets,proto3" json:"latestOneInForecasterNetworkRegrets,omitempty"`
+	// the forecaster (2nd index) regrets made under the regime of the same forecaster as a one-in forecaster
+	LatestOneInForecasterSelfNetworkRegrets []*TopicIdActorIdTimeStampedValue `protobuf:"bytes,48,rep,name=latestOneInForecasterSelfNetworkRegrets,proto3" json:"latestOneInForecasterSelfNetworkRegrets,omitempty"`
+	// / WHITELISTS
 	CoreTeamAddresses []string `protobuf:"bytes,2,rep,name=core_team_addresses,json=coreTeamAddresses,proto3" json:"core_team_addresses,omitempty"`
+	// / RECORD COMMITS
+	TopicLastWorkerCommit   []*TopicIdTimestampedActorNonce `protobuf:"bytes,49,rep,name=topicLastWorkerCommit,proto3" json:"topicLastWorkerCommit,omitempty"`
+	TopicLastReputerCommit  []*TopicIdTimestampedActorNonce `protobuf:"bytes,50,rep,name=topicLastReputerCommit,proto3" json:"topicLastReputerCommit,omitempty"`
+	TopicLastWorkerPayload  []*TopicIdTimestampedActorNonce `protobuf:"bytes,51,rep,name=topicLastWorkerPayload,proto3" json:"topicLastWorkerPayload,omitempty"`
+	TopicLastReputerPayload []*TopicIdTimestampedActorNonce `protobuf:"bytes,52,rep,name=topicLastReputerPayload,proto3" json:"topicLastReputerPayload,omitempty"`
 }
 
 func (x *GenesisState) Reset() {
@@ -624,9 +21908,1712 @@ func (x *GenesisState) GetParams() *Params {
 	return nil
 }
 
+func (x *GenesisState) GetNextTopicId() uint64 {
+	if x != nil {
+		return x.NextTopicId
+	}
+	return 0
+}
+
+func (x *GenesisState) GetTopics() []*TopicIdAndTopic {
+	if x != nil {
+		return x.Topics
+	}
+	return nil
+}
+
+func (x *GenesisState) GetActiveTopics() []uint64 {
+	if x != nil {
+		return x.ActiveTopics
+	}
+	return nil
+}
+
+func (x *GenesisState) GetChurnableTopics() []uint64 {
+	if x != nil {
+		return x.ChurnableTopics
+	}
+	return nil
+}
+
+func (x *GenesisState) GetRewardableTopics() []uint64 {
+	if x != nil {
+		return x.RewardableTopics
+	}
+	return nil
+}
+
+func (x *GenesisState) GetTopicWorkers() []*TopicAndActorId {
+	if x != nil {
+		return x.TopicWorkers
+	}
+	return nil
+}
+
+func (x *GenesisState) GetTopicReputers() []*TopicAndActorId {
+	if x != nil {
+		return x.TopicReputers
+	}
+	return nil
+}
+
+func (x *GenesisState) GetTopicRewardNonce() []*TopicIdAndBlockHeight {
+	if x != nil {
+		return x.TopicRewardNonce
+	}
+	return nil
+}
+
+func (x *GenesisState) GetInfererScoresByBlock() []*TopicIdBlockHeightScores {
+	if x != nil {
+		return x.InfererScoresByBlock
+	}
+	return nil
+}
+
+func (x *GenesisState) GetForecasterScoresByBlock() []*TopicIdBlockHeightScores {
+	if x != nil {
+		return x.ForecasterScoresByBlock
+	}
+	return nil
+}
+
+func (x *GenesisState) GetReputerScoresByBlock() []*TopicIdBlockHeightScores {
+	if x != nil {
+		return x.ReputerScoresByBlock
+	}
+	return nil
+}
+
+func (x *GenesisState) GetLatestInfererScoresByWorker() []*TopicIdActorIdScore {
+	if x != nil {
+		return x.LatestInfererScoresByWorker
+	}
+	return nil
+}
+
+func (x *GenesisState) GetLatestForecasterScoresByWorker() []*TopicIdActorIdScore {
+	if x != nil {
+		return x.LatestForecasterScoresByWorker
+	}
+	return nil
+}
+
+func (x *GenesisState) GetLatestReputerScoresByReputer() []*TopicIdActorIdScore {
+	if x != nil {
+		return x.LatestReputerScoresByReputer
+	}
+	return nil
+}
+
+func (x *GenesisState) GetReputerListeningCoefficient() []*TopicIdActorIdListeningCoefficient {
+	if x != nil {
+		return x.ReputerListeningCoefficient
+	}
+	return nil
+}
+
+func (x *GenesisState) GetPreviousReputerRewardFraction() []*TopicIdActorIdDec {
+	if x != nil {
+		return x.PreviousReputerRewardFraction
+	}
+	return nil
+}
+
+func (x *GenesisState) GetPreviousInferenceRewardFraction() []*TopicIdActorIdDec {
+	if x != nil {
+		return x.PreviousInferenceRewardFraction
+	}
+	return nil
+}
+
+func (x *GenesisState) GetPreviousForecastRewardFraction() []*TopicIdActorIdDec {
+	if x != nil {
+		return x.PreviousForecastRewardFraction
+	}
+	return nil
+}
+
+func (x *GenesisState) GetTotalStake() string {
+	if x != nil {
+		return x.TotalStake
+	}
+	return ""
+}
+
+func (x *GenesisState) GetTopicStake() []*TopicIdAndInt {
+	if x != nil {
+		return x.TopicStake
+	}
+	return nil
+}
+
+func (x *GenesisState) GetStakeReputerAuthority() []*TopicIdActorIdInt {
+	if x != nil {
+		return x.StakeReputerAuthority
+	}
+	return nil
+}
+
+func (x *GenesisState) GetStakeSumFromDelegator() []*TopicIdActorIdInt {
+	if x != nil {
+		return x.StakeSumFromDelegator
+	}
+	return nil
+}
+
+func (x *GenesisState) GetDelegatedStakes() []*TopicIdDelegatorReputerDelegatorInfo {
+	if x != nil {
+		return x.DelegatedStakes
+	}
+	return nil
+}
+
+func (x *GenesisState) GetStakeFromDelegatorsUponReputer() []*TopicIdActorIdInt {
+	if x != nil {
+		return x.StakeFromDelegatorsUponReputer
+	}
+	return nil
+}
+
+func (x *GenesisState) GetDelegateRewardPerShare() []*TopicIdActorIdDec {
+	if x != nil {
+		return x.DelegateRewardPerShare
+	}
+	return nil
+}
+
+func (x *GenesisState) GetStakeRemovalsByBlock() []*BlockHeightTopicIdReputerStakeRemovalInfo {
+	if x != nil {
+		return x.StakeRemovalsByBlock
+	}
+	return nil
+}
+
+func (x *GenesisState) GetStakeRemovalsByActor() []*ActorIdTopicIdBlockHeight {
+	if x != nil {
+		return x.StakeRemovalsByActor
+	}
+	return nil
+}
+
+func (x *GenesisState) GetDelegateStakeRemovalsByBlock() []*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo {
+	if x != nil {
+		return x.DelegateStakeRemovalsByBlock
+	}
+	return nil
+}
+
+func (x *GenesisState) GetDelegateStakeRemovalsByActor() []*DelegatorReputerTopicIdBlockHeight {
+	if x != nil {
+		return x.DelegateStakeRemovalsByActor
+	}
+	return nil
+}
+
+func (x *GenesisState) GetInferences() []*TopicIdActorIdInference {
+	if x != nil {
+		return x.Inferences
+	}
+	return nil
+}
+
+func (x *GenesisState) GetForecasts() []*TopicIdActorIdForecast {
+	if x != nil {
+		return x.Forecasts
+	}
+	return nil
+}
+
+func (x *GenesisState) GetWorkers() []*LibP2PKeyAndOffchainNode {
+	if x != nil {
+		return x.Workers
+	}
+	return nil
+}
+
+func (x *GenesisState) GetReputers() []*LibP2PKeyAndOffchainNode {
+	if x != nil {
+		return x.Reputers
+	}
+	return nil
+}
+
+func (x *GenesisState) GetTopicFeeRevenue() []*TopicIdAndInt {
+	if x != nil {
+		return x.TopicFeeRevenue
+	}
+	return nil
+}
+
+func (x *GenesisState) GetPreviousTopicWeight() []*TopicIdAndDec {
+	if x != nil {
+		return x.PreviousTopicWeight
+	}
+	return nil
+}
+
+func (x *GenesisState) GetAllInferences() []*TopicIdBlockHeightInferences {
+	if x != nil {
+		return x.AllInferences
+	}
+	return nil
+}
+
+func (x *GenesisState) GetAllForecasts() []*TopicIdBlockHeightForecasts {
+	if x != nil {
+		return x.AllForecasts
+	}
+	return nil
+}
+
+func (x *GenesisState) GetAllLossBundles() []*TopicIdBlockHeightReputerValueBundles {
+	if x != nil {
+		return x.AllLossBundles
+	}
+	return nil
+}
+
+func (x *GenesisState) GetNetworkLossBundles() []*TopicIdBlockHeightValueBundles {
+	if x != nil {
+		return x.NetworkLossBundles
+	}
+	return nil
+}
+
+func (x *GenesisState) GetPreviousPercentageRewardToStakedReputers() string {
+	if x != nil {
+		return x.PreviousPercentageRewardToStakedReputers
+	}
+	return ""
+}
+
+func (x *GenesisState) GetUnfulfilledWorkerNonces() []*TopicIdAndNonces {
+	if x != nil {
+		return x.UnfulfilledWorkerNonces
+	}
+	return nil
+}
+
+func (x *GenesisState) GetUnfulfilledReputerNonces() []*TopicIdAndReputerRequestNonces {
+	if x != nil {
+		return x.UnfulfilledReputerNonces
+	}
+	return nil
+}
+
+func (x *GenesisState) GetLatestInfererNetworkRegrets() []*TopicIdActorIdTimeStampedValue {
+	if x != nil {
+		return x.LatestInfererNetworkRegrets
+	}
+	return nil
+}
+
+func (x *GenesisState) GetLatestForecasterNetworkRegrets() []*TopicIdActorIdTimeStampedValue {
+	if x != nil {
+		return x.LatestForecasterNetworkRegrets
+	}
+	return nil
+}
+
+func (x *GenesisState) GetLatestOneInForecasterNetworkRegrets() []*TopicIdActorIdActorIdTimeStampedValue {
+	if x != nil {
+		return x.LatestOneInForecasterNetworkRegrets
+	}
+	return nil
+}
+
+func (x *GenesisState) GetLatestOneInForecasterSelfNetworkRegrets() []*TopicIdActorIdTimeStampedValue {
+	if x != nil {
+		return x.LatestOneInForecasterSelfNetworkRegrets
+	}
+	return nil
+}
+
 func (x *GenesisState) GetCoreTeamAddresses() []string {
 	if x != nil {
 		return x.CoreTeamAddresses
+	}
+	return nil
+}
+
+func (x *GenesisState) GetTopicLastWorkerCommit() []*TopicIdTimestampedActorNonce {
+	if x != nil {
+		return x.TopicLastWorkerCommit
+	}
+	return nil
+}
+
+func (x *GenesisState) GetTopicLastReputerCommit() []*TopicIdTimestampedActorNonce {
+	if x != nil {
+		return x.TopicLastReputerCommit
+	}
+	return nil
+}
+
+func (x *GenesisState) GetTopicLastWorkerPayload() []*TopicIdTimestampedActorNonce {
+	if x != nil {
+		return x.TopicLastWorkerPayload
+	}
+	return nil
+}
+
+func (x *GenesisState) GetTopicLastReputerPayload() []*TopicIdTimestampedActorNonce {
+	if x != nil {
+		return x.TopicLastReputerPayload
+	}
+	return nil
+}
+
+type TopicIdAndTopic struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId uint64 `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	Topic   *Topic `protobuf:"bytes,2,opt,name=Topic,proto3" json:"Topic,omitempty"`
+}
+
+func (x *TopicIdAndTopic) Reset() {
+	*x = TopicIdAndTopic{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[1]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdAndTopic) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdAndTopic) ProtoMessage() {}
+
+// Deprecated: Use TopicIdAndTopic.ProtoReflect.Descriptor instead.
+func (*TopicIdAndTopic) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *TopicIdAndTopic) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdAndTopic) GetTopic() *Topic {
+	if x != nil {
+		return x.Topic
+	}
+	return nil
+}
+
+type TopicAndActorId struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId uint64 `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ActorId string `protobuf:"bytes,2,opt,name=ActorId,proto3" json:"ActorId,omitempty"`
+}
+
+func (x *TopicAndActorId) Reset() {
+	*x = TopicAndActorId{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[2]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicAndActorId) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicAndActorId) ProtoMessage() {}
+
+// Deprecated: Use TopicAndActorId.ProtoReflect.Descriptor instead.
+func (*TopicAndActorId) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *TopicAndActorId) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicAndActorId) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+type TopicIdAndBlockHeight struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId     uint64 `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	BlockHeight int64  `protobuf:"varint,2,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+}
+
+func (x *TopicIdAndBlockHeight) Reset() {
+	*x = TopicIdAndBlockHeight{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdAndBlockHeight) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdAndBlockHeight) ProtoMessage() {}
+
+// Deprecated: Use TopicIdAndBlockHeight.ProtoReflect.Descriptor instead.
+func (*TopicIdAndBlockHeight) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *TopicIdAndBlockHeight) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdAndBlockHeight) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+type TopicIdBlockHeightScores struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId     uint64  `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	BlockHeight int64   `protobuf:"varint,2,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+	Scores      *Scores `protobuf:"bytes,3,opt,name=Scores,proto3" json:"Scores,omitempty"`
+}
+
+func (x *TopicIdBlockHeightScores) Reset() {
+	*x = TopicIdBlockHeightScores{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[4]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdBlockHeightScores) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdBlockHeightScores) ProtoMessage() {}
+
+// Deprecated: Use TopicIdBlockHeightScores.ProtoReflect.Descriptor instead.
+func (*TopicIdBlockHeightScores) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *TopicIdBlockHeightScores) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightScores) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightScores) GetScores() *Scores {
+	if x != nil {
+		return x.Scores
+	}
+	return nil
+}
+
+type TopicIdActorIdScore struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId uint64 `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ActorId string `protobuf:"bytes,2,opt,name=ActorId,proto3" json:"ActorId,omitempty"`
+	Score   *Score `protobuf:"bytes,3,opt,name=Score,proto3" json:"Score,omitempty"`
+}
+
+func (x *TopicIdActorIdScore) Reset() {
+	*x = TopicIdActorIdScore{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[5]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdActorIdScore) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdActorIdScore) ProtoMessage() {}
+
+// Deprecated: Use TopicIdActorIdScore.ProtoReflect.Descriptor instead.
+func (*TopicIdActorIdScore) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *TopicIdActorIdScore) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdActorIdScore) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+func (x *TopicIdActorIdScore) GetScore() *Score {
+	if x != nil {
+		return x.Score
+	}
+	return nil
+}
+
+type TopicIdActorIdListeningCoefficient struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId              uint64                `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ActorId              string                `protobuf:"bytes,2,opt,name=ActorId,proto3" json:"ActorId,omitempty"`
+	ListeningCoefficient *ListeningCoefficient `protobuf:"bytes,3,opt,name=ListeningCoefficient,proto3" json:"ListeningCoefficient,omitempty"`
+}
+
+func (x *TopicIdActorIdListeningCoefficient) Reset() {
+	*x = TopicIdActorIdListeningCoefficient{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[6]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdActorIdListeningCoefficient) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdActorIdListeningCoefficient) ProtoMessage() {}
+
+// Deprecated: Use TopicIdActorIdListeningCoefficient.ProtoReflect.Descriptor instead.
+func (*TopicIdActorIdListeningCoefficient) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *TopicIdActorIdListeningCoefficient) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdActorIdListeningCoefficient) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+func (x *TopicIdActorIdListeningCoefficient) GetListeningCoefficient() *ListeningCoefficient {
+	if x != nil {
+		return x.ListeningCoefficient
+	}
+	return nil
+}
+
+type TopicIdActorIdDec struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId uint64 `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ActorId string `protobuf:"bytes,2,opt,name=ActorId,proto3" json:"ActorId,omitempty"`
+	Dec     string `protobuf:"bytes,3,opt,name=Dec,proto3" json:"Dec,omitempty"`
+}
+
+func (x *TopicIdActorIdDec) Reset() {
+	*x = TopicIdActorIdDec{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[7]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdActorIdDec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdActorIdDec) ProtoMessage() {}
+
+// Deprecated: Use TopicIdActorIdDec.ProtoReflect.Descriptor instead.
+func (*TopicIdActorIdDec) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *TopicIdActorIdDec) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdActorIdDec) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+func (x *TopicIdActorIdDec) GetDec() string {
+	if x != nil {
+		return x.Dec
+	}
+	return ""
+}
+
+type TopicIdAndInt struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId uint64 `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	Int     string `protobuf:"bytes,2,opt,name=Int,proto3" json:"Int,omitempty"`
+}
+
+func (x *TopicIdAndInt) Reset() {
+	*x = TopicIdAndInt{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[8]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdAndInt) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdAndInt) ProtoMessage() {}
+
+// Deprecated: Use TopicIdAndInt.ProtoReflect.Descriptor instead.
+func (*TopicIdAndInt) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *TopicIdAndInt) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdAndInt) GetInt() string {
+	if x != nil {
+		return x.Int
+	}
+	return ""
+}
+
+type TopicIdActorIdInt struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId uint64 `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ActorId string `protobuf:"bytes,2,opt,name=ActorId,proto3" json:"ActorId,omitempty"`
+	Int     string `protobuf:"bytes,3,opt,name=Int,proto3" json:"Int,omitempty"`
+}
+
+func (x *TopicIdActorIdInt) Reset() {
+	*x = TopicIdActorIdInt{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[9]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdActorIdInt) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdActorIdInt) ProtoMessage() {}
+
+// Deprecated: Use TopicIdActorIdInt.ProtoReflect.Descriptor instead.
+func (*TopicIdActorIdInt) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *TopicIdActorIdInt) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdActorIdInt) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+func (x *TopicIdActorIdInt) GetInt() string {
+	if x != nil {
+		return x.Int
+	}
+	return ""
+}
+
+type TopicIdDelegatorReputerDelegatorInfo struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId       uint64         `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	Delegator     string         `protobuf:"bytes,2,opt,name=Delegator,proto3" json:"Delegator,omitempty"`
+	Reputer       string         `protobuf:"bytes,3,opt,name=Reputer,proto3" json:"Reputer,omitempty"`
+	DelegatorInfo *DelegatorInfo `protobuf:"bytes,4,opt,name=DelegatorInfo,proto3" json:"DelegatorInfo,omitempty"`
+}
+
+func (x *TopicIdDelegatorReputerDelegatorInfo) Reset() {
+	*x = TopicIdDelegatorReputerDelegatorInfo{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[10]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdDelegatorReputerDelegatorInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdDelegatorReputerDelegatorInfo) ProtoMessage() {}
+
+// Deprecated: Use TopicIdDelegatorReputerDelegatorInfo.ProtoReflect.Descriptor instead.
+func (*TopicIdDelegatorReputerDelegatorInfo) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *TopicIdDelegatorReputerDelegatorInfo) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdDelegatorReputerDelegatorInfo) GetDelegator() string {
+	if x != nil {
+		return x.Delegator
+	}
+	return ""
+}
+
+func (x *TopicIdDelegatorReputerDelegatorInfo) GetReputer() string {
+	if x != nil {
+		return x.Reputer
+	}
+	return ""
+}
+
+func (x *TopicIdDelegatorReputerDelegatorInfo) GetDelegatorInfo() *DelegatorInfo {
+	if x != nil {
+		return x.DelegatorInfo
+	}
+	return nil
+}
+
+type BlockHeightTopicIdReputerStakeRemovalInfo struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	BlockHeight      int64             `protobuf:"varint,1,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+	TopicId          uint64            `protobuf:"varint,2,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	Reputer          string            `protobuf:"bytes,3,opt,name=Reputer,proto3" json:"Reputer,omitempty"`
+	StakeRemovalInfo *StakeRemovalInfo `protobuf:"bytes,4,opt,name=StakeRemovalInfo,proto3" json:"StakeRemovalInfo,omitempty"`
+}
+
+func (x *BlockHeightTopicIdReputerStakeRemovalInfo) Reset() {
+	*x = BlockHeightTopicIdReputerStakeRemovalInfo{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[11]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BlockHeightTopicIdReputerStakeRemovalInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlockHeightTopicIdReputerStakeRemovalInfo) ProtoMessage() {}
+
+// Deprecated: Use BlockHeightTopicIdReputerStakeRemovalInfo.ProtoReflect.Descriptor instead.
+func (*BlockHeightTopicIdReputerStakeRemovalInfo) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *BlockHeightTopicIdReputerStakeRemovalInfo) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+func (x *BlockHeightTopicIdReputerStakeRemovalInfo) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *BlockHeightTopicIdReputerStakeRemovalInfo) GetReputer() string {
+	if x != nil {
+		return x.Reputer
+	}
+	return ""
+}
+
+func (x *BlockHeightTopicIdReputerStakeRemovalInfo) GetStakeRemovalInfo() *StakeRemovalInfo {
+	if x != nil {
+		return x.StakeRemovalInfo
+	}
+	return nil
+}
+
+type ActorIdTopicIdBlockHeight struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	ActorId     string `protobuf:"bytes,1,opt,name=ActorId,proto3" json:"ActorId,omitempty"`
+	TopicId     uint64 `protobuf:"varint,2,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	BlockHeight int64  `protobuf:"varint,3,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+}
+
+func (x *ActorIdTopicIdBlockHeight) Reset() {
+	*x = ActorIdTopicIdBlockHeight{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[12]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ActorIdTopicIdBlockHeight) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorIdTopicIdBlockHeight) ProtoMessage() {}
+
+// Deprecated: Use ActorIdTopicIdBlockHeight.ProtoReflect.Descriptor instead.
+func (*ActorIdTopicIdBlockHeight) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ActorIdTopicIdBlockHeight) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+func (x *ActorIdTopicIdBlockHeight) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *ActorIdTopicIdBlockHeight) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+type BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	BlockHeight              int64                     `protobuf:"varint,1,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+	TopicId                  uint64                    `protobuf:"varint,2,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	Delegator                string                    `protobuf:"bytes,3,opt,name=Delegator,proto3" json:"Delegator,omitempty"`
+	Reputer                  string                    `protobuf:"bytes,4,opt,name=Reputer,proto3" json:"Reputer,omitempty"`
+	DelegateStakeRemovalInfo *DelegateStakeRemovalInfo `protobuf:"bytes,5,opt,name=DelegateStakeRemovalInfo,proto3" json:"DelegateStakeRemovalInfo,omitempty"`
+}
+
+func (x *BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Reset() {
+	*x = BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[13]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) ProtoMessage() {}
+
+// Deprecated: Use BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.ProtoReflect.Descriptor instead.
+func (*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+func (x *BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) GetDelegator() string {
+	if x != nil {
+		return x.Delegator
+	}
+	return ""
+}
+
+func (x *BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) GetReputer() string {
+	if x != nil {
+		return x.Reputer
+	}
+	return ""
+}
+
+func (x *BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo) GetDelegateStakeRemovalInfo() *DelegateStakeRemovalInfo {
+	if x != nil {
+		return x.DelegateStakeRemovalInfo
+	}
+	return nil
+}
+
+type DelegatorReputerTopicIdBlockHeight struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Delegator   string `protobuf:"bytes,1,opt,name=Delegator,proto3" json:"Delegator,omitempty"`
+	Reputer     string `protobuf:"bytes,2,opt,name=Reputer,proto3" json:"Reputer,omitempty"`
+	TopicId     uint64 `protobuf:"varint,3,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	BlockHeight int64  `protobuf:"varint,4,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+}
+
+func (x *DelegatorReputerTopicIdBlockHeight) Reset() {
+	*x = DelegatorReputerTopicIdBlockHeight{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[14]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DelegatorReputerTopicIdBlockHeight) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DelegatorReputerTopicIdBlockHeight) ProtoMessage() {}
+
+// Deprecated: Use DelegatorReputerTopicIdBlockHeight.ProtoReflect.Descriptor instead.
+func (*DelegatorReputerTopicIdBlockHeight) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *DelegatorReputerTopicIdBlockHeight) GetDelegator() string {
+	if x != nil {
+		return x.Delegator
+	}
+	return ""
+}
+
+func (x *DelegatorReputerTopicIdBlockHeight) GetReputer() string {
+	if x != nil {
+		return x.Reputer
+	}
+	return ""
+}
+
+func (x *DelegatorReputerTopicIdBlockHeight) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *DelegatorReputerTopicIdBlockHeight) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+type TopicIdActorIdInference struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId   uint64     `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ActorId   string     `protobuf:"bytes,2,opt,name=ActorId,proto3" json:"ActorId,omitempty"`
+	Inference *Inference `protobuf:"bytes,3,opt,name=Inference,proto3" json:"Inference,omitempty"`
+}
+
+func (x *TopicIdActorIdInference) Reset() {
+	*x = TopicIdActorIdInference{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[15]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdActorIdInference) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdActorIdInference) ProtoMessage() {}
+
+// Deprecated: Use TopicIdActorIdInference.ProtoReflect.Descriptor instead.
+func (*TopicIdActorIdInference) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *TopicIdActorIdInference) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdActorIdInference) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+func (x *TopicIdActorIdInference) GetInference() *Inference {
+	if x != nil {
+		return x.Inference
+	}
+	return nil
+}
+
+type TopicIdActorIdForecast struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId  uint64    `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ActorId  string    `protobuf:"bytes,2,opt,name=ActorId,proto3" json:"ActorId,omitempty"`
+	Forecast *Forecast `protobuf:"bytes,3,opt,name=Forecast,proto3" json:"Forecast,omitempty"`
+}
+
+func (x *TopicIdActorIdForecast) Reset() {
+	*x = TopicIdActorIdForecast{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[16]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdActorIdForecast) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdActorIdForecast) ProtoMessage() {}
+
+// Deprecated: Use TopicIdActorIdForecast.ProtoReflect.Descriptor instead.
+func (*TopicIdActorIdForecast) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *TopicIdActorIdForecast) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdActorIdForecast) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+func (x *TopicIdActorIdForecast) GetForecast() *Forecast {
+	if x != nil {
+		return x.Forecast
+	}
+	return nil
+}
+
+type LibP2PKeyAndOffchainNode struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	LibP2PKey    string        `protobuf:"bytes,1,opt,name=LibP2pKey,proto3" json:"LibP2pKey,omitempty"`
+	OffchainNode *OffchainNode `protobuf:"bytes,2,opt,name=OffchainNode,proto3" json:"OffchainNode,omitempty"`
+}
+
+func (x *LibP2PKeyAndOffchainNode) Reset() {
+	*x = LibP2PKeyAndOffchainNode{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[17]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *LibP2PKeyAndOffchainNode) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LibP2PKeyAndOffchainNode) ProtoMessage() {}
+
+// Deprecated: Use LibP2PKeyAndOffchainNode.ProtoReflect.Descriptor instead.
+func (*LibP2PKeyAndOffchainNode) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *LibP2PKeyAndOffchainNode) GetLibP2PKey() string {
+	if x != nil {
+		return x.LibP2PKey
+	}
+	return ""
+}
+
+func (x *LibP2PKeyAndOffchainNode) GetOffchainNode() *OffchainNode {
+	if x != nil {
+		return x.OffchainNode
+	}
+	return nil
+}
+
+type TopicIdAndDec struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId uint64 `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	Dec     string `protobuf:"bytes,2,opt,name=Dec,proto3" json:"Dec,omitempty"`
+}
+
+func (x *TopicIdAndDec) Reset() {
+	*x = TopicIdAndDec{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[18]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdAndDec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdAndDec) ProtoMessage() {}
+
+// Deprecated: Use TopicIdAndDec.ProtoReflect.Descriptor instead.
+func (*TopicIdAndDec) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *TopicIdAndDec) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdAndDec) GetDec() string {
+	if x != nil {
+		return x.Dec
+	}
+	return ""
+}
+
+type TopicIdBlockHeightInferences struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId     uint64      `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	BlockHeight int64       `protobuf:"varint,2,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+	Inferences  *Inferences `protobuf:"bytes,3,opt,name=Inferences,proto3" json:"Inferences,omitempty"`
+}
+
+func (x *TopicIdBlockHeightInferences) Reset() {
+	*x = TopicIdBlockHeightInferences{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[19]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdBlockHeightInferences) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdBlockHeightInferences) ProtoMessage() {}
+
+// Deprecated: Use TopicIdBlockHeightInferences.ProtoReflect.Descriptor instead.
+func (*TopicIdBlockHeightInferences) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *TopicIdBlockHeightInferences) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightInferences) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightInferences) GetInferences() *Inferences {
+	if x != nil {
+		return x.Inferences
+	}
+	return nil
+}
+
+type TopicIdBlockHeightForecasts struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId     uint64     `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	BlockHeight int64      `protobuf:"varint,2,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+	Forecasts   *Forecasts `protobuf:"bytes,3,opt,name=Forecasts,proto3" json:"Forecasts,omitempty"`
+}
+
+func (x *TopicIdBlockHeightForecasts) Reset() {
+	*x = TopicIdBlockHeightForecasts{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[20]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdBlockHeightForecasts) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdBlockHeightForecasts) ProtoMessage() {}
+
+// Deprecated: Use TopicIdBlockHeightForecasts.ProtoReflect.Descriptor instead.
+func (*TopicIdBlockHeightForecasts) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *TopicIdBlockHeightForecasts) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightForecasts) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightForecasts) GetForecasts() *Forecasts {
+	if x != nil {
+		return x.Forecasts
+	}
+	return nil
+}
+
+type TopicIdBlockHeightReputerValueBundles struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId             uint64               `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	BlockHeight         int64                `protobuf:"varint,2,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+	ReputerValueBundles *ReputerValueBundles `protobuf:"bytes,3,opt,name=ReputerValueBundles,proto3" json:"ReputerValueBundles,omitempty"`
+}
+
+func (x *TopicIdBlockHeightReputerValueBundles) Reset() {
+	*x = TopicIdBlockHeightReputerValueBundles{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[21]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdBlockHeightReputerValueBundles) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdBlockHeightReputerValueBundles) ProtoMessage() {}
+
+// Deprecated: Use TopicIdBlockHeightReputerValueBundles.ProtoReflect.Descriptor instead.
+func (*TopicIdBlockHeightReputerValueBundles) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *TopicIdBlockHeightReputerValueBundles) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightReputerValueBundles) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightReputerValueBundles) GetReputerValueBundles() *ReputerValueBundles {
+	if x != nil {
+		return x.ReputerValueBundles
+	}
+	return nil
+}
+
+type TopicIdBlockHeightValueBundles struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId     uint64       `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	BlockHeight int64        `protobuf:"varint,2,opt,name=BlockHeight,proto3" json:"BlockHeight,omitempty"`
+	ValueBundle *ValueBundle `protobuf:"bytes,3,opt,name=ValueBundle,proto3" json:"ValueBundle,omitempty"`
+}
+
+func (x *TopicIdBlockHeightValueBundles) Reset() {
+	*x = TopicIdBlockHeightValueBundles{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[22]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdBlockHeightValueBundles) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdBlockHeightValueBundles) ProtoMessage() {}
+
+// Deprecated: Use TopicIdBlockHeightValueBundles.ProtoReflect.Descriptor instead.
+func (*TopicIdBlockHeightValueBundles) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *TopicIdBlockHeightValueBundles) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightValueBundles) GetBlockHeight() int64 {
+	if x != nil {
+		return x.BlockHeight
+	}
+	return 0
+}
+
+func (x *TopicIdBlockHeightValueBundles) GetValueBundle() *ValueBundle {
+	if x != nil {
+		return x.ValueBundle
+	}
+	return nil
+}
+
+type TopicIdAndNonces struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId uint64  `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	Nonces  *Nonces `protobuf:"bytes,2,opt,name=Nonces,proto3" json:"Nonces,omitempty"`
+}
+
+func (x *TopicIdAndNonces) Reset() {
+	*x = TopicIdAndNonces{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[23]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdAndNonces) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdAndNonces) ProtoMessage() {}
+
+// Deprecated: Use TopicIdAndNonces.ProtoReflect.Descriptor instead.
+func (*TopicIdAndNonces) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *TopicIdAndNonces) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdAndNonces) GetNonces() *Nonces {
+	if x != nil {
+		return x.Nonces
+	}
+	return nil
+}
+
+type TopicIdAndReputerRequestNonces struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId              uint64                `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ReputerRequestNonces *ReputerRequestNonces `protobuf:"bytes,2,opt,name=ReputerRequestNonces,proto3" json:"ReputerRequestNonces,omitempty"`
+}
+
+func (x *TopicIdAndReputerRequestNonces) Reset() {
+	*x = TopicIdAndReputerRequestNonces{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[24]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdAndReputerRequestNonces) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdAndReputerRequestNonces) ProtoMessage() {}
+
+// Deprecated: Use TopicIdAndReputerRequestNonces.ProtoReflect.Descriptor instead.
+func (*TopicIdAndReputerRequestNonces) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *TopicIdAndReputerRequestNonces) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdAndReputerRequestNonces) GetReputerRequestNonces() *ReputerRequestNonces {
+	if x != nil {
+		return x.ReputerRequestNonces
+	}
+	return nil
+}
+
+type TopicIdActorIdTimeStampedValue struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId          uint64            `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ActorId          string            `protobuf:"bytes,2,opt,name=ActorId,proto3" json:"ActorId,omitempty"`
+	TimestampedValue *TimestampedValue `protobuf:"bytes,3,opt,name=TimestampedValue,proto3" json:"TimestampedValue,omitempty"`
+}
+
+func (x *TopicIdActorIdTimeStampedValue) Reset() {
+	*x = TopicIdActorIdTimeStampedValue{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[25]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdActorIdTimeStampedValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdActorIdTimeStampedValue) ProtoMessage() {}
+
+// Deprecated: Use TopicIdActorIdTimeStampedValue.ProtoReflect.Descriptor instead.
+func (*TopicIdActorIdTimeStampedValue) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *TopicIdActorIdTimeStampedValue) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdActorIdTimeStampedValue) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
+func (x *TopicIdActorIdTimeStampedValue) GetTimestampedValue() *TimestampedValue {
+	if x != nil {
+		return x.TimestampedValue
+	}
+	return nil
+}
+
+type TopicIdActorIdActorIdTimeStampedValue struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId          uint64            `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	ActorId1         string            `protobuf:"bytes,2,opt,name=ActorId1,proto3" json:"ActorId1,omitempty"`
+	ActorId2         string            `protobuf:"bytes,3,opt,name=ActorId2,proto3" json:"ActorId2,omitempty"`
+	TimestampedValue *TimestampedValue `protobuf:"bytes,4,opt,name=TimestampedValue,proto3" json:"TimestampedValue,omitempty"`
+}
+
+func (x *TopicIdActorIdActorIdTimeStampedValue) Reset() {
+	*x = TopicIdActorIdActorIdTimeStampedValue{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[26]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdActorIdActorIdTimeStampedValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdActorIdActorIdTimeStampedValue) ProtoMessage() {}
+
+// Deprecated: Use TopicIdActorIdActorIdTimeStampedValue.ProtoReflect.Descriptor instead.
+func (*TopicIdActorIdActorIdTimeStampedValue) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *TopicIdActorIdActorIdTimeStampedValue) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdActorIdActorIdTimeStampedValue) GetActorId1() string {
+	if x != nil {
+		return x.ActorId1
+	}
+	return ""
+}
+
+func (x *TopicIdActorIdActorIdTimeStampedValue) GetActorId2() string {
+	if x != nil {
+		return x.ActorId2
+	}
+	return ""
+}
+
+func (x *TopicIdActorIdActorIdTimeStampedValue) GetTimestampedValue() *TimestampedValue {
+	if x != nil {
+		return x.TimestampedValue
+	}
+	return nil
+}
+
+type TopicIdTimestampedActorNonce struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TopicId               uint64                 `protobuf:"varint,1,opt,name=TopicId,proto3" json:"TopicId,omitempty"`
+	TimestampedActorNonce *TimestampedActorNonce `protobuf:"bytes,2,opt,name=TimestampedActorNonce,proto3" json:"TimestampedActorNonce,omitempty"`
+}
+
+func (x *TopicIdTimestampedActorNonce) Reset() {
+	*x = TopicIdTimestampedActorNonce{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_emissions_v1_genesis_proto_msgTypes[27]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TopicIdTimestampedActorNonce) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopicIdTimestampedActorNonce) ProtoMessage() {}
+
+// Deprecated: Use TopicIdTimestampedActorNonce.ProtoReflect.Descriptor instead.
+func (*TopicIdTimestampedActorNonce) Descriptor() ([]byte, []int) {
+	return file_emissions_v1_genesis_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *TopicIdTimestampedActorNonce) GetTopicId() uint64 {
+	if x != nil {
+		return x.TopicId
+	}
+	return 0
+}
+
+func (x *TopicIdTimestampedActorNonce) GetTimestampedActorNonce() *TimestampedActorNonce {
+	if x != nil {
+		return x.TimestampedActorNonce
 	}
 	return nil
 }
@@ -636,19 +23623,563 @@ var File_emissions_v1_genesis_proto protoreflect.FileDescriptor
 var file_emissions_v1_genesis_proto_rawDesc = []byte{
 	0x0a, 0x1a, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x2f, 0x67,
 	0x65, 0x6e, 0x65, 0x73, 0x69, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x0c, 0x65, 0x6d,
-	0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x1a, 0x14, 0x67, 0x6f, 0x67, 0x6f,
-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x67, 0x6f, 0x67, 0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
-	0x1a, 0x19, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x2f, 0x70,
-	0x61, 0x72, 0x61, 0x6d, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x11, 0x61, 0x6d, 0x69,
-	0x6e, 0x6f, 0x2f, 0x61, 0x6d, 0x69, 0x6e, 0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x72,
-	0x0a, 0x0c, 0x47, 0x65, 0x6e, 0x65, 0x73, 0x69, 0x73, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x32,
-	0x0a, 0x06, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14,
-	0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61,
-	0x72, 0x61, 0x6d, 0x73, 0x42, 0x04, 0xc8, 0xde, 0x1f, 0x00, 0x52, 0x06, 0x70, 0x61, 0x72, 0x61,
-	0x6d, 0x73, 0x12, 0x2e, 0x0a, 0x13, 0x63, 0x6f, 0x72, 0x65, 0x5f, 0x74, 0x65, 0x61, 0x6d, 0x5f,
-	0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x65, 0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x09, 0x52,
-	0x11, 0x63, 0x6f, 0x72, 0x65, 0x54, 0x65, 0x61, 0x6d, 0x41, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73,
-	0x65, 0x73, 0x42, 0xc2, 0x01, 0x0a, 0x10, 0x63, 0x6f, 0x6d, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x1a, 0x19, 0x63, 0x6f, 0x73, 0x6d,
+	0x6f, 0x73, 0x5f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x11, 0x61, 0x6d, 0x69, 0x6e, 0x6f, 0x2f, 0x61, 0x6d, 0x69,
+	0x6e, 0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x14, 0x67, 0x6f, 0x67, 0x6f, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x2f, 0x67, 0x6f, 0x67, 0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x19,
+	0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x2f, 0x70, 0x61, 0x72,
+	0x61, 0x6d, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x18, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x2f, 0x73, 0x63, 0x6f, 0x72, 0x65, 0x2e, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x1a, 0x18, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76,
+	0x31, 0x2f, 0x73, 0x74, 0x61, 0x6b, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x18, 0x65,
+	0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x2f, 0x74, 0x79, 0x70, 0x65,
+	0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x18, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f,
+	0x6e, 0x73, 0x2f, 0x76, 0x31, 0x2f, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x1a, 0x19, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x2f,
+	0x77, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x17, 0x65, 0x6d,
+	0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x2f, 0x6e, 0x6f, 0x64, 0x65, 0x2e,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x1a, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73,
+	0x2f, 0x76, 0x31, 0x2f, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x1a, 0x18, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x2f,
+	0x6e, 0x6f, 0x6e, 0x63, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0xae, 0x24, 0x0a, 0x0c,
+	0x47, 0x65, 0x6e, 0x65, 0x73, 0x69, 0x73, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x32, 0x0a, 0x06,
+	0x70, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x65,
+	0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61, 0x72, 0x61,
+	0x6d, 0x73, 0x42, 0x04, 0xc8, 0xde, 0x1f, 0x00, 0x52, 0x06, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x73,
+	0x12, 0x20, 0x0a, 0x0b, 0x6e, 0x65, 0x78, 0x74, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18,
+	0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x0b, 0x6e, 0x65, 0x78, 0x74, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x12, 0x35, 0x0a, 0x06, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x73, 0x18, 0x04, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76,
+	0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x54, 0x6f, 0x70, 0x69,
+	0x63, 0x52, 0x06, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x73, 0x12, 0x22, 0x0a, 0x0c, 0x61, 0x63, 0x74,
+	0x69, 0x76, 0x65, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x73, 0x18, 0x05, 0x20, 0x03, 0x28, 0x04, 0x52,
+	0x0c, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x73, 0x12, 0x28, 0x0a,
+	0x0f, 0x63, 0x68, 0x75, 0x72, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x73,
+	0x18, 0x06, 0x20, 0x03, 0x28, 0x04, 0x52, 0x0f, 0x63, 0x68, 0x75, 0x72, 0x6e, 0x61, 0x62, 0x6c,
+	0x65, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x73, 0x12, 0x2a, 0x0a, 0x10, 0x72, 0x65, 0x77, 0x61, 0x72,
+	0x64, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x73, 0x18, 0x07, 0x20, 0x03, 0x28,
+	0x04, 0x52, 0x10, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x73, 0x12, 0x41, 0x0a, 0x0c, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x57, 0x6f, 0x72, 0x6b,
+	0x65, 0x72, 0x73, 0x18, 0x08, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x65, 0x6d, 0x69, 0x73,
+	0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x41, 0x6e,
+	0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x52, 0x0c, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x57,
+	0x6f, 0x72, 0x6b, 0x65, 0x72, 0x73, 0x12, 0x43, 0x0a, 0x0d, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x52,
+	0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x73, 0x18, 0x09, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1d, 0x2e,
+	0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x41, 0x6e, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x52, 0x0d, 0x74, 0x6f,
+	0x70, 0x69, 0x63, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x73, 0x12, 0x4f, 0x0a, 0x10, 0x74,
+	0x6f, 0x70, 0x69, 0x63, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x18,
+	0x0a, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x23, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e,
+	0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x42,
+	0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x52, 0x10, 0x74, 0x6f, 0x70, 0x69,
+	0x63, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x12, 0x5a, 0x0a, 0x14,
+	0x69, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x72, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x42, 0x79, 0x42,
+	0x6c, 0x6f, 0x63, 0x6b, 0x18, 0x0b, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x65, 0x6d, 0x69,
+	0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x53, 0x63, 0x6f, 0x72,
+	0x65, 0x73, 0x52, 0x14, 0x69, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x72, 0x53, 0x63, 0x6f, 0x72, 0x65,
+	0x73, 0x42, 0x79, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x12, 0x60, 0x0a, 0x17, 0x66, 0x6f, 0x72, 0x65,
+	0x63, 0x61, 0x73, 0x74, 0x65, 0x72, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x42, 0x79, 0x42, 0x6c,
+	0x6f, 0x63, 0x6b, 0x18, 0x0c, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x65, 0x6d, 0x69, 0x73,
+	0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x53, 0x63, 0x6f, 0x72, 0x65,
+	0x73, 0x52, 0x17, 0x66, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x65, 0x72, 0x53, 0x63, 0x6f,
+	0x72, 0x65, 0x73, 0x42, 0x79, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x12, 0x5a, 0x0a, 0x14, 0x72, 0x65,
+	0x70, 0x75, 0x74, 0x65, 0x72, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x42, 0x79, 0x42, 0x6c, 0x6f,
+	0x63, 0x6b, 0x18, 0x0d, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x42,
+	0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73,
+	0x52, 0x14, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x42,
+	0x79, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x12, 0x63, 0x0a, 0x1b, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x74,
+	0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x72, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x42, 0x79, 0x57,
+	0x6f, 0x72, 0x6b, 0x65, 0x72, 0x18, 0x0e, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x65, 0x6d,
+	0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x52, 0x1b,
+	0x6c, 0x61, 0x74, 0x65, 0x73, 0x74, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x72, 0x53, 0x63, 0x6f,
+	0x72, 0x65, 0x73, 0x42, 0x79, 0x57, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x12, 0x69, 0x0a, 0x1e, 0x6c,
+	0x61, 0x74, 0x65, 0x73, 0x74, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x65, 0x72, 0x53,
+	0x63, 0x6f, 0x72, 0x65, 0x73, 0x42, 0x79, 0x57, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x18, 0x0f, 0x20,
+	0x03, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
+	0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49,
+	0x64, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x52, 0x1e, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x74, 0x46, 0x6f,
+	0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x65, 0x72, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x42, 0x79,
+	0x57, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x12, 0x65, 0x0a, 0x1c, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x74,
+	0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x42, 0x79, 0x52,
+	0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x18, 0x10, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x65,
+	0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69,
+	0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x52,
+	0x1c, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x74, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x53, 0x63,
+	0x6f, 0x72, 0x65, 0x73, 0x42, 0x79, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x12, 0x72, 0x0a,
+	0x1b, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x4c, 0x69, 0x73, 0x74, 0x65, 0x6e, 0x69, 0x6e,
+	0x67, 0x43, 0x6f, 0x65, 0x66, 0x66, 0x69, 0x63, 0x69, 0x65, 0x6e, 0x74, 0x18, 0x11, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x30, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76,
+	0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64,
+	0x4c, 0x69, 0x73, 0x74, 0x65, 0x6e, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x65, 0x66, 0x66, 0x69, 0x63,
+	0x69, 0x65, 0x6e, 0x74, 0x52, 0x1b, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x4c, 0x69, 0x73,
+	0x74, 0x65, 0x6e, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x65, 0x66, 0x66, 0x69, 0x63, 0x69, 0x65, 0x6e,
+	0x74, 0x12, 0x65, 0x0a, 0x1d, 0x70, 0x72, 0x65, 0x76, 0x69, 0x6f, 0x75, 0x73, 0x52, 0x65, 0x70,
+	0x75, 0x74, 0x65, 0x72, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x46, 0x72, 0x61, 0x63, 0x74, 0x69,
+	0x6f, 0x6e, 0x18, 0x12, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41,
+	0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x44, 0x65, 0x63, 0x52, 0x1d, 0x70, 0x72, 0x65, 0x76, 0x69,
+	0x6f, 0x75, 0x73, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64,
+	0x46, 0x72, 0x61, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x69, 0x0a, 0x1f, 0x70, 0x72, 0x65, 0x76,
+	0x69, 0x6f, 0x75, 0x73, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x52, 0x65, 0x77,
+	0x61, 0x72, 0x64, 0x46, 0x72, 0x61, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x13, 0x20, 0x03, 0x28,
+	0x0b, 0x32, 0x1f, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31,
+	0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x44,
+	0x65, 0x63, 0x52, 0x1f, 0x70, 0x72, 0x65, 0x76, 0x69, 0x6f, 0x75, 0x73, 0x49, 0x6e, 0x66, 0x65,
+	0x72, 0x65, 0x6e, 0x63, 0x65, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x46, 0x72, 0x61, 0x63, 0x74,
+	0x69, 0x6f, 0x6e, 0x12, 0x67, 0x0a, 0x1e, 0x70, 0x72, 0x65, 0x76, 0x69, 0x6f, 0x75, 0x73, 0x46,
+	0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x46, 0x72, 0x61,
+	0x63, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x14, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x65, 0x6d,
+	0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x44, 0x65, 0x63, 0x52, 0x1e, 0x70, 0x72,
+	0x65, 0x76, 0x69, 0x6f, 0x75, 0x73, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x52, 0x65,
+	0x77, 0x61, 0x72, 0x64, 0x46, 0x72, 0x61, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x50, 0x0a, 0x0a,
+	0x74, 0x6f, 0x74, 0x61, 0x6c, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x18, 0x15, 0x20, 0x01, 0x28, 0x09,
+	0x42, 0x30, 0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f, 0x15, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73,
+	0x73, 0x64, 0x6b, 0x2e, 0x69, 0x6f, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x49, 0x6e, 0x74, 0xd2,
+	0xb4, 0x2d, 0x0a, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x49, 0x6e, 0x74, 0xa8, 0xe7, 0xb0,
+	0x2a, 0x01, 0x52, 0x0a, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x12, 0x3b,
+	0x0a, 0x0a, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x18, 0x16, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76,
+	0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x49, 0x6e, 0x74, 0x52,
+	0x0a, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x12, 0x55, 0x0a, 0x15, 0x73,
+	0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x41, 0x75, 0x74, 0x68, 0x6f,
+	0x72, 0x69, 0x74, 0x79, 0x18, 0x17, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x65, 0x6d, 0x69,
+	0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x49, 0x6e, 0x74, 0x52, 0x15, 0x73, 0x74, 0x61,
+	0x6b, 0x65, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x41, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69,
+	0x74, 0x79, 0x12, 0x55, 0x0a, 0x15, 0x73, 0x74, 0x61, 0x6b, 0x65, 0x53, 0x75, 0x6d, 0x46, 0x72,
+	0x6f, 0x6d, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x18, 0x18, 0x20, 0x03, 0x28,
+	0x0b, 0x32, 0x1f, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31,
+	0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x49,
+	0x6e, 0x74, 0x52, 0x15, 0x73, 0x74, 0x61, 0x6b, 0x65, 0x53, 0x75, 0x6d, 0x46, 0x72, 0x6f, 0x6d,
+	0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x12, 0x5c, 0x0a, 0x0f, 0x64, 0x65, 0x6c,
+	0x65, 0x67, 0x61, 0x74, 0x65, 0x64, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x73, 0x18, 0x19, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x32, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76,
+	0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74,
+	0x6f, 0x72, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74,
+	0x6f, 0x72, 0x49, 0x6e, 0x66, 0x6f, 0x52, 0x0f, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65,
+	0x64, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x73, 0x12, 0x67, 0x0a, 0x1e, 0x73, 0x74, 0x61, 0x6b, 0x65,
+	0x46, 0x72, 0x6f, 0x6d, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x73, 0x55, 0x70,
+	0x6f, 0x6e, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x18, 0x1a, 0x20, 0x03, 0x28, 0x0b, 0x32,
+	0x1f, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54,
+	0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x49, 0x6e, 0x74,
+	0x52, 0x1e, 0x73, 0x74, 0x61, 0x6b, 0x65, 0x46, 0x72, 0x6f, 0x6d, 0x44, 0x65, 0x6c, 0x65, 0x67,
+	0x61, 0x74, 0x6f, 0x72, 0x73, 0x55, 0x70, 0x6f, 0x6e, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72,
+	0x12, 0x57, 0x0a, 0x16, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x77, 0x61,
+	0x72, 0x64, 0x50, 0x65, 0x72, 0x53, 0x68, 0x61, 0x72, 0x65, 0x18, 0x1b, 0x20, 0x03, 0x28, 0x0b,
+	0x32, 0x1f, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e,
+	0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x44, 0x65,
+	0x63, 0x52, 0x16, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x77, 0x61, 0x72,
+	0x64, 0x50, 0x65, 0x72, 0x53, 0x68, 0x61, 0x72, 0x65, 0x12, 0x6b, 0x0a, 0x14, 0x73, 0x74, 0x61,
+	0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x73, 0x42, 0x79, 0x42, 0x6c, 0x6f, 0x63,
+	0x6b, 0x18, 0x1c, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x37, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69,
+	0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67,
+	0x68, 0x74, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72,
+	0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x49, 0x6e, 0x66, 0x6f,
+	0x52, 0x14, 0x73, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x73, 0x42,
+	0x79, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x12, 0x5b, 0x0a, 0x14, 0x73, 0x74, 0x61, 0x6b, 0x65, 0x52,
+	0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x73, 0x42, 0x79, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x18, 0x1d,
+	0x20, 0x03, 0x28, 0x0b, 0x32, 0x27, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73,
+	0x2e, 0x76, 0x31, 0x2e, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x52, 0x14, 0x73,
+	0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x73, 0x42, 0x79, 0x41, 0x63,
+	0x74, 0x6f, 0x72, 0x12, 0x8c, 0x01, 0x0a, 0x1c, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65,
+	0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x73, 0x42, 0x79, 0x42,
+	0x6c, 0x6f, 0x63, 0x6b, 0x18, 0x1e, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x48, 0x2e, 0x65, 0x6d, 0x69,
+	0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48,
+	0x65, 0x69, 0x67, 0x68, 0x74, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x44, 0x65, 0x6c, 0x65,
+	0x67, 0x61, 0x74, 0x6f, 0x72, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x44, 0x65, 0x6c, 0x65,
+	0x67, 0x61, 0x74, 0x65, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c,
+	0x49, 0x6e, 0x66, 0x6f, 0x52, 0x1c, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x53, 0x74,
+	0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x73, 0x42, 0x79, 0x42, 0x6c, 0x6f,
+	0x63, 0x6b, 0x12, 0x74, 0x0a, 0x1c, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x53, 0x74,
+	0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x73, 0x42, 0x79, 0x41, 0x63, 0x74,
+	0x6f, 0x72, 0x18, 0x1f, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x30, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f,
+	0x72, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x42,
+	0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x52, 0x1c, 0x64, 0x65, 0x6c, 0x65,
+	0x67, 0x61, 0x74, 0x65, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c,
+	0x73, 0x42, 0x79, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x12, 0x45, 0x0a, 0x0a, 0x69, 0x6e, 0x66, 0x65,
+	0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x18, 0x20, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x65,
+	0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69,
+	0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65,
+	0x6e, 0x63, 0x65, 0x52, 0x0a, 0x69, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x12,
+	0x42, 0x0a, 0x09, 0x66, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x73, 0x18, 0x21, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x24, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76,
+	0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64,
+	0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x52, 0x09, 0x66, 0x6f, 0x72, 0x65, 0x63, 0x61,
+	0x73, 0x74, 0x73, 0x12, 0x40, 0x0a, 0x07, 0x77, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x73, 0x18, 0x22,
+	0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73,
+	0x2e, 0x76, 0x31, 0x2e, 0x4c, 0x69, 0x62, 0x50, 0x32, 0x70, 0x4b, 0x65, 0x79, 0x41, 0x6e, 0x64,
+	0x4f, 0x66, 0x66, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x4e, 0x6f, 0x64, 0x65, 0x52, 0x07, 0x77, 0x6f,
+	0x72, 0x6b, 0x65, 0x72, 0x73, 0x12, 0x42, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72,
+	0x73, 0x18, 0x23, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69,
+	0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x4c, 0x69, 0x62, 0x50, 0x32, 0x70, 0x4b, 0x65, 0x79,
+	0x41, 0x6e, 0x64, 0x4f, 0x66, 0x66, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x4e, 0x6f, 0x64, 0x65, 0x52,
+	0x08, 0x72, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x73, 0x12, 0x45, 0x0a, 0x0f, 0x74, 0x6f, 0x70,
+	0x69, 0x63, 0x46, 0x65, 0x65, 0x52, 0x65, 0x76, 0x65, 0x6e, 0x75, 0x65, 0x18, 0x24, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76,
+	0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x49, 0x6e, 0x74, 0x52,
+	0x0f, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x46, 0x65, 0x65, 0x52, 0x65, 0x76, 0x65, 0x6e, 0x75, 0x65,
+	0x12, 0x4d, 0x0a, 0x13, 0x70, 0x72, 0x65, 0x76, 0x69, 0x6f, 0x75, 0x73, 0x54, 0x6f, 0x70, 0x69,
+	0x63, 0x57, 0x65, 0x69, 0x67, 0x68, 0x74, 0x18, 0x25, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1b, 0x2e,
+	0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x44, 0x65, 0x63, 0x52, 0x13, 0x70, 0x72, 0x65, 0x76,
+	0x69, 0x6f, 0x75, 0x73, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x57, 0x65, 0x69, 0x67, 0x68, 0x74, 0x12,
+	0x50, 0x0a, 0x0d, 0x61, 0x6c, 0x6c, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73,
+	0x18, 0x26, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f,
+	0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x42, 0x6c, 0x6f,
+	0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63,
+	0x65, 0x73, 0x52, 0x0d, 0x61, 0x6c, 0x6c, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65,
+	0x73, 0x12, 0x4d, 0x0a, 0x0c, 0x61, 0x6c, 0x6c, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74,
+	0x73, 0x18, 0x27, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69,
+	0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x42, 0x6c,
+	0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73,
+	0x74, 0x73, 0x52, 0x0c, 0x61, 0x6c, 0x6c, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x73,
+	0x12, 0x5b, 0x0a, 0x0e, 0x61, 0x6c, 0x6c, 0x4c, 0x6f, 0x73, 0x73, 0x42, 0x75, 0x6e, 0x64, 0x6c,
+	0x65, 0x73, 0x18, 0x28, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x33, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x42,
+	0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65,
+	0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65, 0x73, 0x52, 0x0e, 0x61,
+	0x6c, 0x6c, 0x4c, 0x6f, 0x73, 0x73, 0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65, 0x73, 0x12, 0x5c, 0x0a,
+	0x12, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x4c, 0x6f, 0x73, 0x73, 0x42, 0x75, 0x6e, 0x64,
+	0x6c, 0x65, 0x73, 0x18, 0x29, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2c, 0x2e, 0x65, 0x6d, 0x69, 0x73,
+	0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65,
+	0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65, 0x73, 0x52, 0x12, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b,
+	0x4c, 0x6f, 0x73, 0x73, 0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65, 0x73, 0x12, 0x93, 0x01, 0x0a, 0x28,
+	0x70, 0x72, 0x65, 0x76, 0x69, 0x6f, 0x75, 0x73, 0x50, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x61,
+	0x67, 0x65, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x54, 0x6f, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x64,
+	0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x73, 0x18, 0x2a, 0x20, 0x01, 0x28, 0x09, 0x42, 0x37,
+	0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f, 0x2f, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63,
+	0x6f, 0x6d, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72,
+	0x6b, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x2f, 0x6d,
+	0x61, 0x74, 0x68, 0x2e, 0x44, 0x65, 0x63, 0x52, 0x28, 0x70, 0x72, 0x65, 0x76, 0x69, 0x6f, 0x75,
+	0x73, 0x50, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x52, 0x65, 0x77, 0x61, 0x72,
+	0x64, 0x54, 0x6f, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x64, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72,
+	0x73, 0x12, 0x58, 0x0a, 0x17, 0x75, 0x6e, 0x66, 0x75, 0x6c, 0x66, 0x69, 0x6c, 0x6c, 0x65, 0x64,
+	0x57, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x73, 0x18, 0x2b, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76,
+	0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x4e, 0x6f, 0x6e, 0x63,
+	0x65, 0x73, 0x52, 0x17, 0x75, 0x6e, 0x66, 0x75, 0x6c, 0x66, 0x69, 0x6c, 0x6c, 0x65, 0x64, 0x57,
+	0x6f, 0x72, 0x6b, 0x65, 0x72, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x73, 0x12, 0x68, 0x0a, 0x18, 0x75,
+	0x6e, 0x66, 0x75, 0x6c, 0x66, 0x69, 0x6c, 0x6c, 0x65, 0x64, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65,
+	0x72, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x73, 0x18, 0x2c, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2c, 0x2e,
+	0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x52, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x18, 0x75, 0x6e, 0x66,
+	0x75, 0x6c, 0x66, 0x69, 0x6c, 0x6c, 0x65, 0x64, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x4e,
+	0x6f, 0x6e, 0x63, 0x65, 0x73, 0x12, 0x6e, 0x0a, 0x1b, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x74, 0x49,
+	0x6e, 0x66, 0x65, 0x72, 0x65, 0x72, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x52, 0x65, 0x67,
+	0x72, 0x65, 0x74, 0x73, 0x18, 0x2d, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2c, 0x2e, 0x65, 0x6d, 0x69,
+	0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x53, 0x74, 0x61, 0x6d,
+	0x70, 0x65, 0x64, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x1b, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x74,
+	0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x72, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x52, 0x65,
+	0x67, 0x72, 0x65, 0x74, 0x73, 0x12, 0x74, 0x0a, 0x1e, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x74, 0x46,
+	0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x65, 0x72, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b,
+	0x52, 0x65, 0x67, 0x72, 0x65, 0x74, 0x73, 0x18, 0x2e, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2c, 0x2e,
+	0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x53,
+	0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x1e, 0x6c, 0x61, 0x74,
+	0x65, 0x73, 0x74, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x65, 0x72, 0x4e, 0x65, 0x74,
+	0x77, 0x6f, 0x72, 0x6b, 0x52, 0x65, 0x67, 0x72, 0x65, 0x74, 0x73, 0x12, 0x85, 0x01, 0x0a, 0x23,
+	0x6c, 0x61, 0x74, 0x65, 0x73, 0x74, 0x4f, 0x6e, 0x65, 0x49, 0x6e, 0x46, 0x6f, 0x72, 0x65, 0x63,
+	0x61, 0x73, 0x74, 0x65, 0x72, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x52, 0x65, 0x67, 0x72,
+	0x65, 0x74, 0x73, 0x18, 0x2f, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x33, 0x2e, 0x65, 0x6d, 0x69, 0x73,
+	0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x54, 0x69,
+	0x6d, 0x65, 0x53, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x23,
+	0x6c, 0x61, 0x74, 0x65, 0x73, 0x74, 0x4f, 0x6e, 0x65, 0x49, 0x6e, 0x46, 0x6f, 0x72, 0x65, 0x63,
+	0x61, 0x73, 0x74, 0x65, 0x72, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x52, 0x65, 0x67, 0x72,
+	0x65, 0x74, 0x73, 0x12, 0x86, 0x01, 0x0a, 0x27, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x74, 0x4f, 0x6e,
+	0x65, 0x49, 0x6e, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x65, 0x72, 0x53, 0x65, 0x6c,
+	0x66, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x52, 0x65, 0x67, 0x72, 0x65, 0x74, 0x73, 0x18,
+	0x30, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2c, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e,
+	0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f,
+	0x72, 0x49, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x53, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56, 0x61,
+	0x6c, 0x75, 0x65, 0x52, 0x27, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x74, 0x4f, 0x6e, 0x65, 0x49, 0x6e,
+	0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x65, 0x72, 0x53, 0x65, 0x6c, 0x66, 0x4e, 0x65,
+	0x74, 0x77, 0x6f, 0x72, 0x6b, 0x52, 0x65, 0x67, 0x72, 0x65, 0x74, 0x73, 0x12, 0x2e, 0x0a, 0x13,
+	0x63, 0x6f, 0x72, 0x65, 0x5f, 0x74, 0x65, 0x61, 0x6d, 0x5f, 0x61, 0x64, 0x64, 0x72, 0x65, 0x73,
+	0x73, 0x65, 0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x09, 0x52, 0x11, 0x63, 0x6f, 0x72, 0x65, 0x54,
+	0x65, 0x61, 0x6d, 0x41, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x65, 0x73, 0x12, 0x60, 0x0a, 0x15,
+	0x74, 0x6f, 0x70, 0x69, 0x63, 0x4c, 0x61, 0x73, 0x74, 0x57, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x43,
+	0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x18, 0x31, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x65, 0x6d,
+	0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x41, 0x63, 0x74,
+	0x6f, 0x72, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x52, 0x15, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x4c, 0x61,
+	0x73, 0x74, 0x57, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x43, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x12, 0x62,
+	0x0a, 0x16, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x65, 0x70, 0x75, 0x74,
+	0x65, 0x72, 0x43, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x18, 0x32, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2a,
+	0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f,
+	0x70, 0x69, 0x63, 0x49, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64,
+	0x41, 0x63, 0x74, 0x6f, 0x72, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x52, 0x16, 0x74, 0x6f, 0x70, 0x69,
+	0x63, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x43, 0x6f, 0x6d, 0x6d,
+	0x69, 0x74, 0x12, 0x62, 0x0a, 0x16, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x4c, 0x61, 0x73, 0x74, 0x57,
+	0x6f, 0x72, 0x6b, 0x65, 0x72, 0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x18, 0x33, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76,
+	0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61,
+	0x6d, 0x70, 0x65, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x52, 0x16,
+	0x74, 0x6f, 0x70, 0x69, 0x63, 0x4c, 0x61, 0x73, 0x74, 0x57, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x50,
+	0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x12, 0x64, 0x0a, 0x17, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x4c,
+	0x61, 0x73, 0x74, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61,
+	0x64, 0x18, 0x34, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69,
+	0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x54, 0x69,
+	0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x4e, 0x6f,
+	0x6e, 0x63, 0x65, 0x52, 0x17, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x65,
+	0x70, 0x75, 0x74, 0x65, 0x72, 0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x22, 0x56, 0x0a, 0x0f,
+	0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x12,
+	0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04,
+	0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x29, 0x0a, 0x05, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x52, 0x05, 0x54,
+	0x6f, 0x70, 0x69, 0x63, 0x22, 0x45, 0x0a, 0x0f, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x41, 0x6e, 0x64,
+	0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x12, 0x18, 0x0a, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x22, 0x53, 0x0a, 0x15, 0x54,
+	0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65,
+	0x69, 0x67, 0x68, 0x74, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x20,
+	0x0a, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x03, 0x52, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74,
+	0x22, 0x84, 0x01, 0x0a, 0x18, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x42, 0x6c, 0x6f, 0x63,
+	0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x12, 0x18, 0x0a,
+	0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07,
+	0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x20, 0x0a, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b,
+	0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0b, 0x42, 0x6c,
+	0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x12, 0x2c, 0x0a, 0x06, 0x53, 0x63, 0x6f,
+	0x72, 0x65, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x65, 0x6d, 0x69, 0x73,
+	0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x52,
+	0x06, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x73, 0x22, 0x74, 0x0a, 0x13, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x12, 0x18,
+	0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52,
+	0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x41, 0x63, 0x74, 0x6f,
+	0x72, 0x49, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72,
+	0x49, 0x64, 0x12, 0x29, 0x0a, 0x05, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x13, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31,
+	0x2e, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x52, 0x05, 0x53, 0x63, 0x6f, 0x72, 0x65, 0x22, 0xb0, 0x01,
+	0x0a, 0x22, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64,
+	0x4c, 0x69, 0x73, 0x74, 0x65, 0x6e, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x65, 0x66, 0x66, 0x69, 0x63,
+	0x69, 0x65, 0x6e, 0x74, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x18,
+	0x0a, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x12, 0x56, 0x0a, 0x14, 0x4c, 0x69, 0x73, 0x74,
+	0x65, 0x6e, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x65, 0x66, 0x66, 0x69, 0x63, 0x69, 0x65, 0x6e, 0x74,
+	0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x22, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f,
+	0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x65, 0x6e, 0x69, 0x6e, 0x67, 0x43,
+	0x6f, 0x65, 0x66, 0x66, 0x69, 0x63, 0x69, 0x65, 0x6e, 0x74, 0x52, 0x14, 0x4c, 0x69, 0x73, 0x74,
+	0x65, 0x6e, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x65, 0x66, 0x66, 0x69, 0x63, 0x69, 0x65, 0x6e, 0x74,
+	0x22, 0x92, 0x01, 0x0a, 0x11, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f,
+	0x72, 0x49, 0x64, 0x44, 0x65, 0x63, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x12, 0x18, 0x0a, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x12, 0x49, 0x0a, 0x03, 0x44, 0x65,
+	0x63, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x42, 0x37, 0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f,
+	0x2f, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x6c, 0x6c, 0x6f,
+	0x72, 0x61, 0x2d, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72,
+	0x61, 0x2d, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x44, 0x65, 0x63,
+	0x52, 0x03, 0x44, 0x65, 0x63, 0x22, 0x6d, 0x0a, 0x0d, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x41, 0x6e, 0x64, 0x49, 0x6e, 0x74, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x12, 0x42, 0x0a, 0x03, 0x49, 0x6e, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x42, 0x30, 0xc8,
+	0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f, 0x15, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x73, 0x64, 0x6b,
+	0x2e, 0x69, 0x6f, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x49, 0x6e, 0x74, 0xd2, 0xb4, 0x2d, 0x0a,
+	0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x49, 0x6e, 0x74, 0xa8, 0xe7, 0xb0, 0x2a, 0x01, 0x52,
+	0x03, 0x49, 0x6e, 0x74, 0x22, 0x8b, 0x01, 0x0a, 0x11, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x49, 0x6e, 0x74, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f,
+	0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x12, 0x42,
+	0x0a, 0x03, 0x49, 0x6e, 0x74, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x42, 0x30, 0xc8, 0xde, 0x1f,
+	0x00, 0xda, 0xde, 0x1f, 0x15, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x73, 0x64, 0x6b, 0x2e, 0x69,
+	0x6f, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x49, 0x6e, 0x74, 0xd2, 0xb4, 0x2d, 0x0a, 0x63, 0x6f,
+	0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x49, 0x6e, 0x74, 0xa8, 0xe7, 0xb0, 0x2a, 0x01, 0x52, 0x03, 0x49,
+	0x6e, 0x74, 0x22, 0xbb, 0x01, 0x0a, 0x24, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x44, 0x65,
+	0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x44, 0x65,
+	0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x18, 0x0a, 0x07, 0x54,
+	0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f,
+	0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x1c, 0x0a, 0x09, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74,
+	0x6f, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61,
+	0x74, 0x6f, 0x72, 0x12, 0x18, 0x0a, 0x07, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x18, 0x03,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x12, 0x41, 0x0a,
+	0x0d, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x49, 0x6e, 0x66, 0x6f, 0x18, 0x04,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73,
+	0x2e, 0x76, 0x31, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x49, 0x6e, 0x66,
+	0x6f, 0x52, 0x0d, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x49, 0x6e, 0x66, 0x6f,
+	0x22, 0xcd, 0x01, 0x0a, 0x29, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74,
+	0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x53, 0x74,
+	0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x20,
+	0x0a, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x03, 0x52, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74,
+	0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28,
+	0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x52, 0x65,
+	0x70, 0x75, 0x74, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x52, 0x65, 0x70,
+	0x75, 0x74, 0x65, 0x72, 0x12, 0x4a, 0x0a, 0x10, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d,
+	0x6f, 0x76, 0x61, 0x6c, 0x49, 0x6e, 0x66, 0x6f, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e,
+	0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x74,
+	0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x49, 0x6e, 0x66, 0x6f, 0x52, 0x10,
+	0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x49, 0x6e, 0x66, 0x6f,
+	0x22, 0x71, 0x0a, 0x19, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x12, 0x18, 0x0a,
+	0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07,
+	0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x12, 0x20, 0x0a, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74,
+	0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69,
+	0x67, 0x68, 0x74, 0x22, 0x94, 0x02, 0x0a, 0x3a, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69,
+	0x67, 0x68, 0x74, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61,
+	0x74, 0x6f, 0x72, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61,
+	0x74, 0x65, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x49, 0x6e,
+	0x66, 0x6f, 0x12, 0x20, 0x0a, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68,
+	0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65,
+	0x69, 0x67, 0x68, 0x74, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x1c,
+	0x0a, 0x09, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x09, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x12, 0x18, 0x0a, 0x07,
+	0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x52,
+	0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x12, 0x62, 0x0a, 0x18, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61,
+	0x74, 0x65, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x49, 0x6e,
+	0x66, 0x6f, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65,
+	0x53, 0x74, 0x61, 0x6b, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x49, 0x6e, 0x66, 0x6f,
+	0x52, 0x18, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x53, 0x74, 0x61, 0x6b, 0x65, 0x52,
+	0x65, 0x6d, 0x6f, 0x76, 0x61, 0x6c, 0x49, 0x6e, 0x66, 0x6f, 0x22, 0x98, 0x01, 0x0a, 0x22, 0x44,
+	0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x54,
+	0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68,
+	0x74, 0x12, 0x1c, 0x0a, 0x09, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x6f, 0x72, 0x12,
+	0x18, 0x0a, 0x07, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x07, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x49, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69,
+	0x63, 0x49, 0x64, 0x12, 0x20, 0x0a, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67,
+	0x68, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48,
+	0x65, 0x69, 0x67, 0x68, 0x74, 0x22, 0x84, 0x01, 0x0a, 0x17, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63,
+	0x65, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x41,
+	0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x41, 0x63,
+	0x74, 0x6f, 0x72, 0x49, 0x64, 0x12, 0x35, 0x0a, 0x09, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e,
+	0x63, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63,
+	0x65, 0x52, 0x09, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x22, 0x80, 0x01, 0x0a,
+	0x16, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x46,
+	0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x12, 0x18, 0x0a, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x12, 0x32, 0x0a, 0x08, 0x46,
+	0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x16, 0x2e,
+	0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x46, 0x6f, 0x72,
+	0x65, 0x63, 0x61, 0x73, 0x74, 0x52, 0x08, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x22,
+	0x78, 0x0a, 0x18, 0x4c, 0x69, 0x62, 0x50, 0x32, 0x70, 0x4b, 0x65, 0x79, 0x41, 0x6e, 0x64, 0x4f,
+	0x66, 0x66, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x4e, 0x6f, 0x64, 0x65, 0x12, 0x1c, 0x0a, 0x09, 0x4c,
+	0x69, 0x62, 0x50, 0x32, 0x70, 0x4b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09,
+	0x4c, 0x69, 0x62, 0x50, 0x32, 0x70, 0x4b, 0x65, 0x79, 0x12, 0x3e, 0x0a, 0x0c, 0x4f, 0x66, 0x66,
+	0x63, 0x68, 0x61, 0x69, 0x6e, 0x4e, 0x6f, 0x64, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x1a, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x4f,
+	0x66, 0x66, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x4e, 0x6f, 0x64, 0x65, 0x52, 0x0c, 0x4f, 0x66, 0x66,
+	0x63, 0x68, 0x61, 0x69, 0x6e, 0x4e, 0x6f, 0x64, 0x65, 0x22, 0x74, 0x0a, 0x0d, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x44, 0x65, 0x63, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f,
+	0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70,
+	0x69, 0x63, 0x49, 0x64, 0x12, 0x49, 0x0a, 0x03, 0x44, 0x65, 0x63, 0x18, 0x02, 0x20, 0x01, 0x28,
+	0x09, 0x42, 0x37, 0xc8, 0xde, 0x1f, 0x00, 0xda, 0xde, 0x1f, 0x2f, 0x67, 0x69, 0x74, 0x68, 0x75,
+	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x6e, 0x65, 0x74,
+	0x77, 0x6f, 0x72, 0x6b, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x63, 0x68, 0x61, 0x69,
+	0x6e, 0x2f, 0x6d, 0x61, 0x74, 0x68, 0x2e, 0x44, 0x65, 0x63, 0x52, 0x03, 0x44, 0x65, 0x63, 0x22,
+	0x94, 0x01, 0x0a, 0x1c, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x42, 0x6c, 0x6f, 0x63, 0x6b,
+	0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73,
+	0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x20, 0x0a, 0x0b, 0x42, 0x6c,
+	0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52,
+	0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x12, 0x38, 0x0a, 0x0a,
+	0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x18, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e,
+	0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x0a, 0x49, 0x6e, 0x66, 0x65,
+	0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x22, 0x90, 0x01, 0x0a, 0x1b, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x46, 0x6f, 0x72,
+	0x65, 0x63, 0x61, 0x73, 0x74, 0x73, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x12, 0x20, 0x0a, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67,
+	0x68, 0x74, 0x12, 0x35, 0x0a, 0x09, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x73, 0x18,
+	0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e,
+	0x73, 0x2e, 0x76, 0x31, 0x2e, 0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x73, 0x52, 0x09,
+	0x46, 0x6f, 0x72, 0x65, 0x63, 0x61, 0x73, 0x74, 0x73, 0x22, 0xb8, 0x01, 0x0a, 0x25, 0x54, 0x6f,
+	0x70, 0x69, 0x63, 0x49, 0x64, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74,
+	0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x75, 0x6e, 0x64,
+	0x6c, 0x65, 0x73, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x20, 0x0a,
+	0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x03, 0x52, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x12,
+	0x53, 0x0a, 0x13, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x42,
+	0x75, 0x6e, 0x64, 0x6c, 0x65, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x65,
+	0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x70, 0x75,
+	0x74, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65, 0x73, 0x52,
+	0x13, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x75, 0x6e,
+	0x64, 0x6c, 0x65, 0x73, 0x22, 0x99, 0x01, 0x0a, 0x1e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65,
+	0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65, 0x73, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63,
+	0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49,
+	0x64, 0x12, 0x20, 0x0a, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69, 0x67, 0x68, 0x74,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0b, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x69,
+	0x67, 0x68, 0x74, 0x12, 0x3b, 0x0a, 0x0b, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x75, 0x6e, 0x64,
+	0x6c, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x19, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x75, 0x6e,
+	0x64, 0x6c, 0x65, 0x52, 0x0b, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65,
+	0x22, 0x5a, 0x0a, 0x10, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x4e, 0x6f,
+	0x6e, 0x63, 0x65, 0x73, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x2c,
+	0x0a, 0x06, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14,
+	0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x4e, 0x6f,
+	0x6e, 0x63, 0x65, 0x73, 0x52, 0x06, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x73, 0x22, 0x92, 0x01, 0x0a,
+	0x1e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x6e, 0x64, 0x52, 0x65, 0x70, 0x75, 0x74,
+	0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x73, 0x12,
+	0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04,
+	0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x56, 0x0a, 0x14, 0x52, 0x65, 0x70,
+	0x75, 0x74, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x4e, 0x6f, 0x6e, 0x63, 0x65,
+	0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x22, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69,
+	0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x70, 0x75, 0x74, 0x65, 0x72, 0x52, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x14, 0x52, 0x65, 0x70,
+	0x75, 0x74, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x4e, 0x6f, 0x6e, 0x63, 0x65,
+	0x73, 0x22, 0xa0, 0x01, 0x0a, 0x1e, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x41, 0x63, 0x74,
+	0x6f, 0x72, 0x49, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x53, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56,
+	0x61, 0x6c, 0x75, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x18,
+	0x0a, 0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x07, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x12, 0x4a, 0x0a, 0x10, 0x54, 0x69, 0x6d, 0x65,
+	0x73, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20, 0x01,
+	0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76,
+	0x31, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56, 0x61, 0x6c,
+	0x75, 0x65, 0x52, 0x10, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56,
+	0x61, 0x6c, 0x75, 0x65, 0x22, 0xc5, 0x01, 0x0a, 0x25, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64,
+	0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x54, 0x69,
+	0x6d, 0x65, 0x53, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x18,
+	0x0a, 0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52,
+	0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x41, 0x63, 0x74, 0x6f,
+	0x72, 0x49, 0x64, 0x31, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x41, 0x63, 0x74, 0x6f,
+	0x72, 0x49, 0x64, 0x31, 0x12, 0x1a, 0x0a, 0x08, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x32,
+	0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x49, 0x64, 0x32,
+	0x12, 0x4a, 0x0a, 0x10, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56,
+	0x61, 0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x65, 0x6d, 0x69,
+	0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74,
+	0x61, 0x6d, 0x70, 0x65, 0x64, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x10, 0x54, 0x69, 0x6d, 0x65,
+	0x73, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22, 0x93, 0x01, 0x0a,
+	0x1c, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d,
+	0x70, 0x65, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x12, 0x18, 0x0a,
+	0x07, 0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07,
+	0x54, 0x6f, 0x70, 0x69, 0x63, 0x49, 0x64, 0x12, 0x59, 0x0a, 0x15, 0x54, 0x69, 0x6d, 0x65, 0x73,
+	0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x4e, 0x6f, 0x6e, 0x63, 0x65,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x23, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f,
+	0x6e, 0x73, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x65,
+	0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x52, 0x15, 0x54, 0x69, 0x6d,
+	0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x65, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x4e, 0x6f, 0x6e,
+	0x63, 0x65, 0x42, 0xc2, 0x01, 0x0a, 0x10, 0x63, 0x6f, 0x6d, 0x2e, 0x65, 0x6d, 0x69, 0x73, 0x73,
 	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31, 0x42, 0x0c, 0x47, 0x65, 0x6e, 0x65, 0x73, 0x69, 0x73,
 	0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x4f, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e,
 	0x63, 0x6f, 0x6d, 0x2f, 0x61, 0x6c, 0x6c, 0x6f, 0x72, 0x61, 0x2d, 0x6e, 0x65, 0x74, 0x77, 0x6f,
@@ -675,18 +24206,126 @@ func file_emissions_v1_genesis_proto_rawDescGZIP() []byte {
 	return file_emissions_v1_genesis_proto_rawDescData
 }
 
-var file_emissions_v1_genesis_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_emissions_v1_genesis_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_emissions_v1_genesis_proto_goTypes = []interface{}{
-	(*GenesisState)(nil), // 0: emissions.v1.GenesisState
-	(*Params)(nil),       // 1: emissions.v1.Params
+	(*GenesisState)(nil),                                               // 0: emissions.v1.GenesisState
+	(*TopicIdAndTopic)(nil),                                            // 1: emissions.v1.TopicIdAndTopic
+	(*TopicAndActorId)(nil),                                            // 2: emissions.v1.TopicAndActorId
+	(*TopicIdAndBlockHeight)(nil),                                      // 3: emissions.v1.TopicIdAndBlockHeight
+	(*TopicIdBlockHeightScores)(nil),                                   // 4: emissions.v1.TopicIdBlockHeightScores
+	(*TopicIdActorIdScore)(nil),                                        // 5: emissions.v1.TopicIdActorIdScore
+	(*TopicIdActorIdListeningCoefficient)(nil),                         // 6: emissions.v1.TopicIdActorIdListeningCoefficient
+	(*TopicIdActorIdDec)(nil),                                          // 7: emissions.v1.TopicIdActorIdDec
+	(*TopicIdAndInt)(nil),                                              // 8: emissions.v1.TopicIdAndInt
+	(*TopicIdActorIdInt)(nil),                                          // 9: emissions.v1.TopicIdActorIdInt
+	(*TopicIdDelegatorReputerDelegatorInfo)(nil),                       // 10: emissions.v1.TopicIdDelegatorReputerDelegatorInfo
+	(*BlockHeightTopicIdReputerStakeRemovalInfo)(nil),                  // 11: emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo
+	(*ActorIdTopicIdBlockHeight)(nil),                                  // 12: emissions.v1.ActorIdTopicIdBlockHeight
+	(*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)(nil), // 13: emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo
+	(*DelegatorReputerTopicIdBlockHeight)(nil),                         // 14: emissions.v1.DelegatorReputerTopicIdBlockHeight
+	(*TopicIdActorIdInference)(nil),                                    // 15: emissions.v1.TopicIdActorIdInference
+	(*TopicIdActorIdForecast)(nil),                                     // 16: emissions.v1.TopicIdActorIdForecast
+	(*LibP2PKeyAndOffchainNode)(nil),                                   // 17: emissions.v1.LibP2pKeyAndOffchainNode
+	(*TopicIdAndDec)(nil),                                              // 18: emissions.v1.TopicIdAndDec
+	(*TopicIdBlockHeightInferences)(nil),                               // 19: emissions.v1.TopicIdBlockHeightInferences
+	(*TopicIdBlockHeightForecasts)(nil),                                // 20: emissions.v1.TopicIdBlockHeightForecasts
+	(*TopicIdBlockHeightReputerValueBundles)(nil),                      // 21: emissions.v1.TopicIdBlockHeightReputerValueBundles
+	(*TopicIdBlockHeightValueBundles)(nil),                             // 22: emissions.v1.TopicIdBlockHeightValueBundles
+	(*TopicIdAndNonces)(nil),                                           // 23: emissions.v1.TopicIdAndNonces
+	(*TopicIdAndReputerRequestNonces)(nil),                             // 24: emissions.v1.TopicIdAndReputerRequestNonces
+	(*TopicIdActorIdTimeStampedValue)(nil),                             // 25: emissions.v1.TopicIdActorIdTimeStampedValue
+	(*TopicIdActorIdActorIdTimeStampedValue)(nil),                      // 26: emissions.v1.TopicIdActorIdActorIdTimeStampedValue
+	(*TopicIdTimestampedActorNonce)(nil),                               // 27: emissions.v1.TopicIdTimestampedActorNonce
+	(*Params)(nil),                                                     // 28: emissions.v1.Params
+	(*Topic)(nil),                                                      // 29: emissions.v1.Topic
+	(*Scores)(nil),                                                     // 30: emissions.v1.Scores
+	(*Score)(nil),                                                      // 31: emissions.v1.Score
+	(*ListeningCoefficient)(nil),                                       // 32: emissions.v1.ListeningCoefficient
+	(*DelegatorInfo)(nil),                                              // 33: emissions.v1.DelegatorInfo
+	(*StakeRemovalInfo)(nil),                                           // 34: emissions.v1.StakeRemovalInfo
+	(*DelegateStakeRemovalInfo)(nil),                                   // 35: emissions.v1.DelegateStakeRemovalInfo
+	(*Inference)(nil),                                                  // 36: emissions.v1.Inference
+	(*Forecast)(nil),                                                   // 37: emissions.v1.Forecast
+	(*OffchainNode)(nil),                                               // 38: emissions.v1.OffchainNode
+	(*Inferences)(nil),                                                 // 39: emissions.v1.Inferences
+	(*Forecasts)(nil),                                                  // 40: emissions.v1.Forecasts
+	(*ReputerValueBundles)(nil),                                        // 41: emissions.v1.ReputerValueBundles
+	(*ValueBundle)(nil),                                                // 42: emissions.v1.ValueBundle
+	(*Nonces)(nil),                                                     // 43: emissions.v1.Nonces
+	(*ReputerRequestNonces)(nil),                                       // 44: emissions.v1.ReputerRequestNonces
+	(*TimestampedValue)(nil),                                           // 45: emissions.v1.TimestampedValue
+	(*TimestampedActorNonce)(nil),                                      // 46: emissions.v1.TimestampedActorNonce
 }
 var file_emissions_v1_genesis_proto_depIdxs = []int32{
-	1, // 0: emissions.v1.GenesisState.params:type_name -> emissions.v1.Params
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	28, // 0: emissions.v1.GenesisState.params:type_name -> emissions.v1.Params
+	1,  // 1: emissions.v1.GenesisState.topics:type_name -> emissions.v1.TopicIdAndTopic
+	2,  // 2: emissions.v1.GenesisState.topicWorkers:type_name -> emissions.v1.TopicAndActorId
+	2,  // 3: emissions.v1.GenesisState.topicReputers:type_name -> emissions.v1.TopicAndActorId
+	3,  // 4: emissions.v1.GenesisState.topicRewardNonce:type_name -> emissions.v1.TopicIdAndBlockHeight
+	4,  // 5: emissions.v1.GenesisState.infererScoresByBlock:type_name -> emissions.v1.TopicIdBlockHeightScores
+	4,  // 6: emissions.v1.GenesisState.forecasterScoresByBlock:type_name -> emissions.v1.TopicIdBlockHeightScores
+	4,  // 7: emissions.v1.GenesisState.reputerScoresByBlock:type_name -> emissions.v1.TopicIdBlockHeightScores
+	5,  // 8: emissions.v1.GenesisState.latestInfererScoresByWorker:type_name -> emissions.v1.TopicIdActorIdScore
+	5,  // 9: emissions.v1.GenesisState.latestForecasterScoresByWorker:type_name -> emissions.v1.TopicIdActorIdScore
+	5,  // 10: emissions.v1.GenesisState.latestReputerScoresByReputer:type_name -> emissions.v1.TopicIdActorIdScore
+	6,  // 11: emissions.v1.GenesisState.reputerListeningCoefficient:type_name -> emissions.v1.TopicIdActorIdListeningCoefficient
+	7,  // 12: emissions.v1.GenesisState.previousReputerRewardFraction:type_name -> emissions.v1.TopicIdActorIdDec
+	7,  // 13: emissions.v1.GenesisState.previousInferenceRewardFraction:type_name -> emissions.v1.TopicIdActorIdDec
+	7,  // 14: emissions.v1.GenesisState.previousForecastRewardFraction:type_name -> emissions.v1.TopicIdActorIdDec
+	8,  // 15: emissions.v1.GenesisState.topicStake:type_name -> emissions.v1.TopicIdAndInt
+	9,  // 16: emissions.v1.GenesisState.stakeReputerAuthority:type_name -> emissions.v1.TopicIdActorIdInt
+	9,  // 17: emissions.v1.GenesisState.stakeSumFromDelegator:type_name -> emissions.v1.TopicIdActorIdInt
+	10, // 18: emissions.v1.GenesisState.delegatedStakes:type_name -> emissions.v1.TopicIdDelegatorReputerDelegatorInfo
+	9,  // 19: emissions.v1.GenesisState.stakeFromDelegatorsUponReputer:type_name -> emissions.v1.TopicIdActorIdInt
+	7,  // 20: emissions.v1.GenesisState.delegateRewardPerShare:type_name -> emissions.v1.TopicIdActorIdDec
+	11, // 21: emissions.v1.GenesisState.stakeRemovalsByBlock:type_name -> emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo
+	12, // 22: emissions.v1.GenesisState.stakeRemovalsByActor:type_name -> emissions.v1.ActorIdTopicIdBlockHeight
+	13, // 23: emissions.v1.GenesisState.delegateStakeRemovalsByBlock:type_name -> emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo
+	14, // 24: emissions.v1.GenesisState.delegateStakeRemovalsByActor:type_name -> emissions.v1.DelegatorReputerTopicIdBlockHeight
+	15, // 25: emissions.v1.GenesisState.inferences:type_name -> emissions.v1.TopicIdActorIdInference
+	16, // 26: emissions.v1.GenesisState.forecasts:type_name -> emissions.v1.TopicIdActorIdForecast
+	17, // 27: emissions.v1.GenesisState.workers:type_name -> emissions.v1.LibP2pKeyAndOffchainNode
+	17, // 28: emissions.v1.GenesisState.reputers:type_name -> emissions.v1.LibP2pKeyAndOffchainNode
+	8,  // 29: emissions.v1.GenesisState.topicFeeRevenue:type_name -> emissions.v1.TopicIdAndInt
+	18, // 30: emissions.v1.GenesisState.previousTopicWeight:type_name -> emissions.v1.TopicIdAndDec
+	19, // 31: emissions.v1.GenesisState.allInferences:type_name -> emissions.v1.TopicIdBlockHeightInferences
+	20, // 32: emissions.v1.GenesisState.allForecasts:type_name -> emissions.v1.TopicIdBlockHeightForecasts
+	21, // 33: emissions.v1.GenesisState.allLossBundles:type_name -> emissions.v1.TopicIdBlockHeightReputerValueBundles
+	22, // 34: emissions.v1.GenesisState.networkLossBundles:type_name -> emissions.v1.TopicIdBlockHeightValueBundles
+	23, // 35: emissions.v1.GenesisState.unfulfilledWorkerNonces:type_name -> emissions.v1.TopicIdAndNonces
+	24, // 36: emissions.v1.GenesisState.unfulfilledReputerNonces:type_name -> emissions.v1.TopicIdAndReputerRequestNonces
+	25, // 37: emissions.v1.GenesisState.latestInfererNetworkRegrets:type_name -> emissions.v1.TopicIdActorIdTimeStampedValue
+	25, // 38: emissions.v1.GenesisState.latestForecasterNetworkRegrets:type_name -> emissions.v1.TopicIdActorIdTimeStampedValue
+	26, // 39: emissions.v1.GenesisState.latestOneInForecasterNetworkRegrets:type_name -> emissions.v1.TopicIdActorIdActorIdTimeStampedValue
+	25, // 40: emissions.v1.GenesisState.latestOneInForecasterSelfNetworkRegrets:type_name -> emissions.v1.TopicIdActorIdTimeStampedValue
+	27, // 41: emissions.v1.GenesisState.topicLastWorkerCommit:type_name -> emissions.v1.TopicIdTimestampedActorNonce
+	27, // 42: emissions.v1.GenesisState.topicLastReputerCommit:type_name -> emissions.v1.TopicIdTimestampedActorNonce
+	27, // 43: emissions.v1.GenesisState.topicLastWorkerPayload:type_name -> emissions.v1.TopicIdTimestampedActorNonce
+	27, // 44: emissions.v1.GenesisState.topicLastReputerPayload:type_name -> emissions.v1.TopicIdTimestampedActorNonce
+	29, // 45: emissions.v1.TopicIdAndTopic.Topic:type_name -> emissions.v1.Topic
+	30, // 46: emissions.v1.TopicIdBlockHeightScores.Scores:type_name -> emissions.v1.Scores
+	31, // 47: emissions.v1.TopicIdActorIdScore.Score:type_name -> emissions.v1.Score
+	32, // 48: emissions.v1.TopicIdActorIdListeningCoefficient.ListeningCoefficient:type_name -> emissions.v1.ListeningCoefficient
+	33, // 49: emissions.v1.TopicIdDelegatorReputerDelegatorInfo.DelegatorInfo:type_name -> emissions.v1.DelegatorInfo
+	34, // 50: emissions.v1.BlockHeightTopicIdReputerStakeRemovalInfo.StakeRemovalInfo:type_name -> emissions.v1.StakeRemovalInfo
+	35, // 51: emissions.v1.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.DelegateStakeRemovalInfo:type_name -> emissions.v1.DelegateStakeRemovalInfo
+	36, // 52: emissions.v1.TopicIdActorIdInference.Inference:type_name -> emissions.v1.Inference
+	37, // 53: emissions.v1.TopicIdActorIdForecast.Forecast:type_name -> emissions.v1.Forecast
+	38, // 54: emissions.v1.LibP2pKeyAndOffchainNode.OffchainNode:type_name -> emissions.v1.OffchainNode
+	39, // 55: emissions.v1.TopicIdBlockHeightInferences.Inferences:type_name -> emissions.v1.Inferences
+	40, // 56: emissions.v1.TopicIdBlockHeightForecasts.Forecasts:type_name -> emissions.v1.Forecasts
+	41, // 57: emissions.v1.TopicIdBlockHeightReputerValueBundles.ReputerValueBundles:type_name -> emissions.v1.ReputerValueBundles
+	42, // 58: emissions.v1.TopicIdBlockHeightValueBundles.ValueBundle:type_name -> emissions.v1.ValueBundle
+	43, // 59: emissions.v1.TopicIdAndNonces.Nonces:type_name -> emissions.v1.Nonces
+	44, // 60: emissions.v1.TopicIdAndReputerRequestNonces.ReputerRequestNonces:type_name -> emissions.v1.ReputerRequestNonces
+	45, // 61: emissions.v1.TopicIdActorIdTimeStampedValue.TimestampedValue:type_name -> emissions.v1.TimestampedValue
+	45, // 62: emissions.v1.TopicIdActorIdActorIdTimeStampedValue.TimestampedValue:type_name -> emissions.v1.TimestampedValue
+	46, // 63: emissions.v1.TopicIdTimestampedActorNonce.TimestampedActorNonce:type_name -> emissions.v1.TimestampedActorNonce
+	64, // [64:64] is the sub-list for method output_type
+	64, // [64:64] is the sub-list for method input_type
+	64, // [64:64] is the sub-list for extension type_name
+	64, // [64:64] is the sub-list for extension extendee
+	0,  // [0:64] is the sub-list for field type_name
 }
 
 func init() { file_emissions_v1_genesis_proto_init() }
@@ -695,9 +24334,341 @@ func file_emissions_v1_genesis_proto_init() {
 		return
 	}
 	file_emissions_v1_params_proto_init()
+	file_emissions_v1_score_proto_init()
+	file_emissions_v1_stake_proto_init()
+	file_emissions_v1_types_proto_init()
+	file_emissions_v1_topic_proto_init()
+	file_emissions_v1_worker_proto_init()
+	file_emissions_v1_node_proto_init()
+	file_emissions_v1_reputer_proto_init()
+	file_emissions_v1_nonce_proto_init()
 	if !protoimpl.UnsafeEnabled {
 		file_emissions_v1_genesis_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*GenesisState); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdAndTopic); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicAndActorId); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdAndBlockHeight); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdBlockHeightScores); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdActorIdScore); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdActorIdListeningCoefficient); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdActorIdDec); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdAndInt); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdActorIdInt); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdDelegatorReputerDelegatorInfo); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*BlockHeightTopicIdReputerStakeRemovalInfo); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ActorIdTopicIdBlockHeight); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*DelegatorReputerTopicIdBlockHeight); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdActorIdInference); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdActorIdForecast); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*LibP2PKeyAndOffchainNode); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdAndDec); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdBlockHeightInferences); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdBlockHeightForecasts); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdBlockHeightReputerValueBundles); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdBlockHeightValueBundles); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdAndNonces); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdAndReputerRequestNonces); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdActorIdTimeStampedValue); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdActorIdActorIdTimeStampedValue); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_emissions_v1_genesis_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TopicIdTimestampedActorNonce); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -715,7 +24686,7 @@ func file_emissions_v1_genesis_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_emissions_v1_genesis_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/x/emissions/keeper/genesis.go
+++ b/x/emissions/keeper/genesis.go
@@ -49,8 +49,950 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 		return nil, err
 	}
 
+	nextTopicId, err := k.nextTopicId.Peek(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	topicsIter, err := k.topics.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	topics := make([]*types.TopicIdAndTopic, 0)
+	for ; topicsIter.Valid(); topicsIter.Next() {
+		keyValue, err := topicsIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topic := types.TopicIdAndTopic{
+			TopicId: keyValue.Key,
+			Topic:   &value,
+		}
+		topics = append(topics, &topic)
+	}
+
+	activeTopics := make([]uint64, 0)
+	activeTopicsIter, err := k.activeTopics.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; activeTopicsIter.Valid(); activeTopicsIter.Next() {
+		key, err := activeTopicsIter.Key()
+		if err != nil {
+			return nil, err
+		}
+		activeTopics = append(activeTopics, key)
+	}
+
+	churnableTopics := make([]uint64, 0)
+	churnableTopicsIter, err := k.churnableTopics.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; churnableTopicsIter.Valid(); churnableTopicsIter.Next() {
+		key, err := churnableTopicsIter.Key()
+		if err != nil {
+			return nil, err
+		}
+		churnableTopics = append(churnableTopics, key)
+	}
+
+	rewardableTopics := make([]uint64, 0)
+	rewardableTopicsIter, err := k.rewardableTopics.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; rewardableTopicsIter.Valid(); rewardableTopicsIter.Next() {
+		key, err := rewardableTopicsIter.Key()
+		if err != nil {
+			return nil, err
+		}
+		rewardableTopics = append(rewardableTopics, key)
+	}
+
+	topicWorkers := make([]*types.TopicAndActorId, 0)
+	topicWorkersIter, err := k.topicWorkers.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; topicWorkersIter.Valid(); topicWorkersIter.Next() {
+		key, err := topicWorkersIter.Key()
+		if err != nil {
+			return nil, err
+		}
+		topicIdAndActorId := types.TopicAndActorId{
+			TopicId: key.K1(),
+			ActorId: key.K2(),
+		}
+		topicWorkers = append(topicWorkers, &topicIdAndActorId)
+	}
+
+	topicReputers := make([]*types.TopicAndActorId, 0)
+	topicReputersIter, err := k.topicReputers.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; topicReputersIter.Valid(); topicReputersIter.Next() {
+		key, err := topicReputersIter.Key()
+		if err != nil {
+			return nil, err
+		}
+		topicIdAndActorId := types.TopicAndActorId{
+			TopicId: key.K1(),
+			ActorId: key.K2(),
+		}
+		topicReputers = append(topicReputers, &topicIdAndActorId)
+	}
+
+	topicRewardNonce := make([]*types.TopicIdAndBlockHeight, 0)
+	topicRewardNonceIter, err := k.topicRewardNonce.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; topicRewardNonceIter.Valid(); topicRewardNonceIter.Next() {
+		keyValue, err := topicRewardNonceIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdAndBlockHeight := types.TopicIdAndBlockHeight{
+			TopicId:     keyValue.Key,
+			BlockHeight: keyValue.Value,
+		}
+		topicRewardNonce = append(topicRewardNonce, &topicIdAndBlockHeight)
+	}
+
+	infererScoresByBlock := make([]*types.TopicIdBlockHeightScores, 0)
+	infererScoresByBlockIter, err := k.infererScoresByBlock.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; infererScoresByBlockIter.Valid(); infererScoresByBlockIter.Next() {
+		keyValue, err := infererScoresByBlockIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdBlockHeightScores := types.TopicIdBlockHeightScores{
+			TopicId:     keyValue.Key.K1(),
+			BlockHeight: keyValue.Key.K2(),
+			Scores:      &value,
+		}
+		infererScoresByBlock = append(infererScoresByBlock, &topicIdBlockHeightScores)
+	}
+
+	forecasterScoresByBlock := make([]*types.TopicIdBlockHeightScores, 0)
+	forecasterScoresByBlockIter, err := k.forecasterScoresByBlock.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; forecasterScoresByBlockIter.Valid(); forecasterScoresByBlockIter.Next() {
+		keyValue, err := forecasterScoresByBlockIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdBlockHeightScores := types.TopicIdBlockHeightScores{
+			TopicId:     keyValue.Key.K1(),
+			BlockHeight: keyValue.Key.K2(),
+			Scores:      &value,
+		}
+		forecasterScoresByBlock = append(forecasterScoresByBlock, &topicIdBlockHeightScores)
+	}
+
+	reputerScoresByBlock := make([]*types.TopicIdBlockHeightScores, 0)
+	reputerScoresByBlockIter, err := k.reputerScoresByBlock.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; reputerScoresByBlockIter.Valid(); reputerScoresByBlockIter.Next() {
+		keyValue, err := reputerScoresByBlockIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdBlockHeightScores := types.TopicIdBlockHeightScores{
+			TopicId:     keyValue.Key.K1(),
+			BlockHeight: keyValue.Key.K2(),
+			Scores:      &value,
+		}
+		reputerScoresByBlock = append(reputerScoresByBlock, &topicIdBlockHeightScores)
+	}
+
+	latestInfererScoresByWorker := make([]*types.TopicIdActorIdScore, 0)
+	latestInfererScoresByWorkerIter, err := k.latestInfererScoresByWorker.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; latestInfererScoresByWorkerIter.Valid(); latestInfererScoresByWorkerIter.Next() {
+		keyValue, err := latestInfererScoresByWorkerIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdActorIdScore := types.TopicIdActorIdScore{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Score:   &value,
+		}
+		latestInfererScoresByWorker = append(latestInfererScoresByWorker, &topicIdActorIdScore)
+	}
+
+	latestForecasterScoresByWorker := make([]*types.TopicIdActorIdScore, 0)
+	latestForecasterScoresByWorkerIter, err := k.latestForecasterScoresByWorker.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; latestForecasterScoresByWorkerIter.Valid(); latestForecasterScoresByWorkerIter.Next() {
+		keyValue, err := latestForecasterScoresByWorkerIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdActorIdScore := types.TopicIdActorIdScore{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Score:   &value,
+		}
+		latestForecasterScoresByWorker = append(latestForecasterScoresByWorker, &topicIdActorIdScore)
+	}
+
+	latestReputerScoresByReputer := make([]*types.TopicIdActorIdScore, 0)
+	latestReputerScoresByReputerIter, err := k.latestReputerScoresByReputer.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; latestReputerScoresByReputerIter.Valid(); latestReputerScoresByReputerIter.Next() {
+		keyValue, err := latestReputerScoresByReputerIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdActorIdScore := types.TopicIdActorIdScore{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Score:   &value,
+		}
+		latestReputerScoresByReputer = append(latestReputerScoresByReputer, &topicIdActorIdScore)
+	}
+
+	reputerListeningCoefficient := make([]*types.TopicIdActorIdListeningCoefficient, 0)
+	reputerListeningCoefficientIter, err := k.reputerListeningCoefficient.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; reputerListeningCoefficientIter.Valid(); reputerListeningCoefficientIter.Next() {
+		keyValue, err := reputerListeningCoefficientIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdActorIdListeningCoefficient := types.TopicIdActorIdListeningCoefficient{
+			TopicId:              keyValue.Key.K1(),
+			ActorId:              keyValue.Key.K2(),
+			ListeningCoefficient: &value,
+		}
+		reputerListeningCoefficient = append(reputerListeningCoefficient, &topicIdActorIdListeningCoefficient)
+	}
+
+	previousReputerRewardFraction := make([]*types.TopicIdActorIdDec, 0)
+	previousReputerRewardFractionIter, err := k.previousReputerRewardFraction.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; previousReputerRewardFractionIter.Valid(); previousReputerRewardFractionIter.Next() {
+		keyValue, err := previousReputerRewardFractionIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdDec := types.TopicIdActorIdDec{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Dec:     keyValue.Value,
+		}
+		previousReputerRewardFraction = append(previousReputerRewardFraction, &topicIdActorIdDec)
+	}
+
+	previousInferenceRewardFraction := make([]*types.TopicIdActorIdDec, 0)
+	previousInferenceRewardFractionIter, err := k.previousInferenceRewardFraction.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; previousInferenceRewardFractionIter.Valid(); previousInferenceRewardFractionIter.Next() {
+		keyValue, err := previousInferenceRewardFractionIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdDec := types.TopicIdActorIdDec{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Dec:     keyValue.Value,
+		}
+		previousInferenceRewardFraction = append(previousInferenceRewardFraction, &topicIdActorIdDec)
+	}
+
+	previousForecastRewardFraction := make([]*types.TopicIdActorIdDec, 0)
+	previousForecastRewardFractionIter, err := k.previousForecastRewardFraction.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; previousForecastRewardFractionIter.Valid(); previousForecastRewardFractionIter.Next() {
+		keyValue, err := previousForecastRewardFractionIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdDec := types.TopicIdActorIdDec{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Dec:     keyValue.Value,
+		}
+		previousForecastRewardFraction = append(previousForecastRewardFraction, &topicIdActorIdDec)
+	}
+
+	totalStake, err := k.totalStake.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fill in the values from keeper.go
+
+	// topicStake
+	topicStake := make([]*types.TopicIdAndInt, 0)
+	topicStakeIter, err := k.topicStake.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; topicStakeIter.Valid(); topicStakeIter.Next() {
+		keyValue, err := topicStakeIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdAndInt := types.TopicIdAndInt{
+			TopicId: keyValue.Key,
+			Int:     keyValue.Value,
+		}
+		topicStake = append(topicStake, &topicIdAndInt)
+	}
+
+	// stakeReputerAuthority
+	stakeReputerAuthority := make([]*types.TopicIdActorIdInt, 0)
+	stakeReputerAuthorityIter, err := k.stakeReputerAuthority.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; stakeReputerAuthorityIter.Valid(); stakeReputerAuthorityIter.Next() {
+		keyValue, err := stakeReputerAuthorityIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdInt := types.TopicIdActorIdInt{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Int:     keyValue.Value,
+		}
+		stakeReputerAuthority = append(stakeReputerAuthority, &topicIdActorIdInt)
+	}
+
+	// stakeSumFromDelegator
+	stakeSumFromDelegator := make([]*types.TopicIdActorIdInt, 0)
+	stakeSumFromDelegatorIter, err := k.stakeSumFromDelegator.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; stakeSumFromDelegatorIter.Valid(); stakeSumFromDelegatorIter.Next() {
+		keyValue, err := stakeSumFromDelegatorIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdInt := types.TopicIdActorIdInt{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Int:     keyValue.Value,
+		}
+		stakeSumFromDelegator = append(stakeSumFromDelegator, &topicIdActorIdInt)
+	}
+
+	// delegatedStakes
+	delegatedStakes := make([]*types.TopicIdDelegatorReputerDelegatorInfo, 0)
+	delegatedStakesIter, err := k.delegatedStakes.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; delegatedStakesIter.Valid(); delegatedStakesIter.Next() {
+		keyValue, err := delegatedStakesIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdDelegatorReputerDelegatorInfo := types.TopicIdDelegatorReputerDelegatorInfo{
+			TopicId:       keyValue.Key.K1(),
+			Delegator:     keyValue.Key.K2(),
+			Reputer:       keyValue.Key.K3(),
+			DelegatorInfo: &value,
+		}
+		delegatedStakes = append(delegatedStakes, &topicIdDelegatorReputerDelegatorInfo)
+	}
+
+	// stakeFromDelegatorsUponReputer
+	stakeFromDelegatorsUponReputer := make([]*types.TopicIdActorIdInt, 0)
+	stakeFromDelegatorsUponReputerIter, err := k.stakeFromDelegatorsUponReputer.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; stakeFromDelegatorsUponReputerIter.Valid(); stakeFromDelegatorsUponReputerIter.Next() {
+		keyValue, err := stakeFromDelegatorsUponReputerIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdInt := types.TopicIdActorIdInt{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Int:     keyValue.Value,
+		}
+		stakeFromDelegatorsUponReputer = append(stakeFromDelegatorsUponReputer, &topicIdActorIdInt)
+	}
+
+	// delegateRewardPerShare
+	delegateRewardPerShare := make([]*types.TopicIdActorIdDec, 0)
+	delegateRewardPerShareIter, err := k.delegateRewardPerShare.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; delegateRewardPerShareIter.Valid(); delegateRewardPerShareIter.Next() {
+		keyValue, err := delegateRewardPerShareIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdDec := types.TopicIdActorIdDec{
+			TopicId: keyValue.Key.K1(),
+			ActorId: keyValue.Key.K2(),
+			Dec:     keyValue.Value,
+		}
+		delegateRewardPerShare = append(delegateRewardPerShare, &topicIdActorIdDec)
+	}
+
+	// stakeRemovalsByBlock
+	stakeRemovalsByBlock := make([]*types.BlockHeightTopicIdReputerStakeRemovalInfo, 0)
+	stakeRemovalsByBlockIter, err := k.stakeRemovalsByBlock.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; stakeRemovalsByBlockIter.Valid(); stakeRemovalsByBlockIter.Next() {
+		keyValue, err := stakeRemovalsByBlockIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		blockHeightTopicIdReputerStakeRemovalInfo := types.BlockHeightTopicIdReputerStakeRemovalInfo{
+			BlockHeight:      keyValue.Key.K1(),
+			TopicId:          keyValue.Key.K2(),
+			StakeRemovalInfo: &value,
+		}
+		stakeRemovalsByBlock = append(stakeRemovalsByBlock, &blockHeightTopicIdReputerStakeRemovalInfo)
+	}
+
+	// stakeRemovalsByActor
+	stakeRemovalsByActor := make([]*types.ActorIdTopicIdBlockHeight, 0)
+	stakeRemovalsByActorIter, err := k.stakeRemovalsByActor.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; stakeRemovalsByActorIter.Valid(); stakeRemovalsByActorIter.Next() {
+		key, err := stakeRemovalsByActorIter.Key()
+		if err != nil {
+			return nil, err
+		}
+		actorIdTopicIdBlockHeight := types.ActorIdTopicIdBlockHeight{
+			ActorId:     key.K1(),
+			TopicId:     key.K2(),
+			BlockHeight: key.K3(),
+		}
+		stakeRemovalsByActor = append(stakeRemovalsByActor, &actorIdTopicIdBlockHeight)
+	}
+
+	// delegateStakeRemovalsByBlock
+	delegateStakeRemovalsByBlock := make([]*types.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo, 0)
+	delegateStakeRemovalsByBlockIter, err := k.delegateStakeRemovalsByBlock.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; delegateStakeRemovalsByBlockIter.Valid(); delegateStakeRemovalsByBlockIter.Next() {
+		keyValue, err := delegateStakeRemovalsByBlockIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		blockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo := types.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo{
+			BlockHeight:              keyValue.Key.K1(),
+			TopicId:                  keyValue.Key.K2(),
+			DelegateStakeRemovalInfo: &value,
+		}
+		delegateStakeRemovalsByBlock = append(delegateStakeRemovalsByBlock, &blockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo)
+	}
+
+	// delegateStakeRemovalsByActor
+	delegateStakeRemovalsByActor := make([]*types.DelegatorReputerTopicIdBlockHeight, 0)
+	delegateStakeRemovalsByActorIter, err := k.delegateStakeRemovalsByActor.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; delegateStakeRemovalsByActorIter.Valid(); delegateStakeRemovalsByActorIter.Next() {
+		key, err := delegateStakeRemovalsByActorIter.Key()
+		if err != nil {
+			return nil, err
+		}
+		delegatorReputerTopicIdBlockHeight := types.DelegatorReputerTopicIdBlockHeight{
+			Delegator:   key.K1(),
+			Reputer:     key.K2(),
+			TopicId:     key.K3(),
+			BlockHeight: key.K4(),
+		}
+		delegateStakeRemovalsByActor = append(delegateStakeRemovalsByActor, &delegatorReputerTopicIdBlockHeight)
+	}
+
+	// inferences
+	inferences := make([]*types.TopicIdActorIdInference, 0)
+	inferencesIter, err := k.inferences.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; inferencesIter.Valid(); inferencesIter.Next() {
+		keyValue, err := inferencesIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdActorIdInference := types.TopicIdActorIdInference{
+			TopicId:   keyValue.Key.K1(),
+			ActorId:   keyValue.Key.K2(),
+			Inference: &value,
+		}
+		inferences = append(inferences, &topicIdActorIdInference)
+	}
+
+	// forecasts
+	forecasts := make([]*types.TopicIdActorIdForecast, 0)
+	forecastsIter, err := k.forecasts.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; forecastsIter.Valid(); forecastsIter.Next() {
+		keyValue, err := forecastsIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdActorIdForecast := types.TopicIdActorIdForecast{
+			TopicId:  keyValue.Key.K1(),
+			ActorId:  keyValue.Key.K2(),
+			Forecast: &value,
+		}
+		forecasts = append(forecasts, &topicIdActorIdForecast)
+	}
+
+	// workers
+	workers := make([]*types.LibP2PKeyAndOffchainNode, 0)
+	workersIter, err := k.workers.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; workersIter.Valid(); workersIter.Next() {
+		keyValue, err := workersIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		libP2PKeyAndOffchainNode := types.LibP2PKeyAndOffchainNode{
+			LibP2PKey:    keyValue.Key,
+			OffchainNode: &value,
+		}
+		workers = append(workers, &libP2PKeyAndOffchainNode)
+	}
+
+	// reputers
+	reputers := make([]*types.LibP2PKeyAndOffchainNode, 0)
+	reputersIter, err := k.reputers.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; reputersIter.Valid(); reputersIter.Next() {
+		keyValue, err := reputersIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		libP2PKeyAndOffchainNode := types.LibP2PKeyAndOffchainNode{
+			LibP2PKey:    keyValue.Key,
+			OffchainNode: &keyValue.Value,
+		}
+		reputers = append(reputers, &libP2PKeyAndOffchainNode)
+	}
+
+	// topicFeeRevenue
+	topicFeeRevenue := make([]*types.TopicIdAndInt, 0)
+	topicFeeRevenueIter, err := k.topicFeeRevenue.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; topicFeeRevenueIter.Valid(); topicFeeRevenueIter.Next() {
+		keyValue, err := topicFeeRevenueIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdAndInt := types.TopicIdAndInt{
+			TopicId: keyValue.Key,
+			Int:     keyValue.Value,
+		}
+		topicFeeRevenue = append(topicFeeRevenue, &topicIdAndInt)
+	}
+
+	// previousTopicWeight
+	previousTopicWeight := make([]*types.TopicIdAndDec, 0)
+	previousTopicWeightIter, err := k.previousTopicWeight.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; previousTopicWeightIter.Valid(); previousTopicWeightIter.Next() {
+		keyValue, err := previousTopicWeightIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdAndDec := types.TopicIdAndDec{
+			TopicId: keyValue.Key,
+			Dec:     keyValue.Value,
+		}
+		previousTopicWeight = append(previousTopicWeight, &topicIdAndDec)
+	}
+
+	// allInferences
+	allInferences := make([]*types.TopicIdBlockHeightInferences, 0)
+	allInferencesIter, err := k.allInferences.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; allInferencesIter.Valid(); allInferencesIter.Next() {
+		keyValue, err := allInferencesIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdBlockHeightInferences := types.TopicIdBlockHeightInferences{
+			TopicId:     keyValue.Key.K1(),
+			BlockHeight: keyValue.Key.K2(),
+			Inferences:  &value,
+		}
+		allInferences = append(allInferences, &topicIdBlockHeightInferences)
+	}
+
+	// allForecasts
+	allForecasts := make([]*types.TopicIdBlockHeightForecasts, 0)
+	allForecastsIter, err := k.allForecasts.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; allForecastsIter.Valid(); allForecastsIter.Next() {
+		keyValue, err := allForecastsIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdBlockHeightForecasts := types.TopicIdBlockHeightForecasts{
+			TopicId:     keyValue.Key.K1(),
+			BlockHeight: keyValue.Key.K2(),
+			Forecasts:   &value,
+		}
+		allForecasts = append(allForecasts, &topicIdBlockHeightForecasts)
+	}
+
+	// allLossBundles
+	allLossBundles := make([]*types.TopicIdBlockHeightReputerValueBundles, 0)
+	allLossBundlesIter, err := k.allLossBundles.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; allLossBundlesIter.Valid(); allLossBundlesIter.Next() {
+		keyValue, err := allLossBundlesIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdBlockHeightValueBundles := types.TopicIdBlockHeightReputerValueBundles{
+			TopicId:             keyValue.Key.K1(),
+			BlockHeight:         keyValue.Key.K2(),
+			ReputerValueBundles: &value,
+		}
+		allLossBundles = append(allLossBundles, &topicIdBlockHeightValueBundles)
+	}
+
+	// networkLossBundles
+	networkLossBundles := make([]*types.TopicIdBlockHeightValueBundles, 0)
+	networkLossBundlesIter, err := k.networkLossBundles.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; networkLossBundlesIter.Valid(); networkLossBundlesIter.Next() {
+		keyValue, err := networkLossBundlesIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdBlockHeightValueBundles := types.TopicIdBlockHeightValueBundles{
+			TopicId:     keyValue.Key.K1(),
+			BlockHeight: keyValue.Key.K2(),
+			ValueBundle: &value,
+		}
+		networkLossBundles = append(networkLossBundles, &topicIdBlockHeightValueBundles)
+	}
+
+	// previousPercentageRewardToStakedReputers
+	previousPercentageRewardToStakedReputers, err := k.previousPercentageRewardToStakedReputers.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// unfulfilledWorkerNonces
+	unfulfilledWorkerNonces := make([]*types.TopicIdAndNonces, 0)
+	unfulfilledWorkerNoncesIter, err := k.unfulfilledWorkerNonces.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; unfulfilledWorkerNoncesIter.Valid(); unfulfilledWorkerNoncesIter.Next() {
+		keyValue, err := unfulfilledWorkerNoncesIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdAndNonces := types.TopicIdAndNonces{
+			TopicId: keyValue.Key,
+			Nonces:  &keyValue.Value,
+		}
+		unfulfilledWorkerNonces = append(unfulfilledWorkerNonces, &topicIdAndNonces)
+	}
+
+	// unfulfilledReputerNonces
+	unfulfilledReputerNonces := make([]*types.TopicIdAndReputerRequestNonces, 0)
+	unfulfilledReputerNoncesIter, err := k.unfulfilledReputerNonces.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; unfulfilledReputerNoncesIter.Valid(); unfulfilledReputerNoncesIter.Next() {
+		keyValue, err := unfulfilledReputerNoncesIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		value := keyValue.Value
+		topicIdAndReputerRequestNonces := types.TopicIdAndReputerRequestNonces{
+			TopicId:              keyValue.Key,
+			ReputerRequestNonces: &value,
+		}
+		unfulfilledReputerNonces = append(unfulfilledReputerNonces, &topicIdAndReputerRequestNonces)
+	}
+
+	latestInfererNetworkRegrets := make([]*types.TopicIdActorIdTimeStampedValue, 0)
+	latestInfererNetworkRegretsIter, err := k.latestInfererNetworkRegrets.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; latestInfererNetworkRegretsIter.Valid(); latestInfererNetworkRegretsIter.Next() {
+		keyValue, err := latestInfererNetworkRegretsIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdTimeStampedValue := types.TopicIdActorIdTimeStampedValue{
+			TopicId:          keyValue.Key.K1(),
+			ActorId:          keyValue.Key.K2(),
+			TimestampedValue: &keyValue.Value,
+		}
+		latestInfererNetworkRegrets = append(latestInfererNetworkRegrets, &topicIdActorIdTimeStampedValue)
+	}
+
+	latestForecasterNetworkRegrets := make([]*types.TopicIdActorIdTimeStampedValue, 0)
+	latestForecasterNetworkRegretsIter, err := k.latestForecasterNetworkRegrets.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; latestForecasterNetworkRegretsIter.Valid(); latestForecasterNetworkRegretsIter.Next() {
+		keyValue, err := latestForecasterNetworkRegretsIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdTimeStampedValue := types.TopicIdActorIdTimeStampedValue{
+			TopicId:          keyValue.Key.K1(),
+			ActorId:          keyValue.Key.K2(),
+			TimestampedValue: &keyValue.Value,
+		}
+		latestForecasterNetworkRegrets = append(latestForecasterNetworkRegrets, &topicIdActorIdTimeStampedValue)
+	}
+
+	latestOneInForecasterNetworkRegrets := make([]*types.TopicIdActorIdActorIdTimeStampedValue, 0)
+	latestOneInForecasterNetworkRegretsIter, err := k.latestOneInForecasterNetworkRegrets.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; latestOneInForecasterNetworkRegretsIter.Valid(); latestOneInForecasterNetworkRegretsIter.Next() {
+		keyValue, err := latestOneInForecasterNetworkRegretsIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdActorIdTimeStampedValue := types.TopicIdActorIdActorIdTimeStampedValue{
+			TopicId:          keyValue.Key.K1(),
+			ActorId1:         keyValue.Key.K2(),
+			ActorId2:         keyValue.Key.K3(),
+			TimestampedValue: &keyValue.Value,
+		}
+		latestOneInForecasterNetworkRegrets = append(latestOneInForecasterNetworkRegrets, &topicIdActorIdActorIdTimeStampedValue)
+	}
+
+	latestOneInForecasterSelfNetworkRegrets := make([]*types.TopicIdActorIdTimeStampedValue, 0)
+	latestOneInForecasterSelfNetworkRegretsIter, err := k.latestOneInForecasterSelfNetworkRegrets.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; latestOneInForecasterSelfNetworkRegretsIter.Valid(); latestOneInForecasterSelfNetworkRegretsIter.Next() {
+		keyValue, err := latestOneInForecasterSelfNetworkRegretsIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdActorIdTimeStampedValue := types.TopicIdActorIdTimeStampedValue{
+			TopicId:          keyValue.Key.K1(),
+			ActorId:          keyValue.Key.K2(),
+			TimestampedValue: &keyValue.Value,
+		}
+		latestOneInForecasterSelfNetworkRegrets = append(latestOneInForecasterSelfNetworkRegrets, &topicIdActorIdTimeStampedValue)
+	}
+
+	coreTeamAddresses := make([]string, 0)
+	coreTeamAddressesIter, err := k.whitelistAdmins.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; coreTeamAddressesIter.Valid(); coreTeamAddressesIter.Next() {
+		key, err := coreTeamAddressesIter.Key()
+		if err != nil {
+			return nil, err
+		}
+		coreTeamAddresses = append(coreTeamAddresses, key)
+	}
+
+	topicLastWorkerCommit := make([]*types.TopicIdTimestampedActorNonce, 0)
+	topicLastWorkerCommitIter, err := k.topicLastWorkerCommit.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; topicLastWorkerCommitIter.Valid(); topicLastWorkerCommitIter.Next() {
+		keyValue, err := topicLastWorkerCommitIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdTimestampedActorNonce := types.TopicIdTimestampedActorNonce{
+			TopicId:               keyValue.Key,
+			TimestampedActorNonce: &keyValue.Value,
+		}
+		topicLastWorkerCommit = append(topicLastWorkerCommit, &topicIdTimestampedActorNonce)
+	}
+
+	topicLastReputerCommit := make([]*types.TopicIdTimestampedActorNonce, 0)
+	topicLastReputerCommitIter, err := k.topicLastReputerCommit.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; topicLastReputerCommitIter.Valid(); topicLastReputerCommitIter.Next() {
+		keyValue, err := topicLastReputerCommitIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdTimestampedActorNonce := types.TopicIdTimestampedActorNonce{
+			TopicId:               keyValue.Key,
+			TimestampedActorNonce: &keyValue.Value,
+		}
+		topicLastReputerCommit = append(topicLastReputerCommit, &topicIdTimestampedActorNonce)
+	}
+
+	topicLastWorkerPayload := make([]*types.TopicIdTimestampedActorNonce, 0)
+	topicLastWorkerPayloadIter, err := k.topicLastWorkerPayload.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; topicLastWorkerPayloadIter.Valid(); topicLastWorkerPayloadIter.Next() {
+		keyValue, err := topicLastWorkerPayloadIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdTimestampedActorNonce := types.TopicIdTimestampedActorNonce{
+			TopicId:               keyValue.Key,
+			TimestampedActorNonce: &keyValue.Value,
+		}
+		topicLastWorkerPayload = append(topicLastWorkerPayload, &topicIdTimestampedActorNonce)
+	}
+
+	topicLastReputerPayload := make([]*types.TopicIdTimestampedActorNonce, 0)
+	topicLastReputerPayloadIter, err := k.topicLastReputerPayload.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	for ; topicLastReputerPayloadIter.Valid(); topicLastReputerPayloadIter.Next() {
+		keyValue, err := topicLastReputerPayloadIter.KeyValue()
+		if err != nil {
+			return nil, err
+		}
+		topicIdTimestampedActorNonce := types.TopicIdTimestampedActorNonce{
+			TopicId:               keyValue.Key,
+			TimestampedActorNonce: &keyValue.Value,
+		}
+		topicLastReputerPayload = append(topicLastReputerPayload, &topicIdTimestampedActorNonce)
+	}
+
 	return &types.GenesisState{
-		Params: moduleParams,
+		Params:                                   moduleParams,
+		NextTopicId:                              nextTopicId,
+		Topics:                                   topics,
+		ActiveTopics:                             activeTopics,
+		ChurnableTopics:                          churnableTopics,
+		RewardableTopics:                         rewardableTopics,
+		TopicWorkers:                             topicWorkers,
+		TopicReputers:                            topicReputers,
+		TopicRewardNonce:                         topicRewardNonce,
+		InfererScoresByBlock:                     infererScoresByBlock,
+		ForecasterScoresByBlock:                  forecasterScoresByBlock,
+		ReputerScoresByBlock:                     reputerScoresByBlock,
+		LatestInfererScoresByWorker:              latestInfererScoresByWorker,
+		LatestForecasterScoresByWorker:           latestForecasterScoresByWorker,
+		LatestReputerScoresByReputer:             latestReputerScoresByReputer,
+		ReputerListeningCoefficient:              reputerListeningCoefficient,
+		PreviousReputerRewardFraction:            previousReputerRewardFraction,
+		PreviousInferenceRewardFraction:          previousInferenceRewardFraction,
+		PreviousForecastRewardFraction:           previousForecastRewardFraction,
+		TotalStake:                               totalStake,
+		TopicStake:                               topicStake,
+		StakeReputerAuthority:                    stakeReputerAuthority,
+		StakeSumFromDelegator:                    stakeSumFromDelegator,
+		DelegatedStakes:                          delegatedStakes,
+		StakeFromDelegatorsUponReputer:           stakeFromDelegatorsUponReputer,
+		DelegateRewardPerShare:                   delegateRewardPerShare,
+		StakeRemovalsByBlock:                     stakeRemovalsByBlock,
+		StakeRemovalsByActor:                     stakeRemovalsByActor,
+		DelegateStakeRemovalsByBlock:             delegateStakeRemovalsByBlock,
+		DelegateStakeRemovalsByActor:             delegateStakeRemovalsByActor,
+		Inferences:                               inferences,
+		Forecasts:                                forecasts,
+		Workers:                                  workers,
+		Reputers:                                 reputers,
+		TopicFeeRevenue:                          topicFeeRevenue,
+		PreviousTopicWeight:                      previousTopicWeight,
+		AllInferences:                            allInferences,
+		AllForecasts:                             allForecasts,
+		AllLossBundles:                           allLossBundles,
+		NetworkLossBundles:                       networkLossBundles,
+		PreviousPercentageRewardToStakedReputers: previousPercentageRewardToStakedReputers,
+		UnfulfilledWorkerNonces:                  unfulfilledWorkerNonces,
+		UnfulfilledReputerNonces:                 unfulfilledReputerNonces,
+		LatestInfererNetworkRegrets:              latestInfererNetworkRegrets,
+		LatestForecasterNetworkRegrets:           latestForecasterNetworkRegrets,
+		LatestOneInForecasterNetworkRegrets:      latestOneInForecasterNetworkRegrets,
+		LatestOneInForecasterSelfNetworkRegrets:  latestOneInForecasterSelfNetworkRegrets,
+		CoreTeamAddresses:                        coreTeamAddresses,
+		TopicLastWorkerCommit:                    topicLastWorkerCommit,
+		TopicLastReputerCommit:                   topicLastReputerCommit,
+		TopicLastWorkerPayload:                   topicLastWorkerPayload,
+		TopicLastReputerPayload:                  topicLastReputerPayload,
 	}, nil
 }
 

--- a/x/emissions/keeper/genesis.go
+++ b/x/emissions/keeper/genesis.go
@@ -3,6 +3,8 @@ package keeper
 import (
 	"context"
 
+	"cosmossdk.io/errors"
+
 	"cosmossdk.io/collections"
 	cosmosMath "cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
@@ -24,17 +26,17 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 
 	// params Params
 	if err := k.SetParams(ctx, data.Params); err != nil {
-		return err
+		return errors.Wrap(err, "error setting params")
 	}
 	// nextTopicId uint64
 	if data.NextTopicId == 0 {
 		// reserve topic ID 0 for future use
 		if _, err := k.IncrementTopicId(ctx); err != nil {
-			return err
+			return errors.Wrap(err, "error incrementing topic ID")
 		}
 	} else {
 		if err := k.nextTopicId.Set(ctx, data.NextTopicId); err != nil {
-			return err
+			return errors.Wrap(err, "error setting next topic ID")
 		}
 	}
 	//Topics       []*TopicIdAndTopic
@@ -42,7 +44,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 		for _, topic := range data.Topics {
 			if topic != nil {
 				if err := k.topics.Set(ctx, topic.TopicId, *topic.Topic); err != nil {
-					return err
+					return errors.Wrap(err, "error setting topic")
 				}
 			}
 		}
@@ -51,7 +53,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 	if len(data.ActiveTopics) != 0 {
 		for _, topicId := range data.ActiveTopics {
 			if err := k.activeTopics.Set(ctx, topicId); err != nil {
-				return err
+				return errors.Wrap(err, "error setting activeTopics")
 			}
 		}
 	}
@@ -59,7 +61,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 	if len(data.ChurnableTopics) != 0 {
 		for _, topicId := range data.ChurnableTopics {
 			if err := k.churnableTopics.Set(ctx, topicId); err != nil {
-				return err
+				return errors.Wrap(err, "error setting churnableTopics")
 			}
 		}
 	}
@@ -67,7 +69,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 	if len(data.RewardableTopics) != 0 {
 		for _, topicId := range data.RewardableTopics {
 			if err := k.rewardableTopics.Set(ctx, topicId); err != nil {
-				return err
+				return errors.Wrap(err, "error setting rewardableTopics")
 			}
 		}
 	}
@@ -76,7 +78,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 		for _, topicAndActorId := range data.TopicWorkers {
 			if topicAndActorId != nil {
 				if err := k.topicWorkers.Set(ctx, collections.Join(topicAndActorId.TopicId, topicAndActorId.ActorId)); err != nil {
-					return err
+					return errors.Wrap(err, "error setting topicWorkers")
 				}
 			}
 		}
@@ -87,7 +89,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 		for _, topicAndActorId := range data.TopicReputers {
 			if topicAndActorId != nil {
 				if err := k.topicReputers.Set(ctx, collections.Join(topicAndActorId.TopicId, topicAndActorId.ActorId)); err != nil {
-					return err
+					return errors.Wrap(err, "error setting topicReputers")
 				}
 			}
 		}
@@ -98,7 +100,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 		for _, topicIdAndBlockHeight := range data.TopicRewardNonce {
 			if topicIdAndBlockHeight != nil {
 				if err := k.topicRewardNonce.Set(ctx, topicIdAndBlockHeight.TopicId, topicIdAndBlockHeight.BlockHeight); err != nil {
-					return err
+					return errors.Wrap(err, "error setting topicRewardNonce")
 				}
 			}
 		}
@@ -110,7 +112,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.infererScoresByBlock.Set(ctx,
 					collections.Join(topicIdBlockHeightScores.TopicId, topicIdBlockHeightScores.BlockHeight),
 					*topicIdBlockHeightScores.Scores); err != nil {
-					return err
+					return errors.Wrap(err, "error setting infererScoresByBlock")
 				}
 			}
 		}
@@ -124,7 +126,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 					ctx,
 					collections.Join(topicIdBlockHeightScores.TopicId, topicIdBlockHeightScores.BlockHeight),
 					*topicIdBlockHeightScores.Scores); err != nil {
-					return err
+					return errors.Wrap(err, "error setting forecasterScoresByBlock")
 				}
 			}
 		}
@@ -138,7 +140,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 					ctx,
 					collections.Join(topicIdBlockHeightScores.TopicId, topicIdBlockHeightScores.BlockHeight),
 					*topicIdBlockHeightScores.Scores); err != nil {
-					return err
+					return errors.Wrap(err, "error setting reputerScoresByBlock")
 				}
 			}
 		}
@@ -150,7 +152,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.latestInfererScoresByWorker.Set(ctx,
 					collections.Join(topicIdActorIdScore.TopicId, topicIdActorIdScore.ActorId),
 					*topicIdActorIdScore.Score); err != nil {
-					return err
+					return errors.Wrap(err, "error setting latestInfererScoresByWorker")
 				}
 			}
 		}
@@ -162,7 +164,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.latestForecasterScoresByWorker.Set(ctx,
 					collections.Join(topicIdActorIdScore.TopicId, topicIdActorIdScore.ActorId),
 					*topicIdActorIdScore.Score); err != nil {
-					return err
+					return errors.Wrap(err, "error setting latestForecasterScoresByWorker")
 				}
 			}
 		}
@@ -174,7 +176,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.latestReputerScoresByReputer.Set(ctx,
 					collections.Join(topicIdActorIdScore.TopicId, topicIdActorIdScore.ActorId),
 					*topicIdActorIdScore.Score); err != nil {
-					return err
+					return errors.Wrap(err, "error setting latestReputerScoresByReputer")
 				}
 			}
 		}
@@ -186,7 +188,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.reputerListeningCoefficient.Set(ctx,
 					collections.Join(topicIdActorIdListeningCoefficient.TopicId, topicIdActorIdListeningCoefficient.ActorId),
 					*topicIdActorIdListeningCoefficient.ListeningCoefficient); err != nil {
-					return err
+					return errors.Wrap(err, "error setting reputerListeningCoefficient")
 				}
 			}
 		}
@@ -198,7 +200,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.previousReputerRewardFraction.Set(ctx,
 					collections.Join(topicIdActorIdDec.TopicId, topicIdActorIdDec.ActorId),
 					topicIdActorIdDec.Dec); err != nil {
-					return err
+					return errors.Wrap(err, "error setting previousReputerRewardFraction")
 				}
 			}
 		}
@@ -210,7 +212,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.previousInferenceRewardFraction.Set(ctx,
 					collections.Join(topicIdActorIdDec.TopicId, topicIdActorIdDec.ActorId),
 					topicIdActorIdDec.Dec); err != nil {
-					return err
+					return errors.Wrap(err, "error setting previousInferenceRewardFraction")
 				}
 			}
 		}
@@ -222,7 +224,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.previousForecastRewardFraction.Set(ctx,
 					collections.Join(topicIdActorIdDec.TopicId, topicIdActorIdDec.ActorId),
 					topicIdActorIdDec.Dec); err != nil {
-					return err
+					return errors.Wrap(err, "error setting previousForecastRewardFraction")
 				}
 			}
 		}
@@ -230,11 +232,11 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 	// TotalStake cosmossdk_io_math.Int
 	if data.TotalStake.GT(cosmosMath.ZeroInt()) {
 		if err := k.totalStake.Set(ctx, data.TotalStake); err != nil {
-			return err
+			return errors.Wrap(err, "error setting totalStake")
 		}
 	} else {
 		if err := k.totalStake.Set(ctx, cosmosMath.ZeroInt()); err != nil {
-			return err
+			return errors.Wrap(err, "error setting totalStake to zero int")
 		}
 	}
 	//TopicStake []*TopicIdAndInt
@@ -242,7 +244,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 		for _, topicIdAndInt := range data.TopicStake {
 			if topicIdAndInt != nil {
 				if err := k.topicStake.Set(ctx, topicIdAndInt.TopicId, topicIdAndInt.Int); err != nil {
-					return err
+					return errors.Wrap(err, "error setting topicStake")
 				}
 			}
 		}
@@ -254,7 +256,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.stakeReputerAuthority.Set(ctx,
 					collections.Join(topicIdActorIdInt.TopicId, topicIdActorIdInt.ActorId),
 					topicIdActorIdInt.Int); err != nil {
-					return err
+					return errors.Wrap(err, "error setting stakeReputerAuthority")
 				}
 			}
 		}
@@ -266,7 +268,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.stakeSumFromDelegator.Set(ctx,
 					collections.Join(topicIdActorIdInt.TopicId, topicIdActorIdInt.ActorId),
 					topicIdActorIdInt.Int); err != nil {
-					return err
+					return errors.Wrap(err, "error setting stakeSumFromDelegator")
 				}
 			}
 		}
@@ -282,7 +284,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 						topicIdDelegatorReputerDelegatorInfo.Reputer,
 					),
 					*topicIdDelegatorReputerDelegatorInfo.DelegatorInfo); err != nil {
-					return err
+					return errors.Wrap(err, "error setting delegatedStakes")
 				}
 			}
 		}
@@ -294,7 +296,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.stakeFromDelegatorsUponReputer.Set(ctx,
 					collections.Join(topicIdActorIdInt.TopicId, topicIdActorIdInt.ActorId),
 					topicIdActorIdInt.Int); err != nil {
-					return err
+					return errors.Wrap(err, "error setting stakeFromDelegatorsUponReputer")
 				}
 			}
 		}
@@ -306,7 +308,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				if err := k.delegateRewardPerShare.Set(ctx,
 					collections.Join(topicIdActorIdDec.TopicId, topicIdActorIdDec.ActorId),
 					topicIdActorIdDec.Dec); err != nil {
-					return err
+					return errors.Wrap(err, "error setting delegateRewardPerShare")
 				}
 			}
 		}
@@ -321,7 +323,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 						blockHeightTopicIdReputerStakeRemovalInfo.TopicId,
 						blockHeightTopicIdReputerStakeRemovalInfo.Reputer),
 					*blockHeightTopicIdReputerStakeRemovalInfo.StakeRemovalInfo); err != nil {
-					return err
+					return errors.Wrap(err, "error setting stakeRemovalsByBlock")
 				}
 			}
 		}
@@ -335,7 +337,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 						actorIdTopicIdBlockHeight.ActorId,
 						actorIdTopicIdBlockHeight.TopicId,
 						actorIdTopicIdBlockHeight.BlockHeight)); err != nil {
-					return err
+					return errors.Wrap(err, "error setting stakeRemovalsByActor")
 				}
 			}
 		}
@@ -352,7 +354,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 						blockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.Reputer,
 					),
 					*blockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo.DelegateStakeRemovalInfo); err != nil {
-					return err
+					return errors.Wrap(err, "error setting delegateStakeRemovalsByBlock")
 				}
 			}
 		}
@@ -367,7 +369,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 						delegatorReputerTopicIdBlockHeight.Reputer,
 						delegatorReputerTopicIdBlockHeight.TopicId,
 						delegatorReputerTopicIdBlockHeight.BlockHeight)); err != nil {
-					return err
+					return errors.Wrap(err, "error setting delegateStakeRemovalsByActor")
 				}
 			}
 		}
@@ -381,7 +383,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 						topicIdActorIdInference.TopicId,
 						topicIdActorIdInference.ActorId),
 					*topicIdActorIdInference.Inference); err != nil {
-					return err
+					return errors.Wrap(err, "error setting inferences")
 				}
 			}
 		}
@@ -396,7 +398,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 						topicIdActorIdForecast.TopicId,
 						topicIdActorIdForecast.ActorId),
 					*topicIdActorIdForecast.Forecast); err != nil {
-					return err
+					return errors.Wrap(err, "error setting forecasts")
 				}
 			}
 		}
@@ -410,7 +412,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 					ctx,
 					libP2PKeyAndOffchainNode.LibP2PKey,
 					*libP2PKeyAndOffchainNode.OffchainNode); err != nil {
-					return err
+					return errors.Wrap(err, "error setting workers")
 				}
 			}
 		}
@@ -424,7 +426,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 					ctx,
 					libP2PKeyAndOffchainNode.LibP2PKey,
 					*libP2PKeyAndOffchainNode.OffchainNode); err != nil {
-					return err
+					return errors.Wrap(err, "error setting reputers")
 				}
 			}
 		}
@@ -436,7 +438,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 		for _, topicIdAndInt := range data.TopicFeeRevenue {
 			if topicIdAndInt != nil {
 				if err := k.topicFeeRevenue.Set(ctx, topicIdAndInt.TopicId, topicIdAndInt.Int); err != nil {
-					return err
+					return errors.Wrap(err, "error setting topicFeeRevenue")
 				}
 			}
 		}
@@ -449,7 +451,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 					ctx,
 					topicIdAndDec.TopicId,
 					topicIdAndDec.Dec); err != nil {
-					return err
+					return errors.Wrap(err, "error setting previousTopicWeight")
 				}
 			}
 		}
@@ -461,7 +463,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			if err := k.allInferences.Set(ctx,
 				collections.Join(topicIdBlockHeightInferences.TopicId, topicIdBlockHeightInferences.BlockHeight),
 				*topicIdBlockHeightInferences.Inferences); err != nil {
-				return err
+				return errors.Wrap(err, "error setting allInferences")
 			}
 		}
 	}
@@ -471,7 +473,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			if err := k.allForecasts.Set(ctx,
 				collections.Join(topicIdBlockHeightForecasts.TopicId, topicIdBlockHeightForecasts.BlockHeight),
 				*topicIdBlockHeightForecasts.Forecasts); err != nil {
-				return err
+				return errors.Wrap(err, "error setting allForecasts")
 			}
 		}
 	}
@@ -481,7 +483,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			if err := k.allLossBundles.Set(ctx,
 				collections.Join(topicIdBlockHeightReputerValueBundles.TopicId, topicIdBlockHeightReputerValueBundles.BlockHeight),
 				*topicIdBlockHeightReputerValueBundles.ReputerValueBundles); err != nil {
-				return err
+				return errors.Wrap(err, "error setting allLossBundles")
 			}
 		}
 	}
@@ -491,27 +493,27 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			if err := k.networkLossBundles.Set(ctx,
 				collections.Join(topicIdBlockHeightValueBundles.TopicId, topicIdBlockHeightValueBundles.BlockHeight),
 				*topicIdBlockHeightValueBundles.ValueBundle); err != nil {
-				return err
+				return errors.Wrap(err, "error setting networkLossBundles")
 			}
 		}
 	}
 	//PreviousPercentageRewardToStakedReputers github_com_allora_network_allora_chain_math.Dec
 	if data.PreviousPercentageRewardToStakedReputers != alloraMath.ZeroDec() {
 		if err := k.SetPreviousPercentageRewardToStakedReputers(ctx, data.PreviousPercentageRewardToStakedReputers); err != nil {
-			return err
+			return errors.Wrap(err, "error setting previousPercentageRewardToStakedReputers")
 		}
 	} else {
 		// For mint module inflation rate calculation set the initial
 		// "previous percentage of rewards that went to staked reputers" to 30%
 		if err := k.SetPreviousPercentageRewardToStakedReputers(ctx, alloraMath.MustNewDecFromString("0.3")); err != nil {
-			return err
+			return errors.Wrap(err, "error setting previousPercentageRewardToStakedReputers to 0.3")
 		}
 	}
 	//UnfulfilledWorkerNonces []*TopicIdAndNonces
 	if len(data.UnfulfilledWorkerNonces) != 0 {
 		for _, topicIdAndNonces := range data.UnfulfilledWorkerNonces {
 			if err := k.unfulfilledWorkerNonces.Set(ctx, topicIdAndNonces.TopicId, *topicIdAndNonces.Nonces); err != nil {
-				return err
+				return errors.Wrap(err, "error setting unfulfilledWorkerNonces")
 			}
 		}
 	}
@@ -519,7 +521,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 	if len(data.UnfulfilledReputerNonces) != 0 {
 		for _, topicIdAndReputerRequestNonces := range data.UnfulfilledReputerNonces {
 			if err := k.unfulfilledReputerNonces.Set(ctx, topicIdAndReputerRequestNonces.TopicId, *topicIdAndReputerRequestNonces.ReputerRequestNonces); err != nil {
-				return err
+				return errors.Wrap(err, "error setting unfulfilledReputerNonces")
 			}
 		}
 	}
@@ -529,7 +531,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			if err := k.latestInfererNetworkRegrets.Set(ctx,
 				collections.Join(topicIdActorIdTimeStampedValue.TopicId, topicIdActorIdTimeStampedValue.ActorId),
 				*topicIdActorIdTimeStampedValue.TimestampedValue); err != nil {
-				return err
+				return errors.Wrap(err, "error setting latestInfererNetworkRegrets")
 			}
 		}
 	}
@@ -539,7 +541,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			if err := k.latestForecasterNetworkRegrets.Set(ctx,
 				collections.Join(topicIdActorIdTimeStampedValue.TopicId, topicIdActorIdTimeStampedValue.ActorId),
 				*topicIdActorIdTimeStampedValue.TimestampedValue); err != nil {
-				return err
+				return errors.Wrap(err, "error setting latestForecasterNetworkRegrets")
 			}
 		}
 	}
@@ -552,7 +554,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 					topicIdActorIdActorIdTimeStampedValue.ActorId1,
 					topicIdActorIdActorIdTimeStampedValue.ActorId2),
 				*topicIdActorIdActorIdTimeStampedValue.TimestampedValue); err != nil {
-				return err
+				return errors.Wrap(err, "error setting latestOneInForecasterNetworkRegrets")
 			}
 		}
 	}
@@ -562,7 +564,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			if err := k.latestOneInForecasterSelfNetworkRegrets.Set(ctx,
 				collections.Join(topicIdActorIdTimeStampedValue.TopicId, topicIdActorIdTimeStampedValue.ActorId),
 				*topicIdActorIdTimeStampedValue.TimestampedValue); err != nil {
-				return err
+				return errors.Wrap(err, "error setting latestOneInForecasterSelfNetworkRegrets")
 			}
 		}
 	}
@@ -572,11 +574,11 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 		for _, address := range data.CoreTeamAddresses {
 			_, err := sdk.AccAddressFromBech32(address)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "error converting core team address from bech32")
 			}
 		}
 		if err := k.addCoreTeamToWhitelists(ctx, data.CoreTeamAddresses); err != nil {
-			return err
+			return errors.Wrap(err, "error adding core team addresses to whitelists")
 		}
 	}
 	//TopicLastWorkerCommit   []*TopicIdTimestampedActorNonce
@@ -585,7 +587,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			if err := k.topicLastWorkerCommit.Set(ctx,
 				topicIdTimestampedActorNonce.TopicId,
 				*topicIdTimestampedActorNonce.TimestampedActorNonce); err != nil {
-				return err
+				return errors.Wrap(err, "error setting topicLastWorkerCommit")
 			}
 		}
 	}
@@ -595,7 +597,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			if err := k.topicLastReputerCommit.Set(ctx,
 				topicIdTimestampedActorNonce.TopicId,
 				*topicIdTimestampedActorNonce.TimestampedActorNonce); err != nil {
-				return err
+				return errors.Wrap(err, "error setting topicLastReputerCommit")
 			}
 		}
 	}
@@ -606,7 +608,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 				topicIdTimestampedActorNonce.TopicId,
 				*topicIdTimestampedActorNonce.TimestampedActorNonce,
 			); err != nil {
-				return err
+				return errors.Wrap(err, "error setting topicLastWorkerPayload")
 			}
 		}
 	}
@@ -617,23 +619,23 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) {
 	moduleParams, err := k.GetParams(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to get module params")
 	}
 
 	nextTopicId, err := k.nextTopicId.Peek(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to get next topic ID")
 	}
 
 	topicsIter, err := k.topics.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate topics")
 	}
 	topics := make([]*types.TopicIdAndTopic, 0)
 	for ; topicsIter.Valid(); topicsIter.Next() {
 		keyValue, err := topicsIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: topicsIter")
 		}
 		value := keyValue.Value
 		topic := types.TopicIdAndTopic{
@@ -646,12 +648,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	activeTopics := make([]uint64, 0)
 	activeTopicsIter, err := k.activeTopics.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate active topics")
 	}
 	for ; activeTopicsIter.Valid(); activeTopicsIter.Next() {
 		key, err := activeTopicsIter.Key()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key: activeTopicsIter")
 		}
 		activeTopics = append(activeTopics, key)
 	}
@@ -659,12 +661,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	churnableTopics := make([]uint64, 0)
 	churnableTopicsIter, err := k.churnableTopics.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate churnable topics")
 	}
 	for ; churnableTopicsIter.Valid(); churnableTopicsIter.Next() {
 		key, err := churnableTopicsIter.Key()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key: churnableTopicsIter")
 		}
 		churnableTopics = append(churnableTopics, key)
 	}
@@ -672,12 +674,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	rewardableTopics := make([]uint64, 0)
 	rewardableTopicsIter, err := k.rewardableTopics.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate rewardable topics")
 	}
 	for ; rewardableTopicsIter.Valid(); rewardableTopicsIter.Next() {
 		key, err := rewardableTopicsIter.Key()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key: rewardableTopicsIter")
 		}
 		rewardableTopics = append(rewardableTopics, key)
 	}
@@ -685,12 +687,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	topicWorkers := make([]*types.TopicAndActorId, 0)
 	topicWorkersIter, err := k.topicWorkers.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate topic workers")
 	}
 	for ; topicWorkersIter.Valid(); topicWorkersIter.Next() {
 		key, err := topicWorkersIter.Key()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key: topicWorkersIter")
 		}
 		topicIdAndActorId := types.TopicAndActorId{
 			TopicId: key.K1(),
@@ -702,12 +704,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	topicReputers := make([]*types.TopicAndActorId, 0)
 	topicReputersIter, err := k.topicReputers.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate topic reputers")
 	}
 	for ; topicReputersIter.Valid(); topicReputersIter.Next() {
 		key, err := topicReputersIter.Key()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key: topicReputersIter")
 		}
 		topicIdAndActorId := types.TopicAndActorId{
 			TopicId: key.K1(),
@@ -719,12 +721,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	topicRewardNonce := make([]*types.TopicIdAndBlockHeight, 0)
 	topicRewardNonceIter, err := k.topicRewardNonce.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate topic reward nonce")
 	}
 	for ; topicRewardNonceIter.Valid(); topicRewardNonceIter.Next() {
 		keyValue, err := topicRewardNonceIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: topicRewardNonceIter")
 		}
 		topicIdAndBlockHeight := types.TopicIdAndBlockHeight{
 			TopicId:     keyValue.Key,
@@ -736,12 +738,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	infererScoresByBlock := make([]*types.TopicIdBlockHeightScores, 0)
 	infererScoresByBlockIter, err := k.infererScoresByBlock.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate inferer scores by block")
 	}
 	for ; infererScoresByBlockIter.Valid(); infererScoresByBlockIter.Next() {
 		keyValue, err := infererScoresByBlockIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: infererScoresByBlockIter")
 		}
 		value := keyValue.Value
 		topicIdBlockHeightScores := types.TopicIdBlockHeightScores{
@@ -755,12 +757,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	forecasterScoresByBlock := make([]*types.TopicIdBlockHeightScores, 0)
 	forecasterScoresByBlockIter, err := k.forecasterScoresByBlock.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate forecaster scores by block")
 	}
 	for ; forecasterScoresByBlockIter.Valid(); forecasterScoresByBlockIter.Next() {
 		keyValue, err := forecasterScoresByBlockIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: forecasterScoresByBlockIter")
 		}
 		value := keyValue.Value
 		topicIdBlockHeightScores := types.TopicIdBlockHeightScores{
@@ -774,12 +776,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	reputerScoresByBlock := make([]*types.TopicIdBlockHeightScores, 0)
 	reputerScoresByBlockIter, err := k.reputerScoresByBlock.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate reputer scores by block")
 	}
 	for ; reputerScoresByBlockIter.Valid(); reputerScoresByBlockIter.Next() {
 		keyValue, err := reputerScoresByBlockIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: reputerScoresByBlockIter")
 		}
 		value := keyValue.Value
 		topicIdBlockHeightScores := types.TopicIdBlockHeightScores{
@@ -793,12 +795,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	latestInfererScoresByWorker := make([]*types.TopicIdActorIdScore, 0)
 	latestInfererScoresByWorkerIter, err := k.latestInfererScoresByWorker.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate latest inferer scores by worker")
 	}
 	for ; latestInfererScoresByWorkerIter.Valid(); latestInfererScoresByWorkerIter.Next() {
 		keyValue, err := latestInfererScoresByWorkerIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: latestInfererScoresByWorkerIter")
 		}
 		value := keyValue.Value
 		topicIdActorIdScore := types.TopicIdActorIdScore{
@@ -812,12 +814,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	latestForecasterScoresByWorker := make([]*types.TopicIdActorIdScore, 0)
 	latestForecasterScoresByWorkerIter, err := k.latestForecasterScoresByWorker.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate latest forecaster scores by worker")
 	}
 	for ; latestForecasterScoresByWorkerIter.Valid(); latestForecasterScoresByWorkerIter.Next() {
 		keyValue, err := latestForecasterScoresByWorkerIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: latestForecasterScoresByWorkerIter")
 		}
 		value := keyValue.Value
 		topicIdActorIdScore := types.TopicIdActorIdScore{
@@ -831,12 +833,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	latestReputerScoresByReputer := make([]*types.TopicIdActorIdScore, 0)
 	latestReputerScoresByReputerIter, err := k.latestReputerScoresByReputer.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate latest reputer scores by reputer")
 	}
 	for ; latestReputerScoresByReputerIter.Valid(); latestReputerScoresByReputerIter.Next() {
 		keyValue, err := latestReputerScoresByReputerIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: latestReputerScoresByReputerIter")
 		}
 		value := keyValue.Value
 		topicIdActorIdScore := types.TopicIdActorIdScore{
@@ -850,12 +852,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	reputerListeningCoefficient := make([]*types.TopicIdActorIdListeningCoefficient, 0)
 	reputerListeningCoefficientIter, err := k.reputerListeningCoefficient.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate reputer listening coefficient")
 	}
 	for ; reputerListeningCoefficientIter.Valid(); reputerListeningCoefficientIter.Next() {
 		keyValue, err := reputerListeningCoefficientIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: reputerListeningCoefficientIter")
 		}
 		value := keyValue.Value
 		topicIdActorIdListeningCoefficient := types.TopicIdActorIdListeningCoefficient{
@@ -869,12 +871,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	previousReputerRewardFraction := make([]*types.TopicIdActorIdDec, 0)
 	previousReputerRewardFractionIter, err := k.previousReputerRewardFraction.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate previous reputer reward fraction")
 	}
 	for ; previousReputerRewardFractionIter.Valid(); previousReputerRewardFractionIter.Next() {
 		keyValue, err := previousReputerRewardFractionIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: previousReputerRewardFractionIter")
 		}
 		topicIdActorIdDec := types.TopicIdActorIdDec{
 			TopicId: keyValue.Key.K1(),
@@ -887,12 +889,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	previousInferenceRewardFraction := make([]*types.TopicIdActorIdDec, 0)
 	previousInferenceRewardFractionIter, err := k.previousInferenceRewardFraction.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate previous inference reward fraction")
 	}
 	for ; previousInferenceRewardFractionIter.Valid(); previousInferenceRewardFractionIter.Next() {
 		keyValue, err := previousInferenceRewardFractionIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: previousInferenceRewardFractionIter")
 		}
 		topicIdActorIdDec := types.TopicIdActorIdDec{
 			TopicId: keyValue.Key.K1(),
@@ -905,12 +907,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	previousForecastRewardFraction := make([]*types.TopicIdActorIdDec, 0)
 	previousForecastRewardFractionIter, err := k.previousForecastRewardFraction.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate previous forecast reward fraction")
 	}
 	for ; previousForecastRewardFractionIter.Valid(); previousForecastRewardFractionIter.Next() {
 		keyValue, err := previousForecastRewardFractionIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: previousForecastRewardFractionIter")
 		}
 		topicIdActorIdDec := types.TopicIdActorIdDec{
 			TopicId: keyValue.Key.K1(),
@@ -922,39 +924,35 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 
 	totalStake, err := k.totalStake.Get(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to get total stake")
 	}
 
 	// Fill in the values from keeper.go
 
 	// topicStake
 	topicStake := make([]*types.TopicIdAndInt, 0)
-	topicStakeIter, err := k.topicStake.Iterate(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	for ; topicStakeIter.Valid(); topicStakeIter.Next() {
-		keyValue, err := topicStakeIter.KeyValue()
+	var i uint64
+	for i = 1; i < nextTopicId; i++ {
+		stake, err := k.topicStake.Get(ctx, i)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed to get topic stake %d", i)
 		}
-		topicIdAndInt := types.TopicIdAndInt{
-			TopicId: keyValue.Key,
-			Int:     keyValue.Value,
-		}
-		topicStake = append(topicStake, &topicIdAndInt)
+		topicStake = append(topicStake, &types.TopicIdAndInt{
+			TopicId: i,
+			Int:     stake,
+		})
 	}
 
 	// stakeReputerAuthority
 	stakeReputerAuthority := make([]*types.TopicIdActorIdInt, 0)
 	stakeReputerAuthorityIter, err := k.stakeReputerAuthority.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate stake reputer authority")
 	}
 	for ; stakeReputerAuthorityIter.Valid(); stakeReputerAuthorityIter.Next() {
 		keyValue, err := stakeReputerAuthorityIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: stakeReputerAuthorityIter")
 		}
 		topicIdActorIdInt := types.TopicIdActorIdInt{
 			TopicId: keyValue.Key.K1(),
@@ -968,12 +966,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	stakeSumFromDelegator := make([]*types.TopicIdActorIdInt, 0)
 	stakeSumFromDelegatorIter, err := k.stakeSumFromDelegator.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate stake sum from delegator")
 	}
 	for ; stakeSumFromDelegatorIter.Valid(); stakeSumFromDelegatorIter.Next() {
 		keyValue, err := stakeSumFromDelegatorIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: stakeSumFromDelegatorIter")
 		}
 		topicIdActorIdInt := types.TopicIdActorIdInt{
 			TopicId: keyValue.Key.K1(),
@@ -987,12 +985,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	delegatedStakes := make([]*types.TopicIdDelegatorReputerDelegatorInfo, 0)
 	delegatedStakesIter, err := k.delegatedStakes.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate delegated stakes")
 	}
 	for ; delegatedStakesIter.Valid(); delegatedStakesIter.Next() {
 		keyValue, err := delegatedStakesIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: delegatedStakesIter")
 		}
 		value := keyValue.Value
 		topicIdDelegatorReputerDelegatorInfo := types.TopicIdDelegatorReputerDelegatorInfo{
@@ -1008,12 +1006,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	stakeFromDelegatorsUponReputer := make([]*types.TopicIdActorIdInt, 0)
 	stakeFromDelegatorsUponReputerIter, err := k.stakeFromDelegatorsUponReputer.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate stake from delegators upon reputer")
 	}
 	for ; stakeFromDelegatorsUponReputerIter.Valid(); stakeFromDelegatorsUponReputerIter.Next() {
 		keyValue, err := stakeFromDelegatorsUponReputerIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: stakeFromDelegatorsUponReputerIter")
 		}
 		topicIdActorIdInt := types.TopicIdActorIdInt{
 			TopicId: keyValue.Key.K1(),
@@ -1027,12 +1025,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	delegateRewardPerShare := make([]*types.TopicIdActorIdDec, 0)
 	delegateRewardPerShareIter, err := k.delegateRewardPerShare.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate delegate reward per share")
 	}
 	for ; delegateRewardPerShareIter.Valid(); delegateRewardPerShareIter.Next() {
 		keyValue, err := delegateRewardPerShareIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: delegateRewardPerShareIter")
 		}
 		topicIdActorIdDec := types.TopicIdActorIdDec{
 			TopicId: keyValue.Key.K1(),
@@ -1046,12 +1044,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	stakeRemovalsByBlock := make([]*types.BlockHeightTopicIdReputerStakeRemovalInfo, 0)
 	stakeRemovalsByBlockIter, err := k.stakeRemovalsByBlock.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate stake removals by block")
 	}
 	for ; stakeRemovalsByBlockIter.Valid(); stakeRemovalsByBlockIter.Next() {
 		keyValue, err := stakeRemovalsByBlockIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: stakeRemovalsByBlockIter")
 		}
 		value := keyValue.Value
 		blockHeightTopicIdReputerStakeRemovalInfo := types.BlockHeightTopicIdReputerStakeRemovalInfo{
@@ -1066,12 +1064,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	stakeRemovalsByActor := make([]*types.ActorIdTopicIdBlockHeight, 0)
 	stakeRemovalsByActorIter, err := k.stakeRemovalsByActor.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate stake removals by actor")
 	}
 	for ; stakeRemovalsByActorIter.Valid(); stakeRemovalsByActorIter.Next() {
 		key, err := stakeRemovalsByActorIter.Key()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key: stakeRemovalsByActorIter")
 		}
 		actorIdTopicIdBlockHeight := types.ActorIdTopicIdBlockHeight{
 			ActorId:     key.K1(),
@@ -1085,12 +1083,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	delegateStakeRemovalsByBlock := make([]*types.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo, 0)
 	delegateStakeRemovalsByBlockIter, err := k.delegateStakeRemovalsByBlock.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate delegate stake removals by block")
 	}
 	for ; delegateStakeRemovalsByBlockIter.Valid(); delegateStakeRemovalsByBlockIter.Next() {
 		keyValue, err := delegateStakeRemovalsByBlockIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: delegateStakeRemovalsByBlockIter")
 		}
 		value := keyValue.Value
 		blockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo := types.BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo{
@@ -1105,12 +1103,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	delegateStakeRemovalsByActor := make([]*types.DelegatorReputerTopicIdBlockHeight, 0)
 	delegateStakeRemovalsByActorIter, err := k.delegateStakeRemovalsByActor.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate delegate stake removals by actor")
 	}
 	for ; delegateStakeRemovalsByActorIter.Valid(); delegateStakeRemovalsByActorIter.Next() {
 		key, err := delegateStakeRemovalsByActorIter.Key()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key: delegateStakeRemovalsByActorIter")
 		}
 		delegatorReputerTopicIdBlockHeight := types.DelegatorReputerTopicIdBlockHeight{
 			Delegator:   key.K1(),
@@ -1125,12 +1123,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	inferences := make([]*types.TopicIdActorIdInference, 0)
 	inferencesIter, err := k.inferences.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate inferences")
 	}
 	for ; inferencesIter.Valid(); inferencesIter.Next() {
 		keyValue, err := inferencesIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: inferencesIter")
 		}
 		value := keyValue.Value
 		topicIdActorIdInference := types.TopicIdActorIdInference{
@@ -1145,12 +1143,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	forecasts := make([]*types.TopicIdActorIdForecast, 0)
 	forecastsIter, err := k.forecasts.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate forecasts")
 	}
 	for ; forecastsIter.Valid(); forecastsIter.Next() {
 		keyValue, err := forecastsIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: forecastsIter")
 		}
 		value := keyValue.Value
 		topicIdActorIdForecast := types.TopicIdActorIdForecast{
@@ -1165,12 +1163,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	workers := make([]*types.LibP2PKeyAndOffchainNode, 0)
 	workersIter, err := k.workers.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate workers")
 	}
 	for ; workersIter.Valid(); workersIter.Next() {
 		keyValue, err := workersIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: workersIter")
 		}
 		value := keyValue.Value
 		libP2PKeyAndOffchainNode := types.LibP2PKeyAndOffchainNode{
@@ -1184,12 +1182,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	reputers := make([]*types.LibP2PKeyAndOffchainNode, 0)
 	reputersIter, err := k.reputers.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate reputers")
 	}
 	for ; reputersIter.Valid(); reputersIter.Next() {
 		keyValue, err := reputersIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: reputersIter")
 		}
 		libP2PKeyAndOffchainNode := types.LibP2PKeyAndOffchainNode{
 			LibP2PKey:    keyValue.Key,
@@ -1202,12 +1200,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	topicFeeRevenue := make([]*types.TopicIdAndInt, 0)
 	topicFeeRevenueIter, err := k.topicFeeRevenue.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate topic fee revenue")
 	}
 	for ; topicFeeRevenueIter.Valid(); topicFeeRevenueIter.Next() {
 		keyValue, err := topicFeeRevenueIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: topicFeeRevenueIter")
 		}
 		topicIdAndInt := types.TopicIdAndInt{
 			TopicId: keyValue.Key,
@@ -1220,12 +1218,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	previousTopicWeight := make([]*types.TopicIdAndDec, 0)
 	previousTopicWeightIter, err := k.previousTopicWeight.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate previous topic weight")
 	}
 	for ; previousTopicWeightIter.Valid(); previousTopicWeightIter.Next() {
 		keyValue, err := previousTopicWeightIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: previousTopicWeightIter")
 		}
 		topicIdAndDec := types.TopicIdAndDec{
 			TopicId: keyValue.Key,
@@ -1238,12 +1236,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	allInferences := make([]*types.TopicIdBlockHeightInferences, 0)
 	allInferencesIter, err := k.allInferences.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate all inferences")
 	}
 	for ; allInferencesIter.Valid(); allInferencesIter.Next() {
 		keyValue, err := allInferencesIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: allInferencesIter")
 		}
 		value := keyValue.Value
 		topicIdBlockHeightInferences := types.TopicIdBlockHeightInferences{
@@ -1258,12 +1256,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	allForecasts := make([]*types.TopicIdBlockHeightForecasts, 0)
 	allForecastsIter, err := k.allForecasts.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate all forecasts")
 	}
 	for ; allForecastsIter.Valid(); allForecastsIter.Next() {
 		keyValue, err := allForecastsIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: allForecastsIter")
 		}
 		value := keyValue.Value
 		topicIdBlockHeightForecasts := types.TopicIdBlockHeightForecasts{
@@ -1278,12 +1276,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	allLossBundles := make([]*types.TopicIdBlockHeightReputerValueBundles, 0)
 	allLossBundlesIter, err := k.allLossBundles.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate all loss bundles")
 	}
 	for ; allLossBundlesIter.Valid(); allLossBundlesIter.Next() {
 		keyValue, err := allLossBundlesIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: allLossBundlesIter")
 		}
 		value := keyValue.Value
 		topicIdBlockHeightValueBundles := types.TopicIdBlockHeightReputerValueBundles{
@@ -1298,12 +1296,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	networkLossBundles := make([]*types.TopicIdBlockHeightValueBundles, 0)
 	networkLossBundlesIter, err := k.networkLossBundles.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate network loss bundles")
 	}
 	for ; networkLossBundlesIter.Valid(); networkLossBundlesIter.Next() {
 		keyValue, err := networkLossBundlesIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: networkLossBundlesIter")
 		}
 		value := keyValue.Value
 		topicIdBlockHeightValueBundles := types.TopicIdBlockHeightValueBundles{
@@ -1317,19 +1315,19 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	// previousPercentageRewardToStakedReputers
 	previousPercentageRewardToStakedReputers, err := k.previousPercentageRewardToStakedReputers.Get(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to get previous percentage reward to staked reputers")
 	}
 
 	// unfulfilledWorkerNonces
 	unfulfilledWorkerNonces := make([]*types.TopicIdAndNonces, 0)
 	unfulfilledWorkerNoncesIter, err := k.unfulfilledWorkerNonces.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate unfulfilled worker nonces")
 	}
 	for ; unfulfilledWorkerNoncesIter.Valid(); unfulfilledWorkerNoncesIter.Next() {
 		keyValue, err := unfulfilledWorkerNoncesIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: unfulfilledWorkerNoncesIter")
 		}
 		topicIdAndNonces := types.TopicIdAndNonces{
 			TopicId: keyValue.Key,
@@ -1342,12 +1340,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	unfulfilledReputerNonces := make([]*types.TopicIdAndReputerRequestNonces, 0)
 	unfulfilledReputerNoncesIter, err := k.unfulfilledReputerNonces.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate unfulfilled reputer nonces")
 	}
 	for ; unfulfilledReputerNoncesIter.Valid(); unfulfilledReputerNoncesIter.Next() {
 		keyValue, err := unfulfilledReputerNoncesIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: unfulfilledReputerNoncesIter")
 		}
 		value := keyValue.Value
 		topicIdAndReputerRequestNonces := types.TopicIdAndReputerRequestNonces{
@@ -1360,12 +1358,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	latestInfererNetworkRegrets := make([]*types.TopicIdActorIdTimeStampedValue, 0)
 	latestInfererNetworkRegretsIter, err := k.latestInfererNetworkRegrets.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate latest inferer network regrets")
 	}
 	for ; latestInfererNetworkRegretsIter.Valid(); latestInfererNetworkRegretsIter.Next() {
 		keyValue, err := latestInfererNetworkRegretsIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: latestInfererNetworkRegretsIter")
 		}
 		topicIdActorIdTimeStampedValue := types.TopicIdActorIdTimeStampedValue{
 			TopicId:          keyValue.Key.K1(),
@@ -1378,12 +1376,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	latestForecasterNetworkRegrets := make([]*types.TopicIdActorIdTimeStampedValue, 0)
 	latestForecasterNetworkRegretsIter, err := k.latestForecasterNetworkRegrets.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate latest forecaster network regrets")
 	}
 	for ; latestForecasterNetworkRegretsIter.Valid(); latestForecasterNetworkRegretsIter.Next() {
 		keyValue, err := latestForecasterNetworkRegretsIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: latestForecasterNetworkRegretsIter")
 		}
 		topicIdActorIdTimeStampedValue := types.TopicIdActorIdTimeStampedValue{
 			TopicId:          keyValue.Key.K1(),
@@ -1396,12 +1394,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	latestOneInForecasterNetworkRegrets := make([]*types.TopicIdActorIdActorIdTimeStampedValue, 0)
 	latestOneInForecasterNetworkRegretsIter, err := k.latestOneInForecasterNetworkRegrets.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate latest one in forecaster network regrets")
 	}
 	for ; latestOneInForecasterNetworkRegretsIter.Valid(); latestOneInForecasterNetworkRegretsIter.Next() {
 		keyValue, err := latestOneInForecasterNetworkRegretsIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: latestOneInForecasterNetworkRegretsIter")
 		}
 		topicIdActorIdActorIdTimeStampedValue := types.TopicIdActorIdActorIdTimeStampedValue{
 			TopicId:          keyValue.Key.K1(),
@@ -1415,12 +1413,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	latestOneInForecasterSelfNetworkRegrets := make([]*types.TopicIdActorIdTimeStampedValue, 0)
 	latestOneInForecasterSelfNetworkRegretsIter, err := k.latestOneInForecasterSelfNetworkRegrets.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate latest one in forecaster self network regrets")
 	}
 	for ; latestOneInForecasterSelfNetworkRegretsIter.Valid(); latestOneInForecasterSelfNetworkRegretsIter.Next() {
 		keyValue, err := latestOneInForecasterSelfNetworkRegretsIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: latestOneInForecasterSelfNetworkRegretsIter")
 		}
 		topicIdActorIdTimeStampedValue := types.TopicIdActorIdTimeStampedValue{
 			TopicId:          keyValue.Key.K1(),
@@ -1433,12 +1431,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	coreTeamAddresses := make([]string, 0)
 	coreTeamAddressesIter, err := k.whitelistAdmins.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate core team addresses")
 	}
 	for ; coreTeamAddressesIter.Valid(); coreTeamAddressesIter.Next() {
 		key, err := coreTeamAddressesIter.Key()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key: coreTeamAddressesIter")
 		}
 		coreTeamAddresses = append(coreTeamAddresses, key)
 	}
@@ -1446,12 +1444,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	topicLastWorkerCommit := make([]*types.TopicIdTimestampedActorNonce, 0)
 	topicLastWorkerCommitIter, err := k.topicLastWorkerCommit.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate topic last worker commit")
 	}
 	for ; topicLastWorkerCommitIter.Valid(); topicLastWorkerCommitIter.Next() {
 		keyValue, err := topicLastWorkerCommitIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: topicLastWorkerCommitIter")
 		}
 		topicIdTimestampedActorNonce := types.TopicIdTimestampedActorNonce{
 			TopicId:               keyValue.Key,
@@ -1463,12 +1461,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	topicLastReputerCommit := make([]*types.TopicIdTimestampedActorNonce, 0)
 	topicLastReputerCommitIter, err := k.topicLastReputerCommit.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate topic last reputer commit")
 	}
 	for ; topicLastReputerCommitIter.Valid(); topicLastReputerCommitIter.Next() {
 		keyValue, err := topicLastReputerCommitIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: topicLastReputerCommitIter")
 		}
 		topicIdTimestampedActorNonce := types.TopicIdTimestampedActorNonce{
 			TopicId:               keyValue.Key,
@@ -1480,12 +1478,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	topicLastWorkerPayload := make([]*types.TopicIdTimestampedActorNonce, 0)
 	topicLastWorkerPayloadIter, err := k.topicLastWorkerPayload.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate topic last worker payload")
 	}
 	for ; topicLastWorkerPayloadIter.Valid(); topicLastWorkerPayloadIter.Next() {
 		keyValue, err := topicLastWorkerPayloadIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: topicLastWorkerPayloadIter")
 		}
 		topicIdTimestampedActorNonce := types.TopicIdTimestampedActorNonce{
 			TopicId:               keyValue.Key,
@@ -1497,12 +1495,12 @@ func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error)
 	topicLastReputerPayload := make([]*types.TopicIdTimestampedActorNonce, 0)
 	topicLastReputerPayloadIter, err := k.topicLastReputerPayload.Iterate(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to iterate topic last reputer payload")
 	}
 	for ; topicLastReputerPayloadIter.Valid(); topicLastReputerPayloadIter.Next() {
 		keyValue, err := topicLastReputerPayloadIter.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get key value: topicLastReputerPayloadIter")
 		}
 		topicIdTimestampedActorNonce := types.TopicIdTimestampedActorNonce{
 			TopicId:               keyValue.Key,

--- a/x/emissions/keeper/genesis_test.go
+++ b/x/emissions/keeper/genesis_test.go
@@ -1,0 +1,15 @@
+package keeper_test
+
+import (
+	cosmossdk_io_math "cosmossdk.io/math"
+)
+
+// at minimum test that an import can be done from an export without error
+func (s *KeeperTestSuite) TestImportExportGenesisNoError() {
+	s.emissionsKeeper.SetTopicStake(s.ctx, 0, cosmossdk_io_math.OneInt())
+	genesisState, err := s.emissionsKeeper.ExportGenesis(s.ctx)
+	s.Require().NoError(err)
+
+	err = s.emissionsKeeper.InitGenesis(s.ctx, genesisState)
+	s.Require().NoError(err)
+}

--- a/x/emissions/proto/emissions/v1/genesis.proto
+++ b/x/emissions/proto/emissions/v1/genesis.proto
@@ -1,9 +1,18 @@
 syntax = "proto3";
 package emissions.v1;
 
+import "cosmos_proto/cosmos.proto";
+import "amino/amino.proto";
 import "gogoproto/gogo.proto";
 import "emissions/v1/params.proto";
-import "amino/amino.proto";
+import "emissions/v1/score.proto";
+import "emissions/v1/stake.proto";
+import "emissions/v1/types.proto";
+import "emissions/v1/topic.proto";
+import "emissions/v1/worker.proto";
+import "emissions/v1/node.proto";
+import "emissions/v1/reputer.proto";
+import "emissions/v1/nonce.proto";
 
 option go_package = "github.com/allora-network/allora-chain/x/emissions/types";
 
@@ -11,5 +20,300 @@ option go_package = "github.com/allora-network/allora-chain/x/emissions/types";
 message GenesisState {
   // params defines all the parameters of the module.
   Params params = 1 [(gogoproto.nullable) = false];
+
+  /// TOPIC
+  // the next topic id to be used, equal to the number of topics that have been created
+  uint64 nextTopicId = 3;
+  // every topic that has been created indexed by their topicId starting from 1 (0 is reserved for the root network)
+  repeated TopicIdAndTopic topics = 4;
+  repeated uint64 activeTopics = 5;
+  // every topic that is ready to request inferences and possible also losses
+  repeated uint64 churnableTopics = 6;
+  // every topic that has been churned and ready to be rewarded i.e. reputer losses have been committed
+  repeated uint64 rewardableTopics = 7;
+  // for a topic, what is every worker node that has registered to it?
+  repeated TopicAndActorId topicWorkers = 8;
+  // for a topic, what is every reputer node that has registered to it?
+  repeated TopicAndActorId topicReputers = 9;
+  // map of (topic) -> nonce/block height
+  repeated TopicIdAndBlockHeight topicRewardNonce = 10;
+
+  /// SCORES
+  // map of (topic, block_height, worker) -> score
+  repeated TopicIdBlockHeightScores infererScoresByBlock = 11;
+  // map of (topic, block_height, worker) -> score
+  repeated TopicIdBlockHeightScores forecasterScoresByBlock = 12;
+  // map of (topic, block_height, reputer) -> score
+  repeated TopicIdBlockHeightScores reputerScoresByBlock = 13;
+  // map of (topic, block_height, worker) -> score
+  repeated TopicIdActorIdScore latestInfererScoresByWorker = 14;
+  // map of (topic, block_height, worker) -> score
+  repeated TopicIdActorIdScore latestForecasterScoresByWorker = 15;
+  // map of (topic, block_height, reputer) -> score
+  repeated TopicIdActorIdScore latestReputerScoresByReputer = 16;
+  // map of (topic, reputer) -> listening coefficient
+  repeated TopicIdActorIdListeningCoefficient reputerListeningCoefficient = 17;
+  // map of (topic, reputer) -> previous reward (used for EMA)
+  repeated TopicIdActorIdDec previousReputerRewardFraction = 18;
+  // map of (topic, worker) -> previous reward for inference (used for EMA)
+  repeated TopicIdActorIdDec previousInferenceRewardFraction = 19;
+  // map of (topic, worker) -> previous reward for forecast (used for EMA)
+  repeated TopicIdActorIdDec previousForecastRewardFraction = 20;
+
+  /// STAKING
+
+  // total sum stake of all stakers on the network
+  string totalStake = 21 [
+    (cosmos_proto.scalar) = "cosmos.Int",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false,
+    (amino.dont_omitempty) = true
+  ];
+  // for every topic, how much total stake does that topic have accumulated?
+  repeated TopicIdAndInt topicStake = 22;
+  // stake reputer placed in topic + delegate stake placed in them,
+  // signalling their total authority on the topic
+  // (topic Id, reputer) -> stake from reputer on self + stakeFromDelegatorsUponReputer
+  repeated TopicIdActorIdInt stakeReputerAuthority = 23;
+  // map of (topic id, delegator) -> total amount of stake in that topic placed by that delegator
+  repeated TopicIdActorIdInt stakeSumFromDelegator = 24;
+  // map of (topic id, delegator, reputer) -> amount of stake that has been placed by that delegator on that target
+  repeated TopicIdDelegatorReputerDelegatorInfo delegatedStakes = 25;
+  // map of (topic id, reputer) -> total amount of stake that has been placed on that reputer by delegators
+  repeated TopicIdActorIdInt stakeFromDelegatorsUponReputer = 26;
+  // map of (topicId, reputer) -> share of delegate reward
+  repeated TopicIdActorIdDec delegateRewardPerShare = 27;
+  // stake removals are double indexed to avoid O(n) lookups when removing stake
+  // map of (blockHeight, topic, reputer) -> removal information for that reputer
+  repeated BlockHeightTopicIdReputerStakeRemovalInfo stakeRemovalsByBlock = 28;
+  // key set of (reputer, topic, blockHeight) to existence of a removal in the forwards map
+  repeated ActorIdTopicIdBlockHeight stakeRemovalsByActor = 29;
+  // delegate stake removals are double indexed to avoid O(n) lookups when removing stake
+  // map of (blockHeight, topic, delegator, reputer staked upon) -> (list of reputers delegated upon and info) to have
+  // stake removed at that block
+  repeated BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo delegateStakeRemovalsByBlock = 30;
+  // key set of (delegator, reputer, topicId, blockHeight) to existence of a removal in the forwards map
+  repeated DelegatorReputerTopicIdBlockHeight delegateStakeRemovalsByActor = 31;
+
+	/// MISC GLOBAL STATE
+	// map of (topic, worker) -> inference
+  repeated TopicIdActorIdInference inferences = 32;
+	// map of (topic, worker) -> forecast[]
+  repeated TopicIdActorIdForecast forecasts = 33;
+	// map of worker id to node data about that worker
+  repeated LibP2pKeyAndOffchainNode workers = 34;
+	// map of reputer id to node data about that reputer
+  repeated LibP2pKeyAndOffchainNode reputers = 35;
+	// fee revenue collected by a topic over the course of the last reward cadence
+  repeated TopicIdAndInt topicFeeRevenue = 36;
+	// store previous weights for exponential moving average in rewards calc
+  repeated TopicIdAndDec previousTopicWeight = 37;
+	// map of (topic, block_height) -> Inference
+  repeated TopicIdBlockHeightInferences allInferences = 38;
+	// map of (topic, block_height) -> Forecast
+  repeated TopicIdBlockHeightForecasts allForecasts = 39;
+	// map of (topic, block_height) -> ReputerValueBundles (1 per reputer active at that time)
+  repeated TopicIdBlockHeightReputerValueBundles allLossBundles = 40;
+	// map of (topic, block_height) -> ValueBundle (1 network wide bundle per timestep)
+  repeated TopicIdBlockHeightValueBundles networkLossBundles = 41;
+	// Percentage of all rewards, paid out to staked reputers, during the previous reward cadence. Used by mint module
+  string previousPercentageRewardToStakedReputers = 42
+      [(gogoproto.customtype) = "github.com/allora-network/allora-chain/math.Dec", (gogoproto.nullable) = false];
+
+	/// NONCES
+	// map of (topic) -> unfulfilled nonces
+  repeated TopicIdAndNonces unfulfilledWorkerNonces = 43;
+	// map of (topic) -> unfulfilled nonces
+  repeated TopicIdAndReputerRequestNonces unfulfilledReputerNonces = 44;
+
+	/// REGRETS
+	// map of (topic, worker) -> regret of worker from comparing loss of worker relative to loss of other inferers
+  repeated TopicIdActorIdTimeStampedValue latestInfererNetworkRegrets = 45;
+	// map of (topic, worker) -> regret of worker from comparing loss of worker relative to loss of other forecasters
+  repeated TopicIdActorIdTimeStampedValue latestForecasterNetworkRegrets = 46;
+	// map of (topic, forecaster, inferer) -> R^+_{ij_kk} regret of forecaster loss from comparing one-in loss with
+	// all network inferer (3rd index) regrets L_ij made under the regime of the one-in forecaster (2nd index)
+  repeated TopicIdActorIdActorIdTimeStampedValue latestOneInForecasterNetworkRegrets = 47;
+	// the forecaster (2nd index) regrets made under the regime of the same forecaster as a one-in forecaster
+  repeated TopicIdActorIdTimeStampedValue latestOneInForecasterSelfNetworkRegrets = 48;
+
+	/// WHITELISTS
   repeated string core_team_addresses = 2;
+
+	/// RECORD COMMITS
+  repeated TopicIdTimestampedActorNonce topicLastWorkerCommit = 49;
+  repeated TopicIdTimestampedActorNonce topicLastReputerCommit = 50;
+  repeated TopicIdTimestampedActorNonce topicLastWorkerPayload = 51;
+  repeated TopicIdTimestampedActorNonce topicLastReputerPayload = 52;
+}
+
+message TopicIdAndTopic {
+  uint64 TopicId = 1;
+  Topic Topic = 2;
+}
+
+message TopicAndActorId {
+  uint64 TopicId = 1;
+  string ActorId = 2;
+}
+
+message TopicIdAndBlockHeight {
+  uint64 TopicId = 1;
+  int64 BlockHeight = 2;
+}
+
+message TopicIdBlockHeightScores {
+  uint64 TopicId = 1;
+  int64 BlockHeight = 2;
+  Scores Scores = 3;
+}
+
+message TopicIdActorIdScore {
+  uint64 TopicId = 1;
+  string ActorId = 2;
+  Score Score = 3;
+}
+
+message TopicIdActorIdListeningCoefficient {
+  uint64 TopicId = 1;
+  string ActorId = 2;
+  ListeningCoefficient ListeningCoefficient = 3;
+}
+
+message TopicIdActorIdDec {
+  uint64 TopicId = 1;
+  string ActorId = 2;
+  string Dec = 3
+      [(gogoproto.customtype) = "github.com/allora-network/allora-chain/math.Dec", (gogoproto.nullable) = false];
+}
+
+message TopicIdAndInt {
+  uint64 TopicId = 1;
+  string Int = 2 [
+    (cosmos_proto.scalar) = "cosmos.Int",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false,
+    (amino.dont_omitempty) = true
+  ];
+}
+
+message TopicIdActorIdInt {
+  uint64 TopicId = 1;
+  string ActorId = 2;
+  string Int = 3 [
+    (cosmos_proto.scalar) = "cosmos.Int",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false,
+    (amino.dont_omitempty) = true
+  ];
+}
+
+message TopicIdDelegatorReputerDelegatorInfo {
+  uint64 TopicId = 1;
+  string Delegator = 2;
+  string Reputer = 3;
+  DelegatorInfo DelegatorInfo = 4;
+}
+
+message BlockHeightTopicIdReputerStakeRemovalInfo {
+  int64 BlockHeight = 1;
+  uint64 TopicId = 2;
+  string Reputer = 3;
+  StakeRemovalInfo StakeRemovalInfo = 4;
+}
+
+message ActorIdTopicIdBlockHeight {
+  string ActorId = 1;
+  uint64 TopicId = 2;
+  int64 BlockHeight = 3;
+}
+
+message BlockHeightTopicIdDelegatorReputerDelegateStakeRemovalInfo {
+  int64 BlockHeight = 1;
+  uint64 TopicId = 2;
+  string Delegator = 3;
+  string Reputer = 4;
+  DelegateStakeRemovalInfo DelegateStakeRemovalInfo = 5;
+}
+
+message DelegatorReputerTopicIdBlockHeight {
+  string Delegator = 1;
+  string Reputer = 2;
+  uint64 TopicId = 3;
+  int64 BlockHeight = 4;
+}
+
+message TopicIdActorIdInference {
+  uint64 TopicId = 1;
+  string ActorId = 2;
+  Inference Inference = 3;
+}
+
+message TopicIdActorIdForecast {
+  uint64 TopicId = 1;
+  string ActorId = 2;
+  Forecast Forecast = 3;
+}
+
+message LibP2pKeyAndOffchainNode {
+  string LibP2pKey = 1;
+  OffchainNode OffchainNode = 2;
+}
+
+message TopicIdAndDec {
+  uint64 TopicId = 1;
+  string Dec = 2
+      [(gogoproto.customtype) = "github.com/allora-network/allora-chain/math.Dec", (gogoproto.nullable) = false];
+}
+
+message TopicIdBlockHeightInferences {
+  uint64 TopicId = 1;
+  int64 BlockHeight = 2;
+  Inferences Inferences = 3;
+}
+
+message TopicIdBlockHeightForecasts {
+  uint64 TopicId = 1;
+  int64 BlockHeight = 2;
+  Forecasts Forecasts = 3;
+}
+
+message TopicIdBlockHeightReputerValueBundles {
+  uint64 TopicId = 1;
+  int64 BlockHeight = 2;
+  ReputerValueBundles ReputerValueBundles = 3;
+}
+
+message TopicIdBlockHeightValueBundles {
+  uint64 TopicId = 1;
+  int64 BlockHeight = 2;
+  ValueBundle ValueBundle = 3;
+}
+
+message TopicIdAndNonces {
+  uint64 TopicId = 1;
+  Nonces Nonces = 2;
+}
+
+message TopicIdAndReputerRequestNonces {
+  uint64 TopicId = 1;
+  ReputerRequestNonces ReputerRequestNonces = 2;
+}
+
+message TopicIdActorIdTimeStampedValue {
+  uint64 TopicId = 1;
+  string ActorId = 2;
+  TimestampedValue TimestampedValue = 3;
+}
+
+message TopicIdActorIdActorIdTimeStampedValue {
+  uint64 TopicId = 1;
+  string ActorId1 = 2;
+  string ActorId2 = 3;
+  TimestampedValue TimestampedValue = 4;
+}
+
+message TopicIdTimestampedActorNonce {
+  uint64 TopicId = 1;
+  TimestampedActorNonce TimestampedActorNonce = 2;
 }


### PR DESCRIPTION
## What is the purpose of the change

When we wrote the emissions module we neglected to actually write full `initGenesis` and `exportGenesis` functions for it, opting instead to only export and initialize the core team addresses and the module params. Well in the case of a hard fork the system will be unable to initialize with any state since we never saved it anywhere. Additionally this gives us a useful function to entirely dump a nodes state, should we ever decide we need to.

## Testing and Verifying

This change added tests to cover being able to import the state we exported.

## Documentation and Release Note

There are no documentation relevant implications for this PR