### PR TITLE
[ORA-1911] Removing duplicates on worker payload msg

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -164,9 +164,11 @@ func verifyAndInsertForecastsFromTopForecasters(
 			// We keep what we can, ignoring the forecaster and their contribution (forecast) entirely
 			// if they're left with no valid forecast elements.
 			acceptedForecastElements := make([]*types.ForecastElement, 0)
+			seenInferers := make(map[string]bool)
 			for _, el := range forecast.ForecastElements {
-				if _, ok := acceptedInferersOfBatch[el.Inferer]; ok {
+				if _, ok := acceptedInferersOfBatch[el.Inferer]; ok && !seenInferers[el.Inferer] {
 					acceptedForecastElements = append(acceptedForecastElements, el)
+					seenInferers[el.Inferer] = true
 				}
 			}
 
@@ -176,6 +178,8 @@ func verifyAndInsertForecastsFromTopForecasters(
 			}
 
 			/// Filtering done now, now write what we must for inclusion
+			// Update the forecast with the filtered elements
+			forecast.ForecastElements = acceptedForecastElements
 
 			// Get the latest score for each forecaster => only take top few by score descending
 			latestScore, err := ms.k.GetLatestForecasterScore(ctx, topicId, forecast.Forecaster)

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
@@ -250,7 +250,6 @@ func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithUnregistered
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, topicId := s.setUpMsgInsertBulkWorkerPayload(workerPrivateKey)
 
 	// BEGIN MODIFICATION
@@ -277,6 +276,48 @@ func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayloadFailsWithUnregistered
 
 	require.Equal(forecastsCount0, 0)
 	require.Equal(forecastsCount1, 0)
+}
+
+func (s *MsgServerTestSuite) TestMsgInsertBulkWorkerPayloadFiltersDuplicateForecastElements() {
+	ctx, msgServer := s.ctx, s.msgServer
+	require := s.Require()
+
+	workerPrivateKey := secp256k1.GenPrivKey()
+	workerMsg, topicId := s.setUpMsgInsertBulkWorkerPayload(workerPrivateKey)
+
+	// BEGIN MODIFICATION
+	forecast := workerMsg.WorkerDataBundles[0].InferenceForecastsBundle.Forecast
+	originalElement := forecast.ForecastElements[0]
+	duplicateElement := &types.ForecastElement{
+		Inferer: originalElement.Inferer,
+		Value:   originalElement.Value,
+	}
+	forecast.ForecastElements = append(forecast.ForecastElements, duplicateElement)
+	// END MODIFICATION
+
+	workerMsg = s.signMsgInsertBulkWorkerPayload(workerMsg, workerPrivateKey)
+
+	blockHeight := forecast.BlockHeight
+	forecastsCount0 := s.getCountForecastsAtBlock(topicId, blockHeight)
+
+	_, err := msgServer.InsertBulkWorkerPayload(ctx, &workerMsg)
+	require.NoError(err, "InsertBulkWorkerPayload should not return an error")
+
+	// Check the forecast count to ensure duplicates were filtered out
+	forecastsCount1 := s.getCountForecastsAtBlock(topicId, blockHeight)
+	require.Equal(forecastsCount0+1, forecastsCount1, "Forecast count should increase by one")
+
+	storedForecasts, err := s.emissionsKeeper.GetForecastsAtBlock(ctx, topicId, blockHeight)
+	require.NoError(err, "GetForecastsAtBlock should not return an error")
+
+	for _, forecast := range storedForecasts.Forecasts {
+		infererMap := make(map[string]bool)
+		for _, el := range forecast.ForecastElements {
+			_, exists := infererMap[el.Inferer]
+			require.False(exists, "Each inferer should appear only once in ForecastElements")
+			infererMap[el.Inferer] = true
+		}
+	}
 }
 
 func (s *MsgServerTestSuite) TestInsertingHugeBulkWorkerPayloadFails() {

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -85,8 +85,8 @@ func (k Keeper) AddEcosystemTokensMinted(ctx context.Context, minted math.Int) e
 	if err != nil {
 		return err
 	}
-	new := curr.Add(minted)
-	return k.EcosystemTokensMinted.Set(ctx, new)
+	newTotal := curr.Add(minted)
+	return k.EcosystemTokensMinted.Set(ctx, newTotal)
 }
 
 /// STAKING KEEPER RELATED FUNCTIONS


### PR DESCRIPTION
Fixed `InsertBulkWorkerPayload` accepting duplicated forecast elements.

UPDATE:
Also adding a fix of a compilation error changing the name of a variable related the total number of tokens minted

Ticket: https://linear.app/upshot/issue/ORA-1862/compilation-error-due-to-using-resesrved-word-as-a-name

## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?


Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Allora documentation site `docs.allora.network` source code at: `https://github.com/allora-network/docs`
  - [ ] Code comments?
  - [ ] N/A
