### PR TITLE
Collections.go Iterators need to be manually closed

### DIFF
--- a/x/emissions/keeper/invariants.go
+++ b/x/emissions/keeper/invariants.go
@@ -76,6 +76,7 @@ func StakingInvariantLenStakeRemovalsSame(k Keeper) sdk.Invariant {
 		if err != nil {
 			panic(fmt.Sprintf("failed to get stake removals iterator: %v", err))
 		}
+		defer iterByBlock.Close()
 		valuesByBlock, err := iterByBlock.Values()
 		if err != nil {
 			panic(fmt.Sprintf("failed to get stake removals values: %v", err))
@@ -85,6 +86,7 @@ func StakingInvariantLenStakeRemovalsSame(k Keeper) sdk.Invariant {
 		if err != nil {
 			panic(fmt.Sprintf("failed to get stake removals iterator: %v", err))
 		}
+		defer iterByActor.Close()
 		valuesByActor, err := iterByActor.Keys()
 		if err != nil {
 			panic(fmt.Sprintf("failed to get stake removals values: %v", err))
@@ -165,6 +167,7 @@ func StakingInvariantDelegatedStakes(k Keeper) sdk.Invariant {
 			if err != nil {
 				panic(fmt.Sprintf("failed to get delegated stakes iterator: %v", err))
 			}
+			defer topicIter.Close()
 			type ExpectedSumToComputedSum struct {
 				expected cosmosMath.Int
 				computed cosmosMath.Int
@@ -273,6 +276,7 @@ func StakingInvariantSumStakeFromStakeReputerAuthorityEqualTotalStakeAndTopicSta
 			if err != nil {
 				panic(fmt.Sprintf("failed to get reputer authorities iterator: %v", err))
 			}
+			defer reputerAuthoritiesForTopicIter.Close()
 			for ; reputerAuthoritiesForTopicIter.Valid(); reputerAuthoritiesForTopicIter.Next() {
 				reputerAuthority, err := reputerAuthoritiesForTopicIter.Value()
 				if err != nil {
@@ -314,6 +318,7 @@ func StakingInvariantPendingRewardForDelegatorsEqualRewardPerShareMinusRewardDeb
 		if err != nil {
 			panic("failed to get delegated stakes iterator")
 		}
+		defer iter.Close()
 		type TopicAndReputer struct {
 			topicId uint64
 			reputer string
@@ -351,6 +356,7 @@ func StakingInvariantPendingRewardForDelegatorsEqualRewardPerShareMinusRewardDeb
 		if err != nil {
 			panic("failed to get delegate reward per share iterator")
 		}
+		defer iter2.Close()
 		accumulatedRewardsBeyondRewardDebt := alloraMath.ZeroDec()
 		for ; iter2.Valid(); iter2.Next() {
 			keyValue, err := iter2.KeyValue()

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1297,6 +1297,7 @@ func (k *Keeper) GetStakeRemovalsForBlock(
 	if err != nil {
 		return ret, err
 	}
+	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		val, err := iter.Value()
 		if err != nil {
@@ -1401,6 +1402,7 @@ func (k *Keeper) GetDelegateStakeRemovalsForBlock(
 	if err != nil {
 		return ret, err
 	}
+	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		val, err := iter.Value()
 		if err != nil {
@@ -1931,6 +1933,7 @@ func (k *Keeper) GetInferenceScoresUntilBlock(ctx context.Context, topicId Topic
 	if err != nil {
 		return nil, err
 	}
+	defer iter.Close()
 
 	// Get max number of time steps that should be retrieved
 	moduleParams, err := k.GetParams(ctx)
@@ -2000,6 +2003,7 @@ func (k *Keeper) GetForecastScoresUntilBlock(ctx context.Context, topicId TopicI
 	if err != nil {
 		return nil, err
 	}
+	defer iter.Close()
 
 	// Get max number of time steps that should be retrieved
 	moduleParams, err := k.GetParams(ctx)


### PR DESCRIPTION
## What is the purpose of the change

The collections.go cosmos-sdk library provides a manual iteration function for iterating over all the keys of a collection. However the iterator must be manually closed by the caller. 

I suspect this probably would cause memory leaks if we didn't fix this issue, but deferring an iter.Close() call is trivial so we fix it here

## Testing and Verifying

In terms of the existing code functionality, this change is covered by our existing unit and integration tests.


## Documentation and Release Note

This PR has no implications for our documentation