### PR TITLE
Improve Error Handling in FundTopic and RewardDelegateStake

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server_demand.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand.go
@@ -37,5 +37,9 @@ func (ms msgServer) FundTopic(ctx context.Context, msg *types.MsgFundTopic) (*ty
 
 	// Activate topic if it exhibits minimum weight
 	err = activateTopicIfWeightAtLeastGlobalMin(ctx, ms, msg.TopicId, msg.Amount)
-	return &types.MsgFundTopicResponse{}, err
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.MsgFundTopicResponse{}, nil
 }

--- a/x/emissions/keeper/msgserver/msg_server_stake.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake.go
@@ -304,7 +304,10 @@ func (ms msgServer) RewardDelegateStake(ctx context.Context, msg *types.MsgRewar
 		if err != nil {
 			return nil, err
 		}
-		ms.k.SetDelegateStakePlacement(ctx, msg.TopicId, msg.Sender, msg.Reputer, delegateInfo)
+		err = ms.k.SetDelegateStakePlacement(ctx, msg.TopicId, msg.Sender, msg.Reputer, delegateInfo)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &types.MsgRewardDelegateStakeResponse{}, nil
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR improves error handling in `FundTopic` and `RewardDelegateStake`

In the FundTopic case we return the error correctly but also return a non nil response for the RPC request, which may a) cause issues and confusion for consumers and b) prevent transactions from failing that should not be included in a block (not actually sure about this, just hypothecating)

In the case of RewardDelegateStake, we silently ignore errors allowing transactions to continue with errors, which allows Delegators to claim rewards multiple times. This is actually a serious theft-of-funds bug.

## Testing and Verifying

This change does not require additional test coverage.

## Documentation and Release Note

This change does not have any documentation-related implications.