### PR TITLE
Silent errors in Remove{Delegate}Stake flow causes incorrect states

### DIFF
--- a/x/emissions/module/stake_removals.go
+++ b/x/emissions/module/stake_removals.go
@@ -25,6 +25,26 @@ func RemoveStakes(
 		return
 	}
 	for _, stakeRemoval := range removals {
+		// attempt writes in a cache context, only write finally if there are no errors
+		cacheSdkCtx, write := sdkCtx.CacheContext()
+
+		// Update the stake data structures
+		err = k.RemoveReputerStake(
+			cacheSdkCtx,
+			currentBlock,
+			stakeRemoval.TopicId,
+			stakeRemoval.Reputer,
+			stakeRemoval.Amount,
+		)
+		if err != nil {
+			sdkCtx.Logger().Error(fmt.Sprintf(
+				"Error removing stake data structures: %v | %v",
+				stakeRemoval,
+				err,
+			))
+			continue
+		}
+
 		// do no checking that the stake removal struct is valid. In order to have a stake removal
 		// it would have had to be created in msgServer.RemoveStake which would have done
 		// validation of validity up front before scheduling the delay
@@ -33,32 +53,24 @@ func RemoveStakes(
 		// Bank module does this for us in module SendCoins / subUnlockedCoins so we don't need to check
 		// Send the funds
 		coins := sdk.NewCoins(sdk.NewCoin(chainParams.DefaultBondDenom, stakeRemoval.Amount))
-		err = k.SendCoinsFromModuleToAccount(sdkCtx, emissionstypes.AlloraStakingAccountName, stakeRemoval.Reputer, coins)
+		err = k.SendCoinsFromModuleToAccount(
+			cacheSdkCtx,
+			emissionstypes.AlloraStakingAccountName,
+			stakeRemoval.Reputer,
+			coins,
+		)
 		if err != nil {
 			sdkCtx.Logger().Error(fmt.Sprintf(
-				"Error removing stake: %v | %v",
+				"Error removing stake funds: %v | %v",
 				stakeRemoval,
 				err,
 			))
 			continue
 		}
 
-		// Update the stake data structures
-		err = k.RemoveReputerStake(
-			sdkCtx,
-			currentBlock,
-			stakeRemoval.TopicId,
-			stakeRemoval.Reputer,
-			stakeRemoval.Amount,
-		)
-		if err != nil {
-			sdkCtx.Logger().Error(fmt.Sprintf(
-				"Error removing stake: %v | %v",
-				stakeRemoval,
-				err,
-			))
-			continue
-		}
+		// if there were no errors up to this point, then the removal should be safe to do,
+		// and therefore we can write the cache to the main state
+		write()
 	}
 }
 
@@ -79,27 +91,12 @@ func RemoveDelegateStakes(
 		return
 	}
 	for _, stakeRemoval := range removals {
-		// do no checking that the stake removal struct is valid. In order to have a stake removal
-		// it would have had to be created in msgServer.RemoveDelegateStake which would have done
-		// validation of validity up front before scheduling the delay
-
-		// Check the module has enough funds to send back to the sender
-		// Bank module does this for us in module SendCoins / subUnlockedCoins so we don't need to check
-		// Send the funds
-		coins := sdk.NewCoins(sdk.NewCoin(chainParams.DefaultBondDenom, stakeRemoval.Amount))
-		err = k.SendCoinsFromModuleToAccount(sdkCtx, emissionstypes.AlloraStakingAccountName, stakeRemoval.Delegator, coins)
-		if err != nil {
-			sdkCtx.Logger().Error(fmt.Sprintf(
-				"Error removing stake: %v | %v",
-				stakeRemoval,
-				err,
-			))
-			continue
-		}
+		// attempt writes in a cache context, only write finally if there are no errors
+		cacheSdkCtx, write := sdkCtx.CacheContext()
 
 		// Update the stake data structures
 		err = k.RemoveDelegateStake(
-			sdkCtx,
+			cacheSdkCtx,
 			currentBlock,
 			stakeRemoval.TopicId,
 			stakeRemoval.Delegator,
@@ -108,11 +105,34 @@ func RemoveDelegateStakes(
 		)
 		if err != nil {
 			sdkCtx.Logger().Error(fmt.Sprintf(
-				"Error removing stake: %v | %v",
+				"Error removing delegate stake state: %v | %v",
 				stakeRemoval,
 				err,
 			))
 			continue
 		}
+
+		// do no checking that the stake removal struct is valid. In order to have a stake removal
+		// it would have had to be created in msgServer.RemoveDelegateStake which would have done
+		// validation of validity up front before scheduling the delay
+
+		// Check the module has enough funds to send back to the sender
+		// Bank module does this for us in module SendCoins / subUnlockedCoins so we don't need to check
+		// Send the funds
+		coins := sdk.NewCoins(sdk.NewCoin(chainParams.DefaultBondDenom, stakeRemoval.Amount))
+		err = k.SendCoinsFromModuleToAccount(
+			cacheSdkCtx,
+			emissionstypes.AlloraStakingAccountName,
+			stakeRemoval.Delegator, coins)
+		if err != nil {
+			sdkCtx.Logger().Error(fmt.Sprintf(
+				"Error removing delegate stake send funds: %v | %v",
+				stakeRemoval,
+				err,
+			))
+			continue
+		}
+
+		write()
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The stake removals are processed in ABCI End Blocker and if there is an error sending tokens or an error writing into the keeper state, the intent is to skip that stake removal and keep going. However, if the stake removal is incorrect, it actually can enter an error state where the tokens are sent, but the state machine is not updated, causing a theft of funds.

This PR uses a cache context to try writing the state into the state machine, and, if there is an error, skip writing the state.

## Testing and Verifying

Our existing test cases should confirm that this change does not change the overall flow of stake removal

## Documentation and Release Note

There is no implication on documentation from this PR.
