### PR TITLE
GenerateForecastScores Should Update Forecasted Scores Not Inference Scores

### DIFF
--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -193,7 +193,7 @@ func GenerateForecastScores(
 			Address:     networkLosses.InfererValues[0].Worker,
 			Score:       alloraMath.ZeroDec(),
 		}
-		err := keeper.InsertWorkerInferenceScore(ctx, topicId, block, newScore)
+		err := keeper.InsertWorkerForecastScore(ctx, topicId, block, newScore)
 		if err != nil {
 			return []types.Score{}, errors.Wrapf(err, "Error inserting worker inference score")
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR corrects a really nasty typo bug where we were updating inference scores in a forecaster function

## Testing and Verifying

Our test suite should have caught this. The fact that it didn't means we need further testing. However our existing tests will at least confirm that this PR is directionally correct...

Definitely with the addition of high-precision unit tests that match what the research team's python implementations numbers are will help with this issue, that's coming in a later PR.

## Documentation and Release Note

This is an internal change with no documentation related implications