### PR TITLE
Prevent too big ground truth lag

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server_topics.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics.go
@@ -37,6 +37,9 @@ func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.MsgCreateNewT
 	if msg.EpochLength < params.MinEpochLength {
 		return nil, types.ErrTopicCadenceBelowMinimum
 	}
+	if msg.GroundTruthLag > int64(params.MaxUnfulfilledReputerRequests)*msg.EpochLength {
+		return nil, types.ErrGroundTruthLagTooBig
+	}
 
 	// Before creating topic, transfer fee amount from creator to ecosystem bucket
 	err = ms.k.SendCoinsFromAccountToModule(ctx, msg.Creator, mintTypes.EcosystemModuleName, sdk.NewCoins(fee))

--- a/x/emissions/types/errors.go
+++ b/x/emissions/types/errors.go
@@ -73,4 +73,5 @@ var (
 	ErrInvalidWorkerData                        = errors.Register(ModuleName, 71, "worker data validation is failed")
 	ErrInvalidReputerData                       = errors.Register(ModuleName, 72, "reputer data validation is failed")
 	ErrDataSenderNotEnoughDenom                 = errors.Register(ModuleName, 73, "data sender does not have enough denom")
+	ErrGroundTruthLagTooBig                     = errors.Register(ModuleName, 74, "ground truth lag too big for epoch length")
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #ORA-2037 

## What is the purpose of the change

Prevent topics to be created with a ground truth lag too big so that the reputation nonce could be dropped when the ground truth is revealed. 

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?


Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [X ] Allora documentation site `docs.allora.network` source code at: `https://github.com/allora-network/docs` - as part of pparent ticket 
  - [ ] Code comments?
  - [ ] N/A
