### PR TITLE
Diego/fix docker permissions issue

### DIFF
--- a/test/local_testnet_l1.sh
+++ b/test/local_testnet_l1.sh
@@ -86,6 +86,13 @@ docker run \
     --entrypoint=/data/generate_genesis.sh \
     $DOCKER_IMAGE > /dev/null 2>&1
 
+echo "Ensure permissions on data folder after genesis generation"
+docker run \
+    -u 0:0 \
+    -v ${LOCALNET_DATADIR}:/data \
+    --entrypoint=chmod \
+    $DOCKER_IMAGE -R 777 /data
+
 echo "Updating expedited_voting_period in genesis.json"
 genesis_file="${LOCALNET_DATADIR}/genesis/config/genesis.json"
 tmp_file=$(mktemp)

--- a/test/local_testnet_upgrade_l1.sh
+++ b/test/local_testnet_upgrade_l1.sh
@@ -87,6 +87,13 @@ docker run \
     --entrypoint=/data/generate_genesis.sh \
     $DOCKER_IMAGE > /dev/null 2>&1
 
+echo "Ensure permissions on data folder after genesis generation"
+docker run \
+    -u 0:0 \
+    -v ${LOCALNET_DATADIR}:/data \
+    --entrypoint=chmod \
+    $DOCKER_IMAGE -R 777 /data
+
 echo "Updating expedited_voting_period in genesis.json"
 genesis_file="${LOCALNET_DATADIR}/genesis/config/genesis.json"
 tmp_file=$(mktemp)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fixes a permissions issue happening at least on Ubuntu 22.04 with Docker Desktop (genesis created with different user permissions led to not being able to be modified, hence upgrade tests timing out). 

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Allora documentation site `docs.allora.network` source code at: `https://github.com/allora-network/docs`
  - [ ] Code comments?
  - [X ] N/A
