### PR TITLE
[ORA-1613] Initial Value for emission per unit staked token = target

### DIFF
--- a/x/mint/module/module_test.go
+++ b/x/mint/module/module_test.go
@@ -194,6 +194,7 @@ func (s *MintModuleTestSuite) TestTotalStakeGoUpTargetEmissionPerUnitStakeGoDown
 	_, emissionPerUnitStakedTokenBefore, err := mint.GetEmissionPerMonth(
 		s.ctx,
 		s.mintKeeper,
+		uint64(s.ctx.BlockHeight()),
 		blocksPerMonth,
 		params,
 		cosmosMath.ZeroInt(),
@@ -216,6 +217,7 @@ func (s *MintModuleTestSuite) TestTotalStakeGoUpTargetEmissionPerUnitStakeGoDown
 	_, emissionPerUnitStakedTokenAfter, err := mint.GetEmissionPerMonth(
 		s.ctx,
 		s.mintKeeper,
+		uint64(s.ctx.BlockHeight()),
 		blocksPerMonth,
 		params,
 		cosmosMath.ZeroInt(),


### PR DESCRIPTION
## What is the purpose of the change

We calculate target emission and the emission rate on a monthly cadence. In the first month we have no previous history to use for the exponential moving average which returns e_i. Therefore, in that case, we use the target e_i instead of the exponential moving average, directly.

## Testing and Verifying

Our existing tests should at least cover that this does not break anything

## Documentation and Release Note

No Documentation changes needed.