### PR TITLE
Undo Overwrite of #440 : Remove go func parallelization in ABCI EndBlocker 

### DIFF
--- a/test/invariant/invariants.patch
+++ b/test/invariant/invariants.patch
@@ -1,17 +1,16 @@
 diff --git a/x/emissions/module/abci.go b/x/emissions/module/abci.go
-index 4470c8a4..01ccaa19 100644
+index 8f743b31..0511e66d 100644
 --- a/x/emissions/module/abci.go
 +++ b/x/emissions/module/abci.go
-@@ -5,6 +5,8 @@ import (
+@@ -5,6 +5,7 @@ import (
  	"fmt"
- 	"sync"
  
-+	emissionskeeper "github.com/allora-network/allora-chain/x/emissions/keeper"
-+
  	"cosmossdk.io/errors"
++	emissionskeeper "github.com/allora-network/allora-chain/x/emissions/keeper"
  	allorautils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
  	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
-@@ -14,6 +16,10 @@ import (
+ 	sdk "github.com/cosmos/cosmos-sdk/types"
+@@ -12,6 +13,10 @@ import (
  
  func EndBlocker(ctx context.Context, am AppModule) error {
  	sdkCtx := sdk.UnwrapSDKContext(ctx)
@@ -23,10 +22,10 @@ index 4470c8a4..01ccaa19 100644
  	sdkCtx.Logger().Debug(
  		fmt.Sprintf("\n ---------------- Emissions EndBlock %d ------------------- \n",
 diff --git a/x/emissions/module/module.go b/x/emissions/module/module.go
-index 2cda57ab..3f619551 100644
+index 35906b64..16d5dee4 100644
 --- a/x/emissions/module/module.go
 +++ b/x/emissions/module/module.go
-@@ -18,6 +18,15 @@ import (
+@@ -19,6 +19,15 @@ import (
  	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
  )
  

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -3,10 +3,12 @@ package module
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"cosmossdk.io/errors"
 	allorautils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -39,6 +41,99 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		return errors.Wrapf(err, "Rewards error")
 	}
 
+	// NONCE MGMT with Churnable weights
+	var wg sync.WaitGroup
+	// Loop over and run epochs on topics whose inferences are demanded enough to be served
+	fn := func(sdkCtx sdk.Context, topic *types.Topic) error {
+		// Parallelize nonce management and update of topic to be in a churn ready state
+		wg.Add(1)
+		localTopic := *topic
+		go func(topic types.Topic) {
+			defer wg.Done()
+			// Check the cadence of inferences, and just in case also check multiples of epoch lengths
+			// to avoid potential situations where the block is missed
+			if am.keeper.CheckWorkerOpenCadence(blockHeight, topic) {
+				sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Worker open cadence met for topic: %v metadata: %s . \n",
+					topic.Id,
+					topic.Metadata))
+
+				// Update the last inference ran
+				err = am.keeper.UpdateTopicEpochLastEnded(sdkCtx, topic.Id, blockHeight)
+				if err != nil {
+					sdkCtx.Logger().Warn(fmt.Sprintf("Error updating last inference ran: %s", err.Error()))
+					return
+				}
+				// Add Worker Nonces
+				nextNonce := types.Nonce{BlockHeight: blockHeight}
+				err = am.keeper.AddWorkerNonce(sdkCtx, topic.Id, &nextNonce)
+				if err != nil {
+					sdkCtx.Logger().Warn(fmt.Sprintf("Error adding worker nonce: %s", err.Error()))
+					return
+				}
+				sdkCtx.Logger().Debug(fmt.Sprintf("Added worker nonce for topic %d: %v \n", topic.Id, nextNonce.BlockHeight))
+
+				err = am.keeper.AddWorkerWindowTopicId(sdkCtx, blockHeight+topic.WorkerSubmissionWindow, topic.Id)
+				if err != nil {
+					sdkCtx.Logger().Warn(fmt.Sprintf("Error adding worker window topic id: %s", err.Error()))
+					return
+				}
+
+				MaxUnfulfilledReputerRequests := types.DefaultParams().MaxUnfulfilledReputerRequests
+				moduleParams, err := am.keeper.GetParams(ctx)
+				if err != nil {
+					sdkCtx.Logger().Warn(fmt.Sprintf("Error getting max retries to fulfil nonces for worker requests (using default), err: %s", err.Error()))
+				} else {
+					MaxUnfulfilledReputerRequests = moduleParams.MaxUnfulfilledReputerRequests
+				}
+				// Adding one to cover for one extra epochLength
+				reputerPruningBlock := blockHeight - (int64(MaxUnfulfilledReputerRequests+1)*topic.EpochLength + topic.GroundTruthLag)
+				if reputerPruningBlock > 0 {
+					sdkCtx.Logger().Debug(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, blockHeight))
+					err = am.keeper.PruneReputerNonces(sdkCtx, topic.Id, reputerPruningBlock)
+					if err != nil {
+						sdkCtx.Logger().Warn(fmt.Sprintf("Error pruning reputer nonces: %s", err.Error()))
+					}
+
+					// Reputer nonces need to check worker nonces from one epoch before
+					workerPruningBlock := reputerPruningBlock - topic.EpochLength
+					if workerPruningBlock > 0 {
+						sdkCtx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
+						// Prune old worker nonces previous to current blockHeight to avoid inserting inferences after its time has passed
+						err = am.keeper.PruneWorkerNonces(sdkCtx, topic.Id, workerPruningBlock)
+						if err != nil {
+							sdkCtx.Logger().Warn(fmt.Sprintf("Error pruning worker nonces: %s", err.Error()))
+						}
+					}
+				}
+			}
+			// Check Reputer Close Cadence
+			if am.keeper.CheckReputerCloseCadence(blockHeight, topic) {
+				// Check if there is an unfulfilled nonce
+				nonces, err := am.keeper.GetUnfulfilledReputerNonces(sdkCtx, topic.Id)
+				if err != nil {
+					sdkCtx.Logger().Warn(fmt.Sprintf("Error getting unfulfilled worker nonces: %s", err.Error()))
+					return
+				}
+				for _, nonce := range nonces.Nonces {
+					// Check if current blockheight has reached the blockheight of the nonce + groundTruthLag + epochLength
+					// This means one epochLength is allowed for reputation responses to be sent since ground truth is revealed.
+					closingReputerNonceMinBlockHeight := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag + topic.EpochLength
+					if blockHeight >= closingReputerNonceMinBlockHeight {
+						sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Closing reputer nonce for topic: %v nonce: %v, min: %d. \n",
+							topic.Id, nonce, closingReputerNonceMinBlockHeight))
+						err = allorautils.CloseReputerNonce(&am.keeper, sdkCtx, topic.Id, *nonce.ReputerNonce)
+						if err != nil {
+							sdkCtx.Logger().Warn(fmt.Sprintf("Error closing reputer nonce: %s", err.Error()))
+							// Proactively close the nonce to avoid
+							am.keeper.FulfillReputerNonce(sdkCtx, topic.Id, nonce.ReputerNonce)
+						}
+					}
+				}
+			}
+
+		}(localTopic)
+		return nil
+	}
 	err = rewards.IdentifyChurnableAmongActiveTopicsAndApplyFn(
 		sdkCtx,
 		am.keeper,

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -3,12 +3,10 @@ package module
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"cosmossdk.io/errors"
 	allorautils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
-	"github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -41,111 +39,16 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		return errors.Wrapf(err, "Rewards error")
 	}
 
-	// NONCE MGMT with Churnable weights
-	var wg sync.WaitGroup
-	// Loop over and run epochs on topics whose inferences are demanded enough to be served
-	fn := func(sdkCtx sdk.Context, topic *types.Topic) error {
-		// Parallelize nonce management and update of topic to be in a churn ready state
-		wg.Add(1)
-		localTopic := *topic
-		go func(topic types.Topic) {
-			defer wg.Done()
-			// Check the cadence of inferences, and just in case also check multiples of epoch lengths
-			// to avoid potential situations where the block is missed
-			if am.keeper.CheckWorkerOpenCadence(blockHeight, topic) {
-				sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Worker open cadence met for topic: %v metadata: %s . \n",
-					topic.Id,
-					topic.Metadata))
-
-				// Update the last inference ran
-				err = am.keeper.UpdateTopicEpochLastEnded(sdkCtx, topic.Id, blockHeight)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error updating last inference ran: %s", err.Error()))
-					return
-				}
-				// Add Worker Nonces
-				nextNonce := types.Nonce{BlockHeight: blockHeight}
-				err = am.keeper.AddWorkerNonce(sdkCtx, topic.Id, &nextNonce)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error adding worker nonce: %s", err.Error()))
-					return
-				}
-				sdkCtx.Logger().Debug(fmt.Sprintf("Added worker nonce for topic %d: %v \n", topic.Id, nextNonce.BlockHeight))
-
-				err = am.keeper.AddWorkerWindowTopicId(sdkCtx, blockHeight+topic.WorkerSubmissionWindow, topic.Id)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error adding worker window topic id: %s", err.Error()))
-					return
-				}
-
-				MaxUnfulfilledReputerRequests := types.DefaultParams().MaxUnfulfilledReputerRequests
-				moduleParams, err := am.keeper.GetParams(ctx)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error getting max retries to fulfil nonces for worker requests (using default), err: %s", err.Error()))
-				} else {
-					MaxUnfulfilledReputerRequests = moduleParams.MaxUnfulfilledReputerRequests
-				}
-				// Adding one to cover for one extra epochLength
-				reputerPruningBlock := blockHeight - (int64(MaxUnfulfilledReputerRequests+1)*topic.EpochLength + topic.GroundTruthLag)
-				if reputerPruningBlock > 0 {
-					sdkCtx.Logger().Debug(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, blockHeight))
-					err = am.keeper.PruneReputerNonces(sdkCtx, topic.Id, reputerPruningBlock)
-					if err != nil {
-						sdkCtx.Logger().Warn(fmt.Sprintf("Error pruning reputer nonces: %s", err.Error()))
-					}
-
-					// Reputer nonces need to check worker nonces from one epoch before
-					workerPruningBlock := reputerPruningBlock - topic.EpochLength
-					if workerPruningBlock > 0 {
-						sdkCtx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
-						// Prune old worker nonces previous to current blockHeight to avoid inserting inferences after its time has passed
-						err = am.keeper.PruneWorkerNonces(sdkCtx, topic.Id, workerPruningBlock)
-						if err != nil {
-							sdkCtx.Logger().Warn(fmt.Sprintf("Error pruning worker nonces: %s", err.Error()))
-						}
-					}
-				}
-			}
-			// Check Reputer Close Cadence
-			if am.keeper.CheckReputerCloseCadence(blockHeight, topic) {
-				// Check if there is an unfulfilled nonce
-				nonces, err := am.keeper.GetUnfulfilledReputerNonces(sdkCtx, topic.Id)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error getting unfulfilled worker nonces: %s", err.Error()))
-					return
-				}
-				for _, nonce := range nonces.Nonces {
-					// Check if current blockheight has reached the blockheight of the nonce + groundTruthLag + epochLength
-					// This means one epochLength is allowed for reputation responses to be sent since ground truth is revealed.
-					closingReputerNonceMinBlockHeight := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag + topic.EpochLength
-					if blockHeight >= closingReputerNonceMinBlockHeight {
-						sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Closing reputer nonce for topic: %v nonce: %v, min: %d. \n",
-							topic.Id, nonce, closingReputerNonceMinBlockHeight))
-						err = allorautils.CloseReputerNonce(&am.keeper, sdkCtx, topic.Id, *nonce.ReputerNonce)
-						if err != nil {
-							sdkCtx.Logger().Warn(fmt.Sprintf("Error closing reputer nonce: %s", err.Error()))
-							// Proactively close the nonce to avoid
-							am.keeper.FulfillReputerNonce(sdkCtx, topic.Id, nonce.ReputerNonce)
-						}
-					}
-				}
-			}
-
-		}(localTopic)
-		return nil
-	}
-	err = rewards.IdentifyChurnableAmongActiveTopicsAndApplyFn(
+	err = rewards.PickChurnableActiveTopics(
 		sdkCtx,
 		am.keeper,
 		blockHeight,
-		fn,
 		weights,
 	)
 	if err != nil {
 		sdkCtx.Logger().Error("Error applying function on all rewardable topics: ", err)
 		return err
 	}
-	wg.Wait()
 
 	// Close any open windows due this blockHeight
 	workerWindowsToClose := am.keeper.GetWorkerWindowTopicIds(sdkCtx, blockHeight)

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -3,12 +3,10 @@ package module
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"cosmossdk.io/errors"
 	allorautils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
-	"github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -41,99 +39,6 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		return errors.Wrapf(err, "Rewards error")
 	}
 
-	// NONCE MGMT with Churnable weights
-	var wg sync.WaitGroup
-	// Loop over and run epochs on topics whose inferences are demanded enough to be served
-	fn := func(sdkCtx sdk.Context, topic *types.Topic) error {
-		// Parallelize nonce management and update of topic to be in a churn ready state
-		wg.Add(1)
-		localTopic := *topic
-		go func(topic types.Topic) {
-			defer wg.Done()
-			// Check the cadence of inferences, and just in case also check multiples of epoch lengths
-			// to avoid potential situations where the block is missed
-			if am.keeper.CheckWorkerOpenCadence(blockHeight, topic) {
-				sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Worker open cadence met for topic: %v metadata: %s . \n",
-					topic.Id,
-					topic.Metadata))
-
-				// Update the last inference ran
-				err = am.keeper.UpdateTopicEpochLastEnded(sdkCtx, topic.Id, blockHeight)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error updating last inference ran: %s", err.Error()))
-					return
-				}
-				// Add Worker Nonces
-				nextNonce := types.Nonce{BlockHeight: blockHeight}
-				err = am.keeper.AddWorkerNonce(sdkCtx, topic.Id, &nextNonce)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error adding worker nonce: %s", err.Error()))
-					return
-				}
-				sdkCtx.Logger().Debug(fmt.Sprintf("Added worker nonce for topic %d: %v \n", topic.Id, nextNonce.BlockHeight))
-
-				err = am.keeper.AddWorkerWindowTopicId(sdkCtx, blockHeight+topic.WorkerSubmissionWindow, topic.Id)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error adding worker window topic id: %s", err.Error()))
-					return
-				}
-
-				MaxUnfulfilledReputerRequests := types.DefaultParams().MaxUnfulfilledReputerRequests
-				moduleParams, err := am.keeper.GetParams(ctx)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error getting max retries to fulfil nonces for worker requests (using default), err: %s", err.Error()))
-				} else {
-					MaxUnfulfilledReputerRequests = moduleParams.MaxUnfulfilledReputerRequests
-				}
-				// Adding one to cover for one extra epochLength
-				reputerPruningBlock := blockHeight - (int64(MaxUnfulfilledReputerRequests+1)*topic.EpochLength + topic.GroundTruthLag)
-				if reputerPruningBlock > 0 {
-					sdkCtx.Logger().Debug(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, blockHeight))
-					err = am.keeper.PruneReputerNonces(sdkCtx, topic.Id, reputerPruningBlock)
-					if err != nil {
-						sdkCtx.Logger().Warn(fmt.Sprintf("Error pruning reputer nonces: %s", err.Error()))
-					}
-
-					// Reputer nonces need to check worker nonces from one epoch before
-					workerPruningBlock := reputerPruningBlock - topic.EpochLength
-					if workerPruningBlock > 0 {
-						sdkCtx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
-						// Prune old worker nonces previous to current blockHeight to avoid inserting inferences after its time has passed
-						err = am.keeper.PruneWorkerNonces(sdkCtx, topic.Id, workerPruningBlock)
-						if err != nil {
-							sdkCtx.Logger().Warn(fmt.Sprintf("Error pruning worker nonces: %s", err.Error()))
-						}
-					}
-				}
-			}
-			// Check Reputer Close Cadence
-			if am.keeper.CheckReputerCloseCadence(blockHeight, topic) {
-				// Check if there is an unfulfilled nonce
-				nonces, err := am.keeper.GetUnfulfilledReputerNonces(sdkCtx, topic.Id)
-				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error getting unfulfilled worker nonces: %s", err.Error()))
-					return
-				}
-				for _, nonce := range nonces.Nonces {
-					// Check if current blockheight has reached the blockheight of the nonce + groundTruthLag + epochLength
-					// This means one epochLength is allowed for reputation responses to be sent since ground truth is revealed.
-					closingReputerNonceMinBlockHeight := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag + topic.EpochLength
-					if blockHeight >= closingReputerNonceMinBlockHeight {
-						sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Closing reputer nonce for topic: %v nonce: %v, min: %d. \n",
-							topic.Id, nonce, closingReputerNonceMinBlockHeight))
-						err = allorautils.CloseReputerNonce(&am.keeper, sdkCtx, topic.Id, *nonce.ReputerNonce)
-						if err != nil {
-							sdkCtx.Logger().Warn(fmt.Sprintf("Error closing reputer nonce: %s", err.Error()))
-							// Proactively close the nonce to avoid
-							am.keeper.FulfillReputerNonce(sdkCtx, topic.Id, nonce.ReputerNonce)
-						}
-					}
-				}
-			}
-
-		}(localTopic)
-		return nil
-	}
 	err = rewards.IdentifyChurnableAmongActiveTopicsAndApplyFn(
 		sdkCtx,
 		am.keeper,

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -97,11 +97,10 @@ func SafeApplyFuncOnAllActiveEpochEndingTopics(
 // "Churn-ready topic" is active, has an epoch that ended, and is in top N by weights, has non-zero weight.
 // We iterate through active topics, fetch their weight, skim the top N by weight (these are the churnable topics)
 // then finally apply a function on each of these churnable topics.
-func IdentifyChurnableAmongActiveTopicsAndApplyFn(
+func PickChurnableActiveTopics(
 	ctx sdk.Context,
 	k keeper.Keeper,
 	block BlockHeight,
-	fn func(ctx sdk.Context, topic *types.Topic) error,
 	weights map[TopicId]*alloraMath.Dec,
 ) error {
 	moduleParams, err := k.GetParams(ctx)
@@ -114,22 +113,72 @@ func IdentifyChurnableAmongActiveTopicsAndApplyFn(
 		moduleParams.MaxTopicsPerBlock,
 		block,
 	)
+
 	for _, topicId := range sortedTopActiveTopics {
 		weight := weightsOfTopActiveTopics[topicId]
 		if weight.Equal(alloraMath.ZeroDec()) {
-			Logger(ctx).Debug(fmt.Sprintf("Skipping Topic ID: %d, Weight: %s", topicId, weight))
+			Logger(ctx).Debug("Skipping Topic ID: ", topicId, " Weight: ", weight)
 			continue
 		}
 		// Get the topic
 		topic, err := k.GetTopic(ctx, topicId)
 		if err != nil {
-			Logger(ctx).Debug(fmt.Sprintf("Error getting topic: %v", err))
+			Logger(ctx).Debug("Error getting topic: ", err)
 			continue
 		}
-		// Execute the function
-		err = fn(ctx, &topic)
+		// Loop over and run epochs on topics whose inferences are demanded enough to be served
+		// Check the cadence of inferences, and just in case also check multiples of epoch lengths
+		// to avoid potential situations where the block is missed
+		if k.CheckCadence(block, topic) {
+			ctx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Inference cadence met for topic: %v metadata: %s default arg: %s. \n",
+				topic.Id,
+				topic.Metadata,
+				topic.DefaultArg))
+
+			// Update the last inference ran
+			err = k.UpdateTopicEpochLastEnded(ctx, topic.Id, block)
+			if err != nil {
+				ctx.Logger().Warn(fmt.Sprintf("Error updating last inference ran: %s", err.Error()))
+			}
+			// Add Worker Nonces
+			nextNonce := types.Nonce{BlockHeight: block}
+			err = k.AddWorkerNonce(ctx, topic.Id, &nextNonce)
+			if err != nil {
+				ctx.Logger().Warn(fmt.Sprintf("Error adding worker nonce: %s", err.Error()))
+				continue
+			}
+			ctx.Logger().Debug(fmt.Sprintf("Added worker nonce for topic %d: %v \n", topic.Id, nextNonce.BlockHeight))
+			// To notify topic handler that the topic is ready for churn i.e. requests to be sent to workers and reputers
+			err = k.AddChurnableTopic(ctx, topic.Id)
+			if err != nil {
+				ctx.Logger().Warn(fmt.Sprintf("Error setting churn ready topic: %s", err.Error()))
+				continue
+			}
+
+			MaxUnfulfilledReputerRequests := types.DefaultParams().MaxUnfulfilledReputerRequests
+			moduleParams, err := k.GetParams(ctx)
+			if err != nil {
+				ctx.Logger().Warn(fmt.Sprintf("Error getting max retries to fulfil nonces for worker requests (using default), err: %s", err.Error()))
+			} else {
+				MaxUnfulfilledReputerRequests = moduleParams.MaxUnfulfilledReputerRequests
+			}
+			// Adding one to cover for one extra epochLength
+			reputerPruningBlock := block - (int64(MaxUnfulfilledReputerRequests+1)*topic.EpochLength + topic.GroundTruthLag)
+			if reputerPruningBlock > 0 {
+				ctx.Logger().Warn(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, block))
+				k.PruneReputerNonces(ctx, topic.Id, reputerPruningBlock)
+
+				// Reputer nonces need to check worker nonces from one epoch before
+				workerPruningBlock := reputerPruningBlock - topic.EpochLength
+				if workerPruningBlock > 0 {
+					ctx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
+					// Prune old worker nonces previous to current blockHeight to avoid inserting inferences after its time has passed
+					k.PruneWorkerNonces(ctx, topic.Id, workerPruningBlock)
+				}
+			}
+		}
 		if err != nil {
-			Logger(ctx).Debug(fmt.Sprintf("Error applying function on topic: %v", err))
+			Logger(ctx).Debug("Error applying function on topic: ", err)
 			continue
 		}
 	}

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"cosmossdk.io/errors"
+	allorautils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	cosmosMath "cosmossdk.io/math"
@@ -129,16 +130,16 @@ func PickChurnableActiveTopics(
 		// Loop over and run epochs on topics whose inferences are demanded enough to be served
 		// Check the cadence of inferences, and just in case also check multiples of epoch lengths
 		// to avoid potential situations where the block is missed
-		if k.CheckCadence(block, topic) {
-			ctx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Inference cadence met for topic: %v metadata: %s default arg: %s. \n",
+		if k.CheckWorkerOpenCadence(block, topic) {
+			ctx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Worker open cadence met for topic: %v metadata: %s . \n",
 				topic.Id,
-				topic.Metadata,
-				topic.DefaultArg))
+				topic.Metadata))
 
 			// Update the last inference ran
 			err = k.UpdateTopicEpochLastEnded(ctx, topic.Id, block)
 			if err != nil {
 				ctx.Logger().Warn(fmt.Sprintf("Error updating last inference ran: %s", err.Error()))
+				continue
 			}
 			// Add Worker Nonces
 			nextNonce := types.Nonce{BlockHeight: block}
@@ -148,10 +149,10 @@ func PickChurnableActiveTopics(
 				continue
 			}
 			ctx.Logger().Debug(fmt.Sprintf("Added worker nonce for topic %d: %v \n", topic.Id, nextNonce.BlockHeight))
-			// To notify topic handler that the topic is ready for churn i.e. requests to be sent to workers and reputers
-			err = k.AddChurnableTopic(ctx, topic.Id)
+
+			err = k.AddWorkerWindowTopicId(ctx, block+topic.WorkerSubmissionWindow, topic.Id)
 			if err != nil {
-				ctx.Logger().Warn(fmt.Sprintf("Error setting churn ready topic: %s", err.Error()))
+				ctx.Logger().Warn(fmt.Sprintf("Error adding worker window topic id: %s", err.Error()))
 				continue
 			}
 
@@ -165,15 +166,45 @@ func PickChurnableActiveTopics(
 			// Adding one to cover for one extra epochLength
 			reputerPruningBlock := block - (int64(MaxUnfulfilledReputerRequests+1)*topic.EpochLength + topic.GroundTruthLag)
 			if reputerPruningBlock > 0 {
-				ctx.Logger().Warn(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, block))
-				k.PruneReputerNonces(ctx, topic.Id, reputerPruningBlock)
+				ctx.Logger().Debug(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, block))
+				err = k.PruneReputerNonces(ctx, topic.Id, reputerPruningBlock)
+				if err != nil {
+					ctx.Logger().Warn(fmt.Sprintf("Error pruning reputer nonces: %s", err.Error()))
+				}
 
 				// Reputer nonces need to check worker nonces from one epoch before
 				workerPruningBlock := reputerPruningBlock - topic.EpochLength
 				if workerPruningBlock > 0 {
 					ctx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
-					// Prune old worker nonces previous to current blockHeight to avoid inserting inferences after its time has passed
-					k.PruneWorkerNonces(ctx, topic.Id, workerPruningBlock)
+					// Prune old worker nonces previous to current block to avoid inserting inferences after its time has passed
+					err = k.PruneWorkerNonces(ctx, topic.Id, workerPruningBlock)
+					if err != nil {
+						ctx.Logger().Warn(fmt.Sprintf("Error pruning worker nonces: %s", err.Error()))
+					}
+				}
+			}
+		}
+		// Check Reputer Close Cadence
+		if k.CheckReputerCloseCadence(block, topic) {
+			// Check if there is an unfulfilled nonce
+			nonces, err := k.GetUnfulfilledReputerNonces(ctx, topic.Id)
+			if err != nil {
+				ctx.Logger().Warn(fmt.Sprintf("Error getting unfulfilled worker nonces: %s", err.Error()))
+				continue
+			}
+			for _, nonce := range nonces.Nonces {
+				// Check if current blockheight has reached the blockheight of the nonce + groundTruthLag + epochLength
+				// This means one epochLength is allowed for reputation responses to be sent since ground truth is revealed.
+				closingReputerNonceMinBlockHeight := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag + topic.EpochLength
+				if block >= closingReputerNonceMinBlockHeight {
+					ctx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Closing reputer nonce for topic: %v nonce: %v, min: %d. \n",
+						topic.Id, nonce, closingReputerNonceMinBlockHeight))
+					err = allorautils.CloseReputerNonce(&k, ctx, topic.Id, *nonce.ReputerNonce)
+					if err != nil {
+						ctx.Logger().Warn(fmt.Sprintf("Error closing reputer nonce: %s", err.Error()))
+						// Proactively close the nonce to avoid
+						k.FulfillReputerNonce(ctx, topic.Id, nonce.ReputerNonce)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR is a re-implementation of #440 - at some point #458 overwrote that PR, and reverted all the changes in the PR. This PR restores that PR. The original text below, and see the original PR for some conversation on non-determinism.

This change simplifies a hard-to-read and hard-to-reason about piece of code that parallelized the picking of churn ready topics from the active set. After this PR the code is easier to read and understand, and has less likelihood of causing non-determinism issues. The tradeoff is that the code may run slightly slower in serial.

## Testing and Verifying

This change is not trivial, however it is a small diff / refactor PR and our existing test cases should be able to cover the change.

## Documentation and Release Note

This PR does not have any implications for documentation.


