### PR TITLE
Silence unused function parameter warnings

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server_topics.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics.go
@@ -30,7 +30,7 @@ func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.MsgCreateNewT
 	}
 
 	// Before creating topic, transfer fee amount from creator to ecosystem bucket
-	err = checkBalanceAndSendFee(ctx, ms, msg.Creator, topicId, params.CreateTopicFee, "create topic")
+	err = checkBalanceAndSendFee(ctx, ms, msg.Creator, params.CreateTopicFee)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/msgserver/msg_server_util_payment.go
+++ b/x/emissions/keeper/msgserver/msg_server_util_payment.go
@@ -2,6 +2,7 @@ package msgserver
 
 import (
 	"context"
+
 	"cosmossdk.io/errors"
 	cosmosMath "cosmossdk.io/math"
 	appParams "github.com/allora-network/allora-chain/app/params"
@@ -60,14 +61,11 @@ func activateTopicIfWeightAtLeastGlobalMin(
 }
 
 // Check if user has enough balance to send the fee, then send the fee to EcoSystem bucket
-// insufficientBalanceErrorMsg is appended to error message if sender has insufficient balance
 func checkBalanceAndSendFee(
 	ctx context.Context,
 	ms msgServer,
 	sender string,
-	topicId TopicId,
 	amount Allo,
-	insufficientBalanceErrorMsg string,
 ) error {
 	accAddress, err := sdk.AccAddressFromBech32(sender)
 	if err != nil {
@@ -77,7 +75,6 @@ func checkBalanceAndSendFee(
 	fee := sdk.NewCoin(balance.Denom, amount)
 
 	if balance.IsLT(fee) {
-		//errMsg := insufficientBalanceErrorMsg + " " + strconv.FormatUint(topicId, 10) + " sender " + sender
 		return types.ErrTopicRegistrantNotEnoughDenom
 	}
 
@@ -104,7 +101,7 @@ func sendEffectiveRevenueActivateTopicIfWeightSufficient(
 	amount Allo,
 	insufficientBalanceErrorMsg string,
 ) error {
-	err := checkBalanceAndSendFee(ctx, ms, sender, topicId, amount, insufficientBalanceErrorMsg)
+	err := checkBalanceAndSendFee(ctx, ms, sender, amount)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What is the purpose of the change

We have staticcheck in CI/CD, but apparently visual studio code is using some additional linters as well because staticcheck did not catch these unused function parameters but visual studio code did.

We should at some point figure out what that tool is and use it in ci/cd. Maybe use https://github.com/golangci/golangci-lint instead of just staticcheck.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

No documentation change implications