### PR TITLE
Do not use comos-sdk reserved error 1

### DIFF
--- a/x/emissions/types/errors.go
+++ b/x/emissions/types/errors.go
@@ -3,7 +3,9 @@ package types
 import "cosmossdk.io/errors"
 
 var (
-	ErrTopicReputerStakeDoesNotExist     = errors.Register(ModuleName, 1, "topic reputer stake does not exist")
+	// ERROR 1 IS RESERVED BY COSMOS-SDK PACKAGE
+	// also we don't use ErrTopicReputerStakeDoesNotExist
+	// ErrTopicReputerStakeDoesNotExist     = errors.Register(ModuleName, 1, "topic reputer stake does not exist")
 	ErrIntegerUnderflowTopicReputerStake = errors.Register(ModuleName, 2, "integer underflow for topic reputer stake")
 	ErrIntegerUnderflowTopicStake        = errors.Register(ModuleName, 3, "integer underflow for topic stake")
 	ErrIntegerUnderflowTotalStake        = errors.Register(ModuleName, 4, "integer underflow for total stake")

--- a/x/mint/types/errors.go
+++ b/x/mint/types/errors.go
@@ -3,11 +3,12 @@ package types
 import "cosmossdk.io/errors"
 
 var (
-	ErrUnauthorized                                    = errors.Register(ModuleName, 1, "unauthorized message signer")
+	// ERROR 1 IS RESERVED BY COSMOS-SDK PACKAGE
 	ErrNegativeTargetEmissionPerToken                  = errors.Register(ModuleName, 2, "negative target emission per token")
 	ErrInvalidPreviousRewardEmissionPerUnitStakedToken = errors.Register(ModuleName, 3, "invalid previous reward")
 	ErrInvalidEcosystemTokensMinted                    = errors.Register(ModuleName, 4, "invalid ecosystem tokens minted")
 	ErrZeroDenominator                                 = errors.Register(ModuleName, 5, "zero denominator")
 	ErrNegativeCirculatingSupply                       = errors.Register(ModuleName, 6, "circulating supply cannot be negative")
 	ErrNotFound                                        = errors.Register(ModuleName, 7, "not found")
+	ErrUnauthorized                                    = errors.Register(ModuleName, 8, "unauthorized message signer")
 )


### PR DESCRIPTION
## What is the purpose of the change

According to the Cosmos SDK [Errors documentation](https://docs.cosmos.network/main/build/building-modules/errors#registration), the error code :

    Must be greater than one, as a code value of one is reserved for internal errors.

This fixes that broken rule.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

No documentation changes