### PR TITLE
Added fixes after b7s removal PR

### DIFF
--- a/x/emissions/keeper/actor_utils/worker.go
+++ b/x/emissions/keeper/actor_utils/worker.go
@@ -170,9 +170,11 @@ func insertForecastsFromTopForecasters(
 		// We keep what we can, ignoring the forecaster and their contribution (forecast) entirely
 		// if they're left with no valid forecast elements.
 		acceptedForecastElements := make([]*types.ForecastElement, 0)
+		seenInferers := make(map[string]bool)
 		for _, el := range forecast.ForecastElements {
-			if _, ok := acceptedInferersOfBatch[el.Inferer]; ok {
+			if _, ok := acceptedInferersOfBatch[el.Inferer]; ok && !seenInferers[el.Inferer] {
 				acceptedForecastElements = append(acceptedForecastElements, el)
+				seenInferers[el.Inferer] = true
 			}
 		}
 
@@ -180,6 +182,9 @@ func insertForecastsFromTopForecasters(
 		if len(acceptedForecastElements) == 0 {
 			continue
 		}
+
+		// Update the forecast with the filtered elements
+		forecast.ForecastElements = acceptedForecastElements
 
 		if forecast == nil {
 			ctx.Logger().Warn("Forecast was added that is nil, ignoring")

--- a/x/emissions/keeper/actor_utils/worker.go
+++ b/x/emissions/keeper/actor_utils/worker.go
@@ -174,11 +174,9 @@ func insertForecastsFromTopForecasters(
 		// We keep what we can, ignoring the forecaster and their contribution (forecast) entirely
 		// if they're left with no valid forecast elements.
 		acceptedForecastElements := make([]*types.ForecastElement, 0)
-		seenInferers := make(map[string]bool)
 		for _, el := range forecast.ForecastElements {
-			if _, ok := acceptedInferersOfBatch[el.Inferer]; ok && !seenInferers[el.Inferer] {
+			if _, ok := acceptedInferersOfBatch[el.Inferer]; ok {
 				acceptedForecastElements = append(acceptedForecastElements, el)
-				seenInferers[el.Inferer] = true
 			}
 		}
 
@@ -188,11 +186,8 @@ func insertForecastsFromTopForecasters(
 		}
 
 		// Update the forecast with the filtered elements
-		forecast.ForecastElements = acceptedForecastElements
-
-		if forecast == nil {
-			ctx.Logger().Warn("Forecast was added that is nil, ignoring")
-			continue
+		if forecast.ForecastElements != nil {
+			forecast.ForecastElements = acceptedForecastElements
 		}
 
 		if forecast.Forecaster == "" {

--- a/x/emissions/keeper/actor_utils/worker.go
+++ b/x/emissions/keeper/actor_utils/worker.go
@@ -165,6 +165,10 @@ func insertForecastsFromTopForecasters(
 	forecastsByForecaster := make(map[string]*types.Forecast)
 	latestForecaster := make([]*types.Forecast, 0)
 	for _, forecast := range forecasts {
+		if forecast == nil {
+			continue
+		}
+
 		// Examine forecast elements to verify that they're for inferers in the current set.
 		// We assume that set of inferers has been verified above.
 		// We keep what we can, ignoring the forecaster and their contribution (forecast) entirely

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -1,8 +1,10 @@
 package inference_synthesis
 
 import (
+	"errors"
 	"fmt"
 
+	"cosmossdk.io/collections"
 	errorsmod "cosmossdk.io/errors"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
@@ -53,7 +55,13 @@ func GetNetworkInferencesAtBlock(
 
 	forecasts, err := k.GetForecastsAtBlock(ctx, topicId, inferencesNonce)
 	if err != nil {
-		return nil, nil, infererWeights, forecasterWeights, err
+		if errors.Is(err, collections.ErrNotFound) {
+			forecasts = &emissions.Forecasts{
+				Forecasts: make([]*emissions.Forecast, 0),
+			}
+		} else {
+			return nil, nil, infererWeights, forecasterWeights, err
+		}
 	}
 
 	if len(inferences.Inferences) > 1 {
@@ -164,8 +172,14 @@ func GetLatestNetworkInference(
 
 	forecasts, err := k.GetForecastsAtBlock(ctx, topicId, inferenceBlockHeight)
 	if err != nil {
-		Logger(ctx).Warn(fmt.Sprintf("Error getting forecasts: %s", err.Error()))
-		return networkInferences, nil, infererWeights, forecasterWeights, inferenceBlockHeight, lossBlockHeight, nil
+		if errors.Is(err, collections.ErrNotFound) {
+			forecasts = &emissions.Forecasts{
+				Forecasts: make([]*emissions.Forecast, 0),
+			}
+		} else {
+			Logger(ctx).Warn(fmt.Sprintf("Error getting forecasts: %s", err.Error()))
+			return networkInferences, nil, infererWeights, forecasterWeights, inferenceBlockHeight, lossBlockHeight, nil
+		}
 	}
 
 	if len(inferences.Inferences) > 1 {

--- a/x/emissions/keeper/msgserver/msg_server_demand.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand.go
@@ -17,6 +17,6 @@ func (ms msgServer) FundTopic(ctx context.Context, msg *types.MsgFundTopic) (*ty
 		return nil, err
 	}
 
-	err = sendEffectiveRevenueActivateTopicIfWeightSufficient(ctx, ms, msg.Sender, msg.TopicId, msg.Amount, "fund topic")
+	err = sendEffectiveRevenueActivateTopicIfWeightSufficient(ctx, ms, msg.Sender, msg.TopicId, msg.Amount)
 	return &types.MsgFundTopicResponse{}, err
 }

--- a/x/emissions/keeper/msgserver/msg_server_demand_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand_test.go
@@ -33,8 +33,6 @@ func (s *MsgServerTestSuite) TestFundTopicSimple() {
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
-		r.Amount,
-		cosmosMath.ZeroInt(),
 	)
 	s.Require().NoError(err)
 	response, err := s.msgServer.FundTopic(s.ctx, &r)
@@ -53,8 +51,6 @@ func (s *MsgServerTestSuite) TestFundTopicSimple() {
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
-		r.Amount,
-		cosmosMath.ZeroInt(),
 	)
 	s.Require().NoError(err)
 	s.Require().True(feeRevAfter.GT(feeRevBefore), "Topic fee revenue should be greater after funding the topic")
@@ -111,8 +107,6 @@ func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
-		r.Amount,
-		cosmosMath.ZeroInt(),
 	)
 	s.Require().NoError(err)
 
@@ -123,8 +117,6 @@ func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
-		r2.Amount,
-		cosmosMath.ZeroInt(),
 	)
 	s.Require().NoError(err)
 

--- a/x/emissions/keeper/msgserver/msg_server_registrations.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations.go
@@ -27,7 +27,7 @@ func (ms msgServer) Register(ctx context.Context, msg *types.MsgRegister) (*type
 	if err != nil {
 		return nil, err
 	}
-	err = sendEffectiveRevenueActivateTopicIfWeightSufficient(ctx, ms, msg.Sender, msg.TopicId, params.RegistrationFee, "register")
+	err = sendEffectiveRevenueActivateTopicIfWeightSufficient(ctx, ms, msg.Sender, msg.TopicId, params.RegistrationFee)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/msgserver/msg_server_registrations_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations_test.go
@@ -254,7 +254,7 @@ func (s *MsgServerTestSuite) TestMsgRegisterReputerInsufficientDenom() {
 
 	// Try to register without any funds to pay fees
 	_, err := msgServer.Register(ctx, reputerRegMsg)
-	require.ErrorIs(err, types.ErrTopicRegistrantNotEnoughDenom, "Register should return an error")
+	require.ErrorIs(err, sdkerrors.ErrInsufficientFunds, "Register should return an error")
 }
 
 func (s *MsgServerTestSuite) TestBlocklistedAddressUnableToRegister() {

--- a/x/emissions/keeper/msgserver/msg_server_registrations_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 	minttypes "github.com/allora-network/allora-chain/x/mint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -322,7 +323,7 @@ func (s *MsgServerTestSuite) TestBlocklistedAddressUnableToRegister() {
 		Owner:     reputer.String(),
 	}
 	_, err = s.msgServer.Register(s.ctx, reputerRegMsg)
-	s.Require().ErrorIs(err, types.ErrTopicRegistrantNotEnoughDenom, "Register should return an error")
+	s.Require().ErrorIs(err, sdkerrors.ErrInsufficientFunds, "Register should return an error")
 }
 
 func (s *MsgServerTestSuite) TestMsgRegisterReputerInvalidTopicNotExist() {

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
@@ -67,7 +67,7 @@ func (ms msgServer) InsertReputerPayload(ctx context.Context, msg *types.MsgInse
 	if err != nil {
 		return nil, errorsmod.Wrapf(err, "Error getting params for sender: %v", &msg.Sender)
 	}
-	err = sendEffectiveRevenueActivateTopicIfWeightSufficient(ctx, ms, msg.Sender, topicId, params.DataSendingFee, "insert reputer payload")
+	err = sendEffectiveRevenueActivateTopicIfWeightSufficient(ctx, ms, msg.Sender, topicId, params.DataSendingFee)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/msgserver/msg_server_stake.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake.go
@@ -52,7 +52,7 @@ func (ms msgServer) AddStake(ctx context.Context, msg *types.MsgAddStake) (*type
 		return nil, err
 	}
 
-	err = activateTopicIfWeightAtLeastGlobalMin(ctx, ms, msg.TopicId, cosmosMath.ZeroInt(), msg.Amount)
+	err = activateTopicIfWeightAtLeastGlobalMin(ctx, ms, msg.TopicId)
 	return &types.MsgAddStakeResponse{}, err
 }
 
@@ -166,7 +166,7 @@ func (ms msgServer) DelegateStake(ctx context.Context, msg *types.MsgDelegateSta
 		return nil, err
 	}
 
-	err = activateTopicIfWeightAtLeastGlobalMin(ctx, ms, msg.TopicId, cosmosMath.ZeroInt(), msg.Amount)
+	err = activateTopicIfWeightAtLeastGlobalMin(ctx, ms, msg.TopicId)
 	return &types.MsgDelegateStakeResponse{}, err
 }
 

--- a/x/emissions/keeper/msgserver/msg_server_topics.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics.go
@@ -30,7 +30,7 @@ func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.MsgCreateNewT
 	}
 
 	// Before creating topic, transfer fee amount from creator to ecosystem bucket
-	err = checkBalanceAndSendFee(ctx, ms, msg.Creator, topicId, params.CreateTopicFee, "create topic")
+	err = checkBalanceAndSendFee(ctx, ms, msg.Creator, params.CreateTopicFee)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/msgserver/msg_server_util_payment.go
+++ b/x/emissions/keeper/msgserver/msg_server_util_payment.go
@@ -71,7 +71,7 @@ func checkBalanceAndSendFee(
 	fee := sdk.NewCoin(balance.Denom, amount)
 
 	if balance.IsLT(fee) {
-		return  errors.Wrapf(sdkerrors.ErrInsufficientFunds, "sender has insufficient balance to cover fees")
+		return errors.Wrapf(sdkerrors.ErrInsufficientFunds, "sender has insufficient balance to cover fees")
 	}
 
 	err = ms.k.SendCoinsFromAccountToModule(ctx, sender, minttypes.EcosystemModuleName, sdk.NewCoins(fee))

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -66,59 +66,58 @@ func (ms msgServer) InsertWorkerPayload(ctx context.Context, msg *types.MsgInser
 		return nil, err
 	}
 
-	if msg.WorkerDataBundle.InferenceForecastsBundle.Inference != nil {
-		inference := msg.WorkerDataBundle.InferenceForecastsBundle.Inference
-		if inference.TopicId != msg.WorkerDataBundle.TopicId {
-			return nil, errorsmod.Wrapf(err,
-				"Error inferer not use same topic")
-		}
-		isInfererRegistered, err := ms.k.IsWorkerRegisteredInTopic(ctx, topicId, inference.Inferer)
-		if err != nil {
-			return nil, errorsmod.Wrapf(err,
-				"Error inferer address is not registered in this topic")
-		}
-		if !isInfererRegistered {
-			return nil, errorsmod.Wrapf(err,
-				"Error inferer address is not registered in this topic")
-		}
-		err = ms.k.AppendInference(ctx, topicId, *nonce, inference)
-		if err != nil {
-			return nil, errorsmod.Wrapf(err, "Error appending inference")
-		}
+	inference := msg.WorkerDataBundle.InferenceForecastsBundle.Inference
+	if inference == nil {
+		return nil, errorsmod.Wrapf(err, "Inference not found")
+	}
+	if inference.TopicId != msg.WorkerDataBundle.TopicId {
+		return nil, errorsmod.Wrapf(err,
+			"Error inferer not use same topic")
+	}
+	isInfererRegistered, err := ms.k.IsWorkerRegisteredInTopic(ctx, topicId, inference.Inferer)
+	if err != nil {
+		return nil, errorsmod.Wrapf(err,
+			"Error inferer address is not registered in this topic")
+	}
+	if !isInfererRegistered {
+		return nil, errorsmod.Wrapf(err,
+			"Error inferer address is not registered in this topic")
+	}
+	err = ms.k.AppendInference(ctx, topicId, *nonce, inference)
+	if err != nil {
+		return nil, errorsmod.Wrapf(err, "Error appending inference")
 	}
 
 	// Append this individual inference to all inferences
-	if msg.WorkerDataBundle.InferenceForecastsBundle.Forecast != nil {
-		forecast := msg.WorkerDataBundle.InferenceForecastsBundle.Forecast
-		if forecast.TopicId != msg.WorkerDataBundle.TopicId {
-			return nil, errorsmod.Wrapf(err,
-				"Error forecaster not use same topic")
-		}
-		isForecasterRegistered, err := ms.k.IsWorkerRegisteredInTopic(ctx, topicId, forecast.Forecaster)
-		if err != nil {
-			return nil, errorsmod.Wrapf(err,
-				"Error forecaster address is not registered in this topic")
-		}
-		if !isForecasterRegistered {
-			return nil, errorsmod.Wrapf(err,
-				"Error forecaster address is not registered in this topic")
-		}
+	forecast := msg.WorkerDataBundle.InferenceForecastsBundle.Forecast
+	if forecast == nil {
+		return nil, errorsmod.Wrapf(err, "Forecast not found")
+	}
+	isForecasterRegistered, err := ms.k.IsWorkerRegisteredInTopic(ctx, topicId, forecast.Forecaster)
+	if err != nil {
+		return nil, errorsmod.Wrapf(err,
+			"Error forecaster address is not registered in this topic")
+	}
+	if !isForecasterRegistered {
+		return nil, errorsmod.Wrapf(err,
+			"Error forecaster address is not registered in this topic")
+	}
 
-		// Remove duplicate forecast element
-		acceptedForecastElements := make([]*types.ForecastElement, 0)
-		seenInferers := make(map[string]bool)
-		for _, el := range forecast.ForecastElements {
-			if !seenInferers[el.Inferer] {
-				acceptedForecastElements = append(acceptedForecastElements, el)
-				seenInferers[el.Inferer] = true
-			}
-		}
-		forecast.ForecastElements = acceptedForecastElements
-		err = ms.k.AppendForecast(ctx, topicId, *nonce, forecast)
-		if err != nil {
-			return nil, errorsmod.Wrapf(err,
-				"Error appending forecast")
+	// Remove duplicate forecast element
+	acceptedForecastElements := make([]*types.ForecastElement, 0)
+	seenInferers := make(map[string]bool)
+	for _, el := range forecast.ForecastElements {
+		if !seenInferers[el.Inferer] {
+			acceptedForecastElements = append(acceptedForecastElements, el)
+			seenInferers[el.Inferer] = true
 		}
 	}
+	forecast.ForecastElements = acceptedForecastElements
+	err = ms.k.AppendForecast(ctx, topicId, *nonce, forecast)
+	if err != nil {
+		return nil, errorsmod.Wrapf(err,
+			"Error appending forecast")
+	}
+
 	return &types.MsgInsertWorkerPayloadResponse{}, nil
 }

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -61,7 +61,7 @@ func (ms msgServer) InsertWorkerPayload(ctx context.Context, msg *types.MsgInser
 	if err != nil {
 		return nil, errorsmod.Wrapf(err, "Error getting params for sender: %v", &msg.Sender)
 	}
-	err = sendEffectiveRevenueActivateTopicIfWeightSufficient(ctx, ms, msg.Sender, topicId, params.DataSendingFee, "insert worker payload")
+	err = sendEffectiveRevenueActivateTopicIfWeightSufficient(ctx, ms, msg.Sender, topicId, params.DataSendingFee)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/queryserver/query_server_topics.go
+++ b/x/emissions/keeper/queryserver/query_server_topics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"cosmossdk.io/errors"
-	cosmosMath "cosmossdk.io/math"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -39,8 +38,6 @@ func (qs queryServer) GetTopic(ctx context.Context, req *types.QueryTopicRequest
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
-		cosmosMath.ZeroInt(),
-		cosmosMath.ZeroInt(),
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting current topic weight")

--- a/x/emissions/keeper/topic_weight.go
+++ b/x/emissions/keeper/topic_weight.go
@@ -45,16 +45,13 @@ func (k *Keeper) GetCurrentTopicWeight(
 	topicRewardAlpha alloraMath.Dec,
 	stakeImportance alloraMath.Dec,
 	feeImportance alloraMath.Dec,
-	additionalRevenue cosmosMath.Int,
-	additionalStake cosmosMath.Int,
 ) (weight alloraMath.Dec, topicRevenue cosmosMath.Int, err error) {
 	topicStake, err := k.GetTopicStake(ctx, topicId)
 	if err != nil {
 		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get topic stake")
 	}
 
-	newTopicStake := topicStake.Add(additionalStake)
-	topicStakeDec, err := alloraMath.NewDecFromSdkInt(newTopicStake)
+	topicStakeDec, err := alloraMath.NewDecFromSdkInt(topicStake)
 	if err != nil {
 		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to convert topic stake to dec")
 	}
@@ -66,17 +63,16 @@ func (k *Keeper) GetCurrentTopicWeight(
 	}
 
 	// Calc target weight using fees, epoch length, stake, and params
-	newFeeRevenue := additionalRevenue.Add(topicFeeRevenue)
-	feeRevenue, err := alloraMath.NewDecFromSdkInt(newFeeRevenue)
+	topicFeeRevenueDec, err := alloraMath.NewDecFromSdkInt(topicFeeRevenue)
 	if err != nil {
 		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to convert topic fee revenue to dec")
 	}
 
-	if !feeRevenue.Equal(alloraMath.ZeroDec()) {
+	if !topicFeeRevenueDec.Equal(alloraMath.ZeroDec()) {
 		targetWeight, err := k.GetTargetWeight(
 			topicStakeDec,
 			topicEpochLength,
-			feeRevenue,
+			topicFeeRevenueDec,
 			stakeImportance,
 			feeImportance,
 		)

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -167,8 +167,6 @@ func GetAndUpdateActiveTopicWeights(
 			moduleParams.TopicRewardAlpha,
 			moduleParams.TopicRewardStakeImportance,
 			moduleParams.TopicRewardFeeRevenueImportance,
-			cosmosMath.ZeroInt(),
-			cosmosMath.ZeroInt(),
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get current topic weight")


### PR DESCRIPTION
- Fix network inferences queries - adding back the fix that was overwritten by the PR #458
- Remove Stake double counting on topic weight calculation
- Remove Revenue double counting on topic weight calculation - Fix audit issue: https://github.com/sherlock-audit/2024-06-allora-judging/issues/46
- Removed unused params on `checkBalanceAndSendFee` function

## What is the purpose of the change

> Add a description of the overall background and high level changes that this PR introduces

*(E.g.: This pull request improves documentation of area A by adding ....)*

## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?


Where is the change documented?
  - [ ] Specification (`x/{module}/README.md`)
  - [ ] Allora documentation site `docs.allora.network` source code at: `https://github.com/allora-network/docs`
  - [ ] Code comments?
  - [ ] N/A
