### PR TITLE
Update l1_node.sh

### DIFF
--- a/scripts/l1_node.sh
+++ b/scripts/l1_node.sh
@@ -13,6 +13,7 @@ MONIKER="${MONIKER:-$(hostname)}"
 KEYRING_BACKEND=test                              #! Use test for simplicity, you should decide which backend to use !!!
 GENESIS_FILE="${APP_HOME}/config/genesis.json"
 DENOM="uallo"
+RPC_PORT="${RPC_PORT:-26657}"
 
 # uncomment this block if you want to restore from a snapshot
 # SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -81,6 +82,6 @@ allorad \
     start \
     --moniker=${MONIKER} \
     --minimum-gas-prices=0${DENOM} \
-    --rpc.laddr=tcp://0.0.0.0:26657 \
+    --rpc.laddr=tcp://0.0.0.0:${RPC_PORT} \
     --p2p.seeds=$SEEDS \
     --p2p.persistent_peers $PEERS


### PR DESCRIPTION
## Purpose of Changes and their Description

- allow env var to set RPC_PORT, with default of 26657

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

- none, functional addition

## Are these changes tested and documented?

- tested: tested with bash script
- documented: as with other env vars has clear definition at the top of the script