### PR TITLE
alloraMath -> cosmosMath conversions: make panicking code return errors instead

### DIFF
--- a/math/dec_test.go
+++ b/math/dec_test.go
@@ -2,7 +2,7 @@
 // Their code is under the Apache2.0 License
 // https://github.com/regen-network/regen-ledger/blob/3d818cf6e01af92eed25de5c17728a79070f56a3/types/math/dec_test.go
 
-package math
+package math_test
 
 import (
 	"fmt"
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	cosmosMath "cosmossdk.io/math"
+	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 )
@@ -67,27 +69,27 @@ func TestDec(t *testing.T) {
 	t.Run("TestNumDecimalPlaces", rapid.MakeCheck(testNumDecimalPlaces))
 
 	// Unit tests
-	zero := Dec{}
-	one := NewDecFromInt64(1)
-	two := NewDecFromInt64(2)
-	three := NewDecFromInt64(3)
-	four := NewDecFromInt64(4)
-	five := NewDecFromInt64(5)
-	minusOne := NewDecFromInt64(-1)
+	zero := alloraMath.Dec{}
+	one := alloraMath.NewDecFromInt64(1)
+	two := alloraMath.NewDecFromInt64(2)
+	three := alloraMath.NewDecFromInt64(3)
+	four := alloraMath.NewDecFromInt64(4)
+	five := alloraMath.NewDecFromInt64(5)
+	minusOne := alloraMath.NewDecFromInt64(-1)
 
-	onePointOneFive, err := NewDecFromString("1.15")
+	onePointOneFive, err := alloraMath.NewDecFromString("1.15")
 	require.NoError(t, err)
-	twoPointThreeFour, err := NewDecFromString("2.34")
+	twoPointThreeFour, err := alloraMath.NewDecFromString("2.34")
 	require.NoError(t, err)
-	threePointFourNine, err := NewDecFromString("3.49")
+	threePointFourNine, err := alloraMath.NewDecFromString("3.49")
 	require.NoError(t, err)
-	onePointFourNine, err := NewDecFromString("1.49")
+	onePointFourNine, err := alloraMath.NewDecFromString("1.49")
 	require.NoError(t, err)
-	minusFivePointZero, err := NewDecFromString("-5.0")
+	minusFivePointZero, err := alloraMath.NewDecFromString("-5.0")
 	require.NoError(t, err)
 
-	twoThousand := NewDecFinite(2, 3)
-	require.True(t, twoThousand.Equal(NewDecFromInt64(2000)))
+	twoThousand := alloraMath.NewDecFinite(2, 3)
+	require.True(t, twoThousand.Equal(alloraMath.NewDecFromInt64(2000)))
 
 	res, err := two.Add(zero)
 	require.NoError(t, err)
@@ -159,32 +161,32 @@ func TestDec(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, res.Equal(two))
 
-	ten := NewDecFromInt64(10)
-	oneHundred := NewDecFromInt64(100)
-	logTenOneHundred, err := Log10(oneHundred)
+	ten := alloraMath.NewDecFromInt64(10)
+	oneHundred := alloraMath.NewDecFromInt64(100)
+	logTenOneHundred, err := alloraMath.Log10(oneHundred)
 	require.NoError(t, err)
 	require.True(t, two.Equal(logTenOneHundred))
-	logTenTen, err := Log10(ten)
+	logTenTen, err := alloraMath.Log10(ten)
 	require.NoError(t, err)
 	require.True(t, one.Equal(logTenTen))
-	logTenOne, err := Log10(one)
+	logTenOne, err := alloraMath.Log10(one)
 	require.NoError(t, err)
 	require.True(t, zero.Equal(logTenOne))
 
-	logEOne, err := Ln(one)
+	logEOne, err := alloraMath.Ln(one)
 	require.NoError(t, err)
 	require.True(t, zero.Equal(logEOne))
 
-	eight := NewDecFromInt64(8)
-	twoCubed, err := Pow(two, three)
+	eight := alloraMath.NewDecFromInt64(8)
+	twoCubed, err := alloraMath.Pow(two, three)
 	require.NoError(t, err)
 	require.True(t, eight.Equal(twoCubed))
 
-	oneThousand := NewDecFromInt64(1000)
-	tenSquared, err := Exp10(two)
+	oneThousand := alloraMath.NewDecFromInt64(1000)
+	tenSquared, err := alloraMath.Exp10(two)
 	require.NoError(t, err)
 	require.True(t, oneHundred.Equal(tenSquared))
-	tenCubed, err := Exp10(three)
+	tenCubed, err := alloraMath.Exp10(three)
 	require.NoError(t, err)
 	require.True(t, oneThousand.Equal(tenCubed))
 
@@ -192,7 +194,7 @@ func TestDec(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, two.Equal(cielOnePointFourNine))
 
-	onePointFiveOne, err := NewDecFromString("1.51")
+	onePointFiveOne, err := alloraMath.NewDecFromString("1.51")
 	require.NoError(t, err)
 	floorOnePointFiveOne, err := onePointFiveOne.Floor()
 	require.NoError(t, err)
@@ -200,9 +202,9 @@ func TestDec(t *testing.T) {
 }
 
 // generate a dec value on the fly
-var genDec *rapid.Generator[Dec] = rapid.Custom(func(t *rapid.T) Dec {
+var genDec *rapid.Generator[alloraMath.Dec] = rapid.Custom(func(t *rapid.T) alloraMath.Dec {
 	f := rapid.Float64().Draw(t, "f")
-	dec, err := NewDecFromString(fmt.Sprintf("%g", f))
+	dec, err := alloraMath.NewDecFromString(fmt.Sprintf("%g", f))
 	require.NoError(t, err)
 	return dec
 })
@@ -210,30 +212,30 @@ var genDec *rapid.Generator[Dec] = rapid.Custom(func(t *rapid.T) Dec {
 // A Dec value and the float used to create it
 type floatAndDec struct {
 	float float64
-	dec   Dec
+	dec   alloraMath.Dec
 }
 
 // Generate a Dec value along with the float used to create it
 var genFloatAndDec *rapid.Generator[floatAndDec] = rapid.Custom(func(t *rapid.T) floatAndDec {
 	f := rapid.Float64().Draw(t, "f")
-	dec, err := NewDecFromString(fmt.Sprintf("%g", f))
+	dec, err := alloraMath.NewDecFromString(fmt.Sprintf("%g", f))
 	require.NoError(t, err)
 	return floatAndDec{f, dec}
 })
 
-// Property: n == NewDecFromInt64(n).Int64()
+// Property: n == alloraMath.NewDecFromInt64(n).Int64()
 func testDecInt64(t *rapid.T) {
 	nIn := rapid.Int64().Draw(t, "n")
-	nOut, err := NewDecFromInt64(nIn).Int64()
+	nOut, err := alloraMath.NewDecFromInt64(nIn).Int64()
 
 	require.NoError(t, err)
 	require.Equal(t, nIn, nOut)
 }
 
-// Property: invalid_number_string(s) => NewDecFromString(s) == err
+// Property: invalid_number_string(s) => alloraMath.NewDecFromString(s) == err
 func testInvalidNewDecFromString(t *rapid.T) {
 	s := rapid.StringMatching("[[:alpha:]]+").Draw(t, "s")
-	_, err := NewDecFromString(s)
+	_, err := alloraMath.NewDecFromString(s)
 	require.Error(t, err)
 }
 
@@ -246,7 +248,7 @@ func testInvalidNewNonNegativeDecFromString(t *rapid.T) {
 			func(s string) bool { return !strings.HasPrefix(s, "-0") && !strings.HasPrefix(s, "-.0") },
 		),
 	).Draw(t, "s")
-	_, err := NewNonNegativeDecFromString(s)
+	_, err := alloraMath.NewNonNegativeDecFromString(s)
 	require.Error(t, err)
 }
 
@@ -261,7 +263,7 @@ func testInvalidNewNonNegativeFixedDecFromString(t *rapid.T) {
 		),
 		rapid.StringMatching(fmt.Sprintf(`\d*\.\d{%d,}`, n+1)),
 	).Draw(t, "s")
-	_, err := NewNonNegativeFixedDecFromString(s, n)
+	_, err := alloraMath.NewNonNegativeFixedDecFromString(s, n)
 	require.Error(t, err)
 }
 
@@ -272,7 +274,7 @@ func testInvalidNewPositiveDecFromString(t *rapid.T) {
 		rapid.StringMatching("[[:alpha:]]+"),
 		rapid.StringMatching(`^-\d*\.?\d+|0$`),
 	).Draw(t, "s")
-	_, err := NewPositiveDecFromString(s)
+	_, err := alloraMath.NewPositiveDecFromString(s)
 	require.Error(t, err)
 }
 
@@ -285,14 +287,14 @@ func testInvalidNewPositiveFixedDecFromString(t *rapid.T) {
 		rapid.StringMatching(`^-\d*\.?\d+|0$`),
 		rapid.StringMatching(fmt.Sprintf(`\d*\.\d{%d,}`, n+1)),
 	).Draw(t, "s")
-	_, err := NewPositiveFixedDecFromString(s, n)
+	_, err := alloraMath.NewPositiveFixedDecFromString(s, n)
 	require.Error(t, err)
 }
 
 // Property: 0 + a == a
 func testAddLeftIdentity(t *rapid.T) {
 	a := genDec.Draw(t, "a")
-	zero := NewDecFromInt64(0)
+	zero := alloraMath.NewDecFromInt64(0)
 
 	b, err := zero.Add(a)
 	require.NoError(t, err)
@@ -303,7 +305,7 @@ func testAddLeftIdentity(t *rapid.T) {
 // Property: a + 0 == a
 func testAddRightIdentity(t *rapid.T) {
 	a := genDec.Draw(t, "a")
-	zero := NewDecFromInt64(0)
+	zero := alloraMath.NewDecFromInt64(0)
 
 	b, err := a.Add(zero)
 	require.NoError(t, err)
@@ -351,7 +353,7 @@ func testAddAssociative(t *rapid.T) {
 // Property: a - 0 == a
 func testSubRightIdentity(t *rapid.T) {
 	a := genDec.Draw(t, "a")
-	zero := NewDecFromInt64(0)
+	zero := alloraMath.NewDecFromInt64(0)
 
 	b, err := a.Sub(zero)
 	require.NoError(t, err)
@@ -362,7 +364,7 @@ func testSubRightIdentity(t *rapid.T) {
 // Property: a - a == 0
 func testSubZero(t *rapid.T) {
 	a := genDec.Draw(t, "a")
-	zero := NewDecFromInt64(0)
+	zero := alloraMath.NewDecFromInt64(0)
 
 	b, err := a.Sub(a)
 	require.NoError(t, err)
@@ -373,7 +375,7 @@ func testSubZero(t *rapid.T) {
 // Property: 1 * a == a
 func testMulLeftIdentity(t *rapid.T) {
 	a := genDec.Draw(t, "a")
-	one := NewDecFromInt64(1)
+	one := alloraMath.NewDecFromInt64(1)
 
 	b, err := one.Mul(a)
 	require.NoError(t, err)
@@ -384,7 +386,7 @@ func testMulLeftIdentity(t *rapid.T) {
 // Property: a * 1 == a
 func testMulRightIdentity(t *rapid.T) {
 	a := genDec.Draw(t, "a")
-	one := NewDecFromInt64(1)
+	one := alloraMath.NewDecFromInt64(1)
 
 	b, err := a.Mul(one)
 	require.NoError(t, err)
@@ -460,7 +462,7 @@ func testAddSub(t *rapid.T) {
 // Property: a * 0 = 0
 func testMulZero(t *rapid.T) {
 	a := genDec.Draw(t, "a")
-	zero := Dec{}
+	zero := alloraMath.Dec{}
 
 	c, err := a.Mul(zero)
 	require.NoError(t, err)
@@ -469,9 +471,9 @@ func testMulZero(t *rapid.T) {
 
 // Property: a/a = 1
 func testSelfQuo(t *rapid.T) {
-	decNotZero := func(d Dec) bool { return !d.IsZero() }
+	decNotZero := func(d alloraMath.Dec) bool { return !d.IsZero() }
 	a := genDec.Filter(decNotZero).Draw(t, "a")
-	one := NewDecFromInt64(1)
+	one := alloraMath.NewDecFromInt64(1)
 
 	b, err := a.Quo(a)
 	require.NoError(t, err)
@@ -481,7 +483,7 @@ func testSelfQuo(t *rapid.T) {
 // Property: a/1 = a
 func testQuoByOne(t *rapid.T) {
 	a := genDec.Draw(t, "a")
-	one := NewDecFromInt64(1)
+	one := alloraMath.NewDecFromInt64(1)
 
 	b, err := a.Quo(one)
 	require.NoError(t, err)
@@ -490,7 +492,7 @@ func testQuoByOne(t *rapid.T) {
 
 // Property: (a * b) / a == b
 func testMulQuoA(t *rapid.T) {
-	decNotZero := func(d Dec) bool { return !d.IsZero() }
+	decNotZero := func(d alloraMath.Dec) bool { return !d.IsZero() }
 	a := genDec.Filter(decNotZero).Draw(t, "a")
 	b := genDec.Draw(t, "b")
 
@@ -505,7 +507,7 @@ func testMulQuoA(t *rapid.T) {
 
 // Property: (a * b) / b == a
 func testMulQuoB(t *rapid.T) {
-	decNotZero := func(d Dec) bool { return !d.IsZero() }
+	decNotZero := func(d alloraMath.Dec) bool { return !d.IsZero() }
 	a := genDec.Draw(t, "a")
 	b := genDec.Filter(decNotZero).Draw(t, "b")
 
@@ -522,10 +524,10 @@ func testMulQuoB(t *rapid.T) {
 // and a with no more than b decimal places (b <= 32).
 func testMulQuoExact(t *rapid.T) {
 	b := rapid.Uint32Range(0, 32).Draw(t, "b")
-	decPrec := func(d Dec) bool { return d.NumDecimalPlaces() <= b }
+	decPrec := func(d alloraMath.Dec) bool { return d.NumDecimalPlaces() <= b }
 	a := genDec.Filter(decPrec).Draw(t, "a")
 
-	c := NewDecFinite(1, int32(b))
+	c := alloraMath.NewDecFinite(1, int32(b))
 
 	d, err := a.MulExact(c)
 	require.NoError(t, err)
@@ -540,10 +542,10 @@ func testMulQuoExact(t *rapid.T) {
 // a as an integer.
 func testQuoMulExact(t *rapid.T) {
 	a := rapid.Uint64().Draw(t, "a")
-	aDec, err := NewDecFromString(fmt.Sprintf("%d", a))
+	aDec, err := alloraMath.NewDecFromString(fmt.Sprintf("%d", a))
 	require.NoError(t, err)
 	b := rapid.Uint32Range(0, 32).Draw(t, "b")
-	c := NewDecFinite(1, int32(b))
+	c := alloraMath.NewDecFinite(1, int32(b))
 
 	require.NoError(t, err)
 
@@ -645,19 +647,19 @@ func floatDecimalPlaces(t *rapid.T, f float64) uint32 {
 }
 
 func TestIsFinite(t *testing.T) {
-	a, err := NewDecFromString("1.5")
+	a, err := alloraMath.NewDecFromString("1.5")
 	require.NoError(t, err)
 
 	require.True(t, a.IsFinite())
 
-	b, err := NewDecFromString("NaN")
+	b, err := alloraMath.NewDecFromString("NaN")
 	require.NoError(t, err)
 
 	require.False(t, b.IsFinite())
 }
 
 func TestReduce(t *testing.T) {
-	a, err := NewDecFromString("1.30000")
+	a, err := alloraMath.NewDecFromString("1.30000")
 	require.NoError(t, err)
 	b, n := a.Reduce()
 	require.Equal(t, 4, n)
@@ -666,9 +668,9 @@ func TestReduce(t *testing.T) {
 }
 
 func TestMulExactGood(t *testing.T) {
-	a, err := NewDecFromString("1.000001")
+	a, err := alloraMath.NewDecFromString("1.000001")
 	require.NoError(t, err)
-	b := NewDecFinite(1, 6)
+	b := alloraMath.NewDecFinite(1, 6)
 	c, err := a.MulExact(b)
 	require.NoError(t, err)
 	d, err := c.Int64()
@@ -677,17 +679,17 @@ func TestMulExactGood(t *testing.T) {
 }
 
 func TestMulExactBad(t *testing.T) {
-	a, err := NewDecFromString("1.000000000000000000000000000000000000123456789")
+	a, err := alloraMath.NewDecFromString("1.000000000000000000000000000000000000123456789")
 	require.NoError(t, err)
-	b := NewDecFinite(1, 10)
+	b := alloraMath.NewDecFinite(1, 10)
 	_, err = a.MulExact(b)
-	require.ErrorIs(t, err, ErrUnexpectedRounding)
+	require.ErrorIs(t, err, alloraMath.ErrUnexpectedRounding)
 }
 
 func TestQuoExactGood(t *testing.T) {
-	a, err := NewDecFromString("1000001")
+	a, err := alloraMath.NewDecFromString("1000001")
 	require.NoError(t, err)
-	b := NewDecFinite(1, 6)
+	b := alloraMath.NewDecFinite(1, 6)
 	c, err := a.QuoExact(b)
 	require.NoError(t, err)
 	t.Logf("%s\n", c.String())
@@ -695,11 +697,11 @@ func TestQuoExactGood(t *testing.T) {
 }
 
 func TestQuoExactBad(t *testing.T) {
-	a, err := NewDecFromString("1000000000000000000000000000000000000123456789")
+	a, err := alloraMath.NewDecFromString("1000000000000000000000000000000000000123456789")
 	require.NoError(t, err)
-	b := NewDecFinite(1, 10)
+	b := alloraMath.NewDecFinite(1, 10)
 	_, err = a.QuoExact(b)
-	require.ErrorIs(t, err, ErrUnexpectedRounding)
+	require.ErrorIs(t, err, alloraMath.ErrUnexpectedRounding)
 }
 
 func TestToBigInt(t *testing.T) {
@@ -712,10 +714,10 @@ func TestToBigInt(t *testing.T) {
 		{i1, i1, nil},
 		{"1000000000000000000000000000000000000123456789.00000000", i1, nil},
 		{"123.456e6", "123456000", nil},
-		{"12345.6", "", ErrNonIntegeral},
+		{"12345.6", "", alloraMath.ErrNonIntegeral},
 	}
 	for idx, tc := range tcs {
-		a, err := NewDecFromString(tc.intStr)
+		a, err := alloraMath.NewDecFromString(tc.intStr)
 		require.NoError(t, err)
 		b, err := a.BigInt()
 		if tc.isError == nil {
@@ -745,12 +747,22 @@ func TestToSdkInt(t *testing.T) {
 		{"-0.9", "0"},
 	}
 	for idx, tc := range tcs {
-		a, err := NewDecFromString(tc.intStr)
+		a, err := alloraMath.NewDecFromString(tc.intStr)
 		require.NoError(t, err)
 		b, err := a.SdkIntTrim()
 		require.NoError(t, err)
 		require.Equal(t, tc.out, b.String(), "test_%d", idx)
 	}
+}
+
+func TestToSdkIntFail(t *testing.T) {
+	// 2 **256 - 1 (~1.15e77) should be the largest
+	// representable integer in the cosmos SDK Int
+	a, err := alloraMath.NewDecFromString("1.2e77")
+	require.NoError(t, err)
+	b, err := a.SdkIntTrim()
+	require.Error(t, err)
+	require.Equal(t, cosmosMath.Int{}, b)
 }
 
 func TestToSdkLegacy(t *testing.T) {
@@ -771,7 +783,7 @@ func TestToSdkLegacy(t *testing.T) {
 		{"-0.9", "-0.900000000000000000"},
 	}
 	for idx, tc := range tcs {
-		a, err := NewDecFromString(tc.intStr)
+		a, err := alloraMath.NewDecFromString(tc.intStr)
 		require.NoError(t, err)
 		b, err := a.SdkLegacyDec()
 		require.NoError(t, err)
@@ -779,30 +791,30 @@ func TestToSdkLegacy(t *testing.T) {
 	}
 }
 func TestInfDecString(t *testing.T) {
-	_, err := NewDecFromString("iNf")
+	_, err := alloraMath.NewDecFromString("iNf")
 	require.Error(t, err)
-	require.ErrorIs(t, err, ErrInfiniteString)
+	require.ErrorIs(t, err, alloraMath.ErrInfiniteString)
 }
 
 func TestInDelta(t *testing.T) {
 	// Test cases
 	testCases := []struct {
-		expected       Dec
-		result         Dec
-		epsilon        Dec
+		expected       alloraMath.Dec
+		result         alloraMath.Dec
+		epsilon        alloraMath.Dec
 		expectedResult bool
 	}{
-		{NewDecFromInt64(10), NewDecFromInt64(10), NewDecFromInt64(1), true},   // expected == result, within epsilon
-		{NewDecFromInt64(10), NewDecFromInt64(9), NewDecFromInt64(1), true},    // expected != result, but within epsilon
-		{NewDecFromInt64(10), NewDecFromInt64(8), NewDecFromInt64(1), false},   // expected != result, outside epsilon
-		{NewDecFromInt64(10), NewDecFromInt64(10), NewDecFromInt64(0), true},   // expected == result, epsilon is zero
-		{NewDecFromInt64(10), NewDecFromInt64(-10), NewDecFromInt64(1), false}, // expected != result, outside epsilon
-		{NewDecFromInt64(-10), NewDecFromInt64(-10), NewDecFromInt64(0), true}, // expected == result, epsilon is zero
+		{alloraMath.NewDecFromInt64(10), alloraMath.NewDecFromInt64(10), alloraMath.NewDecFromInt64(1), true},   // expected == result, within epsilon
+		{alloraMath.NewDecFromInt64(10), alloraMath.NewDecFromInt64(9), alloraMath.NewDecFromInt64(1), true},    // expected != result, but within epsilon
+		{alloraMath.NewDecFromInt64(10), alloraMath.NewDecFromInt64(8), alloraMath.NewDecFromInt64(1), false},   // expected != result, outside epsilon
+		{alloraMath.NewDecFromInt64(10), alloraMath.NewDecFromInt64(10), alloraMath.NewDecFromInt64(0), true},   // expected == result, epsilon is zero
+		{alloraMath.NewDecFromInt64(10), alloraMath.NewDecFromInt64(-10), alloraMath.NewDecFromInt64(1), false}, // expected != result, outside epsilon
+		{alloraMath.NewDecFromInt64(-10), alloraMath.NewDecFromInt64(-10), alloraMath.NewDecFromInt64(0), true}, // expected == result, epsilon is zero
 	}
 
 	// Run test cases
 	for _, tc := range testCases {
-		result := InDelta(tc.expected, tc.result, tc.epsilon)
+		result := alloraMath.InDelta(tc.expected, tc.result, tc.epsilon)
 		require.Equal(t, tc.expectedResult, result)
 	}
 }
@@ -811,58 +823,58 @@ func TestSlicesInDelta(t *testing.T) {
 	// Test cases
 	testCases := []struct {
 		name     string
-		a        []Dec
-		b        []Dec
-		epsilon  Dec
+		a        []alloraMath.Dec
+		b        []alloraMath.Dec
+		epsilon  alloraMath.Dec
 		expected bool
 	}{
 		{
 			name:     "Equal slices within epsilon",
-			a:        []Dec{NewDecFromInt64(1), NewDecFromInt64(2), NewDecFromInt64(3)},
-			b:        []Dec{NewDecFromInt64(1), NewDecFromInt64(2), NewDecFromInt64(3)},
-			epsilon:  NewDecFromInt64(0),
+			a:        []alloraMath.Dec{alloraMath.NewDecFromInt64(1), alloraMath.NewDecFromInt64(2), alloraMath.NewDecFromInt64(3)},
+			b:        []alloraMath.Dec{alloraMath.NewDecFromInt64(1), alloraMath.NewDecFromInt64(2), alloraMath.NewDecFromInt64(3)},
+			epsilon:  alloraMath.NewDecFromInt64(0),
 			expected: true,
 		},
 		{
 			name:     "Equal slices within epsilon",
-			a:        []Dec{NewDecFromInt64(0), NewDecFromInt64(-1), NewDecFromInt64(4)},
-			b:        []Dec{NewDecFromInt64(-1), NewDecFromInt64(-2), NewDecFromInt64(3)},
-			epsilon:  NewDecFromInt64(1),
+			a:        []alloraMath.Dec{alloraMath.NewDecFromInt64(0), alloraMath.NewDecFromInt64(-1), alloraMath.NewDecFromInt64(4)},
+			b:        []alloraMath.Dec{alloraMath.NewDecFromInt64(-1), alloraMath.NewDecFromInt64(-2), alloraMath.NewDecFromInt64(3)},
+			epsilon:  alloraMath.NewDecFromInt64(1),
 			expected: true,
 		},
 		{
 			name:     "Equal slices NOT within epsilon",
-			a:        []Dec{NewDecFromInt64(1), NewDecFromInt64(2), NewDecFromInt64(5)},
-			b:        []Dec{NewDecFromInt64(1), NewDecFromInt64(2), NewDecFromInt64(3)},
-			epsilon:  NewDecFromInt64(1),
+			a:        []alloraMath.Dec{alloraMath.NewDecFromInt64(1), alloraMath.NewDecFromInt64(2), alloraMath.NewDecFromInt64(5)},
+			b:        []alloraMath.Dec{alloraMath.NewDecFromInt64(1), alloraMath.NewDecFromInt64(2), alloraMath.NewDecFromInt64(3)},
+			epsilon:  alloraMath.NewDecFromInt64(1),
 			expected: false,
 		},
 		{
 			name:     "Different slices within epsilon",
-			a:        []Dec{NewDecFromInt64(-1), NewDecFromInt64(2), NewDecFromInt64(3)},
-			b:        []Dec{NewDecFromInt64(2), NewDecFromInt64(5), NewDecFromInt64(6)},
-			epsilon:  NewDecFromInt64(3),
+			a:        []alloraMath.Dec{alloraMath.NewDecFromInt64(-1), alloraMath.NewDecFromInt64(2), alloraMath.NewDecFromInt64(3)},
+			b:        []alloraMath.Dec{alloraMath.NewDecFromInt64(2), alloraMath.NewDecFromInt64(5), alloraMath.NewDecFromInt64(6)},
+			epsilon:  alloraMath.NewDecFromInt64(3),
 			expected: true,
 		},
 		{
 			name:     "Different slices outside epsilon",
-			a:        []Dec{NewDecFromInt64(1), NewDecFromInt64(2), NewDecFromInt64(3)},
-			b:        []Dec{NewDecFromInt64(4), NewDecFromInt64(5), NewDecFromInt64(6)},
-			epsilon:  NewDecFromInt64(1),
+			a:        []alloraMath.Dec{alloraMath.NewDecFromInt64(1), alloraMath.NewDecFromInt64(2), alloraMath.NewDecFromInt64(3)},
+			b:        []alloraMath.Dec{alloraMath.NewDecFromInt64(4), alloraMath.NewDecFromInt64(5), alloraMath.NewDecFromInt64(6)},
+			epsilon:  alloraMath.NewDecFromInt64(1),
 			expected: false,
 		},
 		{
 			name:     "Different slice lengths",
-			a:        []Dec{NewDecFromInt64(1), NewDecFromInt64(2), NewDecFromInt64(3)},
-			b:        []Dec{NewDecFromInt64(1), NewDecFromInt64(2)},
-			epsilon:  NewDecFromInt64(0),
+			a:        []alloraMath.Dec{alloraMath.NewDecFromInt64(1), alloraMath.NewDecFromInt64(2), alloraMath.NewDecFromInt64(3)},
+			b:        []alloraMath.Dec{alloraMath.NewDecFromInt64(1), alloraMath.NewDecFromInt64(2)},
+			epsilon:  alloraMath.NewDecFromInt64(0),
 			expected: false,
 		},
 		{
 			name:     "Empty slice",
-			a:        []Dec{},
-			b:        []Dec{},
-			epsilon:  NewDecFromInt64(0),
+			a:        []alloraMath.Dec{},
+			b:        []alloraMath.Dec{},
+			epsilon:  alloraMath.NewDecFromInt64(0),
 			expected: true,
 		},
 	}
@@ -870,7 +882,7 @@ func TestSlicesInDelta(t *testing.T) {
 	// Run test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := SlicesInDelta(tc.a, tc.b, tc.epsilon)
+			result := alloraMath.SlicesInDelta(tc.a, tc.b, tc.epsilon)
 			require.Equal(t, tc.expected, result)
 		})
 	}
@@ -878,109 +890,46 @@ func TestSlicesInDelta(t *testing.T) {
 
 func TestSumDecSlice(t *testing.T) {
 	// Test case 1: Empty slice
-	x := []Dec{}
-	expectedSum := ZeroDec()
+	x := []alloraMath.Dec{}
+	expectedSum := alloraMath.ZeroDec()
 
-	sum, err := SumDecSlice(x)
+	sum, err := alloraMath.SumDecSlice(x)
 	require.NoError(t, err)
 	require.True(t, sum.Equal(expectedSum), "Expected sum to be zero")
 
 	// Test case 2: Slice with positive values
-	x = []Dec{
-		NewDecFromInt64(1),
-		NewDecFromInt64(2),
-		NewDecFromInt64(3),
+	x = []alloraMath.Dec{
+		alloraMath.NewDecFromInt64(1),
+		alloraMath.NewDecFromInt64(2),
+		alloraMath.NewDecFromInt64(3),
 	}
-	expectedSum = NewDecFromInt64(6)
+	expectedSum = alloraMath.NewDecFromInt64(6)
 
-	sum, err = SumDecSlice(x)
+	sum, err = alloraMath.SumDecSlice(x)
 	require.NoError(t, err)
 	require.True(t, sum.Equal(expectedSum), "Expected sum to be 6")
 
 	// Test case 3: Slice with negative values
-	x = []Dec{
-		NewDecFromInt64(-1),
-		NewDecFromInt64(-2),
-		NewDecFromInt64(-3),
+	x = []alloraMath.Dec{
+		alloraMath.NewDecFromInt64(-1),
+		alloraMath.NewDecFromInt64(-2),
+		alloraMath.NewDecFromInt64(-3),
 	}
-	expectedSum = NewDecFromInt64(-6)
+	expectedSum = alloraMath.NewDecFromInt64(-6)
 
-	sum, err = SumDecSlice(x)
+	sum, err = alloraMath.SumDecSlice(x)
 	require.NoError(t, err)
 	require.True(t, sum.Equal(expectedSum), "Expected sum to be -6")
 
 	// Test case 4: Slice with mixed positive and negative values
-	x = []Dec{
-		NewDecFromInt64(1),
-		NewDecFromInt64(-2),
-		NewDecFromInt64(3),
+	x = []alloraMath.Dec{
+		alloraMath.NewDecFromInt64(1),
+		alloraMath.NewDecFromInt64(-2),
+		alloraMath.NewDecFromInt64(3),
 	}
-	expectedSum = NewDecFromInt64(2)
+	expectedSum = alloraMath.NewDecFromInt64(2)
 
-	sum, err = SumDecSlice(x)
+	sum, err = alloraMath.SumDecSlice(x)
 	require.NoError(t, err)
 	require.True(t, sum.Equal(expectedSum), "Expected sum to be 2")
-}
-
-func TestDecReduce(t *testing.T) {
-	// Test case 1
-	x := NewDecFromInt64(12345678900)
-	expectedY := NewDecFromInt64(123456789)
-	expectedN := 2
-
-	y, n := x.Reduce()
-
-	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
-	require.Equal(t, expectedN, n)
-
-	// Test case 2
-	x = NewDecFromInt64(0)
-	expectedY = NewDecFromInt64(0)
-	expectedN = 0
-
-	y, n = x.Reduce()
-
-	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
-	require.Equal(t, expectedN, n)
-
-	// Test case 3
-	x = NewDecFromInt64(10000.000)
-	expectedY = NewDecFromInt64(1)
-	expectedN = 4
-
-	y, n = x.Reduce()
-
-	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
-	require.Equal(t, expectedN, n)
-
-	// Test case 4
-	x = NewDecFromInt64(0000.000)
-	expectedY = NewDecFromInt64(0)
-	expectedN = 0
-
-	y, n = x.Reduce()
-
-	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
-	require.Equal(t, expectedN, n)
-
-	// Test case 5
-	x = NewDecFromInt64(-1234560000.000)
-	expectedY = NewDecFromInt64(123456)
-	expectedN = 4
-
-	y, n = x.Reduce()
-
-	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
-	require.True(t, y.dec.Negative)
-	require.Equal(t, expectedN, n)
-
-	// Test case 6
-	x = NewDecFromInt64(-123456000000.000)
-	expectedN = 6
-	strX := "-123456000000"
-
-	y, n = x.Reduce()
-
-	require.Equal(t, strX, y.String())
-	require.Equal(t, expectedN, n)
 }

--- a/math/dec_test.go
+++ b/math/dec_test.go
@@ -765,7 +765,7 @@ func TestToSdkIntFail(t *testing.T) {
 	require.Equal(t, cosmosMath.Int{}, b)
 }
 
-func TestToSdkLegacy(t *testing.T) {
+func TestToSdkLegacyDec(t *testing.T) {
 	i1 := "1000000000000000000000000000000000000123456789.321000000000000000"
 	tcs := []struct {
 		intStr string
@@ -790,6 +790,14 @@ func TestToSdkLegacy(t *testing.T) {
 		require.Equal(t, tc.out, b.String(), "test_%d", idx)
 	}
 }
+
+func TestToSdkLegacyDecFail(t *testing.T) {
+	a, err := alloraMath.NewDecFromString("1.2e77")
+	require.NoError(t, err)
+	_, err = a.SdkLegacyDec()
+	require.Error(t, err)
+}
+
 func TestInfDecString(t *testing.T) {
 	_, err := alloraMath.NewDecFromString("iNf")
 	require.Error(t, err)

--- a/math/dec_test.go
+++ b/math/dec_test.go
@@ -747,7 +747,8 @@ func TestToSdkInt(t *testing.T) {
 	for idx, tc := range tcs {
 		a, err := NewDecFromString(tc.intStr)
 		require.NoError(t, err)
-		b := a.SdkIntTrim()
+		b, err := a.SdkIntTrim()
+		require.NoError(t, err)
 		require.Equal(t, tc.out, b.String(), "test_%d", idx)
 	}
 }
@@ -772,7 +773,8 @@ func TestToSdkLegacy(t *testing.T) {
 	for idx, tc := range tcs {
 		a, err := NewDecFromString(tc.intStr)
 		require.NoError(t, err)
-		b := a.SdkLegacyDec()
+		b, err := a.SdkLegacyDec()
+		require.NoError(t, err)
 		require.Equal(t, tc.out, b.String(), "test_%d", idx)
 	}
 }

--- a/math/dec_test_internal.go
+++ b/math/dec_test_internal.go
@@ -1,0 +1,72 @@
+package math
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This function cannot run in the math_test package
+// because it needs direct access to the apd.Coeff field
+func TestDecReduce(t *testing.T) {
+	// Test case 1
+	x := NewDecFromInt64(12345678900)
+	expectedY := NewDecFromInt64(123456789)
+	expectedN := 2
+
+	y, n := x.Reduce()
+
+	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
+	require.Equal(t, expectedN, n)
+
+	// Test case 2
+	x = NewDecFromInt64(0)
+	expectedY = NewDecFromInt64(0)
+	expectedN = 0
+
+	y, n = x.Reduce()
+
+	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
+	require.Equal(t, expectedN, n)
+
+	// Test case 3
+	x = NewDecFromInt64(10000.000)
+	expectedY = NewDecFromInt64(1)
+	expectedN = 4
+
+	y, n = x.Reduce()
+
+	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
+	require.Equal(t, expectedN, n)
+
+	// Test case 4
+	x = NewDecFromInt64(0000.000)
+	expectedY = NewDecFromInt64(0)
+	expectedN = 0
+
+	y, n = x.Reduce()
+
+	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
+	require.Equal(t, expectedN, n)
+
+	// Test case 5
+	x = NewDecFromInt64(-1234560000.000)
+	expectedY = NewDecFromInt64(123456)
+	expectedN = 4
+
+	y, n = x.Reduce()
+
+	require.Equal(t, expectedY.dec.Coeff, y.dec.Coeff)
+	require.True(t, y.dec.Negative)
+	require.Equal(t, expectedN, n)
+
+	// Test case 6
+	x = NewDecFromInt64(-123456000000.000)
+	expectedN = 6
+	strX := "-123456000000"
+
+	y, n = x.Reduce()
+
+	require.Equal(t, strX, y.String())
+	require.Equal(t, expectedN, n)
+}

--- a/x/emissions/keeper/invariants.go
+++ b/x/emissions/keeper/invariants.go
@@ -181,7 +181,10 @@ func StakingInvariantDelegatedStakes(k Keeper) sdk.Invariant {
 				}
 				delegator := delegatorInfo.Key.K2()
 				reputer := delegatorInfo.Key.K3()
-				amount := delegatorInfo.Value.Amount.SdkIntTrim()
+				amount, err := delegatorInfo.Value.Amount.SdkIntTrim()
+				if err != nil {
+					panic(fmt.Sprintf("failed to get amount from delegated stake: %v", err))
+				}
 				existingSumsDelegator, presentDelegator := delegatorsToSumsMap[delegator]
 				if !presentDelegator {
 					stakeSumForDelegator, err := k.stakeSumFromDelegator.Get(ctx, collections.Join(i, delegator))
@@ -388,7 +391,10 @@ func StakingInvariantPendingRewardForDelegatorsEqualRewardPerShareMinusRewardDeb
 		// now check the total pending rewards bank balance is equal to the accumulated rewards beyond reward debt
 		alloraPendingAddr := k.authKeeper.GetModuleAccount(ctx, emissionstypes.AlloraPendingRewardForDelegatorAccountName).GetAddress()
 		bal := k.GetBankBalance(ctx, alloraPendingAddr, params.DefaultBondDenom).Amount
-		rewards := accumulatedRewardsBeyondRewardDebt.SdkIntTrim()
+		rewards, err := accumulatedRewardsBeyondRewardDebt.SdkIntTrim()
+		if err != nil {
+			panic("failed to convert accumulated rewards beyond reward debt to sdk.Int")
+		}
 		// we define the invariant as holding if the rewards we think we
 		// have to pay people is equal to the balance we have earmarked to pay them
 		// OR if the balance we have earmarked to pay them is greater than the rewards

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1116,11 +1116,15 @@ func (k *Keeper) AddDelegateStake(
 			return err
 		}
 		if pendingReward.Gt(alloraMath.NewDecFromInt64(0)) {
+			pendingRewardInt, err := pendingReward.SdkIntTrim()
+			if err != nil {
+				return err
+			}
 			err = k.SendCoinsFromModuleToAccount(
 				ctx,
 				types.AlloraPendingRewardForDelegatorAccountName,
 				delegator,
-				sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, pendingReward.SdkIntTrim())),
+				sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, pendingRewardInt)),
 			)
 			if err != nil {
 				return err
@@ -1298,11 +1302,15 @@ func (k *Keeper) RemoveDelegateStake(
 		return err
 	}
 	if pendingReward.Gt(alloraMath.NewDecFromInt64(0)) {
+		pendingRewardInt, err := pendingReward.SdkIntTrim()
+		if err != nil {
+			return err
+		}
 		err = k.SendCoinsFromModuleToAccount(
 			ctx,
 			types.AlloraPendingRewardForDelegatorAccountName,
 			delegator,
-			sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, pendingReward.SdkIntTrim())),
+			sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, pendingRewardInt)),
 		)
 		if err != nil {
 			return errorsmod.Wrapf(err, "Sending pending reward to delegator failed")
@@ -2044,7 +2052,10 @@ func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topicId TopicId, block Blo
 		if err != nil {
 			return err
 		}
-		newTopicFeeRevenue = val.SdkIntTrim()
+		newTopicFeeRevenue, err = val.SdkIntTrim()
+		if err != nil {
+			return err
+		}
 	}
 
 	ctx.Logger().Debug(fmt.Sprintf("Dripping topic fee revenue: block %d, topicId %d, oldRevenue %v, newRevenue %v", ctx.BlockHeight(), topicId, topicFeeRevenue, newTopicFeeRevenue))

--- a/x/emissions/keeper/msgserver/msg_server_stake.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake.go
@@ -296,7 +296,11 @@ func (ms msgServer) RewardDelegateStake(ctx context.Context, msg *types.MsgRewar
 		return nil, err
 	}
 	if pendingReward.Gt(alloraMath.NewDecFromInt64(0)) {
-		coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, pendingReward.SdkIntTrim()))
+		pendingRewardInt, err := pendingReward.SdkIntTrim()
+		if err != nil {
+			return nil, err
+		}
+		coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, pendingRewardInt))
 		err = ms.k.SendCoinsFromModuleToAccount(ctx, types.AlloraPendingRewardForDelegatorAccountName, msg.Sender, coins)
 		if err != nil {
 			return nil, err

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -1642,6 +1642,7 @@ func (s *MsgServerTestSuite) Test1000xDelegatorStakeVsReputerStake() {
 	s.Require().NoError(err)
 
 	normalizedDelegatorRewardInt, err := normalizedDelegatorReward.SdkIntTrim()
+	s.Require().NoError(err)
 	s.Require().Equal(normalizedDelegatorRewardInt, reputerReward, "Delegator and reputer rewards must be equal")
 }
 
@@ -1711,6 +1712,7 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 	block++
 
 	reputerReward1, err := s.insertValueBundlesAndGetRewards(reputerAddr, topicId, block, score)[0].Reward.SdkIntTrim()
+	require.NoError(err)
 
 	_, err = s.msgServer.RewardDelegateStake(ctx, delegateRewardsMsg)
 	require.NoError(err)

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -481,7 +481,9 @@ func (s *MsgServerTestSuite) TestDelegateStake() {
 
 	amount1, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegatorAddr.String(), reputerAddr.String())
 	require.NoError(err)
-	require.Equal(stakeAmount, amount1.Amount.SdkIntTrim())
+	amountInt, err := amount1.Amount.SdkIntTrim()
+	require.NoError(err)
+	require.Equal(stakeAmount, amountInt)
 }
 
 func (s *MsgServerTestSuite) TestReputerCantSelfDelegateStake() {
@@ -549,7 +551,9 @@ func (s *MsgServerTestSuite) TestDelegateeCantWithdrawDelegatedStake() {
 
 	amount1, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegatorAddr.String(), reputerAddr.String())
 	require.NoError(err)
-	require.Equal(stakeAmount, amount1.Amount.SdkIntTrim())
+	amountInt, err := amount1.Amount.SdkIntTrim()
+	require.NoError(err)
+	require.Equal(stakeAmount, amountInt)
 
 	// Attempt to withdraw the delegated stake
 	removeMsg := &types.MsgRemoveStake{
@@ -1548,7 +1552,8 @@ func (s *MsgServerTestSuite) TestEqualStakeRewardsToDelegatorAndReputer() {
 	s.Require().Greater(delegatorBal1.Amount.Uint64(), delegatorBal0.Amount.Uint64(), "Balance must be increased")
 
 	delegatorReward0 := delegatorBal1.Amount.Sub(delegatorBal0.Amount)
-	reputerReward := reputerRewards[0].Reward.SdkIntTrim()
+	reputerReward, err := reputerRewards[0].Reward.SdkIntTrim()
+	s.Require().NoError(err)
 
 	// in the case where the rewards is an odd number e.g.
 	// 9 / 2 = 4.5
@@ -1631,11 +1636,13 @@ func (s *MsgServerTestSuite) Test1000xDelegatorStakeVsReputerStake() {
 	s.Require().NoError(err)
 
 	delegatorRewardRaw := delegatorBal1.Amount.Sub(delegatorBal0.Amount)
-	reputerReward := reputerRewards[0].Reward.SdkIntTrim()
+	reputerReward, err := reputerRewards[0].Reward.SdkIntTrim()
+	s.Require().NoError(err)
 	normalizedDelegatorReward, err := alloraMath.NewDecFromInt64(delegatorRewardRaw.Int64()).Quo(alloraMath.NewDecFromInt64(delegatorRatio.Int64()))
 	s.Require().NoError(err)
 
-	s.Require().Equal(normalizedDelegatorReward.SdkIntTrim(), reputerReward, "Delegator and reputer rewards must be equal")
+	normalizedDelegatorRewardInt, err := normalizedDelegatorReward.SdkIntTrim()
+	s.Require().Equal(normalizedDelegatorRewardInt, reputerReward, "Delegator and reputer rewards must be equal")
 }
 
 func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
@@ -1683,7 +1690,8 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 	require.NotNil(delegateStakeResponse, "Response should not be nil after successful delegation")
 
 	// STEP 2 Calculate rewards for the first round
-	reputerReward0 := s.insertValueBundlesAndGetRewards(reputerAddr, topicId, block, score)[0].Reward.SdkIntTrim()
+	reputerReward0, err := s.insertValueBundlesAndGetRewards(reputerAddr, topicId, block, score)[0].Reward.SdkIntTrim()
+	require.NoError(err)
 
 	delegatorBal0 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 
@@ -1693,7 +1701,7 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 		Reputer: reputerAddr.String(),
 	}
 	_, err = s.msgServer.RewardDelegateStake(ctx, delegateRewardsMsg)
-	s.Require().NoError(err)
+	require.NoError(err)
 
 	delegatorBal1 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 
@@ -1702,10 +1710,10 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 	// STEP 2 Calculate rewards for the second round
 	block++
 
-	reputerReward1 := s.insertValueBundlesAndGetRewards(reputerAddr, topicId, block, score)[0].Reward.SdkIntTrim()
+	reputerReward1, err := s.insertValueBundlesAndGetRewards(reputerAddr, topicId, block, score)[0].Reward.SdkIntTrim()
 
 	_, err = s.msgServer.RewardDelegateStake(ctx, delegateRewardsMsg)
-	s.Require().NoError(err)
+	require.NoError(err)
 
 	delegatorBal2 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 
@@ -1727,10 +1735,11 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 
 	// STEP 4 Calculate rewards for the third round
 	block++
-	reputerReward2 := s.insertValueBundlesAndGetRewards(reputerAddr, topicId, block, score)[0].Reward.SdkIntTrim()
+	reputerReward2, err := s.insertValueBundlesAndGetRewards(reputerAddr, topicId, block, score)[0].Reward.SdkIntTrim()
+	require.NoError(err)
 
 	_, err = s.msgServer.RewardDelegateStake(ctx, delegateRewardsMsg)
-	s.Require().NoError(err)
+	require.NoError(err)
 
 	largeDelegateRewardsMsg := &types.MsgRewardDelegateStake{
 		Sender:  largeDelegatorAddr.String(),
@@ -1738,7 +1747,7 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 		Reputer: reputerAddr.String(),
 	}
 	_, err = s.msgServer.RewardDelegateStake(ctx, largeDelegateRewardsMsg)
-	s.Require().NoError(err)
+	require.NoError(err)
 
 	delegatorBal3 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	largeDelegatorBal3 := s.bankKeeper.GetBalance(ctx, largeDelegatorAddr, params.DefaultBondDenom)
@@ -1747,25 +1756,27 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 	largeDelegatorReward2 := largeDelegatorBal3.Amount.Sub(largeDelegatorBal2.Amount)
 
 	condition := delegatorReward0.Equal(reputerReward0) || delegatorReward0.AddRaw(1).Equal(reputerReward0)
-	s.Require().True(condition,
+	require.True(condition,
 		fmt.Sprintf("Delegator and reputer rewards must be equal (or reputer = delegator + 1) in all rounds: %s | %s",
 			delegatorReward0.String(), reputerReward0.String()),
 	)
 	condition = delegatorReward1.Equal(reputerReward1) || delegatorReward1.AddRaw(1).Equal(reputerReward1)
-	s.Require().True(condition, fmt.Sprintf("Delegator and reputer rewards must be equal in all rounds %s | %s",
+	require.True(condition, fmt.Sprintf("Delegator and reputer rewards must be equal in all rounds %s | %s",
 		delegatorReward1.String(), reputerReward1.String()),
 	)
-	s.Require().Equal(reputerReward0, reputerReward1, "Delegator and reputer rewards must be equal from the first to the second round")
+	require.Equal(reputerReward0, reputerReward1, "Delegator and reputer rewards must be equal from the first to the second round")
 	condition = delegatorReward2.Equal(reputerReward2) || delegatorReward2.AddRaw(1).Equal(reputerReward2)
-	s.Require().True(condition, fmt.Sprintf("Delegator and reputer rewards must be equal in all rounds %s | %s",
+	require.True(condition, fmt.Sprintf("Delegator and reputer rewards must be equal in all rounds %s | %s",
 		delegatorReward2.String(), reputerReward2.String()),
 	)
 
 	normalizedLargeDelegatorReward, err := alloraMath.NewDecFromInt64(largeDelegatorReward2.Int64()).Quo(alloraMath.NewDecFromInt64(largeDelegatorRatio.Int64()))
-	s.Require().NoError(err)
+	require.NoError(err)
 
-	s.Require().Equal(normalizedLargeDelegatorReward.SdkIntTrim(), reputerReward2, "Normalized large delegator rewards must be equal to reputer rewards")
-	s.Require().Equal(normalizedLargeDelegatorReward.SdkIntTrim(), delegatorReward2, "Normalized large delegator rewards must be equal to delegator rewards")
+	normalizedLargeDelegatorRewardInt, err := normalizedLargeDelegatorReward.SdkIntTrim()
+	require.NoError(err)
+	require.Equal(normalizedLargeDelegatorRewardInt, reputerReward2, "Normalized large delegator rewards must be equal to reputer rewards")
+	require.Equal(normalizedLargeDelegatorRewardInt, delegatorReward2, "Normalized large delegator rewards must be equal to delegator rewards")
 
 	totalRewardsSecondRound := reputerReward1.Add(delegatorReward1)
 	totalRewardsThirdRound := reputerReward2.Add(delegatorReward2).Add(largeDelegatorReward2)

--- a/x/emissions/keeper/queryserver/query_server_stake.go
+++ b/x/emissions/keeper/queryserver/query_server_stake.go
@@ -154,7 +154,11 @@ func (qs queryServer) GetStakeFromDelegatorInTopicInReputer(ctx context.Context,
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	return &types.QueryStakeFromDelegatorInTopicInReputerResponse{Amount: stake.Amount.SdkIntTrim()}, nil
+	stakeInt, err := stake.Amount.SdkIntTrim()
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &types.QueryStakeFromDelegatorInTopicInReputerResponse{Amount: stakeInt}, nil
 }
 
 func (qs queryServer) GetStakeFromDelegatorInTopic(ctx context.Context, req *types.QueryStakeFromDelegatorInTopicRequest) (*types.QueryStakeFromDelegatorInTopicResponse, error) {

--- a/x/emissions/module/rewards/reputer_rewards.go
+++ b/x/emissions/module/rewards/reputer_rewards.go
@@ -178,7 +178,10 @@ func GetRewardForReputerFromTotalReward(
 		if err != nil {
 			return nil, err
 		}
-		delegatorRewardInt := delegatorRewardDec.SdkIntTrim()
+		delegatorRewardInt, err := delegatorRewardDec.SdkIntTrim()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to sdk int trim delegator reward")
+		}
 		delegatorRewardDec, err = alloraMath.NewDecFromSdkInt(delegatorRewardInt)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to reconvert delegator reward from int to dec")

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -452,7 +452,11 @@ func payoutRewards(
 			continue
 		}
 
-		rewardInt := reward.Reward.SdkIntTrim()
+		rewardInt, err := reward.Reward.SdkIntTrim()
+		if err != nil {
+			ret = append(ret, errors.Wrapf(err, "failed to convert reward to sdk.Int: %s", reward.Reward.String()))
+			continue
+		}
 		coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, rewardInt))
 
 		if reward.Type == types.ReputerAndDelegatorRewardType {

--- a/x/mint/keeper/emissions_test.go
+++ b/x/mint/keeper/emissions_test.go
@@ -138,10 +138,14 @@ func (s *IntegrationTestSuite) TestEHatTargetFromCsv() {
 	expectedResult := epoch61("ehat_target_i")
 
 	simulatorFEmission := cosmosMath.LegacyMustNewDecFromStr("0.025")
-	networkTokensTotal := epoch("network_tokens_total").SdkIntTrim()
-	ecosystemTokensTotal := epoch("ecosystem_tokens_total").SdkIntTrim()
-	networkTokensCirculating := epoch("network_tokens_circulating").SdkIntTrim()
-	networkTokensStaked := epoch("network_tokens_staked").SdkIntTrim()
+	networkTokensTotal, err := epoch("network_tokens_total").SdkIntTrim()
+	s.Require().NoError(err)
+	ecosystemTokensTotal, err := epoch("ecosystem_tokens_total").SdkIntTrim()
+	s.Require().NoError(err)
+	networkTokensCirculating, err := epoch("network_tokens_circulating").SdkIntTrim()
+	s.Require().NoError(err)
+	networkTokensStaked, err := epoch("network_tokens_staked").SdkIntTrim()
+	s.Require().NoError(err)
 	fmt.Println("f_emission", simulatorFEmission)
 	fmt.Println("ecosystem_tokens_total", ecosystemTokensTotal)
 	fmt.Println("network_tokens_circulating", networkTokensCirculating)
@@ -192,8 +196,10 @@ func (s *IntegrationTestSuite) TestEHatMaxAtGenesisFromCsv() {
 func (s *IntegrationTestSuite) TestEhatIFromCsv() {
 	epoch := s.epochGet[61]
 	expectedResult := epoch("ehat_i")
-	ehatMaxI := epoch("ehat_max_i").SdkLegacyDec()
-	ehatTargetI := epoch("ehat_target_i").SdkLegacyDec()
+	ehatMaxI, err := epoch("ehat_max_i").SdkLegacyDec()
+	s.Require().NoError(err)
+	ehatTargetI, err := epoch("ehat_target_i").SdkLegacyDec()
+	s.Require().NoError(err)
 
 	result := keeper.GetCappedTargetEmissionPerUnitStakedToken(
 		ehatTargetI,
@@ -207,8 +213,10 @@ func (s *IntegrationTestSuite) TestEhatIFromCsv() {
 // calculate e_i for the 61st epoch
 func (s *IntegrationTestSuite) TestESubIFromCsv() {
 	expectedResult := s.epochGet[61]("e_i")
-	targetE_i := s.epochGet[61]("ehat_target_i").SdkLegacyDec()
-	previousE_i := s.epochGet[60]("e_i").SdkLegacyDec()
+	targetE_i, err := s.epochGet[61]("ehat_target_i").SdkLegacyDec()
+	s.Require().NoError(err)
+	previousE_i, err := s.epochGet[60]("e_i").SdkLegacyDec()
+	s.Require().NoError(err)
 
 	// this is taken directly from the python notebook
 	alpha_Emission := cosmosMath.LegacyMustNewDecFromStr("0.1")
@@ -227,10 +235,12 @@ func (s *IntegrationTestSuite) TestESubIFromCsv() {
 // GetTotalEmissionPerMonth
 func (s *IntegrationTestSuite) TestCalEFromCsv() {
 	expectedResult := s.epochGet[61]("ecosystem_tokens_emission")
-	rewardEmissionPerUnitStakedToken := s.epochGet[61]("e_i").SdkLegacyDec()
+	rewardEmissionPerUnitStakedToken, err := s.epochGet[61]("e_i").SdkLegacyDec()
+	s.Require().NoError(err)
 	// use the value from epoch 60 rather than 61 because the python notebook
 	// updates the value AFTER calculating the total emission and handing out rewards
-	numStakedTokens := s.epochGet[60]("network_tokens_staked").SdkIntTrim()
+	numStakedTokens, err := s.epochGet[60]("network_tokens_staked").SdkIntTrim()
+	s.Require().NoError(err)
 	totalEmission := keeper.GetTotalEmissionPerMonth(
 		rewardEmissionPerUnitStakedToken,
 		numStakedTokens,

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -201,7 +201,11 @@ func (k Keeper) GetPreviousPercentageRewardToStakedReputers(ctx context.Context)
 	if err != nil {
 		return math.LegacyDec{}, err
 	}
-	return stakedPercent.SdkLegacyDec(), nil
+	stakedPercentLegacyDec, err := stakedPercent.SdkLegacyDec()
+	if err != nil {
+		return math.LegacyDec{}, err
+	}
+	return stakedPercentLegacyDec, nil
 }
 
 // wrapper around emissions keeper call to get the number of blocks expected in a month

--- a/x/mint/keeper/query_server.go
+++ b/x/mint/keeper/query_server.go
@@ -135,7 +135,10 @@ func (q queryServer) EmissionInfo(ctx context.Context, _ *types.QueryEmissionInf
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get validators vs allora percent reward")
 	}
-	vPercent := vPercentADec.SdkLegacyDec()
+	vPercent, err := vPercentADec.SdkLegacyDec()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert validators vs allora percent reward to legacy dec")
+	}
 	maximumMonthlyEmissionPerUnitStakedToken := GetMaximumMonthlyEmissionPerUnitStakedToken(
 		moduleParams.MaximumMonthlyPercentageYield,
 		reputersPercent,

--- a/x/mint/module/abci.go
+++ b/x/mint/module/abci.go
@@ -146,7 +146,10 @@ func BeginBlocker(ctx context.Context, k keeper.Keeper) error {
 	if err != nil {
 		return err
 	}
-	vPercent := vPercentADec.SdkLegacyDec()
+	vPercent, err := vPercentADec.SdkLegacyDec()
+	if err != nil {
+		return err
+	}
 	// every month on the first block of the month, update the emissions rate
 	if blockHeight%blocksPerMonth == 1 { // easier to test when genesis starts at 1
 		emissionPerMonth, emissionPerUnitStakedToken, err := GetEmissionPerMonth(


### PR DESCRIPTION
## Purpose of Changes and their Description

While debugging other issues I observed a case where a conversion from alloraMath.Dec -> cosmosMath.LegacyDec caused a silently failing error. Also the conversion from alloraMath.Dec -> cosmosMath.Int is capable of panicking, which, if ever happened, could cause a chain halt.

The solution is to make these conversions throw errors instead, and then the calling code can figure out the appropriate way to deal with the error (or halt the chain in extreme cases).

This code also moves the `dec_test.go` file from package `math` (so compiled into every binary we produce) to package `math_test` (only compiled in test binaries)

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/PROTO-2058/sdkinttrim-and-sdklegacydec-can-panic-causing-chain-halt

## Are these changes tested and documented?

These changes are covered by existing unit tests on the happy path.

These changes add `TestToSdkLegacyDecFail` and `TestToSdkIntFail` for testing the unhappy path

No documentation changes.