### PR TITLE
Add zero check on the cosmosInt + conversion tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#478](https://github.com/allora-network/allora-chain/pull/478) Create and apply abstraction for augmenting topic fee revenue that is sure to check for topic activation criteria for both funding events, fee payments, and stake additions
 * [#482](https://github.com/allora-network/allora-chain/pull/482) Creation of an official Upgrade Flow
 
+
 ### Removed
 
 * [#458](https://github.com/allora-network/allora-chain/pull/458) Removal of Blockless and batch processing; Introduction of online, individual payload processing. This resolves many security, performance, and scalability issues.
@@ -74,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#484](https://github.com/allora-network/allora-chain/pull/484) Fix issue with permissions within Docker container
 * [#477](https://github.com/allora-network/allora-chain/pull/477) Fix issue arising from no forecasts being sent in worker payload
 * [#436](https://github.com/allora-network/allora-chain/pull/436/files) Fix bug related to excessive usage of topic ground truth lag and misleading error message
+* [#544](https://github.com/allora-network/allora-chain/pull/544) Added check against zero-rewards after conversion to cosmosInt
 * Additional bugfixes and improvements
 
 ### Security

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -3,6 +3,7 @@ package msgserver_test
 import (
 	"errors"
 	"fmt"
+
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	cosmosMath "cosmossdk.io/math"
@@ -1491,6 +1492,28 @@ func (s *MsgServerTestSuite) insertValueBundlesAndGetRewards(
 	s.Require().Equal(1, len(reputerRewards))
 
 	return reputerRewards
+}
+
+func (s *MsgServerTestSuite) TestRewardConversionsOverInt64Limit() {
+	// Initialize with a value > int64 max (9223372036854775807)
+	intValueAsString := "18395576023021260086"
+	newDec := alloraMath.MustNewDecFromString("18395576023021260086.00000000000000")
+	rewardInt, err := newDec.SdkIntTrim()
+	s.Require().NoError(err)
+	s.Require().Equal(intValueAsString, rewardInt.String(), "The SdkIntTrim method should return int part")
+
+	// Create cosmos int from string
+	cosmosIntFromString, ok := cosmosMath.NewIntFromString(intValueAsString)
+	s.Require().Equal(true, ok)
+	// Assert the expected result
+	s.Require().Equal(cosmosIntFromString, rewardInt, "The cosmos ints created from string or Dec should match")
+
+	coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosIntFromString))
+	s.Require().Equal("18395576023021260086uallo", coins.String(), "The sdk.Coins object should be created with the correct amount")
+
+	// Create cosmos int from cosmos int
+	cosmosInt := cosmosMath.Int(cosmosIntFromString)
+	s.Require().Equal(cosmosInt, rewardInt, "The cosmos ints created from string or Dec should match")
 }
 
 func (s *MsgServerTestSuite) TestEqualStakeRewardsToDelegatorAndReputer() {

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -1518,22 +1518,24 @@ func (s *MsgServerTestSuite) TestRewardConversionsOverInt64Limit() {
 
 func (s *MsgServerTestSuite) TestRewardConversionsZeroIntWithDecimals() {
 	// Initialize with a value > int64 max (9223372036854775807)
-	intValueAsString := "0"
-	newDec := alloraMath.MustNewDecFromString(intValueAsString + ".000000000001")
+	zeroStr := "0"
+	newDec := alloraMath.MustNewDecFromString(zeroStr + ".000000000001")
 	s.Require().Equal(newDec.IsZero(), false)
-	rewardInt, err := newDec.SdkIntTrim()
+	decTrimmedToInt, err := newDec.SdkIntTrim()
 	s.Require().NoError(err)
-	s.Require().Equal(intValueAsString, rewardInt.String(), "SdkIntTrim with zero-int should return int part")
+	s.Require().Equal(zeroStr, decTrimmedToInt.String(), "SdkIntTrim with zero-int should return int part")
 
 	// Create cosmos int from string
-	cosmosIntFromString, ok := cosmosMath.NewIntFromString(intValueAsString)
+	intFromStr, ok := cosmosMath.NewIntFromString(zeroStr)
 	s.Require().Equal(true, ok)
 	// Assert the expected result
-	s.Require().Equal(cosmosIntFromString, rewardInt, "The cosmos zero-ints created from string or Dec should match")
+	s.Require().True(intFromStr.Equal(decTrimmedToInt), "Trimming a decimal 1 > dec > 0 to int should return 0")
 
 	// Create cosmos int from cosmos int
-	cosmosInt := cosmosMath.Int(cosmosIntFromString)
-	s.Require().Equal(cosmosInt, rewardInt, "The cosmos zero-ints created from string or Dec should match")
+	intCreatedFromInt := cosmosMath.Int(intFromStr)
+	s.Require().True(
+		intCreatedFromInt.Equal(decTrimmedToInt),
+		"A cosmos zero-ints created from another int should still equal a dec trimmed to zero")
 }
 
 func (s *MsgServerTestSuite) TestEqualStakeRewardsToDelegatorAndReputer() {

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -1497,7 +1497,7 @@ func (s *MsgServerTestSuite) insertValueBundlesAndGetRewards(
 func (s *MsgServerTestSuite) TestRewardConversionsOverInt64Limit() {
 	// Initialize with a value > int64 max (9223372036854775807)
 	intValueAsString := "18395576023021260086"
-	newDec := alloraMath.MustNewDecFromString("18395576023021260086.00000000000000")
+	newDec := alloraMath.MustNewDecFromString(intValueAsString + ".00000000000000")
 	rewardInt, err := newDec.SdkIntTrim()
 	s.Require().NoError(err)
 	s.Require().Equal(intValueAsString, rewardInt.String(), "The SdkIntTrim method should return int part")
@@ -1509,11 +1509,31 @@ func (s *MsgServerTestSuite) TestRewardConversionsOverInt64Limit() {
 	s.Require().Equal(cosmosIntFromString, rewardInt, "The cosmos ints created from string or Dec should match")
 
 	coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosIntFromString))
-	s.Require().Equal("18395576023021260086uallo", coins.String(), "The sdk.Coins object should be created with the correct amount")
+	s.Require().Equal(intValueAsString+"uallo", coins.String(), "The sdk.Coins object should be created with the correct amount")
 
 	// Create cosmos int from cosmos int
 	cosmosInt := cosmosMath.Int(cosmosIntFromString)
 	s.Require().Equal(cosmosInt, rewardInt, "The cosmos ints created from string or Dec should match")
+}
+
+func (s *MsgServerTestSuite) TestRewardConversionsZeroIntWithDecimals() {
+	// Initialize with a value > int64 max (9223372036854775807)
+	intValueAsString := "0"
+	newDec := alloraMath.MustNewDecFromString(intValueAsString + ".000000000001")
+	s.Require().Equal(newDec.IsZero(), false)
+	rewardInt, err := newDec.SdkIntTrim()
+	s.Require().NoError(err)
+	s.Require().Equal(intValueAsString, rewardInt.String(), "SdkIntTrim with zero-int should return int part")
+
+	// Create cosmos int from string
+	cosmosIntFromString, ok := cosmosMath.NewIntFromString(intValueAsString)
+	s.Require().Equal(true, ok)
+	// Assert the expected result
+	s.Require().Equal(cosmosIntFromString, rewardInt, "The cosmos zero-ints created from string or Dec should match")
+
+	// Create cosmos int from cosmos int
+	cosmosInt := cosmosMath.Int(cosmosIntFromString)
+	s.Require().Equal(cosmosInt, rewardInt, "The cosmos zero-ints created from string or Dec should match")
 }
 
 func (s *MsgServerTestSuite) TestEqualStakeRewardsToDelegatorAndReputer() {

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -1506,14 +1506,14 @@ func (s *MsgServerTestSuite) TestRewardConversionsOverInt64Limit() {
 	cosmosIntFromString, ok := cosmosMath.NewIntFromString(intValueAsString)
 	s.Require().Equal(true, ok)
 	// Assert the expected result
-	s.Require().Equal(cosmosIntFromString, rewardInt, "The cosmos ints created from string or Dec should match")
+	s.Require().True(rewardInt.Equal(cosmosIntFromString), "The cosmos ints created from string or Dec should match: %s = %s", rewardInt.String(), cosmosIntFromString.String())
 
 	coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosIntFromString))
 	s.Require().Equal(intValueAsString+"uallo", coins.String(), "The sdk.Coins object should be created with the correct amount")
 
 	// Create cosmos int from cosmos int
 	cosmosInt := cosmosMath.Int(cosmosIntFromString)
-	s.Require().Equal(cosmosInt, rewardInt, "The cosmos ints created from string or Dec should match")
+	s.Require().True(rewardInt.Equal(cosmosInt), "The cosmos ints created from ints should match: %s = %s", rewardInt.String(), cosmosInt.String())
 }
 
 func (s *MsgServerTestSuite) TestRewardConversionsZeroIntWithDecimals() {

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -463,6 +463,9 @@ func payoutRewards(
 			ret = append(ret, errors.Wrapf(err, "failed to convert reward to sdk.Int: %s", reward.Reward.String()))
 			continue
 		}
+		if rewardInt.IsZero() {
+			continue
+		}
 		coins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, rewardInt))
 
 		if reward.Type == types.ReputerAndDelegatorRewardType {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
Add a zero-check on rewards once converted to cosmosInt.
Added two tests on rewards conversion checks.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
PROTO-2244 

## Are these changes tested and documented?

- [X] If tested, please describe how. If not, why tests are not needed. -- Adds a test for conversions
- [X] If documented, please describe where. If not, describe why docs are not needed. -- trivial change, no need
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

Define if this is the best place for those tests to exist
