### PR TITLE
Refactor: Rename TestSuite names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Implements merit based sortition for top N inferers, forecasters, and reputers. 
 * [#544](https://github.com/allora-network/allora-chain/pull/544) Added check against zero-rewards after conversion to cosmosInt
 * [#547](https://github.com/allora-network/allora-chain/pull/547) Improve error handling on InsertPayload, fixed/added tests err handling
 * [#550](https://github.com/allora-network/allora-chain/pull/550) Fix reputer window upper limit
-
+* [#555](https://github.com/allora-network/allora-chain/pull/555) Refactor: Rename TestSuite names
 
 ### Security
 

--- a/x/emissions/keeper/actor_utils/losses_test.go
+++ b/x/emissions/keeper/actor_utils/losses_test.go
@@ -1,3 +1,0 @@
-package actorutils_test
-
-// TODO losses tests

--- a/x/emissions/keeper/actor_utils/worker_test.go
+++ b/x/emissions/keeper/actor_utils/worker_test.go
@@ -1,3 +1,0 @@
-package actorutils_test
-
-// TODO worker tests

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
@@ -144,7 +144,7 @@ func (s *InferenceSynthesisTestSuite) SetupTest() {
 	s.Require().NoError(err)
 }
 
-func TestModuleTestSuite(t *testing.T) {
+func TestInferenceSynthesisTestSuite(t *testing.T) {
 	suite.Run(t, new(InferenceSynthesisTestSuite))
 }
 

--- a/x/emissions/keeper/queryserver/query_server_forecasts_test.go
+++ b/x/emissions/keeper/queryserver/query_server_forecasts_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (s *KeeperTestSuite) TestGetForecastsAtBlock() {
+func (s *QueryServerTestSuite) TestGetForecastsAtBlock() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	keeper := s.emissionsKeeper

--- a/x/emissions/keeper/queryserver/query_server_inferences_test.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences_test.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *KeeperTestSuite) TestGetInferencesAtBlock() {
+func (s *QueryServerTestSuite) TestGetInferencesAtBlock() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
@@ -47,7 +47,7 @@ func (s *KeeperTestSuite) TestGetInferencesAtBlock() {
 	s.Require().Equal(&expectedInferences, results.Inferences)
 }
 
-func (s *KeeperTestSuite) TestGetWorkerLatestInferenceByTopicId() {
+func (s *QueryServerTestSuite) TestGetWorkerLatestInferenceByTopicId() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	queryServer := s.queryServer
@@ -107,7 +107,7 @@ func (s *KeeperTestSuite) TestGetWorkerLatestInferenceByTopicId() {
 	s.Require().Equal(&inference, response.LatestInference, "The latest inference should match the expected data")
 }
 
-func (s *KeeperTestSuite) TestGetNetworkInferencesAtBlock() {
+func (s *QueryServerTestSuite) TestGetNetworkInferencesAtBlock() {
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
 
@@ -256,7 +256,7 @@ func (s *KeeperTestSuite) TestGetNetworkInferencesAtBlock() {
 	require.NotNil(response, "Response should not be nil")
 }
 
-func (s *KeeperTestSuite) TestGetLatestNetworkInferences() {
+func (s *QueryServerTestSuite) TestGetLatestNetworkInferences() {
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
 
@@ -424,7 +424,7 @@ func (s *KeeperTestSuite) TestGetLatestNetworkInferences() {
 	require.Equal(len(response.ForecastImpliedInferences), 3)
 }
 
-func (s *KeeperTestSuite) TestIsWorkerNonceUnfulfilled() {
+func (s *QueryServerTestSuite) TestIsWorkerNonceUnfulfilled() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -449,7 +449,7 @@ func (s *KeeperTestSuite) TestIsWorkerNonceUnfulfilled() {
 	s.Require().True(response.IsWorkerNonceUnfulfilled)
 }
 
-func (s *KeeperTestSuite) TestGetUnfulfilledWorkerNonces() {
+func (s *QueryServerTestSuite) TestGetUnfulfilledWorkerNonces() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -481,7 +481,7 @@ func (s *KeeperTestSuite) TestGetUnfulfilledWorkerNonces() {
 	}
 }
 
-func (s *KeeperTestSuite) TestGetInfererNetworkRegret() {
+func (s *QueryServerTestSuite) TestGetInfererNetworkRegret() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := s.CreateOneTopic()
@@ -510,7 +510,7 @@ func (s *KeeperTestSuite) TestGetInfererNetworkRegret() {
 	s.Require().Equal(response.Regret, &regret)
 }
 
-func (s *KeeperTestSuite) TestGetForecasterNetworkRegret() {
+func (s *QueryServerTestSuite) TestGetForecasterNetworkRegret() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := s.CreateOneTopic()
@@ -539,7 +539,7 @@ func (s *KeeperTestSuite) TestGetForecasterNetworkRegret() {
 	s.Require().Equal(response.Regret, &regret)
 }
 
-func (s *KeeperTestSuite) TestGetOneInForecasterNetworkRegret() {
+func (s *QueryServerTestSuite) TestGetOneInForecasterNetworkRegret() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := s.CreateOneTopic()
@@ -570,7 +570,7 @@ func (s *KeeperTestSuite) TestGetOneInForecasterNetworkRegret() {
 	s.Require().Equal(response.Regret, &regret)
 }
 
-func (s *KeeperTestSuite) TestGetLatestTopicInferences() {
+func (s *QueryServerTestSuite) TestGetLatestTopicInferences() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 
@@ -633,7 +633,7 @@ func (s *KeeperTestSuite) TestGetLatestTopicInferences() {
 	s.Require().Equal(blockHeight2, latestBlockHeight, "Latest block height should match the second inserted set")
 }
 
-func (s *KeeperTestSuite) TestGetLatestAvailableNetworkInference() {
+func (s *QueryServerTestSuite) TestGetLatestAvailableNetworkInference() {
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
 
@@ -829,7 +829,7 @@ func (s *KeeperTestSuite) TestGetLatestAvailableNetworkInference() {
 	require.Equal(response.LossBlockHeight, lossBlockHeight)
 }
 
-func (s *KeeperTestSuite) TestTestGetLatestAvailableNetworkInferenceWithMissingInferences() {
+func (s *QueryServerTestSuite) TestTestGetLatestAvailableNetworkInferenceWithMissingInferences() {
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
 

--- a/x/emissions/keeper/queryserver/query_server_losses_test.go
+++ b/x/emissions/keeper/queryserver/query_server_losses_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (s *KeeperTestSuite) TestGetNetworkLossBundleAtBlock() {
+func (s *QueryServerTestSuite) TestGetNetworkLossBundleAtBlock() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
@@ -36,7 +36,7 @@ func (s *KeeperTestSuite) TestGetNetworkLossBundleAtBlock() {
 	s.Require().Equal(expectedBundle, response.LossBundle, "Retrieved loss bundle should match the expected bundle")
 }
 
-func (s *KeeperTestSuite) TestIsReputerNonceUnfulfilled() {
+func (s *QueryServerTestSuite) TestIsReputerNonceUnfulfilled() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -61,7 +61,7 @@ func (s *KeeperTestSuite) TestIsReputerNonceUnfulfilled() {
 	s.Require().True(response.IsReputerNonceUnfulfilled)
 }
 
-func (s *KeeperTestSuite) TestGetUnfulfilledReputerNonces() {
+func (s *QueryServerTestSuite) TestGetUnfulfilledReputerNonces() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -93,7 +93,7 @@ func (s *KeeperTestSuite) TestGetUnfulfilledReputerNonces() {
 	}
 }
 
-func (s *KeeperTestSuite) TestGetReputerLossBundlesAtBlock() {
+func (s *QueryServerTestSuite) TestGetReputerLossBundlesAtBlock() {
 	ctx := s.ctx
 	require := s.Require()
 	topicId := uint64(1)
@@ -121,7 +121,7 @@ func (s *KeeperTestSuite) TestGetReputerLossBundlesAtBlock() {
 	require.Equal(&reputerLossBundles, result, "Retrieved data should match inserted data")
 }
 
-func (s *KeeperTestSuite) TestGetDeleteDelegateStake() {
+func (s *QueryServerTestSuite) TestGetDeleteDelegateStake() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 

--- a/x/emissions/keeper/queryserver/query_server_params_test.go
+++ b/x/emissions/keeper/queryserver/query_server_params_test.go
@@ -2,7 +2,7 @@ package queryserver_test
 
 import "github.com/allora-network/allora-chain/x/emissions/types"
 
-func (s *KeeperTestSuite) TestParams() {
+func (s *QueryServerTestSuite) TestParams() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	queryServer := s.queryServer

--- a/x/emissions/keeper/queryserver/query_server_registrations_test.go
+++ b/x/emissions/keeper/queryserver/query_server_registrations_test.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *KeeperTestSuite) TestGetWorkerNodeInfo() {
+func (s *QueryServerTestSuite) TestGetWorkerNodeInfo() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	queryServer := s.queryServer
@@ -40,7 +40,7 @@ func (s *KeeperTestSuite) TestGetWorkerNodeInfo() {
 	s.Require().Error(err, "Expected an error for nonexistent key")
 }
 
-func (s *KeeperTestSuite) TestGetReputerNodeInfo() {
+func (s *QueryServerTestSuite) TestGetReputerNodeInfo() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	queryServer := s.queryServer
@@ -73,7 +73,7 @@ func (s *KeeperTestSuite) TestGetReputerNodeInfo() {
 	s.Require().Error(err, "Expected an error for nonexistent key")
 }
 
-func (s *KeeperTestSuite) TestUnregisteredWorkerIsUnregisteredInTopicId() {
+func (s *QueryServerTestSuite) TestUnregisteredWorkerIsUnregisteredInTopicId() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	queryServer := s.queryServer
@@ -91,7 +91,7 @@ func (s *KeeperTestSuite) TestUnregisteredWorkerIsUnregisteredInTopicId() {
 	s.Require().False(invalidResponse.IsRegistered, "The worker should not be registered for the topic")
 }
 
-func (s *KeeperTestSuite) TestRegisteredWorkerIsRegisteredInTopicId() {
+func (s *QueryServerTestSuite) TestRegisteredWorkerIsRegisteredInTopicId() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -144,7 +144,7 @@ func (s *KeeperTestSuite) TestRegisteredWorkerIsRegisteredInTopicId() {
 	require.True(queryResp.IsRegistered, "Query response should confirm worker is registered")
 }
 
-func (s *KeeperTestSuite) TestRegisteredReputerIsRegisteredInTopicId() {
+func (s *QueryServerTestSuite) TestRegisteredReputerIsRegisteredInTopicId() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 

--- a/x/emissions/keeper/queryserver/query_server_reward_test.go
+++ b/x/emissions/keeper/queryserver/query_server_reward_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (s *KeeperTestSuite) TestGetPreviousReputerRewardFraction() {
+func (s *QueryServerTestSuite) TestGetPreviousReputerRewardFraction() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -39,7 +39,7 @@ func (s *KeeperTestSuite) TestGetPreviousReputerRewardFraction() {
 	s.Require().False(notFound, "Should not return no prior value after setting")
 }
 
-func (s *KeeperTestSuite) TestGetPreviousInferenceRewardFraction() {
+func (s *QueryServerTestSuite) TestGetPreviousInferenceRewardFraction() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -72,7 +72,7 @@ func (s *KeeperTestSuite) TestGetPreviousInferenceRewardFraction() {
 	s.Require().True(response.RewardFraction.Equal(setReward), "The fetched reward fraction should match the set value")
 }
 
-func (s *KeeperTestSuite) TestGetPreviousForecastRewardFraction() {
+func (s *QueryServerTestSuite) TestGetPreviousForecastRewardFraction() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -106,7 +106,7 @@ func (s *KeeperTestSuite) TestGetPreviousForecastRewardFraction() {
 	s.Require().False(noPrior, "Should not return no prior value after setting")
 }
 
-func (s *KeeperTestSuite) TestGetPreviousPercentageRewardToStakedReputers() {
+func (s *QueryServerTestSuite) TestGetPreviousPercentageRewardToStakedReputers() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	previousPercentageReward := alloraMath.NewDecFromInt64(50)

--- a/x/emissions/keeper/queryserver/query_server_score_test.go
+++ b/x/emissions/keeper/queryserver/query_server_score_test.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *KeeperTestSuite) TestGetLatestInfererScore() {
+func (s *QueryServerTestSuite) TestGetLatestInfererScore() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -32,7 +32,7 @@ func (s *KeeperTestSuite) TestGetLatestInfererScore() {
 	s.Require().NotEqual(oldScore.Score, updatedScore.Score, "Older score should not replace newer score")
 }
 
-func (s *KeeperTestSuite) TestGetLatestForecasterScore() {
+func (s *QueryServerTestSuite) TestGetLatestForecasterScore() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -54,7 +54,7 @@ func (s *KeeperTestSuite) TestGetLatestForecasterScore() {
 	s.Require().Equal(newScore.Score, forecasterScore.Score, "Newer forecaster score should be set")
 }
 
-func (s *KeeperTestSuite) TestGetLatestReputerScore() {
+func (s *QueryServerTestSuite) TestGetLatestReputerScore() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -76,7 +76,7 @@ func (s *KeeperTestSuite) TestGetLatestReputerScore() {
 	s.Require().Equal(newScore.Score, reputerScore.Score, "Newer reputer score should be set")
 }
 
-func (s *KeeperTestSuite) TestGetInferenceScoresUntilBlock() {
+func (s *QueryServerTestSuite) TestGetInferenceScoresUntilBlock() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -117,7 +117,7 @@ func (s *KeeperTestSuite) TestGetInferenceScoresUntilBlock() {
 	}
 }
 
-func (s *KeeperTestSuite) TestGetWorkerInferenceScoresAtBlock() {
+func (s *QueryServerTestSuite) TestGetWorkerInferenceScoresAtBlock() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -153,7 +153,7 @@ func (s *KeeperTestSuite) TestGetWorkerInferenceScoresAtBlock() {
 	s.Require().Len(scores.Scores, maxNumScores, "Scores should not exceed the maximum limit")
 }
 
-func (s *KeeperTestSuite) TestGetForecastScoresUntilBlock() {
+func (s *QueryServerTestSuite) TestGetForecastScoresUntilBlock() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -179,7 +179,7 @@ func (s *KeeperTestSuite) TestGetForecastScoresUntilBlock() {
 	s.Require().Len(scores, 6, "Should retrieve correct number of scores up to block 105")
 }
 
-func (s *KeeperTestSuite) TestGetWorkerForecastScoresAtBlock() {
+func (s *QueryServerTestSuite) TestGetWorkerForecastScoresAtBlock() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -208,7 +208,7 @@ func (s *KeeperTestSuite) TestGetWorkerForecastScoresAtBlock() {
 	s.Require().Len(scores.Scores, 5, "Should retrieve all scores at the block")
 }
 
-func (s *KeeperTestSuite) TestGetReputersScoresAtBlock() {
+func (s *QueryServerTestSuite) TestGetReputersScoresAtBlock() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -238,7 +238,7 @@ func (s *KeeperTestSuite) TestGetReputersScoresAtBlock() {
 	s.Require().Len(scores.Scores, 5, "Should retrieve all scores at the block")
 }
 
-func (s *KeeperTestSuite) TestGetListeningCoefficient() {
+func (s *QueryServerTestSuite) TestGetListeningCoefficient() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)

--- a/x/emissions/keeper/queryserver/query_server_stake_test.go
+++ b/x/emissions/keeper/queryserver/query_server_stake_test.go
@@ -9,7 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *KeeperTestSuite) TestGetTotalStake() {
+func (s *QueryServerTestSuite) TestGetTotalStake() {
 	ctx := s.ctx
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
@@ -25,7 +25,7 @@ func (s *KeeperTestSuite) TestGetTotalStake() {
 	s.Require().Equal(expectedTotalStake, response.Amount, "The retrieved total stake should match the expected value")
 }
 
-func (s *KeeperTestSuite) TestGetReputerStakeInTopic() {
+func (s *QueryServerTestSuite) TestGetReputerStakeInTopic() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	queryServer := s.queryServer
@@ -50,7 +50,7 @@ func (s *KeeperTestSuite) TestGetReputerStakeInTopic() {
 	s.Require().Equal(initialStake, response.Amount, "The retrieved stake should match the initial stake set for the reputer in the topic")
 }
 
-func (s *KeeperTestSuite) TestGetMultiReputerStakeInTopic() {
+func (s *QueryServerTestSuite) TestGetMultiReputerStakeInTopic() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	queryServer := s.queryServer
@@ -83,7 +83,7 @@ func (s *KeeperTestSuite) TestGetMultiReputerStakeInTopic() {
 	s.Require().Equal(initialStake2, response.Amounts[1].Amount, "The retrieved stake should match the initial stake set for the second reputer in the topic")
 }
 
-func (s *KeeperTestSuite) TestGetDelegateStakeInTopicInReputer() {
+func (s *QueryServerTestSuite) TestGetDelegateStakeInTopicInReputer() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	queryServer := s.queryServer
@@ -111,7 +111,7 @@ func (s *KeeperTestSuite) TestGetDelegateStakeInTopicInReputer() {
 	s.Require().Equal(initialStakeAmount, response.Amount, "The retrieved delegate stake should match the initial stake set for the reputer in the topic")
 }
 
-func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopicInReputer() {
+func (s *QueryServerTestSuite) TestGetStakeFromDelegatorInTopicInReputer() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	queryServer := s.queryServer
@@ -141,7 +141,7 @@ func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopicInReputer() {
 	s.Require().Equal(stakeAmount, response.Amount, "The retrieved stake amount should match the delegated stake")
 }
 
-func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopic() {
+func (s *QueryServerTestSuite) TestGetStakeFromDelegatorInTopic() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	queryServer := s.queryServer
@@ -172,7 +172,7 @@ func (s *KeeperTestSuite) TestGetStakeFromDelegatorInTopic() {
 	s.Require().Equal(expectedTotalStake, response.Amount, "The retrieved stake amount should match the total delegated stake")
 }
 
-func (s *KeeperTestSuite) TestGetTopicStake() {
+func (s *QueryServerTestSuite) TestGetTopicStake() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	queryServer := s.queryServer
@@ -195,7 +195,7 @@ func (s *KeeperTestSuite) TestGetTopicStake() {
 	s.Require().Equal(stakeAmount, response.Amount, "The retrieved topic stake should match the stake amount added")
 }
 
-func (s *KeeperTestSuite) TestGetStakeRemovalInfo() {
+func (s *QueryServerTestSuite) TestGetStakeRemovalInfo() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	queryServer := s.queryServer
@@ -222,7 +222,7 @@ func (s *KeeperTestSuite) TestGetStakeRemovalInfo() {
 	s.Require().Equal(removal, *response.Removal, "The retrieved stake removal info should match the expected value")
 }
 
-func (s *KeeperTestSuite) TestGetDelegateStakeRemovalInfo() {
+func (s *QueryServerTestSuite) TestGetDelegateStakeRemovalInfo() {
 	s.CreateOneTopic()
 	ctx := s.ctx
 	queryServer := s.queryServer
@@ -255,7 +255,7 @@ func (s *KeeperTestSuite) TestGetDelegateStakeRemovalInfo() {
 	require.Equal(&expectedRemoval, response.Removal, "The retrieved stake removal info should match the expected value")
 }
 
-func (s *KeeperTestSuite) TestGetStakeRemovalsForBlock() {
+func (s *QueryServerTestSuite) TestGetStakeRemovalsForBlock() {
 	ctx := s.ctx
 	qs := s.queryServer
 	keeper := s.emissionsKeeper
@@ -294,7 +294,7 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsForBlock() {
 	require.Equal(expecteds[1], *response.Removals[1], "The retrieved stake removals should match the expected stake removals")
 }
 
-func (s *KeeperTestSuite) TestGetDelegateStakeRemovalsForBlock() {
+func (s *QueryServerTestSuite) TestGetDelegateStakeRemovalsForBlock() {
 	ctx := s.ctx
 	qs := s.queryServer
 	keeper := s.emissionsKeeper
@@ -335,7 +335,7 @@ func (s *KeeperTestSuite) TestGetDelegateStakeRemovalsForBlock() {
 	require.Equal(expecteds[1], *response.Removals[1], "The retrieved stake removals should match the expected stake removals")
 }
 
-func (s *KeeperTestSuite) TestGetStakeReputerAuthority() {
+func (s *QueryServerTestSuite) TestGetStakeReputerAuthority() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -357,7 +357,7 @@ func (s *KeeperTestSuite) TestGetStakeReputerAuthority() {
 	s.Require().Equal(stakeAmount, stakeAuthority, "Delegator stake should be equal to stake amount after addition")
 }
 
-func (s *KeeperTestSuite) TestGetDelegateStakePlacement() {
+func (s *QueryServerTestSuite) TestGetDelegateStakePlacement() {
 	ctx := s.ctx
 	require := s.Require()
 	keeper := s.emissionsKeeper
@@ -417,7 +417,7 @@ func (s *KeeperTestSuite) TestGetDelegateStakePlacement() {
 	require.Equal(value0, value1)
 }
 
-func (s *KeeperTestSuite) TestGetDelegateStakeUponReputer() {
+func (s *QueryServerTestSuite) TestGetDelegateStakeUponReputer() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -469,7 +469,7 @@ func (s *KeeperTestSuite) TestGetDelegateStakeUponReputer() {
 	s.Require().Equal(expected, stakeUponReputer, "Remaining reputer stake should be initial minus removed amount")
 }
 
-func (s *KeeperTestSuite) TestGetStakeRemovalForReputerAndTopicId() {
+func (s *QueryServerTestSuite) TestGetStakeRemovalForReputerAndTopicId() {
 	k := s.emissionsKeeper
 	ctx := s.ctx
 	reputer := "reputer"

--- a/x/emissions/keeper/queryserver/query_server_test.go
+++ b/x/emissions/keeper/queryserver/query_server_test.go
@@ -50,7 +50,7 @@ var (
 	ValAddr = GeneratePrivateKeys(10)
 )
 
-type KeeperTestSuite struct {
+type QueryServerTestSuite struct {
 	suite.Suite
 
 	ctx             sdk.Context
@@ -65,11 +65,11 @@ type KeeperTestSuite struct {
 	addrsStr        []string
 }
 
-func TestKeeperTestSuite(t *testing.T) {
-	suite.Run(t, new(KeeperTestSuite))
+func TestQueryServerTestSuite(t *testing.T) {
+	suite.Run(t, new(QueryServerTestSuite))
 }
 
-func (s *KeeperTestSuite) SetupTest() {
+func (s *QueryServerTestSuite) SetupTest() {
 	key := storetypes.NewKVStoreKey("emissions")
 	storeService := runtime.NewKVStoreService(key)
 	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
@@ -158,7 +158,7 @@ func GeneratePrivateKeys(numKeys int) []ChainKey {
 	return testAddrs
 }
 
-func (s *KeeperTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
+func (s *QueryServerTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
 
 	err := s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
@@ -167,7 +167,7 @@ func (s *KeeperTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cos
 	s.Require().NoError(err)
 }
 
-func (s *KeeperTestSuite) CreateOneTopic() uint64 {
+func (s *QueryServerTestSuite) CreateOneTopic() uint64 {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
@@ -197,7 +197,7 @@ func (s *KeeperTestSuite) CreateOneTopic() uint64 {
 	return result.TopicId
 }
 
-func (s *KeeperTestSuite) TestCreateSeveralTopics() {
+func (s *QueryServerTestSuite) TestCreateSeveralTopics() {
 	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 	// Mock setup for metadata and validation steps

--- a/x/emissions/keeper/queryserver/query_server_topics_test.go
+++ b/x/emissions/keeper/queryserver/query_server_topics_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (s *KeeperTestSuite) TestGetNextTopicId() {
+func (s *QueryServerTestSuite) TestGetNextTopicId() {
 	ctx := s.ctx
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
@@ -34,7 +34,7 @@ func (s *KeeperTestSuite) TestGetNextTopicId() {
 	s.Require().Equal(expectedNextTopicId, response.NextTopicId, "The next topic ID should match the expected value after topic creation")
 }
 
-func (s *KeeperTestSuite) TestGetTopic() {
+func (s *QueryServerTestSuite) TestGetTopic() {
 	ctx := s.ctx
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
@@ -58,7 +58,7 @@ func (s *KeeperTestSuite) TestGetTopic() {
 	s.Require().Equal(metadata, response.Topic.Metadata, "The metadata of the retrieved topic should match")
 }
 
-func (s *KeeperTestSuite) TestGetActiveTopics() {
+func (s *QueryServerTestSuite) TestGetActiveTopics() {
 	ctx := s.ctx
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
@@ -97,7 +97,7 @@ func (s *KeeperTestSuite) TestGetActiveTopics() {
 	}
 }
 
-func (s *KeeperTestSuite) TestGetLatestCommit() {
+func (s *QueryServerTestSuite) TestGetLatestCommit() {
 	ctx := s.ctx
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper
@@ -148,7 +148,7 @@ func (s *KeeperTestSuite) TestGetLatestCommit() {
 	s.Require().Equal(&nonce, response2.LastCommit.Nonce, "The metadata of the retrieved nonce should match")
 }
 
-func (s *KeeperTestSuite) TestGetSetDeleteTopicRewardNonce() {
+func (s *QueryServerTestSuite) TestGetSetDeleteTopicRewardNonce() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -184,7 +184,7 @@ func (s *KeeperTestSuite) TestGetSetDeleteTopicRewardNonce() {
 	s.Require().Equal(int64(0), nonce, "Nonce should be 0 after deletion")
 }
 
-func (s *KeeperTestSuite) TestGetPreviousTopicWeight() {
+func (s *QueryServerTestSuite) TestGetPreviousTopicWeight() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -203,7 +203,7 @@ func (s *KeeperTestSuite) TestGetPreviousTopicWeight() {
 	s.Require().Equal(weightToSet, retrievedWeight, "Retrieved weight should match the set weight")
 }
 
-func (s *KeeperTestSuite) TestTopicExists() {
+func (s *QueryServerTestSuite) TestTopicExists() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 
@@ -232,7 +232,7 @@ func (s *KeeperTestSuite) TestTopicExists() {
 	s.Require().True(exists, "Topic should exist for a newly created topic ID")
 }
 
-func (s *KeeperTestSuite) TestIsTopicActive() {
+func (s *QueryServerTestSuite) TestIsTopicActive() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(3)
@@ -276,7 +276,7 @@ func (s *KeeperTestSuite) TestIsTopicActive() {
 	s.Require().True(topicActive, "Topic should be active again")
 }
 
-func (s *KeeperTestSuite) TestGetTopicFeeRevenue() {
+func (s *QueryServerTestSuite) TestGetTopicFeeRevenue() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(1)
@@ -306,7 +306,7 @@ func (s *KeeperTestSuite) TestGetTopicFeeRevenue() {
 	s.Require().Equal(feeRev.String(), initialRevenueInt.String(), "Revenue should match the initial setup")
 }
 
-func (s *KeeperTestSuite) TestGetRewardableTopics() {
+func (s *QueryServerTestSuite) TestGetRewardableTopics() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(789)

--- a/x/emissions/keeper/queryserver/query_server_whitelist_test.go
+++ b/x/emissions/keeper/queryserver/query_server_whitelist_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (s *KeeperTestSuite) TestIsWhitelistAdmin() {
+func (s *QueryServerTestSuite) TestIsWhitelistAdmin() {
 	ctx := s.ctx
 	queryServer := s.queryServer
 	keeper := s.emissionsKeeper

--- a/x/emissions/migrations/v2/migrate_test.go
+++ b/x/emissions/migrations/v2/migrate_test.go
@@ -36,7 +36,7 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
-type MigrationsTestSuite struct {
+type EmissionsV2MigrationsTestSuite struct {
 	suite.Suite
 	ctx             sdk.Context
 	codec           codec.Codec
@@ -44,7 +44,7 @@ type MigrationsTestSuite struct {
 	emissionsKeeper keeper.Keeper
 }
 
-func (s *MigrationsTestSuite) SetupTest() {
+func (s *EmissionsV2MigrationsTestSuite) SetupTest() {
 	key := storetypes.NewKVStoreKey("emissions")
 	storeService := runtime.NewKVStoreService(key)
 	s.storeService = storeService
@@ -92,16 +92,16 @@ func (s *MigrationsTestSuite) SetupTest() {
 		authtypes.FeeCollectorName)
 }
 
-func TestMigrationsTestSuite(t *testing.T) {
-	suite.Run(t, new(MigrationsTestSuite))
+func TestEmissionsV2MigrationsTestSuite(t *testing.T) {
+	suite.Run(t, new(EmissionsV2MigrationsTestSuite))
 }
 
-func (s *MigrationsTestSuite) TestMigrateStore() {
+func (s *EmissionsV2MigrationsTestSuite) TestMigrateStore() {
 	err := v2.MigrateStore(s.ctx, s.emissionsKeeper)
 	s.Require().NoError(err)
 }
 
-func (s *MigrationsTestSuite) TestMigrateTopic() {
+func (s *EmissionsV2MigrationsTestSuite) TestMigrateTopic() {
 	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
 	cdc := s.emissionsKeeper.GetBinaryCodec()
 
@@ -151,7 +151,7 @@ func (s *MigrationsTestSuite) TestMigrateTopic() {
 	s.Require().Equal(oldTopic.EpochLastEnded, newMsg.EpochLastEnded)
 }
 
-func (s *MigrationsTestSuite) MigrateOffchainNodeStore(store prefix.Store, cdc codec.BinaryCodec, prefixKey collections.Prefix) {
+func (s *EmissionsV2MigrationsTestSuite) MigrateOffchainNodeStore(store prefix.Store, cdc codec.BinaryCodec, prefixKey collections.Prefix) {
 	oldOffchainNode := oldtypes.OffchainNode{
 		LibP2PKey:    "testLibP2PKey",
 		MultiAddress: "testMultiAddress",
@@ -203,14 +203,14 @@ func (s *MigrationsTestSuite) MigrateOffchainNodeStore(store prefix.Store, cdc c
 	s.Require().Equal(oldOffchainNode2.NodeAddress, newMsg.NodeAddress)
 }
 
-func (s *MigrationsTestSuite) TestMigrateOffchainNodeWorkers() {
+func (s *EmissionsV2MigrationsTestSuite) TestMigrateOffchainNodeWorkers() {
 	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
 	cdc := s.emissionsKeeper.GetBinaryCodec()
 	offchainNodeStoreWorker := prefix.NewStore(store, types.WorkerNodesKey)
 	s.MigrateOffchainNodeStore(offchainNodeStoreWorker, cdc, types.WorkerNodesKey)
 }
 
-func (s *MigrationsTestSuite) TestMigrateOffchainNodeReputers() {
+func (s *EmissionsV2MigrationsTestSuite) TestMigrateOffchainNodeReputers() {
 	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
 	cdc := s.emissionsKeeper.GetBinaryCodec()
 	offchainNodeStoreReputer := prefix.NewStore(store, types.ReputerNodesKey)
@@ -241,7 +241,7 @@ func areWithHeldArraysEqual(oldValues []*oldtypes.WithheldWorkerAttributedValue,
 	return true
 }
 
-func (s *MigrationsTestSuite) TestMigrateValueBundle() {
+func (s *EmissionsV2MigrationsTestSuite) TestMigrateValueBundle() {
 	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
 	cdc := s.emissionsKeeper.GetBinaryCodec()
 
@@ -322,7 +322,7 @@ func (s *MigrationsTestSuite) TestMigrateValueBundle() {
 	s.Require().Empty(newMsg.OneOutInfererForecasterValues)
 }
 
-func (s *MigrationsTestSuite) TestMigrateAllLossBundles() {
+func (s *EmissionsV2MigrationsTestSuite) TestMigrateAllLossBundles() {
 	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
 	cdc := s.emissionsKeeper.GetBinaryCodec()
 
@@ -420,7 +420,7 @@ func (s *MigrationsTestSuite) TestMigrateAllLossBundles() {
 	s.Require().Equal(reputerValueBundle.Pubkey, newMsg.ReputerValueBundles[0].Pubkey)
 }
 
-func (s *MigrationsTestSuite) TestMigrateAllRecordCommits() {
+func (s *EmissionsV2MigrationsTestSuite) TestMigrateAllRecordCommits() {
 	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
 	cdc := s.emissionsKeeper.GetBinaryCodec()
 
@@ -477,7 +477,7 @@ func (s *MigrationsTestSuite) TestMigrateAllRecordCommits() {
 	s.Require().Equal(oldTimestampedActorNonce2.Nonce.BlockHeight, newMsg2.Nonce.BlockHeight)
 }
 
-func (s *MigrationsTestSuite) TestMigrateParams() {
+func (s *EmissionsV2MigrationsTestSuite) TestMigrateParams() {
 	// Create an empty Params
 	prevParams := types.Params{
 		Version: "v1",

--- a/x/emissions/migrations/v3/migrate_test.go
+++ b/x/emissions/migrations/v3/migrate_test.go
@@ -34,7 +34,7 @@ import (
 	cosmostestutil "github.com/cosmos/cosmos-sdk/testutil"
 )
 
-type MigrationTestSuite struct {
+type EmissionsV3MigrationTestSuite struct {
 	suite.Suite
 	ctrl *gomock.Controller
 
@@ -42,11 +42,11 @@ type MigrationTestSuite struct {
 	emissionsKeeper *keeper.Keeper
 }
 
-func TestKeeperTestSuite(t *testing.T) {
-	suite.Run(t, new(MigrationTestSuite))
+func TestEmissionsV3MigrationTestSuite(t *testing.T) {
+	suite.Run(t, new(EmissionsV3MigrationTestSuite))
 }
 
-func (s *MigrationTestSuite) SetupTest() {
+func (s *EmissionsV3MigrationTestSuite) SetupTest() {
 	encCfg := moduletestutil.MakeTestEncodingConfig(emissions.AppModule{})
 	key := storetypes.NewKVStoreKey(types.StoreKey)
 	storeService := runtime.NewKVStoreService(key)
@@ -68,7 +68,7 @@ func (s *MigrationTestSuite) SetupTest() {
 	s.emissionsKeeper = &emissionsKeeper
 }
 
-func (s *MigrationTestSuite) TestMigrate() {
+func (s *EmissionsV3MigrationTestSuite) TestMigrate() {
 	storageService := s.emissionsKeeper.GetStorageService()
 	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
 	cdc := s.emissionsKeeper.GetBinaryCodec()
@@ -175,7 +175,7 @@ func (s *MigrationTestSuite) TestMigrate() {
 	s.Require().Equal(paramsExpected, params)
 }
 
-func (s *MigrationTestSuite) TestActiveTopicsMigration() {
+func (s *EmissionsV3MigrationTestSuite) TestActiveTopicsMigration() {
 	storageService := s.emissionsKeeper.GetStorageService()
 	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
 
@@ -200,7 +200,7 @@ func (s *MigrationTestSuite) TestActiveTopicsMigration() {
 	}
 }
 
-func (s *MigrationTestSuite) TestLimitedActiveTopicsMigration() {
+func (s *EmissionsV3MigrationTestSuite) TestLimitedActiveTopicsMigration() {
 	storageService := s.emissionsKeeper.GetStorageService()
 	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
 
@@ -229,7 +229,7 @@ func (s *MigrationTestSuite) TestLimitedActiveTopicsMigration() {
 	}
 }
 
-func (s *MigrationTestSuite) setUpOldTopicsData(store storetypes.KVStore, topicCnt int) {
+func (s *EmissionsV3MigrationTestSuite) setUpOldTopicsData(store storetypes.KVStore, topicCnt int) {
 	topicStore := prefix.NewStore(store, types.TopicsKey)
 	topicFeeRevenueStore := prefix.NewStore(store, types.TopicFeeRevenueKey)
 	topicStakeStore := prefix.NewStore(store, types.TopicStakeKey)

--- a/x/emissions/module/rewards/rewards_internal_test.go
+++ b/x/emissions/module/rewards/rewards_internal_test.go
@@ -13,18 +13,18 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type MathTestSuite struct {
+type RewardsMathTestSuite struct {
 	suite.Suite
 }
 
-func (s *MathTestSuite) SetupTest() {
+func (s *RewardsMathTestSuite) SetupTest() {
 }
 
-func TestMathTestSuite(t *testing.T) {
-	suite.Run(t, new(MathTestSuite))
+func TestRewardsMathTestSuite(t *testing.T) {
+	suite.Run(t, new(RewardsMathTestSuite))
 }
 
-func (s *MathTestSuite) TestAdjustedStakeSimple() {
+func (s *RewardsMathTestSuite) TestAdjustedStakeSimple() {
 	// for this example we use
 	// 3 reputers with stakes of 50_000, 100_000, 150_000
 	// listening coefficients of 0.25, 0.18, 0.63 for those reputers
@@ -55,7 +55,7 @@ func (s *MathTestSuite) TestAdjustedStakeSimple() {
 	s.Require().True(alloraMath.InDelta(expected, result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
-func (s *MathTestSuite) TestNormalizeAgainstSlice() {
+func (s *RewardsMathTestSuite) TestNormalizeAgainstSlice() {
 	a := []alloraMath.Dec{
 		alloraMath.MustNewDecFromString("2.0"),
 		alloraMath.MustNewDecFromString("3.0"),
@@ -75,7 +75,7 @@ func (s *MathTestSuite) TestNormalizeAgainstSlice() {
 	}
 }
 
-func (s *MathTestSuite) TestEntropySimple() {
+func (s *RewardsMathTestSuite) TestEntropySimple() {
 	f_ij := []alloraMath.Dec{
 		alloraMath.MustNewDecFromString("0.2"),
 		alloraMath.MustNewDecFromString("0.3"),
@@ -93,7 +93,7 @@ func (s *MathTestSuite) TestEntropySimple() {
 	s.Require().True(alloraMath.InDelta(expected, result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
-func (s *MathTestSuite) TestNumberRatio() {
+func (s *RewardsMathTestSuite) TestNumberRatio() {
 	rewardFractions := []alloraMath.Dec{
 		alloraMath.MustNewDecFromString("0.2"),
 		alloraMath.MustNewDecFromString("0.3"),
@@ -113,21 +113,21 @@ func (s *MathTestSuite) TestNumberRatio() {
 	s.Require().True(alloraMath.InDelta(expected, result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
-func (s *MathTestSuite) TestNumberRatioZeroFractions() {
+func (s *RewardsMathTestSuite) TestNumberRatioZeroFractions() {
 	zeroFractions := []alloraMath.Dec{alloraMath.ZeroDec()}
 
 	_, err := rewards.NumberRatio(zeroFractions)
 	s.Require().ErrorIs(err, emissionstypes.ErrNumberRatioDivideByZero)
 }
 
-func (s *MathTestSuite) TestNumberRatioEmptyList() {
+func (s *RewardsMathTestSuite) TestNumberRatioEmptyList() {
 	emptyFractions := []alloraMath.Dec{}
 
 	_, err := rewards.NumberRatio(emptyFractions)
 	s.Require().ErrorIs(err, emissionstypes.ErrNumberRatioInvalidSliceLength)
 }
 
-func (s *MathTestSuite) TestInferenceRewardsSimple() {
+func (s *RewardsMathTestSuite) TestInferenceRewardsSimple() {
 	// T_i = log L naive - log L = 2 - 1 = 1
 	// X = 0.5 when T_i >= 1
 	// U_i = ((1 - 0.5) * 2 * 2 * 2 ) / (2 + 2 + 4)
@@ -173,7 +173,7 @@ func (s *MathTestSuite) TestInferenceRewardsSimple() {
 	)
 }
 
-func (s *MathTestSuite) TestInferenceRewardsZero() {
+func (s *RewardsMathTestSuite) TestInferenceRewardsZero() {
 	totalReward := alloraMath.ZeroDec()
 	infererScores := []emissionstypes.Score{
 		{Score: alloraMath.MustNewDecFromString("0.5")},
@@ -203,7 +203,7 @@ func (s *MathTestSuite) TestInferenceRewardsZero() {
 	s.Require().True(alloraMath.InDelta(alloraMath.ZeroDec(), result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
-func (s *MathTestSuite) TestForecastRewardsSimple() {
+func (s *RewardsMathTestSuite) TestForecastRewardsSimple() {
 	// T_i = log L naive - log L = 2 - 1 = 1
 	// X = 0.5 if T_i >= 1
 	// V_i = (X * γ * G_i * E_i) / (F_i + G_i + H_i)
@@ -249,7 +249,7 @@ func (s *MathTestSuite) TestForecastRewardsSimple() {
 }
 
 // Cross test of U_i / V_i
-func (s *MathTestSuite) TestU_iOverV_i() {
+func (s *RewardsMathTestSuite) TestU_iOverV_i() {
 	// U_i / V_i = ((1 - χ) * γ * F_i * E_i ) / (F_i + G_i + H_i) / (χ * γ * G_i * E_i) / (F_i + G_i + H_i)
 	// U_i / V_i = ((1 - χ) * γ * F_i * E_i ) / (χ * γ * G_i * E_i)
 	// U_i / V_i = ((1 - χ) * F_i ) / (χ  * G_i)
@@ -308,7 +308,7 @@ func (s *MathTestSuite) TestU_iOverV_i() {
 	)
 }
 
-func (s *MathTestSuite) TestForecastRewardsZero() {
+func (s *RewardsMathTestSuite) TestForecastRewardsZero() {
 	totalReward := alloraMath.ZeroDec()
 	infererScores := []emissionstypes.Score{
 		{Score: alloraMath.MustNewDecFromString("0.5")},
@@ -339,7 +339,7 @@ func (s *MathTestSuite) TestForecastRewardsZero() {
 	s.Require().True(alloraMath.InDelta(alloraMath.ZeroDec(), result, alloraMath.ZeroDec()))
 }
 
-func (s *MathTestSuite) TestReputerRewardSimple() {
+func (s *RewardsMathTestSuite) TestReputerRewardSimple() {
 	// W_i = (2 * 2) / (4 + 2 + 2)
 	// W_i = 4 / 8
 	// W_i = 0.5
@@ -354,7 +354,7 @@ func (s *MathTestSuite) TestReputerRewardSimple() {
 	s.Require().True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.5"), result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
-func (s *MathTestSuite) TestReputerRewardZero() {
+func (s *RewardsMathTestSuite) TestReputerRewardZero() {
 	totalReward := alloraMath.ZeroDec()
 	result, err := rewards.GetRewardForReputerTaskInTopic(
 		alloraMath.MustNewDecFromString("2"),
@@ -366,7 +366,7 @@ func (s *MathTestSuite) TestReputerRewardZero() {
 	s.Require().True(alloraMath.InDelta(alloraMath.ZeroDec(), result, alloraMath.MustNewDecFromString("0.0001")))
 }
 
-func (s *MathTestSuite) TestReputerRewardFromCsv() {
+func (s *RewardsMathTestSuite) TestReputerRewardFromCsv() {
 	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
 	epoch3Get := epochGet[300]
 	totalReward, err := testutil.GetTotalRewardForTopicInEpoch(epoch3Get)
@@ -383,7 +383,7 @@ func (s *MathTestSuite) TestReputerRewardFromCsv() {
 	testutil.InEpsilon5(s.T(), result, expectedTotalReputerReward.String())
 }
 
-func (s *MathTestSuite) TestForecastingPerformanceScoreSimple() {
+func (s *RewardsMathTestSuite) TestForecastingPerformanceScoreSimple() {
 	networkInferenceLoss := alloraMath.MustNewDecFromString("100.0")
 	naiveNetworkInferenceLoss := alloraMath.MustNewDecFromString("1000.0")
 	score, err := rewards.ForecastingPerformanceScore(naiveNetworkInferenceLoss, networkInferenceLoss)
@@ -391,14 +391,14 @@ func (s *MathTestSuite) TestForecastingPerformanceScoreSimple() {
 	s.Require().True(alloraMath.InDelta(alloraMath.MustNewDecFromString("900.0"), score, alloraMath.MustNewDecFromString("0.0001")))
 }
 
-func (s *MathTestSuite) TestSigmoidSimple() {
+func (s *RewardsMathTestSuite) TestSigmoidSimple() {
 	x := alloraMath.MustNewDecFromString("-4")
 	result, err := rewards.Sigmoid(x)
 	s.Require().NoError(err)
 	s.Require().True(alloraMath.InDelta(alloraMath.MustNewDecFromString("0.01798621"), result, alloraMath.MustNewDecFromString("0.00000001")))
 }
 
-func (s *MathTestSuite) TestForecastingUtilitySimple() {
+func (s *RewardsMathTestSuite) TestForecastingUtilitySimple() {
 	alpha := alloraMath.OneDec()
 	previousForecasterScoreRatio := alloraMath.ZeroDec()
 	// Test case where score < 0
@@ -426,7 +426,7 @@ func (s *MathTestSuite) TestForecastingUtilitySimple() {
 	s.Require().True(alloraMath.InDelta(expectedResult, ret, alloraMath.MustNewDecFromString("0.0001")))
 }
 
-func (s *MathTestSuite) TestNormalizationFactorSimple() {
+func (s *RewardsMathTestSuite) TestNormalizationFactorSimple() {
 	entropyInference := alloraMath.MustNewDecFromString("4.0")
 	entropyForecasting := alloraMath.MustNewDecFromString("6.0")
 	chi := alloraMath.MustNewDecFromString("0.5")

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -171,7 +171,7 @@ func (s *RewardsTestSuite) FundAccount(amount int64, accAddress sdk.AccAddress) 
 	s.Require().NoError(err)
 }
 
-func TestModuleTestSuite(t *testing.T) {
+func TestRewardsTestSuite(t *testing.T) {
 	suite.Run(t, new(RewardsTestSuite))
 }
 

--- a/x/mint/keeper/emissions_test.go
+++ b/x/mint/keeper/emissions_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/allora-network/allora-chain/x/mint/types"
 )
 
-func (s *IntegrationTestSuite) TestTotalEmissionPerMonthSimple() {
+func (s *MintKeeperTestSuite) TestTotalEmissionPerMonthSimple() {
 	// 1. Set up the test inputs
 	rewardEmissionPerUnitStakedToken := cosmosMath.NewInt(5).ToLegacyDec()
 	numStakedTokens := cosmosMath.NewInt(100)
@@ -27,7 +27,7 @@ func (s *IntegrationTestSuite) TestTotalEmissionPerMonthSimple() {
 // all the staking stuff which is a pain in the behind
 // we will test that in integration, for now just test the value is non
 // negative aka zero when you don't have stakers
-func (s *IntegrationTestSuite) TestGetNumStakedTokensNonNegative() {
+func (s *MintKeeperTestSuite) TestGetNumStakedTokensNonNegative() {
 	s.stakingKeeper.EXPECT().TotalBondedTokens(s.ctx).Return(cosmosMath.NewInt(0), nil)
 	s.emissionsKeeper.EXPECT().GetTotalStake(s.ctx).Return(cosmosMath.NewInt(0), nil)
 	nst, err := keeper.GetNumStakedTokens(s.ctx, s.mintKeeper)
@@ -35,7 +35,7 @@ func (s *IntegrationTestSuite) TestGetNumStakedTokensNonNegative() {
 	s.False(nst.IsNegative())
 }
 
-func (s *IntegrationTestSuite) TestGetExponentialMovingAverageSimple() {
+func (s *MintKeeperTestSuite) TestGetExponentialMovingAverageSimple() {
 	// e_i = α_e * ^e_i + (1 − α_e)*e_{i−1}
 	// random numbers for test
 	// e_i = 0.1 * 1000 + (1 - 0.1) * 800
@@ -52,7 +52,7 @@ func (s *IntegrationTestSuite) TestGetExponentialMovingAverageSimple() {
 	s.Require().True(expectedValue.Equal(result))
 }
 
-func (s *IntegrationTestSuite) TestNumberLockedTokensBeforeVest() {
+func (s *MintKeeperTestSuite) TestNumberLockedTokensBeforeVest() {
 	defaultParams := types.DefaultParams()
 	fullPreseedInvestors := defaultParams.InvestorsPreseedPercentOfTotalSupply.
 		Mul(defaultParams.MaxSupply.ToLegacyDec()).TruncateInt()
@@ -73,7 +73,7 @@ func (s *IntegrationTestSuite) TestNumberLockedTokensBeforeVest() {
 	s.Require().True(result.Equal(expectedLocked), "expected %s, got %s", expectedLocked, result)
 }
 
-func (s *IntegrationTestSuite) TestNumberLockedTokensDuringVest() {
+func (s *MintKeeperTestSuite) TestNumberLockedTokensDuringVest() {
 	defaultParams := types.DefaultParams()
 	// after 13 months investors and team should get 1/3 + 1/36 = 13/36
 	fractionUnlocked := cosmosMath.LegacyNewDec(13).Quo(cosmosMath.LegacyNewDec(36))
@@ -99,7 +99,7 @@ func (s *IntegrationTestSuite) TestNumberLockedTokensDuringVest() {
 	s.Require().True(result.Equal(expectedLocked), "expected %s, got %s", expectedLocked, result)
 }
 
-func (s *IntegrationTestSuite) TestNumberLockedTokensAfterVest() {
+func (s *MintKeeperTestSuite) TestNumberLockedTokensAfterVest() {
 	defaultParams := types.DefaultParams()
 	s.emissionsKeeper.EXPECT().GetParamsBlocksPerMonth(s.ctx).Return(uint64(525960), nil)
 	bpm, err := s.emissionsKeeper.GetParamsBlocksPerMonth(s.ctx)
@@ -112,7 +112,7 @@ func (s *IntegrationTestSuite) TestNumberLockedTokensAfterVest() {
 	s.Require().True(result.Equal(cosmosMath.ZeroInt()))
 }
 
-func (s *IntegrationTestSuite) TestTargetRewardEmissionPerUnitStakedTokenSimple() {
+func (s *MintKeeperTestSuite) TestTargetRewardEmissionPerUnitStakedTokenSimple() {
 	// ^e_i = ((f_e*T_{total,i}) / N_{staked,i}) * (N_{circ,i} / N_{total,i})
 	// using some random sample values
 	//  ^e_i = ((0.015*2000)/400)*(10000000/12000000)
@@ -128,7 +128,7 @@ func (s *IntegrationTestSuite) TestTargetRewardEmissionPerUnitStakedTokenSimple(
 }
 
 // match ^e_i from row 61
-func (s *IntegrationTestSuite) TestEHatTargetFromCsv() {
+func (s *MintKeeperTestSuite) TestEHatTargetFromCsv() {
 	epoch := s.epochGet[60]
 	epoch61 := s.epochGet[61]
 	// because of how the simulator is written, the target is
@@ -157,7 +157,7 @@ func (s *IntegrationTestSuite) TestEHatTargetFromCsv() {
 	testutil.InEpsilon5Dec(s.T(), resultD, expectedResult)
 }
 
-func (s *IntegrationTestSuite) TestEHatMaxAtGenesisFromCsv() {
+func (s *MintKeeperTestSuite) TestEHatMaxAtGenesisFromCsv() {
 	epoch0Get := s.epochGet[0]
 	expectedResult := epoch0Get("ehat_max_i")
 	// not exposed in csv, but taken looking directly from python notebook:
@@ -186,7 +186,7 @@ func (s *IntegrationTestSuite) TestEHatMaxAtGenesisFromCsv() {
 	testutil.InEpsilon5Dec(s.T(), resultD, expectedResult)
 }
 
-func (s *IntegrationTestSuite) TestEhatIFromCsv() {
+func (s *MintKeeperTestSuite) TestEhatIFromCsv() {
 	epoch := s.epochGet[61]
 	expectedResult := epoch("ehat_i")
 	ehatMaxI, err := epoch("ehat_max_i").SdkLegacyDec()
@@ -204,7 +204,7 @@ func (s *IntegrationTestSuite) TestEhatIFromCsv() {
 }
 
 // calculate e_i for the 61st epoch
-func (s *IntegrationTestSuite) TestESubIFromCsv() {
+func (s *MintKeeperTestSuite) TestESubIFromCsv() {
 	expectedResult := s.epochGet[61]("e_i")
 	targetE_i, err := s.epochGet[61]("ehat_target_i").SdkLegacyDec()
 	s.Require().NoError(err)
@@ -226,7 +226,7 @@ func (s *IntegrationTestSuite) TestESubIFromCsv() {
 
 // calculate \cal E for the 61st epoch
 // GetTotalEmissionPerMonth
-func (s *IntegrationTestSuite) TestCalEFromCsv() {
+func (s *MintKeeperTestSuite) TestCalEFromCsv() {
 	expectedResult := s.epochGet[61]("ecosystem_tokens_emission")
 	rewardEmissionPerUnitStakedToken, err := s.epochGet[61]("e_i").SdkLegacyDec()
 	s.Require().NoError(err)
@@ -243,7 +243,7 @@ func (s *IntegrationTestSuite) TestCalEFromCsv() {
 	testutil.InEpsilon5Dec(s.T(), resultD, expectedResult)
 }
 
-func (s *IntegrationTestSuite) TestGetLockedVestingTokens() {
+func (s *MintKeeperTestSuite) TestGetLockedVestingTokens() {
 	_1e18 := alloraMath.NewDecFinite(1, 18)
 	blocksPerMonth := uint64(525960)
 	epoch0 := s.epochGet[0]

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -24,7 +24,7 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 )
 
-type IntegrationTestSuite struct {
+type MintKeeperTestSuite struct {
 	suite.Suite
 
 	mintKeeper      keeper.Keeper
@@ -39,11 +39,11 @@ type IntegrationTestSuite struct {
 	epochGet        map[int]func(string) alloraMath.Dec
 }
 
-func TestKeeperTestSuite(t *testing.T) {
-	suite.Run(t, new(IntegrationTestSuite))
+func TestMintKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(MintKeeperTestSuite))
 }
 
-func (s *IntegrationTestSuite) SetupTest() {
+func (s *MintKeeperTestSuite) SetupTest() {
 	encCfg := moduletestutil.MakeTestEncodingConfig(mint.AppModuleBasic{})
 	key := storetypes.NewKVStoreKey(types.StoreKey)
 	storeService := runtime.NewKVStoreService(key)
@@ -86,7 +86,7 @@ func (s *IntegrationTestSuite) SetupTest() {
 	s.epochGet = alloratestutil.GetTokenomicsSimulatorValuesGetterForEpochs()
 }
 
-func (s *IntegrationTestSuite) TestAliasFunctions() {
+func (s *MintKeeperTestSuite) TestAliasFunctions() {
 	stakingTokenSupply := math.NewIntFromUint64(100000000000)
 	s.stakingKeeper.EXPECT().TotalBondedTokens(s.ctx).Return(stakingTokenSupply, nil)
 	tokenSupply, err := s.mintKeeper.CosmosValidatorStakedSupply(s.ctx)

--- a/x/mint/keeper/msg_server_test.go
+++ b/x/mint/keeper/msg_server_test.go
@@ -9,7 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *IntegrationTestSuite) TestUpdateParams() {
+func (s *MintKeeperTestSuite) TestUpdateParams() {
 	params := types.DefaultParams()
 	params.MintDenom = "testcoin"
 
@@ -24,7 +24,7 @@ func (s *IntegrationTestSuite) TestUpdateParams() {
 	s.Require().Equal(&types.MsgUpdateParamsResponse{}, resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidSigner() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidSigner() {
 	// Setup a non-whitelisted sender address
 	nonAdminPrivateKey := secp256k1.GenPrivKey()
 	nonAdminAddr := sdk.AccAddress(nonAdminPrivateKey.PubKey().Address()).String()
@@ -44,7 +44,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidSigner() {
 	s.Require().Nil(resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsNonAddressSigner() {
+func (s *MintKeeperTestSuite) TestUpdateParamsNonAddressSigner() {
 	defaultParams := types.DefaultParams()
 
 	notAnAddress := "not an address lol"
@@ -58,7 +58,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsNonAddressSigner() {
 	s.Require().Nil(resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsMintDenom() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsMintDenom() {
 	params := types.DefaultParams()
 	params.MintDenom = ""
 	request := &types.MsgUpdateParams{
@@ -71,7 +71,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsMintDenom() {
 	s.Require().Nil(resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsMaxSupply() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsMaxSupply() {
 	params := types.DefaultParams()
 	params.MaxSupply = sdkmath.NewIntFromUint64(0)
 	request := &types.MsgUpdateParams{
@@ -84,7 +84,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsMaxSupply() {
 	s.Require().Nil(resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsFEmission() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsFEmission() {
 	params := types.DefaultParams()
 	params.FEmission = sdkmath.LegacyNewDec(205)
 	request := &types.MsgUpdateParams{
@@ -97,7 +97,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsFEmission() {
 	s.Require().Nil(resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsOneMonthSmoothingDegree() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsOneMonthSmoothingDegree() {
 	params := types.DefaultParams()
 	params.OneMonthSmoothingDegree = sdkmath.LegacyNewDec(15)
 	request := &types.MsgUpdateParams{
@@ -110,7 +110,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsOneMonthSmoothingDeg
 	s.Require().Nil(resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsEcosystemTreasuryPercentOfTotalSupply() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsEcosystemTreasuryPercentOfTotalSupply() {
 	params := types.DefaultParams()
 	params.EcosystemTreasuryPercentOfTotalSupply = sdkmath.LegacyNewDec(101)
 	request := &types.MsgUpdateParams{
@@ -123,7 +123,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsEcosystemTreasuryPer
 	s.Require().Nil(resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsFoundationTreasuryPercentOfTotalSupply() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsFoundationTreasuryPercentOfTotalSupply() {
 	params := types.DefaultParams()
 	params.FoundationTreasuryPercentOfTotalSupply = sdkmath.LegacyNewDec(101)
 	request := &types.MsgUpdateParams{
@@ -136,7 +136,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsFoundationTreasuryPe
 	s.Require().Nil(resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsParticipantsPercentOfTotalSupply() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsParticipantsPercentOfTotalSupply() {
 	params := types.DefaultParams()
 	params.ParticipantsPercentOfTotalSupply = sdkmath.LegacyNewDec(101)
 	request := &types.MsgUpdateParams{
@@ -149,7 +149,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsParticipantsPercentO
 	s.Require().Nil(resp)
 }
 
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsInvestorsPercentOfTotalSupply() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsInvestorsPercentOfTotalSupply() {
 	params := types.DefaultParams()
 	params.ParticipantsPercentOfTotalSupply = sdkmath.LegacyNewDec(101)
 	request := &types.MsgUpdateParams{
@@ -161,7 +161,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsInvestorsPercentOfTo
 	s.Require().Error(err)
 	s.Require().Nil(resp)
 }
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsTeamPercentOfTotalSupply() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsTeamPercentOfTotalSupply() {
 	params := types.DefaultParams()
 	params.TeamPercentOfTotalSupply = sdkmath.LegacyNewDec(101)
 	request := &types.MsgUpdateParams{
@@ -173,7 +173,7 @@ func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsTeamPercentOfTotalSu
 	s.Require().Error(err)
 	s.Require().Nil(resp)
 }
-func (s *IntegrationTestSuite) TestUpdateParamsInvalidParamsMaximumMonthlyPercentageYield() {
+func (s *MintKeeperTestSuite) TestUpdateParamsInvalidParamsMaximumMonthlyPercentageYield() {
 	params := types.DefaultParams()
 	params.MaximumMonthlyPercentageYield = sdkmath.LegacyNewDec(101)
 	request := &types.MsgUpdateParams{


### PR DESCRIPTION
## Purpose of Changes and their Description

This is a refactoring PR with no state changes. It renames testify TestSuites to match with the packages they are actually testing.

## Are these changes tested and documented?

These changes are tested by running them / our existing tests

This is an internal change that does not require documentation.