### PR TITLE
Hot fix:  Ensuring worker presence between reputer reports

### DIFF
--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -122,7 +122,7 @@ func CloseReputerNonce(
 		// We keep what we can, ignoring the reputer and their contribution (losses) entirely
 		// if they're left with no valid losses.
 
-		filteredBundle, err := filterUnacceptedWorkersFromReputerValueBundle(k, ctx, topicId, *bundle.ValueBundle.ReputerRequestNonce, bundle)
+		filteredBundle, err := FilterUnacceptedWorkersFromReputerValueBundle(k, ctx, topicId, *bundle.ValueBundle.ReputerRequestNonce, bundle)
 		if err != nil {
 			continue
 		}
@@ -215,7 +215,7 @@ func CloseReputerNonce(
 // Filter out values of unaccepted workers.
 // It is assumed that the work of inferers and forecasters stored at the nonce is already filtered for acceptance.
 // This also removes duplicate values of the same worker.
-func filterUnacceptedWorkersFromReputerValueBundle(
+func FilterUnacceptedWorkersFromReputerValueBundle(
 	k *keeper.Keeper,
 	ctx context.Context,
 	topicId uint64,

--- a/x/emissions/keeper/actor_utils/losses_test.go
+++ b/x/emissions/keeper/actor_utils/losses_test.go
@@ -1,3 +1,265 @@
 package actor_utils_test
 
-// TODO losses tests
+import (
+	"testing"
+	"time"
+
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+
+	"cosmossdk.io/core/header"
+	clog "cosmossdk.io/log"
+
+	storetypes "cosmossdk.io/store/types"
+	"github.com/allora-network/allora-chain/app/params"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
+	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
+	"github.com/allora-network/allora-chain/x/emissions/module"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+	"github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	auth "github.com/cosmos/cosmos-sdk/x/auth"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	multiPerm  = "multiple permissions account"
+	randomPerm = "random permission"
+)
+
+type ActorUtilsTestSuite struct {
+	suite.Suite
+
+	ctx             sdk.Context
+	accountKeeper   keeper.AccountKeeper
+	bankKeeper      keeper.BankKeeper
+	emissionsKeeper keeper.Keeper
+	appModule       module.AppModule
+	msgServer       emissionstypes.MsgServer
+	key             *storetypes.KVStoreKey
+	addrs           []sdk.AccAddress
+	addrsStr        []string
+}
+
+func (s *ActorUtilsTestSuite) SetupTest() {
+	key := storetypes.NewKVStoreKey("emissions")
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()})
+	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
+	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
+
+	maccPerms := map[string][]string{
+		"fee_collector":                         {"minter"},
+		"mint":                                  {"minter"},
+		emissionstypes.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		emissionstypes.AlloraRewardsAccountName: {"minter"},
+		emissionstypes.AlloraPendingRewardForDelegatorAccountName: {"minter"},
+		"bonded_tokens_pool":     {"burner", "staking"},
+		"not_bonded_tokens_pool": {"burner", "staking"},
+		multiPerm:                {"burner", "minter", "staking"},
+		randomPerm:               {"random"},
+	}
+
+	accountKeeper := authkeeper.NewAccountKeeper(
+		encCfg.Codec,
+		storeService,
+		authtypes.ProtoBaseAccount,
+		maccPerms,
+		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
+		params.Bech32PrefixAccAddr,
+		authtypes.NewModuleAddress("gov").String(),
+	)
+
+	var addrs []sdk.AccAddress = make([]sdk.AccAddress, 0)
+	var addrsStr []string = make([]string, 0)
+	pubkeys := simtestutil.CreateTestPubKeys(50)
+	for i := 0; i < 50; i++ {
+		addrs = append(addrs, sdk.AccAddress(pubkeys[i].Address()))
+		addrsStr = append(addrsStr, addrs[i].String())
+	}
+	s.addrs = addrs
+	s.addrsStr = addrsStr
+
+	bankKeeper := bankkeeper.NewBaseKeeper(
+		encCfg.Codec,
+		storeService,
+		accountKeeper,
+		map[string]bool{},
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		clog.NewNopLogger(),
+	)
+
+	s.ctx = ctx
+	s.accountKeeper = accountKeeper
+	s.bankKeeper = bankKeeper
+	s.emissionsKeeper = keeper.NewKeeper(
+		encCfg.Codec,
+		addressCodec,
+		storeService,
+		accountKeeper,
+		bankKeeper,
+		authtypes.FeeCollectorName,
+	)
+	s.key = key
+	appModule := module.NewAppModule(encCfg.Codec, s.emissionsKeeper)
+	defaultGenesis := appModule.DefaultGenesis(encCfg.Codec)
+	appModule.InitGenesis(ctx, encCfg.Codec, defaultGenesis)
+	s.msgServer = msgserver.NewMsgServerImpl(s.emissionsKeeper)
+	s.appModule = appModule
+
+	// Add all tests addresses in whitelists
+	for _, addr := range addrsStr {
+		s.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
+	}
+
+	err := s.emissionsKeeper.SetTopic(s.ctx, 1, emissionstypes.Topic{
+		Id:                     1,
+		Creator:                "creator",
+		Metadata:               "metadata",
+		LossMethod:             "mse",
+		EpochLastEnded:         0,
+		EpochLength:            100,
+		GroundTruthLag:         10,
+		WorkerSubmissionWindow: 10,
+		PNorm:                  alloraMath.NewDecFromInt64(3),
+		AlphaRegret:            alloraMath.MustNewDecFromString("0.1"),
+		AllowNegative:          false,
+		InitialRegret:          alloraMath.MustNewDecFromString("0.0001"),
+	})
+	s.Require().NoError(err)
+}
+
+func TestModuleTestSuite(t *testing.T) {
+	suite.Run(t, new(ActorUtilsTestSuite))
+}
+
+func (a *ActorUtilsTestSuite) TestFilterUnacceptedWorkersFromReputerValueBundle() {
+	workerNonce := emissionstypes.Nonce{
+		BlockHeight: 1,
+	}
+
+	infererLossBundle := emissionstypes.Inferences{
+		Inferences: []*emissionstypes.Inference{
+			{
+				TopicId:     1,
+				BlockHeight: 1,
+				Inferer:     "inferer1",
+				Value:       alloraMath.NewDecFromInt64(1),
+			},
+			{
+				TopicId:     1,
+				BlockHeight: 1,
+				Inferer:     "inferer2",
+				Value:       alloraMath.NewDecFromInt64(2),
+			},
+			{
+				TopicId:     1,
+				BlockHeight: 1,
+				Inferer:     "inferer4",
+				Value:       alloraMath.NewDecFromInt64(3),
+			},
+		},
+	}
+	err := a.emissionsKeeper.InsertInferences(a.ctx, 1, workerNonce, infererLossBundle)
+	a.Require().NoError(err)
+
+	forecasterLossBundle := emissionstypes.Forecasts{
+		Forecasts: []*emissionstypes.Forecast{
+			{
+				TopicId:     1,
+				BlockHeight: 1,
+				Forecaster:  "forecaster1",
+				ForecastElements: []*emissionstypes.ForecastElement{
+					{
+						Inferer: "inferer1",
+						Value:   alloraMath.NewDecFromInt64(1),
+					},
+					{
+						Inferer: "inferer2",
+						Value:   alloraMath.NewDecFromInt64(2),
+					},
+				},
+			},
+			{
+				TopicId:     1,
+				BlockHeight: 1,
+				Forecaster:  "forecaster2",
+				ForecastElements: []*emissionstypes.ForecastElement{
+					{
+						Inferer: "inferer1",
+						Value:   alloraMath.NewDecFromInt64(3),
+					},
+				},
+			},
+		},
+	}
+	err = a.emissionsKeeper.InsertForecasts(a.ctx, 1, workerNonce, forecasterLossBundle)
+	a.Require().NoError(err)
+
+	// Prepare a sample ReputerValueBundle
+	reputerValueBundle := &emissionstypes.ReputerValueBundle{
+		ValueBundle: &emissionstypes.ValueBundle{
+			TopicId: 1,
+			InfererValues: []*emissionstypes.WorkerAttributedValue{
+				{Worker: "inferer1", Value: alloraMath.NewDecFromInt64(100)},
+				{Worker: "inferer2", Value: alloraMath.NewDecFromInt64(100)},
+				{Worker: "inferer5", Value: alloraMath.NewDecFromInt64(200)}, // Should be filtered out
+			},
+			ForecasterValues: []*emissionstypes.WorkerAttributedValue{
+				{Worker: "forecaster1", Value: alloraMath.NewDecFromInt64(300)},
+				{Worker: "forecaster3", Value: alloraMath.NewDecFromInt64(400)}, // Should be filtered out
+			},
+			OneOutInfererValues: []*emissionstypes.WithheldWorkerAttributedValue{
+				{Worker: "inferer1", Value: alloraMath.NewDecFromInt64(500)},
+				{Worker: "inferer5", Value: alloraMath.NewDecFromInt64(600)}, // Should be filtered out
+			},
+			OneOutForecasterValues: []*emissionstypes.WithheldWorkerAttributedValue{
+				{Worker: "forecaster1", Value: alloraMath.NewDecFromInt64(700)},
+				{Worker: "forecaster4", Value: alloraMath.NewDecFromInt64(800)}, // Should be filtered out
+			},
+			OneOutInfererForecasterValues: []*emissionstypes.OneOutInfererForecasterValues{
+				{
+					Forecaster: "forecaster1",
+					OneOutInfererValues: []*emissionstypes.WithheldWorkerAttributedValue{
+						{Worker: "inferer1", Value: alloraMath.NewDecFromInt64(900)},
+						{Worker: "inferer5", Value: alloraMath.NewDecFromInt64(1000)}, // Should be filtered out
+					},
+				},
+				{
+					Forecaster: "forecaster3", // Should be filtered out
+					OneOutInfererValues: []*emissionstypes.WithheldWorkerAttributedValue{
+						{Worker: "inferer1", Value: alloraMath.NewDecFromInt64(1100)},
+					},
+				},
+			},
+			OneInForecasterValues: []*emissionstypes.WorkerAttributedValue{
+				{Worker: "forecaster1", Value: alloraMath.NewDecFromInt64(1200)},
+				{Worker: "forecaster5", Value: alloraMath.NewDecFromInt64(1300)}, // Should be filtered out
+			},
+		},
+		Signature: []byte("signature"),
+	}
+
+	acceptedBundle, err := actorutils.FilterUnacceptedWorkersFromReputerValueBundle(&a.emissionsKeeper, a.ctx, 1, emissionstypes.ReputerRequestNonce{ReputerNonce: &workerNonce}, reputerValueBundle)
+	a.Require().NoError(err)
+
+	// Validate the bundle
+	a.Require().Len(acceptedBundle.ValueBundle.InfererValues, 2)
+	a.Require().Len(acceptedBundle.ValueBundle.ForecasterValues, 1)
+	a.Require().Len(acceptedBundle.ValueBundle.OneOutInfererValues, 1)
+	a.Require().Len(acceptedBundle.ValueBundle.OneOutForecasterValues, 1)
+	a.Require().Len(acceptedBundle.ValueBundle.OneOutInfererForecasterValues, 1)
+	a.Require().Len(acceptedBundle.ValueBundle.OneOutInfererForecasterValues[0].OneOutInfererValues, 1)
+	a.Require().Len(acceptedBundle.ValueBundle.OneInForecasterValues, 1)
+}

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -77,8 +77,7 @@ func (ms msgServer) InsertWorkerPayload(ctx context.Context, msg *types.MsgInser
 		}
 		isInfererRegistered, err := ms.k.IsWorkerRegisteredInTopic(ctx, topicId, inference.Inferer)
 		if err != nil {
-			return nil, errorsmod.Wrapf(err,
-				"Error inferer address is not registered in this topic")
+			return nil, err
 		}
 		if !isInfererRegistered {
 			return nil, errorsmod.Wrapf(err,
@@ -111,6 +110,15 @@ func (ms msgServer) InsertWorkerPayload(ctx context.Context, msg *types.MsgInser
 		acceptedForecastElements := make([]*types.ForecastElement, 0)
 		seenInferers := make(map[string]bool)
 		for _, el := range forecast.ForecastElements {
+			// Check if the forecasted inferer is registered in the topic
+			isInfererRegistered, err := ms.k.IsWorkerRegisteredInTopic(ctx, topicId, el.Inferer)
+			if err != nil {
+				return nil, err
+			}
+			if !isInfererRegistered {
+				return nil, errorsmod.Wrapf(err,
+					"Error forecasted inferer address is not registered in this topic")
+			}
 			if !seenInferers[el.Inferer] {
 				acceptedForecastElements = append(acceptedForecastElements, el)
 				seenInferers[el.Inferer] = true

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -42,6 +42,7 @@ func EmitRewards(
 	}
 	// Sorted, active topics by weight descending. Still need skim top N to truly be the rewardable topics
 	sortedRewardableTopics := alloraMath.GetSortedElementsByDecWeightDesc(rewardableTopics, weights)
+	Logger(ctx).Debug(fmt.Sprintf("Rewardable topics: %v", sortedRewardableTopics))
 
 	if len(sortedRewardableTopics) == 0 {
 		Logger(ctx).Warn("No rewardable topics found")
@@ -72,6 +73,8 @@ func EmitRewards(
 	// Calculate then pay out topic rewards to topic participants
 	totalRewardToStakedReputers := alloraMath.ZeroDec() // This is used to communicate with the mint module
 	for _, topicId := range sortedRewardableTopics {
+		Logger(ctx).Debug(fmt.Sprintf("Distributing rewards for topic %d", topicId))
+
 		topicReward := topicRewards[topicId]
 		if topicReward == nil {
 			Logger(ctx).Warn(fmt.Sprintf("Topic %d has no reward, skipping", topicId))

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -256,6 +256,8 @@ func GenerateForecastScores(
 // Returns the reported losses adding NaN values for missing workers in uncompleted reported losses
 func EnsureWorkerPresence(reportedLosses types.ReputerValueBundles) types.ReputerValueBundles {
 	// Consolidate all unique worker addresses and forecaster addresses
+	allWorkersInferer := make(map[string]struct{})
+	allWorkersForecaster := make(map[string]struct{})
 	allWorkersOneOutInferer := make(map[string]struct{})
 	allWorkersOneOutForecaster := make(map[string]struct{})
 	allWorkersOneInForecaster := make(map[string]struct{})
@@ -263,6 +265,12 @@ func EnsureWorkerPresence(reportedLosses types.ReputerValueBundles) types.Repute
 
 	for _, bundle := range reportedLosses.ReputerValueBundles {
 		// Collect unique workers for each type
+		for _, workerValue := range bundle.ValueBundle.InfererValues {
+			allWorkersInferer[workerValue.Worker] = struct{}{}
+		}
+		for _, workerValue := range bundle.ValueBundle.ForecasterValues {
+			allWorkersForecaster[workerValue.Worker] = struct{}{}
+		}
 		for _, workerValue := range bundle.ValueBundle.OneOutInfererValues {
 			allWorkersOneOutInferer[workerValue.Worker] = struct{}{}
 		}
@@ -287,6 +295,8 @@ func EnsureWorkerPresence(reportedLosses types.ReputerValueBundles) types.Repute
 
 	// Ensure each set has all workers, add NaN value for missing workers
 	for _, bundle := range reportedLosses.ReputerValueBundles {
+		bundle.ValueBundle.InfererValues = EnsureAllWorkersPresent(bundle.ValueBundle.InfererValues, allWorkersInferer)
+		bundle.ValueBundle.ForecasterValues = EnsureAllWorkersPresent(bundle.ValueBundle.ForecasterValues, allWorkersForecaster)
 		bundle.ValueBundle.OneOutInfererValues = EnsureAllWorkersPresentWithheld(bundle.ValueBundle.OneOutInfererValues, allWorkersOneOutInferer)
 		bundle.ValueBundle.OneOutForecasterValues = EnsureAllWorkersPresentWithheld(bundle.ValueBundle.OneOutForecasterValues, allWorkersOneOutForecaster)
 		bundle.ValueBundle.OneInForecasterValues = EnsureAllWorkersPresent(bundle.ValueBundle.OneInForecasterValues, allWorkersOneInForecaster)

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -255,13 +255,14 @@ func GenerateForecastScores(
 // Check if all workers are present in the reported losses and add NaN values for missing workers
 // Returns the reported losses adding NaN values for missing workers in uncompleted reported losses
 func EnsureWorkerPresence(reportedLosses types.ReputerValueBundles) types.ReputerValueBundles {
-	// Consolidate all unique worker addresses from the three slices
+	// Consolidate all unique worker addresses and forecaster addresses
 	allWorkersOneOutInferer := make(map[string]struct{})
 	allWorkersOneOutForecaster := make(map[string]struct{})
 	allWorkersOneInForecaster := make(map[string]struct{})
-	allWorkersOneOutInfererForecaster := make(map[string]struct{})
+	allForecastersOneOutInferer := make(map[string]map[string]struct{})
 
 	for _, bundle := range reportedLosses.ReputerValueBundles {
+		// Collect unique workers for each type
 		for _, workerValue := range bundle.ValueBundle.OneOutInfererValues {
 			allWorkersOneOutInferer[workerValue.Worker] = struct{}{}
 		}
@@ -271,9 +272,15 @@ func EnsureWorkerPresence(reportedLosses types.ReputerValueBundles) types.Repute
 		for _, workerValue := range bundle.ValueBundle.OneInForecasterValues {
 			allWorkersOneInForecaster[workerValue.Worker] = struct{}{}
 		}
+		// Collect unique forecasters and their workers
 		for _, forecasterValue := range bundle.ValueBundle.OneOutInfererForecasterValues {
+			// Ensure a map exists for this forecaster
+			if _, exists := allForecastersOneOutInferer[forecasterValue.Forecaster]; !exists {
+				allForecastersOneOutInferer[forecasterValue.Forecaster] = make(map[string]struct{})
+			}
+			// Collect all workers associated with this forecaster
 			for _, workerValue := range forecasterValue.OneOutInfererValues {
-				allWorkersOneOutInfererForecaster[workerValue.Worker] = struct{}{}
+				allForecastersOneOutInferer[forecasterValue.Forecaster][workerValue.Worker] = struct{}{}
 			}
 		}
 	}
@@ -283,12 +290,41 @@ func EnsureWorkerPresence(reportedLosses types.ReputerValueBundles) types.Repute
 		bundle.ValueBundle.OneOutInfererValues = EnsureAllWorkersPresentWithheld(bundle.ValueBundle.OneOutInfererValues, allWorkersOneOutInferer)
 		bundle.ValueBundle.OneOutForecasterValues = EnsureAllWorkersPresentWithheld(bundle.ValueBundle.OneOutForecasterValues, allWorkersOneOutForecaster)
 		bundle.ValueBundle.OneInForecasterValues = EnsureAllWorkersPresent(bundle.ValueBundle.OneInForecasterValues, allWorkersOneInForecaster)
-		for _, forecasterValue := range bundle.ValueBundle.OneOutInfererForecasterValues {
-			forecasterValue.OneOutInfererValues = EnsureAllWorkersPresentWithheld(forecasterValue.OneOutInfererValues, allWorkersOneOutInfererForecaster)
+
+		// Ensure all forecasters and their associated workers are present
+		for forecaster, workers := range allForecastersOneOutInferer {
+			found := false
+			for _, forecasterValue := range bundle.ValueBundle.OneOutInfererForecasterValues {
+				if forecasterValue.Forecaster == forecaster {
+					forecasterValue.OneOutInfererValues = EnsureAllWorkersPresentWithheld(forecasterValue.OneOutInfererValues, workers)
+					found = true
+					break
+				}
+			}
+			// If forecaster is missing, add it with NaN values for all workers
+			if !found {
+				newForecasterValue := types.OneOutInfererForecasterValues{
+					Forecaster:          forecaster,
+					OneOutInfererValues: createNaNWithheldValues(workers),
+				}
+				bundle.ValueBundle.OneOutInfererForecasterValues = append(bundle.ValueBundle.OneOutInfererForecasterValues, &newForecasterValue)
+			}
 		}
 	}
 
 	return reportedLosses
+}
+
+// Helper function to create NaN values for missing workers
+func createNaNWithheldValues(workers map[string]struct{}) []*types.WithheldWorkerAttributedValue {
+	var values []*types.WithheldWorkerAttributedValue
+	for worker := range workers {
+		values = append(values, &types.WithheldWorkerAttributedValue{
+			Worker: worker,
+			Value:  alloraMath.NewNaN(),
+		})
+	}
+	return values
 }
 
 // ensureAllWorkersPresent checks and adds missing

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -468,6 +468,13 @@ func (s *RewardsTestSuite) TestEnsureWorkerPresenceConsistency() {
 			{
 				Pubkey: "reputer1",
 				ValueBundle: &types.ValueBundle{
+					InfererValues: []*types.WorkerAttributedValue{
+						{Worker: "worker1", Value: alloraMath.NewDecFromInt64(100)},
+						{Worker: "worker2", Value: alloraMath.NewDecFromInt64(200)},
+					},
+					ForecasterValues: []*types.WorkerAttributedValue{
+						{Worker: "worker1", Value: alloraMath.NewDecFromInt64(300)},
+					},
 					OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
 						{Worker: "worker1", Value: alloraMath.NewDecFromInt64(100)},
 						{Worker: "worker2", Value: alloraMath.NewDecFromInt64(200)},
@@ -491,6 +498,9 @@ func (s *RewardsTestSuite) TestEnsureWorkerPresenceConsistency() {
 			{
 				Pubkey: "reputer2",
 				ValueBundle: &types.ValueBundle{
+					InfererValues: []*types.WorkerAttributedValue{
+						{Worker: "worker5", Value: alloraMath.NewDecFromInt64(100)},
+					},
 					OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
 						{Worker: "worker1", Value: alloraMath.NewDecFromInt64(100)},
 						{Worker: "worker2", Value: alloraMath.NewDecFromInt64(200)},

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -465,7 +465,7 @@ func (s *RewardsTestSuite) TestEnsureWorkerPresenceConsistency() {
 	// Create sample input where reputer1 has fewer workers
 	reportedLosses := types.ReputerValueBundles{
 		ReputerValueBundles: []*types.ReputerValueBundle{
-			{	
+			{
 				Pubkey: "reputer1",
 				ValueBundle: &types.ValueBundle{
 					OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
@@ -507,6 +507,12 @@ func (s *RewardsTestSuite) TestEnsureWorkerPresenceConsistency() {
 					},
 					OneOutInfererForecasterValues: []*types.OneOutInfererForecasterValues{
 						{
+							Forecaster: "forecaster1",
+							OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
+								{Worker: "worker6", Value: alloraMath.NewDecFromInt64(1000)},
+							},
+						},
+						{
 							Forecaster: "forecaster2",
 							OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
 								{Worker: "worker3", Value: alloraMath.NewDecFromInt64(900)},
@@ -518,20 +524,21 @@ func (s *RewardsTestSuite) TestEnsureWorkerPresenceConsistency() {
 			},
 		},
 	}
-	
-	// flatten losses and compare the lengths - not equal
+
+	// Flatten losses and compare lengths before processing
 	reputer1Losses := rewards.ExtractValues(reportedLosses.ReputerValueBundles[0].ValueBundle)
 	reputer2Losses := rewards.ExtractValues(reportedLosses.ReputerValueBundles[1].ValueBundle)
-	s.Require().NotEqual(len(reputer1Losses), len(reputer2Losses))
+	s.Require().NotEqual(len(reputer1Losses), len(reputer2Losses), "Initial lengths should not be equal")
 
 	// Run the function under test
 	updatedLosses := rewards.EnsureWorkerPresence(reportedLosses)
 
-	// flatten losses and compare the lengths - equal
+	// Flatten losses and compare lengths after processing
 	reputer1Losses = rewards.ExtractValues(updatedLosses.ReputerValueBundles[0].ValueBundle)
 	reputer2Losses = rewards.ExtractValues(updatedLosses.ReputerValueBundles[1].ValueBundle)
 
-	s.Require().Equal(len(reputer1Losses), len(reputer2Losses))
+	// Ensure the lengths are equal
+	s.Require().Equal(len(reputer1Losses), len(reputer2Losses), "Lengths should be equal after processing")
 }
 
 func GenerateReputerLatestScores(s *RewardsTestSuite, reputers []sdk.AccAddress, blockHeight int64, topicId uint64) error {

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -461,6 +461,79 @@ func (s *RewardsTestSuite) TestEnsureAllWorkersPresentWithheld() {
 	}
 }
 
+func (s *RewardsTestSuite) TestEnsureWorkerPresenceConsistency() {
+	// Create sample input where reputer1 has fewer workers
+	reportedLosses := types.ReputerValueBundles{
+		ReputerValueBundles: []*types.ReputerValueBundle{
+			{	
+				Pubkey: "reputer1",
+				ValueBundle: &types.ValueBundle{
+					OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
+						{Worker: "worker1", Value: alloraMath.NewDecFromInt64(100)},
+						{Worker: "worker2", Value: alloraMath.NewDecFromInt64(200)},
+					},
+					OneOutForecasterValues: []*types.WithheldWorkerAttributedValue{
+						{Worker: "worker1", Value: alloraMath.NewDecFromInt64(300)},
+					},
+					OneInForecasterValues: []*types.WorkerAttributedValue{
+						{Worker: "worker2", Value: alloraMath.NewDecFromInt64(400)},
+					},
+					OneOutInfererForecasterValues: []*types.OneOutInfererForecasterValues{
+						{
+							Forecaster: "forecaster1",
+							OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
+								{Worker: "worker1", Value: alloraMath.NewDecFromInt64(500)},
+							},
+						},
+					},
+				},
+			},
+			{
+				Pubkey: "reputer2",
+				ValueBundle: &types.ValueBundle{
+					OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
+						{Worker: "worker1", Value: alloraMath.NewDecFromInt64(100)},
+						{Worker: "worker2", Value: alloraMath.NewDecFromInt64(200)},
+						{Worker: "worker3", Value: alloraMath.NewDecFromInt64(300)},
+						{Worker: "worker4", Value: alloraMath.NewDecFromInt64(400)},
+					},
+					OneOutForecasterValues: []*types.WithheldWorkerAttributedValue{
+						{Worker: "worker1", Value: alloraMath.NewDecFromInt64(500)},
+						{Worker: "worker3", Value: alloraMath.NewDecFromInt64(600)},
+					},
+					OneInForecasterValues: []*types.WorkerAttributedValue{
+						{Worker: "worker2", Value: alloraMath.NewDecFromInt64(700)},
+						{Worker: "worker4", Value: alloraMath.NewDecFromInt64(800)},
+					},
+					OneOutInfererForecasterValues: []*types.OneOutInfererForecasterValues{
+						{
+							Forecaster: "forecaster2",
+							OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
+								{Worker: "worker3", Value: alloraMath.NewDecFromInt64(900)},
+								{Worker: "worker4", Value: alloraMath.NewDecFromInt64(1000)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	
+	// flatten losses and compare the lengths - not equal
+	reputer1Losses := rewards.ExtractValues(reportedLosses.ReputerValueBundles[0].ValueBundle)
+	reputer2Losses := rewards.ExtractValues(reportedLosses.ReputerValueBundles[1].ValueBundle)
+	s.Require().NotEqual(len(reputer1Losses), len(reputer2Losses))
+
+	// Run the function under test
+	updatedLosses := rewards.EnsureWorkerPresence(reportedLosses)
+
+	// flatten losses and compare the lengths - equal
+	reputer1Losses = rewards.ExtractValues(updatedLosses.ReputerValueBundles[0].ValueBundle)
+	reputer2Losses = rewards.ExtractValues(updatedLosses.ReputerValueBundles[1].ValueBundle)
+
+	s.Require().Equal(len(reputer1Losses), len(reputer2Losses))
+}
+
 func GenerateReputerLatestScores(s *RewardsTestSuite, reputers []sdk.AccAddress, blockHeight int64, topicId uint64) error {
 	var scores = []alloraMath.Dec{
 		alloraMath.MustNewDecFromString("17.53436"),


### PR DESCRIPTION
One of the properties of the reputer bundle was not being considered in this function, causing a chain halt!