### PR TITLE
only close worker nonces after topic window submission number of blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for all versions `v1.0.0` and beyond (still considered experimental prior to v1.0.0).
 
-## [Unreleased] -- will be v0.4.0
+## [Unreleased]
+
+## v0.4.0
 
 ### Summary
 
@@ -62,6 +64,7 @@ Implements fixes for our [June 2024](https://github.com/sherlock-audit/2024-06-a
 * [#547](https://github.com/allora-network/allora-chain/pull/547) Improve error handling on InsertPayload, fixed/added tests err handling
 * [#550](https://github.com/allora-network/allora-chain/pull/550) Fix reputer window upper limit
 * [#555](https://github.com/allora-network/allora-chain/pull/555) Refactor: Rename TestSuite names
+* [#567](https://github.com/allora-network/allora-chain/pull/567) Fix worker nonce window closing as soon as it opens
 
 ### Security
 

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -2659,18 +2659,9 @@ func (k *Keeper) PruneReputerNonces(ctx context.Context, topicId uint64, blockHe
 	return nil
 }
 
-// Return true if the topic has met its cadence or is the first run
-func (k *Keeper) CheckWorkerOpenCadence(blockHeight int64, topic types.Topic) bool {
-	return (blockHeight-topic.EpochLastEnded)%topic.EpochLength == 0 ||
-		topic.EpochLastEnded == 0
-}
-
-func (k *Keeper) CheckWorkerCloseCadence(blockHeight int64, topic types.Topic) bool {
-	return blockHeight-topic.EpochLastEnded == topic.WorkerSubmissionWindow
-}
-
-func (k *Keeper) CheckReputerCloseCadence(blockHeight int64, topic types.Topic) bool {
-	return (blockHeight-topic.EpochLastEnded)%topic.EpochLength == 0
+// Return true if the nonce is within the worker submission window for the topic
+func (k *Keeper) BlockWithinWorkerSubmissionWindowOfNonce(topic types.Topic, nonce types.Nonce, blockHeight int64) bool {
+	return nonce.BlockHeight <= blockHeight && blockHeight < topic.WorkerSubmissionWindow+nonce.BlockHeight
 }
 
 func (k *Keeper) ValidateStringIsBech32(actor ActorId) error {

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -82,7 +82,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 				}
 				for _, nonce := range nonces.Nonces {
 					// If the nonce plus the worker submission window is greater than the current block height, then the window is still open => skip
-					if nonce.BlockHeight+topic.WorkerSubmissionWindow > blockHeight {
+					if am.keeper.BlockWithinWorkerSubmissionWindowOfNonce(topic, *nonce, blockHeight) {
 						sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker %d: Worker window still open for topic: %d, nonce: %v", blockHeight, topicId, nonce))
 						continue
 					}

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -81,7 +81,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 					continue
 				}
 				for _, nonce := range nonces.Nonces {
-					// If the nonce plus the worker submission window is greater than the current block height, then the window is still open => skip
+					// Skip rest of logic if the worker submission window is still open (i.e. don't close the window yet)
 					if am.keeper.BlockWithinWorkerSubmissionWindowOfNonce(topic, *nonce, blockHeight) {
 						sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker %d: Worker window still open for topic: %d, nonce: %v", blockHeight, topicId, nonce))
 						continue

--- a/x/emissions/module/rewards/nonce_management.go
+++ b/x/emissions/module/rewards/nonce_management.go
@@ -59,7 +59,7 @@ func PruneReputerAndWorkerNonces(ctx sdk.Context, k keeper.Keeper, topic types.T
 		// Reputer nonces need to check worker nonces from one epoch before
 		workerPruningBlock := reputerPruningBlock - topic.EpochLength
 		if workerPruningBlock > 0 {
-			ctx.Logger().Debug("Pruning worker nonces before block: ", workerPruningBlock, " for topic: ", topic.Id)
+			ctx.Logger().Debug(fmt.Sprintf("Pruning worker nonces before block: %d  for topic: %d", workerPruningBlock, topic.Id))
 			// Prune old worker nonces previous to current block to avoid inserting inferences after its time has passed
 			err = k.PruneWorkerNonces(ctx, topic.Id, workerPruningBlock)
 			if err != nil {

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -1455,6 +1455,7 @@ type TestWorkerValue struct {
 func GenerateSimpleWorkerDataBundles(
 	s *RewardsTestSuite,
 	topicId uint64,
+	nonce int64,
 	blockHeight int64,
 	workerValues []TestWorkerValue,
 	infererAddrs []sdk.AccAddress,
@@ -1508,7 +1509,7 @@ func GenerateSimpleWorkerDataBundles(
 		s.Require().NoError(err)
 		workerBundle := &types.WorkerDataBundle{
 			Worker:                             workerValue.Address.String(),
-			Nonce:                              &types.Nonce{BlockHeight: blockHeight},
+			Nonce:                              &types.Nonce{BlockHeight: nonce},
 			TopicId:                            topicId,
 			InferenceForecastsBundle:           newWorkerInferenceForecastBundle,
 			InferencesForecastsBundleSignature: workerSig,
@@ -1523,6 +1524,7 @@ func GenerateSimpleWorkerDataBundles(
 func GenerateSimpleLossBundles(
 	s *RewardsTestSuite,
 	topicId uint64,
+	nonce int64,
 	blockHeight int64,
 	workerValues []TestWorkerValue,
 	reputerValues []TestWorkerValue,
@@ -1543,7 +1545,7 @@ func GenerateSimpleLossBundles(
 			TopicId: topicId,
 			ReputerRequestNonce: &types.ReputerRequestNonce{
 				ReputerNonce: &types.Nonce{
-					BlockHeight: blockHeight,
+					BlockHeight: nonce,
 				},
 			},
 			Reputer:                reputer.Address.String(),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Issue originally identified by @RedBird96 

Our devnet revealed the following suspicious coincidences in time of worker nonce creation and fulfillment:

<img width="573" alt="image" src="https://github.com/user-attachments/assets/5ca4b565-6878-4128-a66d-19e0b09191be">

and:
<img width="773" alt="image" src="https://github.com/user-attachments/assets/b15bd61d-4ddf-47dc-9c89-9710863909e9">

This was in addition to a glut logs on our workers that showed many attempts to commit data yet minimal success.
Additionally, many community members have been reporting inability to participate in testnet for quite some time.

It appears our worker nonces are sometimes being closed immediately after they're opened.

I don't understand why this is not universally the case, but my reading of the code is congruent with the observation that this is overwhelmingly the case, making it impossible to join a topic epoch unless you happen to time yourself exactly when the worker nonce is opened/closed.

## After Merge

Must also merge to `dev` branch.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
