### PR TITLE
Do not migrate active topic management 

### DIFF
--- a/x/emissions/migrations/v3/migrate.go
+++ b/x/emissions/migrations/v3/migrate.go
@@ -151,7 +151,7 @@ func getNewTopic(oldMsg oldtypes.Topic) types.Topic {
 		PNorm:          oldMsg.PNorm,
 		AlphaRegret:    oldMsg.AlphaRegret,
 		AllowNegative:  oldMsg.AllowNegative,
-		Epsilon:        alloraMath.MustNewDecFromString("0.01"),
+		Epsilon:        oldMsg.Epsilon,
 		// InitialRegret is being reset to account for NaNs that were previously stored due to insufficient validation
 		InitialRegret:          alloraMath.MustNewDecFromString("0"),
 		WorkerSubmissionWindow: oldMsg.WorkerSubmissionWindow,


### PR DESCRIPTION
## Purpose of Changes and their Description

This PR forgoes migrating which topics are active, in favor of an approach where we manually re-activate topics after the upgrade.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
#574 

## Are these changes tested and documented?

Re-uses existing tests.
