### PR TITLE
clear rewardable topics each block after rewards paid

### DIFF
--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -2430,11 +2430,13 @@ func (s *KeeperTestSuite) TestAddTopicFeeRevenue() {
 
 /// REWARDABLE TOPICS
 
-func (s *KeeperTestSuite) TestRewardableTopics() {
+func (s *KeeperTestSuite) TestClearRewardableTopics() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 	topicId := uint64(789)
 	topicId2 := uint64(101112)
+
+	keeper.SetParams(ctx, types.Params{MaxActiveTopicsPerBlock: 2})
 
 	// Add rewardable topics
 	err := keeper.AddRewardableTopic(ctx, topicId)
@@ -2449,13 +2451,13 @@ func (s *KeeperTestSuite) TestRewardableTopics() {
 	s.Require().Len(retrievedIds, 2, "Should retrieve all rewardable topics")
 
 	// Reset the rewardable topics
-	err = keeper.RemoveRewardableTopic(ctx, topicId)
+	err = keeper.ClearRewardableTopics(ctx)
 	s.Require().NoError(err)
 
 	// Ensure no topics remain
 	remainingIds, err := keeper.GetRewardableTopics(ctx)
 	s.Require().NoError(err)
-	s.Require().Len(remainingIds, 1)
+	s.Require().Len(remainingIds, 0)
 }
 
 /// SCORES

--- a/x/emissions/keeper/queryserver/query_server_topics_test.go
+++ b/x/emissions/keeper/queryserver/query_server_topics_test.go
@@ -273,6 +273,8 @@ func (s *QueryServerTestSuite) TestGetRewardableTopics() {
 	topicId := uint64(789)
 	topicId2 := uint64(101112)
 
+	keeper.SetParams(ctx, types.Params{MaxActiveTopicsPerBlock: 2})
+
 	// Add rewardable topics
 	err := keeper.AddRewardableTopic(ctx, topicId)
 	s.Require().NoError(err)
@@ -288,13 +290,11 @@ func (s *QueryServerTestSuite) TestGetRewardableTopics() {
 	s.Require().Len(retrievedIds, 2, "Should retrieve all rewardable topics")
 
 	// Reset the rewardable topics
-	err = keeper.RemoveRewardableTopic(ctx, topicId)
+	err = keeper.ClearRewardableTopics(ctx)
 	s.Require().NoError(err)
 
 	// Ensure no topics remain
-	req = &types.QueryRewardableTopicsRequest{}
-	response, err = s.queryServer.GetRewardableTopics(ctx, req)
-	remainingIds := response.RewardableTopicIds
+	remainingIds, err := keeper.GetRewardableTopics(ctx)
 	s.Require().NoError(err)
-	s.Require().Len(remainingIds, 1)
+	s.Require().Len(remainingIds, 0)
 }

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -49,6 +49,10 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		sdkCtx.Logger().Error("Error calculating global emission per topic: ", err)
 		return errors.Wrapf(err, "Rewards error")
 	}
+	err = am.keeper.ClearRewardableTopics(ctx)
+	if err != nil {
+		sdkCtx.Logger().Error("Failed to clear rewardable topics", err)
+	}
 
 	err = rewards.PickChurnableActiveTopics(
 		sdkCtx,

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -140,18 +140,6 @@ func EmitRewards(
 			)
 			continue
 		}
-
-		err = k.RemoveRewardableTopic(ctx, topicId)
-		if err != nil {
-			Logger(ctx).Warn(
-				fmt.Sprintf(
-					"Failed to remove rewardable topic:\nTopic Id %d\nError:\n%s\n\n",
-					topicId,
-					err.Error(),
-				),
-			)
-			continue
-		}
 	}
 	Logger(ctx).Debug(
 		fmt.Sprintf("Paid out %s to staked reputers over %d topics",

--- a/x/emissions/module/rewards/topic_rewards_test.go
+++ b/x/emissions/module/rewards/topic_rewards_test.go
@@ -3,8 +3,10 @@ package rewards_test
 import (
 	cosmosMath "cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
+	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (s *RewardsTestSuite) TestGetAndUpdateActiveTopicWeights() {
@@ -73,4 +75,124 @@ func (s *RewardsTestSuite) TestGetAndUpdateActiveTopicWeights() {
 	activeTopics, err = s.emissionsKeeper.GetActiveTopicIdsAtBlock(ctx, 46)
 	s.Require().NoError(err, "Fetching active topics should not produce an error")
 	s.Require().Equal(1, len(activeTopics.TopicIds), "Should retrieve exactly one active topics")
+}
+
+func (s *RewardsTestSuite) TestGetRewardAndRemovedRewardableTopics() {
+	block := int64(1)
+	s.ctx = s.ctx.WithBlockHeight(block)
+
+	s.SetParamsForTest()
+
+	reputerAddrs := s.returnAddresses(0, 3)
+
+	workerAddrs := s.returnAddresses(3, 3)
+	// setup topics
+	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
+
+	alphaRegret := alloraMath.MustNewDecFromString("0.1")
+	epochLength := int64(100)
+	topicId0 := s.setUpTopicWithEpochLength(block, workerAddrs, reputerAddrs, stake, alphaRegret, epochLength)
+	//topicId1 := s.setUpTopicWithEpochLength(block, workerAddrs, reputerAddrs, stake, alphaRegret, epochLength)
+	//
+	// setup values to be identical for both topics
+	reputerValues := []TestWorkerValue{
+		{Address: reputerAddrs[0], Value: "0.2"},
+		{Address: reputerAddrs[1], Value: "0.2"},
+		{Address: reputerAddrs[2], Value: "0.2"},
+	}
+
+	workerValues := []TestWorkerValue{
+		{Address: workerAddrs[0], Value: "0.2"},
+		{Address: workerAddrs[1], Value: "0.2"},
+		{Address: workerAddrs[2], Value: "0.2"},
+	}
+
+	// mint some rewards to give out
+	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(100000))
+
+	// Move to end of this epoch block
+	nextBlock, _, err := s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId0)
+	s.Require().NoError(err)
+	block = nextBlock
+	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	err = s.emissionsAppModule.EndBlock(s.ctx)
+	s.Require().NoError(err)
+
+	topic0, err := s.emissionsKeeper.GetTopic(s.ctx, topicId0)
+	s.Require().NoError(err)
+
+	// Insert inference
+	inferenceBundles := GenerateSimpleWorkerDataBundles(s, topicId0, topic0.EpochLastEnded, block, workerValues, workerAddrs)
+	for _, payload := range inferenceBundles {
+		s.RegisterAllWorkersOfPayload(topicId0, payload)
+		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.MsgInsertWorkerPayload{
+			Sender:           payload.Worker,
+			WorkerDataBundle: payload,
+		})
+		s.Require().NoError(err)
+	}
+
+	// Advance to close the window
+	block = block + topic0.WorkerSubmissionWindow
+	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+
+	// EndBlock closes the  worker nonce
+	err = s.emissionsAppModule.EndBlock(s.ctx)
+	s.Require().NoError(err)
+
+	// Generate loss data
+	lossBundles := GenerateSimpleLossBundles(
+		s,
+		topicId0,
+		topic0.EpochLastEnded,
+		block,
+		workerValues,
+		reputerValues,
+		workerAddrs[0],
+		"0.1",
+		"0.1",
+	)
+
+	// Insert reputation
+	block = block + topic0.GroundTruthLag
+	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	for _, payload := range lossBundles.ReputerValueBundles {
+		s.RegisterAllReputersOfPayload(topicId0, payload)
+		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.MsgInsertReputerPayload{
+			Sender:             payload.ValueBundle.Reputer,
+			ReputerValueBundle: payload,
+		})
+		s.Require().NoError(err)
+	}
+
+	block = block + 1
+	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	err = s.emissionsAppModule.EndBlock(s.ctx)
+	s.Require().NoError(err)
+
+	// Move to next end of epoch
+	nextBlock, _, err = s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId0)
+	s.Require().NoError(err)
+	block = nextBlock
+	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	// EndBlock for closes the reputer nonce & add rewardable nonce
+	err = s.emissionsAppModule.EndBlock(s.ctx)
+	s.Require().NoError(err)
+
+	rewardableTopics, err := s.emissionsKeeper.GetRewardableTopics(s.ctx)
+	s.Require().NoError(err)
+
+	// Check topic0 added to rewardable topics store
+	s.Require().Len(rewardableTopics, 1)
+	s.Require().Equal(topicId0, rewardableTopics[0])
+
+	block = block + 1
+	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	err = s.emissionsAppModule.EndBlock(s.ctx)
+	s.Require().NoError(err)
+
+	// Check if rewardable topics are removed
+	rewardableTopics, err = s.emissionsKeeper.GetRewardableTopics(s.ctx)
+	s.Require().NoError(err)
+	s.Require().Len(rewardableTopics, 0)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Rewards are not being cleared each block.
This was causing issue when there was error in at least 1 epoch per topic after the migration, as was expected and did occur (for just 1 epoch).
This error meant that rewards would "bug out" before the topic could be removed from the rewardable set.
We fix this by clearing out the whole rewardable set after rewards calculation of each block.

I set a hard bound of `MaxActiveTopicsPerBlock + 1` because one less than that many should ever be part of the rewardable set per block. If there are errors, then the +1 ensure that they automatically, eventually get cleared off.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
   - Unit tests
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo
