### PR TITLE
resolve exhaustruct on synth while preserving builder

### DIFF
--- a/x/emissions/keeper/inference_synthesis/network_losses.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses.go
@@ -263,6 +263,7 @@ func CalcNetworkLosses(
 		OneOutInfererValues:           oneOutInfererLosses,
 		OneOutForecasterValues:        oneOutForecasterLosses,
 		OneInForecasterValues:         oneInForecasterLosses,
+		ExtraData:                     make([]byte, 0),
 	}
 
 	return output, nil

--- a/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_bootstrap.go
@@ -93,6 +93,7 @@ func (p SynthPalette) Clone() SynthPalette {
 		Ctx:                              p.Ctx,
 		K:                                p.K,
 		Logger:                           p.Logger,
+		Nonce:                            p.Nonce,
 		TopicId:                          p.TopicId,
 		Inferers:                         append([]Worker(nil), p.Inferers...),
 		InferenceByWorker:                inferenceByWorker,
@@ -106,5 +107,6 @@ func (p SynthPalette) Clone() SynthPalette {
 		EpsilonSafeDiv:                   p.EpsilonSafeDiv,
 		PNorm:                            p.PNorm,
 		CNorm:                            p.CNorm,
+		AllInferersAreNew:                p.AllInferersAreNew,
 	}
 }

--- a/x/emissions/keeper/inference_synthesis/synth_palette_factory.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_factory.go
@@ -22,6 +22,7 @@ func (f *SynthPaletteFactory) BuildPaletteFromRequest(req SynthRequest) (SynthPa
 		K:                                req.K,
 		Logger:                           Logger(req.Ctx),
 		TopicId:                          req.TopicId,
+		Nonce:                            *req.Nonce,
 		AllInferersAreNew:                topic.InitialRegret.Equal(alloraMath.ZeroDec()), // If initial regret is 0, all inferers are new
 		Inferers:                         sortedInferers,
 		InferenceByWorker:                inferenceByWorker,

--- a/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied.go
+++ b/x/emissions/keeper/inference_synthesis/synth_palette_forecast_implied.go
@@ -61,8 +61,12 @@ func (p *SynthPalette) CalcForecastImpliedInferences() (map[Worker]*emissionstyp
 				}
 
 				forecastImpliedInference := emissionstypes.Inference{
-					Inferer: forecaster,
-					Value:   medianValue,
+					Inferer:     forecaster,
+					Value:       medianValue,
+					TopicId:     p.TopicId,
+					BlockHeight: p.Nonce.BlockHeight,
+					ExtraData:   make([]byte, 0),
+					Proof:       "",
 				}
 				I_i[forecaster] = &forecastImpliedInference
 			} else {
@@ -127,8 +131,12 @@ func (p *SynthPalette) CalcForecastImpliedInferences() (map[Worker]*emissionstyp
 						return nil, errorsmod.Wrapf(err, "error calculating forecast value")
 					}
 					forecastImpliedInference := emissionstypes.Inference{
-						Inferer: forecaster,
-						Value:   forecastValue,
+						Inferer:     forecaster,
+						Value:       forecastValue,
+						TopicId:     p.TopicId,
+						BlockHeight: p.Nonce.BlockHeight,
+						ExtraData:   make([]byte, 0),
+						Proof:       "",
 					}
 					I_i[forecaster] = &forecastImpliedInference
 				}

--- a/x/emissions/keeper/inference_synthesis/types.go
+++ b/x/emissions/keeper/inference_synthesis/types.go
@@ -29,6 +29,7 @@ type SynthRequest struct {
 	Ctx                 sdk.Context
 	K                   keeper.Keeper
 	TopicId             TopicId
+	Nonce               *emissions.Nonce
 	Inferences          *emissions.Inferences
 	Forecasts           *emissions.Forecasts
 	NetworkCombinedLoss Loss
@@ -44,6 +45,7 @@ type SynthPalette struct {
 	Ctx               sdk.Context
 	K                 keeper.Keeper
 	Logger            log.Logger
+	Nonce             emissions.Nonce
 	TopicId           TopicId
 	AllInferersAreNew bool
 	// Should use this as a source of truth regarding for which inferers to have data calculated


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

This is my alternative to https://github.com/allora-network/allora-chain/pull/538

I have absolutely been burned before for having too many arg params. I've fixed many bugs directly resulting from this. The pattern employed there is really not great in my opinion.

In this PR I ready synth for exhaustruct while preserving the patterns.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

* I have not applied exhaustruct remediation to tests
* Testing and remediation of rest of code for exhaustruct (though perhaps for another PR)
* Other improvements and any bug fixes @relyt29 identified in https://github.com/allora-network/allora-chain/pull/538 should be included here
* The optimization @guilherme-brandao identified in our chats (to remove duplicate valiations and clone operation) could neatly be included here as well