### PR TITLE
rm excessive tx length check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Summary TBD
 ### Refactor
 
 * [#538](https://github.com/allora-network/allora-chain/pull/538) Refactor Inference Synthesis to use Functions instead of "Builder Pattern"
+* [#623](https://github.com/allora-network/allora-chain/pull/623) Optimize worker and reputer payload ingress
 
 ### Monitoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ Summary TBD
 * [#620](https://github.com/allora-network/allora-chain/pull/620) Add a static analyzer to detect non-deferred `.Close()` calls, improve migration error handling
 * [#622](https://github.com/allora-network/allora-chain/pull/622) Add telemetry metrics on queries/txs
 
+### Removed
+
+* [#626](https://github.com/allora-network/allora-chain/pull/626) Remove excess check on input length for worker and reputer payloads and deprecate related `max_serialized_msg_length` parameter
+
 ### Refactor
 
 * [#538](https://github.com/allora-network/allora-chain/pull/538) Refactor Inference Synthesis to use Functions instead of "Builder Pattern"

--- a/x/emissions/keeper/msgserver/msg_server.go
+++ b/x/emissions/keeper/msgserver/msg_server.go
@@ -3,7 +3,6 @@ package msgserver
 import (
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	"github.com/gogo/protobuf/proto"
 )
 
 type msgServer struct {
@@ -15,18 +14,4 @@ var _ types.MsgServiceServer = msgServer{k: keeper.Keeper{}}
 // NewMsgServerImpl returns an implementation of the module MsgServer interface.
 func NewMsgServerImpl(keeper keeper.Keeper) types.MsgServiceServer {
 	return &msgServer{k: keeper}
-}
-
-func checkInputLength(maxSerializedMsgLength int64, msg proto.Message) error {
-	serializedMsg, err := proto.Marshal(msg)
-	if err != nil {
-		return types.ErrFailedToSerializePayload
-	}
-
-	// Check the length of the serialized message
-	if int64(len(serializedMsg)) > maxSerializedMsgLength {
-		return types.ErrQueryTooLarge
-	}
-
-	return nil
 }

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
@@ -32,10 +32,6 @@ func (ms msgServer) InsertReputerPayload(ctx context.Context, msg *types.InsertR
 	if err != nil {
 		return nil, errorsmod.Wrapf(err, "Error getting params for sender: %v", &msg.Sender)
 	}
-	err = checkInputLength(moduleParams.MaxSerializedMsgLength, msg)
-	if err != nil {
-		return nil, err
-	}
 
 	nonce := msg.ReputerValueBundle.ValueBundle.ReputerRequestNonce
 	topicId := msg.ReputerValueBundle.ValueBundle.TopicId

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -35,10 +35,6 @@ func (ms msgServer) InsertWorkerPayload(ctx context.Context, msg *types.InsertWo
 	if err != nil {
 		return nil, errorsmod.Wrapf(err, "Error getting params for sender: %v", &msg.Sender)
 	}
-	err = checkInputLength(moduleParams.MaxSerializedMsgLength, msg)
-	if err != nil {
-		return nil, err
-	}
 
 	nonce := msg.WorkerDataBundle.Nonce
 	topicId := msg.WorkerDataBundle.TopicId

--- a/x/emissions/proto/emissions/v4/params.proto
+++ b/x/emissions/proto/emissions/v4/params.proto
@@ -14,7 +14,7 @@ message Params {
 
   string version = 1; // version of the protocol should be in lockstep with
   // github release tag version
-  int64 max_serialized_msg_length = 2; // max length of input data for msg and query server calls
+  int64 max_serialized_msg_length = 2 [deprecated = true]; // max length of input data for msg and query server calls
   string min_topic_weight = 3 [
     (gogoproto.customtype) = "github.com/allora-network/allora-chain/math.Dec",
     (gogoproto.nullable) = false

--- a/x/emissions/proto/emissions/v4/tx.proto
+++ b/x/emissions/proto/emissions/v4/tx.proto
@@ -60,7 +60,7 @@ message OptionalParams {
   reserved "max_topics_per_block", "min_effective_topic_revenue", "max_retries_to_fulfil_nonces_worker", "topic_fee_revenue_decay_rate", "max_retries_to_fulfil_nonces_reputer";
 
   repeated string version = 1;
-  repeated int64 max_serialized_msg_length = 2;
+  repeated int64 max_serialized_msg_length = 2 [deprecated = true];
   repeated string min_topic_weight = 3 [
     (gogoproto.customtype) = "github.com/allora-network/allora-chain/math.Dec",
     (gogoproto.nullable) = false


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

I think `checkInputLength()`, a check of the total msg size on each data ingress, is redundant and partially causing slowdowns at scale, shown here edited in [Guilherme’s recent PR](https://github.com/allora-network/allora-chain/pull/623)

Our profiling shows a lot of marshalling taking up precious memory, and this check is on every singple data ingress => easily could be one of the culprits. This check marshalls the entire proto msg afterall.

Meanwhile, there are configs to handle this already in `config.toml` and `app.toml` e.g. `max_tx_bytes` and gas-related params and market action. We obviosuly didn’t know this when we first added these checks.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
