### PR TITLE
Use a pool to reduce allocations and GC operations on marshal calls

### DIFF
--- a/test/testutil/testdata.go
+++ b/test/testutil/testdata.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
-	"sync"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/utils"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
@@ -15,11 +15,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var valueBundleBufferPool = sync.Pool{
-	New: func() interface{} {
-		return make([]byte, 0, 1024)
-	},
-}
+var valueBundleBufferPool = utils.NewBytesPool(1024, 0)
 
 func GenerateTestAccounts(count int) (
 	privKeys []secp256k1.PrivKey,
@@ -538,9 +534,8 @@ func GetNetworkLossFromCsv(
 }
 
 func signValueBundle(valueBundle *emissionstypes.ValueBundle, privateKey secp256k1.PrivKey) []byte {
-	buf := valueBundleBufferPool.Get().([]byte) // nolint:forcetypeassert
-	defer valueBundleBufferPool.Put(buf)        //nolint:staticcheck
-	buf = buf[:0]
+	buf := valueBundleBufferPool.Get()
+	defer valueBundleBufferPool.Put(buf)
 	marshaled, err := valueBundle.XXX_Marshal(buf, true)
 	if err != nil {
 		panic(err)

--- a/utils/syncpool.go
+++ b/utils/syncpool.go
@@ -1,0 +1,59 @@
+package utils
+
+import "sync"
+
+type Pool[T any] struct {
+	sync.Pool
+	reset func(T) T
+	valid func(T) bool
+}
+
+func (p *Pool[T]) Get() T {
+	return p.Pool.Get().(T) //nolint:forcetypeassert // we know the type from the pool definition
+}
+
+func (p *Pool[T]) Put(x T) {
+	// Check if the item is valid
+	if p.valid != nil {
+		if !p.valid(x) {
+			return
+		}
+	}
+
+	// Reset
+	if p.reset != nil {
+		x = p.reset(x)
+	}
+
+	// Put it back in the pool
+	p.Pool.Put(x)
+}
+
+func NewPool[T any](newF func() T, reset func(T) T, valid func(T) bool) *Pool[T] {
+	return &Pool[T]{
+		Pool: sync.Pool{
+			New: func() any {
+				return newF()
+			},
+		},
+		reset: reset,
+		valid: valid,
+	}
+}
+
+func NewBytesPool(size int, maxSize int) *Pool[[]byte] {
+	return NewPool[[]byte](func() []byte {
+		return make([]byte, 0, size)
+	}, func(b []byte) []byte {
+		return b[:0]
+	}, func(b []byte) bool {
+		if cap(b) < size {
+			return false
+		}
+
+		if maxSize == 0 {
+			return true
+		}
+		return cap(b) <= maxSize
+	})
+}

--- a/utils/syncpool_test.go
+++ b/utils/syncpool_test.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPool(t *testing.T) {
@@ -12,15 +14,10 @@ func TestNewPool(t *testing.T) {
 		return x + 1
 	}
 	pool := NewPool(newFunc, resetFunc, nil)
-
-	if pool == nil {
-		t.Fatal("Expected pool to be initialized")
-	}
+	require.NotNil(t, pool, "Expected pool to be initialized")
 
 	x := pool.Get()
-	if x != 42 {
-		t.Errorf("Expected Get() to return 42, got %d", x)
-	}
+	require.Equal(t, 42, x, "Expected Get() to return 42")
 }
 
 func TestPool_GetPut(t *testing.T) {
@@ -28,31 +25,23 @@ func TestPool_GetPut(t *testing.T) {
 
 	// Get a new item
 	s := pool.Get()
-	if s != "initial" {
-		t.Errorf("Expected 'initial', got '%s'", s)
-	}
+	require.Equal(t, "initial", s, "Expected 'initial'")
 
 	// Put back a different string
 	pool.Put("updated")
 
 	// Get should return the updated string
 	s = pool.Get()
-	if s != "updated" {
-		t.Errorf("Expected 'updated', got '%s'", s)
-	}
+	require.Equal(t, "updated", s, "Expected 'updated'")
 }
 
 func TestNewBytesPool(t *testing.T) {
 	size := 1024
 	bytesPool := NewBytesPool(size, 0)
-	if bytesPool == nil {
-		t.Fatal("Expected bytes pool to be initialized")
-	}
+	require.NotNil(t, bytesPool, "Expected bytes pool to be initialized")
 
 	b := bytesPool.Get()
-	if cap(b) != size {
-		t.Errorf("Expected byte slice with capacity %d, got %d", size, cap(b))
-	}
+	require.Equal(t, size, cap(b), "Expected byte slice with capacity %d", size)
 
 	// Modify and put back
 	b = append(b, 1, 2, 3)
@@ -60,31 +49,23 @@ func TestNewBytesPool(t *testing.T) {
 
 	// Get again and check reset
 	b = bytesPool.Get()
-	if len(b) != 0 {
-		t.Errorf("Expected byte slice length 0 after reset, got %d", len(b))
-	}
+	require.Empty(t, b, "Expected byte slice length 0 after reset")
 
 	// Change the size of b
 	b = make([]byte, size+1)
 	bytesPool.Put(b)
 	b = bytesPool.Get()
-	if cap(b) != size+1 {
-		t.Errorf("Expected byte slice with capacity %d, got %d", size+1, cap(b))
-	}
+	require.Equal(t, size+1, cap(b), "Expected byte slice with capacity %d", size+1)
 
 	bytesPool = NewBytesPool(size, size+1)
 	b = make([]byte, size+2)
 	bytesPool.Put(b)
 	b = bytesPool.Get()
-	if cap(b) != size {
-		t.Errorf("Expected byte slice with capacity %d, got %d", size, cap(b))
-	}
+	require.Equal(t, size, cap(b), "Expected byte slice with capacity %d", size)
 
 	bytesPool = NewBytesPool(size, 0)
 	b = nil
 	bytesPool.Put(b)
 	b = bytesPool.Get()
-	if cap(b) != size {
-		t.Errorf("Expected byte slice with capacity %d, got %d", size, cap(b))
-	}
+	require.Equal(t, size, cap(b), "Expected byte slice with capacity %d", size)
 }

--- a/utils/syncpool_test.go
+++ b/utils/syncpool_test.go
@@ -1,0 +1,90 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestNewPool(t *testing.T) {
+	newFunc := func() int {
+		return 42
+	}
+	resetFunc := func(x int) int {
+		return x + 1
+	}
+	pool := NewPool(newFunc, resetFunc, nil)
+
+	if pool == nil {
+		t.Fatal("Expected pool to be initialized")
+	}
+
+	x := pool.Get()
+	if x != 42 {
+		t.Errorf("Expected Get() to return 42, got %d", x)
+	}
+}
+
+func TestPool_GetPut(t *testing.T) {
+	pool := NewPool(func() string { return "initial" }, nil, nil)
+
+	// Get a new item
+	s := pool.Get()
+	if s != "initial" {
+		t.Errorf("Expected 'initial', got '%s'", s)
+	}
+
+	// Put back a different string
+	pool.Put("updated")
+
+	// Get should return the updated string
+	s = pool.Get()
+	if s != "updated" {
+		t.Errorf("Expected 'updated', got '%s'", s)
+	}
+}
+
+func TestNewBytesPool(t *testing.T) {
+	size := 1024
+	bytesPool := NewBytesPool(size, 0)
+	if bytesPool == nil {
+		t.Fatal("Expected bytes pool to be initialized")
+	}
+
+	b := bytesPool.Get()
+	if cap(b) != size {
+		t.Errorf("Expected byte slice with capacity %d, got %d", size, cap(b))
+	}
+
+	// Modify and put back
+	b = append(b, 1, 2, 3)
+	bytesPool.Put(b)
+
+	// Get again and check reset
+	b = bytesPool.Get()
+	if len(b) != 0 {
+		t.Errorf("Expected byte slice length 0 after reset, got %d", len(b))
+	}
+
+	// Change the size of b
+	b = make([]byte, size+1)
+	bytesPool.Put(b)
+	b = bytesPool.Get()
+	if cap(b) != size+1 {
+		t.Errorf("Expected byte slice with capacity %d, got %d", size+1, cap(b))
+	}
+
+	bytesPool = NewBytesPool(size, size+1)
+	b = make([]byte, size+2)
+	bytesPool.Put(b)
+	b = bytesPool.Get()
+	if cap(b) != size {
+		t.Errorf("Expected byte slice with capacity %d, got %d", size, cap(b))
+	}
+
+	bytesPool = NewBytesPool(size, 0)
+	b = nil
+	bytesPool.Put(b)
+	b = bytesPool.Get()
+	if cap(b) != size {
+		t.Errorf("Expected byte slice with capacity %d, got %d", size, cap(b))
+	}
+}

--- a/x/emissions/keeper/msgserver/msg_server.go
+++ b/x/emissions/keeper/msgserver/msg_server.go
@@ -25,13 +25,10 @@ func checkInputLength(ctx context.Context, ms msgServer, msg proto.Message) erro
 		return err
 	}
 
-	serializedMsg, err := proto.Marshal(msg)
-	if err != nil {
-		return types.ErrFailedToSerializePayload
-	}
+	size := proto.Size(msg)
 
 	// Check the length of the serialized message
-	if int64(len(serializedMsg)) > params.MaxSerializedMsgLength {
+	if int64(size) > params.MaxSerializedMsgLength {
 		return types.ErrQueryTooLarge
 	}
 

--- a/x/emissions/types/validations.go
+++ b/x/emissions/types/validations.go
@@ -2,27 +2,20 @@ package types
 
 import (
 	"encoding/hex"
-	"sync"
 
 	"cosmossdk.io/errors"
 	cosmosMath "cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/utils"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-var reputerValueBundleBufferPool = sync.Pool{
-	New: func() interface{} {
-		return make([]byte, 0, 1024)
-	},
-}
-
-var inferenceForecastsBundleBufferPool = sync.Pool{
-	New: func() interface{} {
-		return make([]byte, 0, 1024)
-	},
-}
+var (
+	reputerValueBundleBufferPool       = utils.NewBytesPool(1024, 0)
+	inferenceForecastsBundleBufferPool = utils.NewBytesPool(1024, 0)
+)
 
 /// EXTERNAL TYPE VALIDATIONS
 
@@ -225,9 +218,8 @@ func (bundle *WorkerDataBundle) Validate() error {
 	}
 
 	// Check signature from the bundle, throw if invalid!
-	buf := inferenceForecastsBundleBufferPool.Get().([]byte) // nolint:forcetypeassert
-	defer inferenceForecastsBundleBufferPool.Put(buf)        //nolint:staticcheck
-	buf = buf[:0]
+	buf := inferenceForecastsBundleBufferPool.Get()
+	defer inferenceForecastsBundleBufferPool.Put(buf)
 	marshaled, err := bundle.InferenceForecastsBundle.XXX_Marshal(buf, true)
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "failed to marshal inference forecasts bundle: %s", err)
@@ -338,9 +330,8 @@ func (bundle *ReputerValueBundle) Validate() error {
 		return errors.Wrap(err, "value bundle is invalid")
 	}
 
-	buf := reputerValueBundleBufferPool.Get().([]byte) // nolint:forcetypeassert
-	defer reputerValueBundleBufferPool.Put(buf)        //nolint:staticcheck
-	buf = buf[:0]
+	buf := reputerValueBundleBufferPool.Get()
+	defer reputerValueBundleBufferPool.Put(buf)
 	marshaled, err := bundle.ValueBundle.XXX_Marshal(buf, true)
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "failed to marshal value bundle: %s", err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Reduce memory allocations and GC operations by reusing buffers from a pool when we call marshal.

Inspired by https://github.com/cosmos/cosmos-sdk/blob/ee3d320eaa55e5aab1bf216f03a8d8aa5833d549/store/v2/internal/encoding/encoding.go#L140-L141

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/cosm/efficient-protobuf-serialization

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
