### PR TITLE
missing InitGenesis entry for rewardCurrentBlockEmission

### DIFF
--- a/x/emissions/keeper/genesis.go
+++ b/x/emissions/keeper/genesis.go
@@ -881,6 +881,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 		}
 	}
 
+	// TotalSumPreviousTopicWeights
 	if data.TotalSumPreviousTopicWeights.Gt(alloraMath.ZeroDec()) {
 		if err := k.SetTotalSumPreviousTopicWeights(ctx, data.TotalSumPreviousTopicWeights); err != nil {
 			return errors.Wrap(err, "error setting TotalSumPreviousTopicWeights")
@@ -890,6 +891,18 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 			return errors.Wrap(err, "error setting TotalSumPreviousTopicWeights to zero int")
 		}
 	}
+
+	// RewardsCurrentBlockEmission cosmossdk_io_math.Int
+	if data.RewardCurrentBlockEmission.GT(cosmosMath.ZeroInt()) {
+		if err := k.SetRewardCurrentBlockEmission(ctx, data.RewardCurrentBlockEmission); err != nil {
+			return errors.Wrap(err, "error setting RewardCurrentBlockEmission")
+		}
+	} else {
+		if err := k.SetRewardCurrentBlockEmission(ctx, cosmosMath.ZeroInt()); err != nil {
+			return errors.Wrap(err, "error setting RewardCurrentBlockEmission to zero int")
+		}
+	}
+
 	return nil
 }
 

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -320,7 +320,7 @@ func NewKeeper(
 		activeReputers:                            collections.NewKeySet(sb, types.ActiveReputersKey, "active_reputers", collections.PairKeyCodec(collections.Uint64Key, collections.StringKey)),
 		lowestReputerScoreEma:                     collections.NewMap(sb, types.LowestReputerScoreEmaKey, "lowest_reputer_score_ema", collections.Uint64Key, codec.CollValue[types.Score](cdc)),
 		totalSumPreviousTopicWeights:              collections.NewItem(sb, types.TotalSumPreviousTopicWeightsKey, "total_sum_previous_topic_weights", alloraMath.DecValue),
-		rewardCurrentBlockEmission:                collections.NewItem(sb, types.RewardCurrentBlockEmissionKey, "rewardcurrentblockemission", sdk.IntValue),
+		rewardCurrentBlockEmission:                collections.NewItem(sb, types.RewardCurrentBlockEmissionKey, "reward_current_block_emission", sdk.IntValue),
 	}
 
 	schema, err := sb.Build()


### PR DESCRIPTION
## Purpose of Changes and their Description

* Implement `InitGenesis` section for `RewardCurrentBlockEmission`

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [X] If tested, please describe how. If not, why tests are not needed. -- Ran tests on it, but not a full migration.
- [ ] If documented, please describe where. If not, describe why docs are not needed. -- inner release fix, no need 
- [ ] Added to `Unreleased` section of `CHANGELOG.md`? -- inner release fix, no need 

