### PR TITLE
wipe all values in v5 emissions module migration instead of just some

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#624](https://github.com/allora-network/allora-chain/pull/624) Add `nurse` internal healthcheck service based on `pprof`.  See `health/README.md`.
 * [#642](https://github.com/allora-network/allora-chain/pull/642) Add release signing keys
+* [#648](https://github.com/allora-network/allora-chain/pull/648) Update emissions v5 migration to reset way more maps => complete cleanup of poisonously negative values
 
 ### Changed
 

--- a/utils/migutils/migutils.go
+++ b/utils/migutils/migutils.go
@@ -28,7 +28,7 @@ func SafelyClearWholeMap(store storetypes.KVStore, keyPrefix []byte, maxPageSize
 		}
 		err := iterator.Close()
 		if err != nil {
-			return false, errorsmod.Wrap(err, "while closing iterator in `safelyClearWholeMap`")
+			return false, errorsmod.Wrap(err, "while closing iterator in `SafelyClearWholeMap`")
 		}
 
 		// Delete the keys

--- a/utils/migutils/migutils.go
+++ b/utils/migutils/migutils.go
@@ -4,10 +4,11 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Deletes all keys in the store with the given keyPrefix `maxPageSize` keys at a time
-func SafelyClearWholeMap(store storetypes.KVStore, keyPrefix []byte, maxPageSize uint64) error {
+func SafelyClearWholeMap(ctx sdk.Context, store storetypes.KVStore, keyPrefix []byte, maxPageSize uint64) error {
 	s := prefix.NewStore(store, keyPrefix)
 
 	// `clearPage` deletes `maxPageSize` keys at a time
@@ -44,13 +45,16 @@ func SafelyClearWholeMap(store storetypes.KVStore, keyPrefix []byte, maxPageSize
 	// Loop until all keys are deleted.
 	// Unbounded not best practice but we are sure that the number of keys will be limited
 	// and not deleting all keys means "poison" will remain in the store.
+	count := uint64(0)
 	for {
+		ctx.Logger().Info("MIGRATION: DELETING keys in store with prefix", "prefix", keyPrefix, "page", count)
 		more, err := clearPage()
 		if err != nil {
 			return err
 		} else if !more {
 			break
 		}
+		count++
 	}
 	return nil
 }

--- a/utils/migutils/migutils_test.go
+++ b/utils/migutils/migutils_test.go
@@ -127,7 +127,7 @@ func runSafelyClearWholeMapCase[K, V any](
 		keys = append(keys, key)
 	}
 
-	err := migutils.SafelyClearWholeMap(testDB.Store, prefix, maxPageSize)
+	err := migutils.SafelyClearWholeMap(testDB.TestCtx.Ctx, testDB.Store, prefix, maxPageSize)
 	require.NoError(t, err)
 
 	for _, key := range keys {

--- a/x/emissions/migrations/v3/migrate.go
+++ b/x/emissions/migrations/v3/migrate.go
@@ -42,7 +42,7 @@ func MigrateStore(ctx sdk.Context, emissionsKeeper keeper.Keeper) error {
 	}
 
 	ctx.Logger().Info("INVOKING MIGRATION HANDLER ResetMapsWithNonNumericValues() FROM VERSION 2 TO VERSION 3")
-	err := ResetMapsWithNonNumericValues(store, cdc)
+	err := ResetMapsWithNonNumericValues(ctx, store, cdc)
 	if err != nil {
 		ctx.Logger().Error("ERROR RESETTING MAPS WITH NON NUMERIC VALUES: %v", err)
 		return err
@@ -297,7 +297,7 @@ func getNewTopic(oldMsg oldtypes.Topic) types.Topic {
 	}
 }
 
-func ResetMapsWithNonNumericValues(store storetypes.KVStore, cdc codec.BinaryCodec) error {
+func ResetMapsWithNonNumericValues(ctx sdk.Context, store storetypes.KVStore, cdc codec.BinaryCodec) error {
 	prefixes := []collections.Prefix{
 		types.InferenceScoresKey,
 		types.ForecastScoresKey,
@@ -317,7 +317,7 @@ func ResetMapsWithNonNumericValues(store storetypes.KVStore, cdc codec.BinaryCod
 		types.LatestOneOutForecasterForecasterNetworkRegretsKey,
 	}
 	for _, prefix := range prefixes {
-		err := migutils.SafelyClearWholeMap(store, prefix, maxPageSize)
+		err := migutils.SafelyClearWholeMap(ctx, store, prefix, maxPageSize)
 		if err != nil {
 			return err
 		}

--- a/x/emissions/migrations/v3/migrate_test.go
+++ b/x/emissions/migrations/v3/migrate_test.go
@@ -517,7 +517,7 @@ func (s *EmissionsV3MigrationTestSuite) TestResetMapsWithNonNumericValues() {
 	iterator.Close()
 	s.Require().Len(scores.Scores, 1)
 
-	err = v3.ResetMapsWithNonNumericValues(store, cdc)
+	err = v3.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly

--- a/x/emissions/migrations/v4/migrate.go
+++ b/x/emissions/migrations/v4/migrate.go
@@ -217,7 +217,7 @@ func ResetMapsWithNonNumericValues(ctx sdk.Context, store storetypes.KVStore, cd
 
 	for _, prefix := range prefixes {
 		ctx.Logger().Info("MIGRATION V4: RESETTING %v MAP", prefix.name)
-		err := migutils.SafelyClearWholeMap(store, prefix.prefix, maxPageSize)
+		err := migutils.SafelyClearWholeMap(ctx, store, prefix.prefix, maxPageSize)
 		if err != nil {
 			return err
 		}

--- a/x/emissions/migrations/v5/migrate.go
+++ b/x/emissions/migrations/v5/migrate.go
@@ -221,7 +221,7 @@ func ResetMapsWithNonNumericValues(ctx sdk.Context, store storetypes.KVStore, cd
 	}
 
 	for _, prefix := range prefixes {
-		ctx.Logger().Info("MIGRATION V5: RESETTING %v MAP", prefix.name)
+		ctx.Logger().Info(fmt.Sprintf("MIGRATION V5: RESETTING %v MAP", prefix.name))
 		err := migutils.SafelyClearWholeMap(store, prefix.prefix, maxPageSize)
 		if err != nil {
 			return err

--- a/x/emissions/migrations/v5/migrate.go
+++ b/x/emissions/migrations/v5/migrate.go
@@ -222,7 +222,7 @@ func ResetMapsWithNonNumericValues(ctx sdk.Context, store storetypes.KVStore, cd
 
 	for _, prefix := range prefixes {
 		ctx.Logger().Info(fmt.Sprintf("MIGRATION V5: RESETTING %v MAP", prefix.name))
-		err := migutils.SafelyClearWholeMap(store, prefix.prefix, maxPageSize)
+		err := migutils.SafelyClearWholeMap(ctx, store, prefix.prefix, maxPageSize)
 		if err != nil {
 			return err
 		}

--- a/x/emissions/migrations/v5/migrate_test.go
+++ b/x/emissions/migrations/v5/migrate_test.go
@@ -452,7 +452,8 @@ func testPreviousQuantileMapDeletion(
 	s.Require().True(iterator.Valid())
 	defer iterator.Close()
 
-	v5.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
+	err = v5.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
+	s.Require().NoError(err)
 
 	// Verify the inferer store has been updated correctly
 	iterator = mapInfererStore.Iterator(nil, nil)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

This is a patch, but still part of v0.6.0 release.

We were not deleting enough values in the KV store that may have been affected by initial regret poisoning. This had to be corrected or else other values would risk re-poisoning everything else within each topic.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
   - Re-uses existing function + unit test
- [x] If documented, please describe where. If not, describe why docs are not needed.
   - Was original intention of original author of that migration. Documented through comments.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
