### PR TITLE
Make fuzzer setup run through every state transition once before fuzzing starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-[#652](https://github.com/allora-network/allora-chain/pull/652) Reduce code duplication, set local_testnet_upgrade_l1.sh using environment variables with local_testnet_l1.sh instead #652 
+* [#652](https://github.com/allora-network/allora-chain/pull/652) Reduce code duplication, set local_testnet_upgrade_l1.sh using environment variables with local_testnet_l1.sh instead
+* [#650](https://github.com/allora-network/allora-chain/pull/650) Make fuzzer setup run through every state transition once before fuzzing starts
+
+### Changed
 
 ### Deprecated
 
@@ -101,7 +104,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#603](https://github.com/allora-network/allora-chain/pull/603) Validate all Values for Correctness Prior to Storing them in the Keeper
 * [#620](https://github.com/allora-network/allora-chain/pull/620) Add a static analyzer to detect non-deferred `.Close()` calls, improve migration error handling
 * [#622](https://github.com/allora-network/allora-chain/pull/622) Add telemetry metrics on queries/txs
-
 
 ## v0.5.0
 

--- a/test/invariant/README.md
+++ b/test/invariant/README.md
@@ -8,21 +8,21 @@ Example invocation:
 INVARIANT_TEST=TRUE SEED=1 RPC_MODE="SingleRpc" \
     RPC_URLS="http://localhost:26657" \
     MAX_ITERATIONS=100 MODE="alternate" \
-    NUM_ACTORS=10 EPOCH_LENGTH=14 \
+    NUM_ACTORS=12 EPOCH_LENGTH=14 \
     /usr/bin/go test -timeout 15m -run ^TestInvariantTestSuite$ -v ./test/invariant
 ```
 
 # Shell Environment Parameters
 
 ```bash
-INVARIANT_TEST=true # required to run the invariant test, otherwise the script will not run
-SEED=1 # an integer used to seed randomness and name actors during the test (e.g. run3_actor7)
+INVARIANT_TEST=true # Required to run the invariant test, otherwise the script will not run
+SEED=1 # An integer used to seed randomness and name actors during the test (e.g. run3_actor7)
 RPC_MODE="SingleRpc" # Either SingleRpc, RoundRobin, or RandomBasedOnDeterministicSeed - how to interact with multiple RPC endpoints
 RPC_URLS="http://localhost:26657" # RPC endpoint urls, separated by comma if multiple
-MAX_ITERATIONS=100 # how many times to send transactions. Set to zero to continue forever
+MAX_ITERATIONS=100 # How many times to send transactions. Set to zero to continue forever
 MODE="alternating" # See Mode section below. Valid options: "behave" "fuzz" "alternate" or "manual"
-NUM_ACTORS=10 # how many private keys to create to use as actors in this play
-EPOCH_LENGTH=14 # when we submit inferences and reputation scores, how long to wait in between the inference and the reputation
+NUM_ACTORS=12 # How many actors to fuzz with. Must be large enough to do the fuzz setup (at time of writing: >=11)
+EPOCH_LENGTH=14 # How long to wait in between submitting inference and reputation bundles (at time of writing: >=12).
 ```
 
 # Simulation Modes
@@ -33,7 +33,8 @@ In order to assist with testing, the simulator supports four modes:
 2. Fuzz mode: the simulator will enter a more traditional fuzzing style approach - it will submit state transition transactions that may or may not be valid in a random order. If the RPC url returns an error, the test will not halt or complain. This is useful for trying to really spam the chain with state transitions.
 3. Alternate mode: the simulator will begin in behaved mode for the first 20 iterations. After that it will start flip-flopping between behaving and fuzzing. The simulator is 80% likely to continue the mode it was previously on. This should stimulate chains of successful transactions in a row followed by chains of fuzzed transactions in a row.
 4. Manual mode: if you find a bug you wish to replay, you can use manual mode to run the manual commands given in the `simulateManual` function in `invariant_test.go`. This is basically the same thing as an integration test.
- automatic or manual. In the automatic mode it simply counts up to `MAX_ITERATIONS` and for every iteration, chooses a transaction to send to the network. If manual mode is set to true, then the `MAX_ITERATIONS` flag will be ignored. In manual mode, you should set the iteration counter yourself.
+
+Automatic or manual: In the automatic mode it simply counts up to `MAX_ITERATIONS` (plus the iterations for the setup) and for every iteration, chooses a transaction to send to the network. If manual mode is set to true, then the `MAX_ITERATIONS` flag will be ignored. In manual mode, you should set the iteration counter yourself.
 
 The simulator runs in a single threaded process, it does not attempt to do concurrency. To do concurrency, run two separate `go test` invocations at the same time (perhaps with the same seed, to mess with the same actors!)
 
@@ -62,4 +63,4 @@ The output of the simulator contains a count of every attempted state transition
         }
 ```
 
-In this example workers have _successfully_ registered 7 times, and unregistered 6 times. That means that at the time of this log, only one worker is currently registered
+In this example workers have _successfully_ registered 7 times, and unregistered 6 times. That means that at the time of this log, only one worker is currently registered.

--- a/test/invariant/actors_setup_test.go
+++ b/test/invariant/actors_setup_test.go
@@ -11,7 +11,78 @@ import (
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ignite/cli/v28/ignite/pkg/cosmosaccount"
+	"github.com/stretchr/testify/require"
 )
+
+// set up the common state for the simulator
+// prior to either doing random simulation
+// or manual simulation
+func simulateSetUp(
+	m *testcommon.TestConfig,
+	numActors int,
+	epochLength int,
+	mode SimulationMode,
+) (
+	faucet Actor,
+	simulationData *SimulationData,
+) {
+	// fund all actors from the faucet with some amount
+	// give everybody the same amount of money to start with
+	actorsList := createActors(m, numActors)
+	faucet = Actor{
+		name: getFaucetName(m.Seed),
+		addr: m.FaucetAddr,
+		acc:  m.FaucetAcc,
+	}
+	preFundAmount, err := getPreFundAmount(m, faucet, numActors)
+	if err != nil {
+		m.T.Fatal(err)
+	}
+	err = fundActors(
+		m,
+		faucet,
+		actorsList,
+		preFundAmount,
+	)
+	if err != nil {
+		m.T.Fatal(err)
+	}
+	data := SimulationData{
+		epochLength: int64(epochLength),
+		actors:      actorsList,
+		counts: StateTransitionCounts{
+			createTopic:                0,
+			fundTopic:                  0,
+			registerWorker:             0,
+			registerReputer:            0,
+			unregisterWorker:           0,
+			unregisterReputer:          0,
+			stakeAsReputer:             0,
+			delegateStake:              0,
+			unstakeAsReputer:           0,
+			undelegateStake:            0,
+			cancelStakeRemoval:         0,
+			cancelDelegateStakeRemoval: 0,
+			collectDelegatorRewards:    0,
+			doInferenceAndReputation:   0,
+		},
+		registeredWorkers:  testcommon.NewRandomKeyMap[Registration, struct{}](m.Client.Rand),
+		registeredReputers: testcommon.NewRandomKeyMap[Registration, struct{}](m.Client.Rand),
+		reputerStakes: testcommon.NewRandomKeyMap[Registration, cosmossdk_io_math.Int](
+			m.Client.Rand,
+		),
+		delegatorStakes: testcommon.NewRandomKeyMap[Delegation, cosmossdk_io_math.Int](
+			m.Client.Rand,
+		),
+		mode:      mode,
+		failOnErr: false,
+	}
+	// if we're in manual mode or behaving mode we want to fail on errors
+	if mode == Manual || mode == Behave {
+		data.failOnErr = true
+	}
+	return faucet, &data
+}
 
 // creates a new actor and registers them in the nodes account registry
 func createNewActor(m *testcommon.TestConfig, numActors int) Actor {
@@ -152,4 +223,337 @@ func (a *Actor) GetBalance(m *testcommon.TestConfig) (cosmossdk_io_math.Int, err
 		return cosmossdk_io_math.ZeroInt(), err
 	}
 	return bal.Balance.Amount, nil
+}
+
+// for initial state for the automatic test
+// 5 workers, 4 reputers, and 2 delegators
+// each set unique actors, no actor repeated anywhere
+func pickAutoSetupActors(m *testcommon.TestConfig, data *SimulationData) (reputers []Actor, workers []Actor, delegators []Actor) {
+	numReputers := 4
+	numWorkers := 5
+	numDelegators := 2
+	totalActorsForSetup := numReputers + numWorkers + numDelegators
+
+	reputers = make([]Actor, numReputers)
+	workers = make([]Actor, numWorkers)
+	delegators = make([]Actor, numDelegators)
+	require.GreaterOrEqual(
+		m.T,
+		len(data.actors),
+		totalActorsForSetup,
+		"not enough actors to do the setup, must have at least %d actors: have %d",
+		totalActorsForSetup,
+		len(data.actors),
+	)
+
+	for i := 0; i < numReputers; i++ {
+		newActor := data.actors[i]
+		reputers[i] = newActor
+	}
+
+	for i := 0; i < numWorkers; i++ {
+		newActor := data.actors[numReputers+i]
+		workers[i] = newActor
+	}
+
+	for i := 0; i < numDelegators; i++ {
+		newActor := data.actors[numReputers+numWorkers+i]
+		delegators[i] = newActor
+	}
+
+	return reputers, workers, delegators
+}
+
+// startRegisterReputers registers and then stakes a list of reputers to a list of topics.
+func startRegisterReputers(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startReputers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for _, reputer := range startReputers {
+		for _, topicId := range listTopics {
+			// register reputer on the topic
+			registerReputer(m, reputer, UnusedActor, nil, topicId, data, iterationCount)
+			iterationCount++
+			// stake reputer on the topic
+			bal, err := pickRandomBalanceLessThanHalf(m, reputer)
+			requireNoError(m.T, true, err)
+			stakeAsReputer(m, reputer, UnusedActor, &bal, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// startRegisterWorkers registers and then stakes a list of workers to a list of topics.
+func startRegisterWorkers(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startWorkers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for _, worker := range startWorkers {
+		for _, topicId := range listTopics {
+			registerWorker(m, worker, UnusedActor, nil, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// startDelegateDelegators delegates a list of delegators to a list of reputers on a list of topics.
+func startDelegateDelegators(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startDelegators []Actor,
+	startReputers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for i, delegator := range startDelegators {
+		for _, topicId := range listTopics {
+			bal, err := pickRandomBalanceLessThanHalf(m, delegator)
+			requireNoError(m.T, true, err)
+			delegateStake(m, delegator, startReputers[i], &bal, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// startFundTopics funds the topics with random amounts of money
+func startFundTopics(
+	m *testcommon.TestConfig,
+	faucet Actor,
+	data *SimulationData,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for _, topicId := range listTopics {
+		fundAmount, err := pickRandomBalanceLessThanHalf(m, faucet)
+		requireNoError(m.T, true, err)
+		fundTopic(m, faucet, UnusedActor, &fundAmount, topicId, data, iterationCount)
+		iterationCount++
+	}
+	return iterationCount
+}
+
+// startDoInferenceAndReputation does inference and reputation for both topics
+func startDoInferenceAndReputation(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for _, topicId := range listTopics {
+		doInferenceAndReputation(m, UnusedActor, UnusedActor, nil, topicId, data, iterationCount)
+		iterationCount++
+	}
+	return iterationCount
+}
+
+// collect delegator rewards for delegators on reputers on topics
+func startCollectDelegatorRewards(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startDelegators []Actor,
+	startReputers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for i, delegator := range startDelegators {
+		for _, topicId := range listTopics {
+			collectDelegatorRewards(m, delegator, startReputers[i], nil, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// startUnregisterWorkers unregisters a list of workers from a list of topics.
+func startUnregisterWorkers(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startWorkers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for _, worker := range startWorkers {
+		for _, topicId := range listTopics {
+			unregisterWorker(m, worker, UnusedActor, nil, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// startUnregisterReputers unregisters a list of reputers from a list of topics.
+func startUnregisterReputers(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startReputers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for _, reputer := range startReputers {
+		for _, topicId := range listTopics {
+			unregisterReputer(m, reputer, UnusedActor, nil, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// startUndelegateStake undelegates a list of delegators from a list of reputers on a list of topics.
+func startUndelegateStake(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startDelegators []Actor,
+	startReputers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for i, delegator := range startDelegators {
+		for _, topicId := range listTopics {
+			amount := data.pickPercentOfStakeByDelegator(m.Client.Rand, topicId, delegator, startReputers[i])
+			undelegateStake(m, delegator, startReputers[i], &amount, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// startUnstakeAsReputer unstakes a list of reputers from a list of topics.
+func startUnstakeAsReputer(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startReputers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for _, reputer := range startReputers {
+		for _, topicId := range listTopics {
+			amount := data.pickPercentOfStakeByReputer(m.Client.Rand, topicId, reputer)
+			unstakeAsReputer(m, reputer, UnusedActor, &amount, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// startCancelStakeRemoval cancels the removal of stake from a list of reputers on a list of topics.
+func startCancelStakeRemoval(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startReputers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for _, reputer := range startReputers {
+		for _, topicId := range listTopics {
+			cancelStakeRemoval(m, reputer, UnusedActor, nil, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// startCancelDelegateStakeRemoval cancels the removal of delegated stake from a list of delegators on a list of topics.
+// startReputers must correspond to the reputers startDelegators are staked upon
+func startCancelDelegateStakeRemoval(
+	m *testcommon.TestConfig,
+	data *SimulationData,
+	startDelegators []Actor,
+	startReputers []Actor,
+	listTopics []uint64,
+	iterationCountStart int,
+) (iterationCountAfter int) {
+	iterationCount := iterationCountStart
+	for i, delegator := range startDelegators {
+		for _, topicId := range listTopics {
+			cancelDelegateStakeRemoval(m, delegator, startReputers[i], nil, topicId, data, iterationCount)
+			iterationCount++
+		}
+	}
+	return iterationCount
+}
+
+// run every state transition, at least once.
+func simulateAutomaticInitialState(
+	m *testcommon.TestConfig,
+	faucet Actor,
+	data *SimulationData,
+) (iterationCountAfter int) {
+	iterationCount := 0
+	listTopics := []uint64{1, 2}
+
+	// make sure that the setup always fails on error
+	failOnErrWanted := data.failOnErr
+	data.failOnErr = true
+
+	// additive actions
+
+	// create two topics
+	createTopic(m, faucet, UnusedActor, nil, 0, data, iterationCount)
+	iterationCount++
+	createTopic(m, faucet, UnusedActor, nil, 0, data, iterationCount)
+	iterationCount++
+	// pick 4 reputers, 4 workers, and 2 delegators
+	startReputers, startWorkers, startDelegators := pickAutoSetupActors(m, data)
+	// register all 4 reputers on both topics
+	iterationCount = startRegisterReputers(m, data, startReputers, listTopics, iterationCount)
+	// register all 5 workers on both topics
+	iterationCount = startRegisterWorkers(m, data, startWorkers, listTopics, iterationCount)
+	// delegate stake to both topics from the delegators
+	iterationCount = startDelegateDelegators(m, data, startDelegators, startReputers, listTopics, iterationCount)
+	// fund the topics
+	iterationCount = startFundTopics(m, faucet, data, listTopics, iterationCount)
+	// do inference and reputation for both topics
+	iterationCount = startDoInferenceAndReputation(m, data, listTopics, iterationCount)
+	// collect delegator rewards for both topics
+	iterationCount = startCollectDelegatorRewards(m, data, startDelegators, startReputers, listTopics, iterationCount)
+
+	// subtractive actions
+
+	unregisterWorkers := []Actor{startWorkers[0], startWorkers[1]}
+	unregisterReputer := []Actor{startReputers[1]}
+
+	unStakeReputer := []Actor{startReputers[0]}
+	unStakeDelegator := []Actor{startDelegators[0]}
+	unStakeDelegatorReputer := []Actor{startReputers[0]}
+
+	justFirstTopic := []uint64{1}
+
+	// unregister 2 workers from topic 1
+	iterationCount = startUnregisterWorkers(m, data, unregisterWorkers, justFirstTopic, iterationCount)
+	// unregister 1 reputer from topic 1
+	iterationCount = startUnregisterReputers(m, data, unregisterReputer, justFirstTopic, iterationCount)
+	// undelegate 1 delegator from 1 reputers on topic 1
+	iterationCount = startUndelegateStake(m, data, unStakeDelegator, unStakeReputer, justFirstTopic, iterationCount)
+	// unstake 1 reputer on topic 1
+	iterationCount = startUnstakeAsReputer(m, data, unStakeReputer, justFirstTopic, iterationCount)
+
+	// cancel the removal of stake from 1 reputer on topic 1
+	iterationCount = startCancelStakeRemoval(m, data, unStakeReputer, justFirstTopic, iterationCount)
+	// cancel the removal of delegated stake from 1 delegator on reputer 1 on topic 1
+	iterationCount = startCancelDelegateStakeRemoval(m, data, unStakeDelegator, unStakeDelegatorReputer, justFirstTopic, iterationCount)
+
+	// set back the failOnErr status the user requested for the fuzz run
+	data.failOnErr = failOnErrWanted
+
+	return iterationCount
 }

--- a/test/invariant/inferences_test.go
+++ b/test/invariant/inferences_test.go
@@ -36,6 +36,7 @@ func doInferenceAndReputation(
 	requireNoError(m.T, data.failOnErr, err)
 	wasErr = orErr(wasErr, err)
 	topic := resp.Topic
+	iterLog(m.T, iteration, "Inference topic epoch last ended ", topic.EpochLastEnded, " epoch length ", topic.EpochLength)
 	workerNonce := topic.EpochLastEnded + topic.EpochLength
 	blockHeightNow, err := m.Client.BlockHeight(ctx)
 	requireNoError(m.T, data.failOnErr, err)

--- a/test/invariant/invariants.patch
+++ b/test/invariant/invariants.patch
@@ -1,5 +1,5 @@
 diff --git a/x/emissions/module/abci.go b/x/emissions/module/abci.go
-index 65270d4a..2e68ab82 100644
+index 8ff85b13..88779b6e 100644
 --- a/x/emissions/module/abci.go
 +++ b/x/emissions/module/abci.go
 @@ -6,6 +6,7 @@ import (
@@ -22,10 +22,10 @@ index 65270d4a..2e68ab82 100644
  	sdkCtx.Logger().Debug(
  		fmt.Sprintf("\n ---------------- Emissions EndBlock %d ------------------- \n",
 diff --git a/x/emissions/module/module.go b/x/emissions/module/module.go
-index bbe013e2..1e63e08c 100644
+index f8ddae02..0a8cc692 100644
 --- a/x/emissions/module/module.go
 +++ b/x/emissions/module/module.go
-@@ -21,6 +21,15 @@ import (
+@@ -22,6 +22,15 @@ import (
  	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
  )
  
@@ -41,3 +41,18 @@ index bbe013e2..1e63e08c 100644
  var (
  	_ module.AppModuleBasic   = AppModule{} // nolint: exhaustruct
  	_ module.HasGenesis       = AppModule{} // nolint: exhaustruct
+@@ -135,14 +144,6 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
+ 
+ // EndBlock returns the end blocker for the emissions module.
+ func (am AppModule) EndBlock(ctx context.Context) error {
+-	sdkCtx := sdk.UnwrapSDKContext(ctx)
+-	defer func() {
+-		if r := recover(); r != nil {
+-			err := fmt.Errorf("error: %v", r)
+-			sdkCtx.Logger().Error("Recover panic in EndBlocker", err)
+-		}
+-	}()
+-
+ 	err := EndBlocker(ctx, am)
+ 	if err != nil {
+ 		sdkCtx := sdk.UnwrapSDKContext(ctx)

--- a/test/invariant/simulation_data_test.go
+++ b/test/invariant/simulation_data_test.go
@@ -293,30 +293,6 @@ func (s *SimulationData) isReputerRegistered(topicId uint64, actor Actor) bool {
 	return exists
 }
 
-// pick a random worker from a topic. This function is O(n) over the list of workers
-func (s *SimulationData) pickRandomWorkerRegisteredInTopic(rand *rand.Rand, topicId uint64) (Actor, error) {
-	workers, _ := s.registeredWorkers.Filter(func(reg Registration) bool {
-		return reg.TopicId == topicId
-	})
-	if len(workers) == 0 {
-		return Actor{}, fmt.Errorf("no workers in topic %d", topicId)
-	}
-	randIndex := rand.Intn(len(workers))
-	return workers[randIndex].Actor, nil
-}
-
-// pick a random reputer registered in a topic. This function is O(n) over the list of reputers
-func (s *SimulationData) pickRandomReputerRegisteredInTopic(rand *rand.Rand, topicId uint64) (Actor, error) {
-	reputers, _ := s.registeredReputers.Filter(func(reg Registration) bool {
-		return reg.TopicId == topicId
-	})
-	if len(reputers) == 0 {
-		return Actor{}, fmt.Errorf("no reputers in topic %d", topicId)
-	}
-	randIndex := rand.Intn(len(reputers))
-	return reputers[randIndex].Actor, nil
-}
-
 // isAnyWorkerRegisteredInTopic checks if any worker is registered in a topic
 func (s *SimulationData) isAnyWorkerRegisteredInTopic(topicId uint64) bool {
 	workers, _ := s.registeredWorkers.Filter(func(reg Registration) bool {

--- a/test/invariant/stake_test.go
+++ b/test/invariant/stake_test.go
@@ -191,7 +191,7 @@ func cancelStakeRemoval(
 	data *SimulationData,
 	iteration int,
 ) {
-	wasErr := true
+	wasErr := false
 	iterLog(
 		m.T,
 		iteration,
@@ -217,13 +217,21 @@ func cancelStakeRemoval(
 	requireNoError(m.T, data.failOnErr, err)
 	wasErr = orErr(wasErr, err)
 
-	response := &emissionstypes.RemoveStakeResponse{}
+	response := &emissionstypes.CancelRemoveStakeResponse{}
 	err = txResp.Decode(response)
 	requireNoError(m.T, data.failOnErr, err)
 	wasErr = orErr(wasErr, err)
 
 	if !wasErr {
 		data.counts.incrementCancelStakeRemovalCount()
+		iterSuccessLog(
+			m.T,
+			iteration,
+			"cancelled stake removal as a reputer",
+			actor,
+			"in topic id",
+			topicId,
+		)
 	} else {
 		iterFailLog(m.T, iteration, "cancelling stake removal as a reputer failed", actor, "in topic id", topicId)
 	}
@@ -412,12 +420,14 @@ func cancelDelegateStakeRemoval(
 	data *SimulationData,
 	iteration int,
 ) {
-	wasErr := true
+	wasErr := false
 	iterLog(
 		m.T,
 		iteration,
 		"cancelling stake removal as a delegator",
 		delegator,
+		"on reputer",
+		reputer,
 		"in topic id",
 		topicId,
 	)
@@ -446,6 +456,14 @@ func cancelDelegateStakeRemoval(
 	wasErr = orErr(wasErr, err)
 	if !wasErr {
 		data.counts.incrementCancelDelegateStakeRemovalCount()
+		iterSuccessLog(
+			m.T,
+			iteration,
+			"cancelled stake removal as a delegator",
+			delegator,
+			"in topic id",
+			topicId,
+		)
 	} else {
 		iterFailLog(m.T, iteration, "cancelling stake removal as a delegator failed delegator ", delegator, " reputer", reputer, "in topic id", topicId)
 	}

--- a/test/invariant/transitions_test.go
+++ b/test/invariant/transitions_test.go
@@ -294,19 +294,9 @@ func pickActorAndTopicIdForStateTransition(
 		}
 		topics := findActiveTopicsAtThisBlock(m, data, blockHeightNow)
 		if len(topics) > 0 {
-			for i := 0; i < 10; i++ {
-				randIndex := m.Client.Rand.Intn(len(topics))
-				topicId := topics[randIndex].Id
-				worker, err := data.pickRandomWorkerRegisteredInTopic(m.Client.Rand, topicId)
-				if err != nil {
-					continue
-				}
-				reputer, err := data.pickRandomReputerRegisteredInTopic(m.Client.Rand, topicId)
-				if err != nil {
-					continue
-				}
-				return true, worker, reputer, nil, topicId
-			}
+			randIndex := m.Client.Rand.Intn(len(topics))
+			topicId := topics[randIndex].Id
+			return true, UnusedActor, UnusedActor, nil, topicId
 		}
 		return false, UnusedActor, UnusedActor, nil, 0
 	default:


### PR DESCRIPTION
## Purpose of Changes and their Description

This PR does two things:

1. Relaxes an invariant check. Before we checked that the sum of reward debt for all actors is exactly equal to the amount of tokens stored in the `AlloraPendingRewardForDelegatorAccountName` module account. Now instead we only check that the value is _greater_ than the sum of all reward debt. Rounding errors from integer division make perfectly checking the invariant for equality difficult. The real concern is that we should always have enough money to pay every delegator their fair share, which is a greater than check rather than an equals.
2. Makes the fuzzer setup run through every state transition at least once before fuzzing actually starts. Before this PR, we do have a fuzzing setup, but the thought originally was to just make it so the fuzzer is in a suitable state to start. Now in addition, we do every transition at least once to prove that all the transitions are working, before the fuzzer goes to town.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

PROTO-2753

## Are these changes tested and documented

These changes have been tested by manual interaction with the fuzzer. The fuzzer Readme.MD file has been updated for documentation purposes.
