### PR TITLE
 Rename v0.5.0 to v0.6.0

### DIFF
--- a/Dockerfile.cosmovisor
+++ b/Dockerfile.cosmovisor
@@ -38,8 +38,8 @@ ADD https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor/${COSMOVIS
 RUN tar -xvf /tmp/cosmovisor.tar.gz -C /usr/local/bin/ && \
     chmod +x /usr/local/bin/cosmovisor
 
-ARG ALLORAD_CURRENT_VERSION="v0.4.0"
-ARG ALLORAD_UPGRADE_VERSION="v0.5.0"
+ARG ALLORAD_CURRENT_VERSION="v0.5.0"
+ARG ALLORAD_UPGRADE_VERSION="v0.6.0"
 
 RUN mkdir -p ${INITIAL_COSMOVISOR_DIR}/genesis/bin && \
     curl -Lo ${INITIAL_COSMOVISOR_DIR}/genesis/bin/allorad https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_CURRENT_VERSION}/allorad_linux_amd64 && \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 services:
   node:
     container_name: sample_validator
-    image: "alloranetwork/allora-chain:v0.5.0-docker-upgrade" # docker image without cosmovisor. use vx.x.x-docker-upgrade for upgrade image
+    image: "alloranetwork/allora-chain:v0.6.0-docker-upgrade" # docker image without cosmovisor. use vx.x.x-docker-upgrade for upgrade image
     environment:
       - NETWORK=allora-testnet-1
       - MONIKER=sample_validator

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -5,8 +5,8 @@
 # to the network to trigger the upgrade process.
 
 # Update the variables below to match current conditions and desired upgrade
-current_verison=v0.4.0
-new_version=v0.5.0
+current_verison=v0.5.0
+new_version=v0.6.0
 expedited=true
 deposit=50000000uallo
 num_minutes_between_proposal_and_upgrade=6


### PR DESCRIPTION
## Purpose of Changes and their Description

This PR bumps the release version from v0.5.0 -> v0.6.0 in various docker configs and other places we forgot prior to the release.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

N/A trivial refactor

## Are these changes tested and documented?

No need, trivial one-line refactor
