### PR TITLE
Remove ABCI blockers method duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#538](https://github.com/allora-network/allora-chain/pull/538) Refactor Inference Synthesis to use Functions instead of "Builder Pattern"
 * [#625](https://github.com/allora-network/allora-chain/pull/625) Determine what percentage of rewards to pay to each topic based on time-based accumulation rather than instantaneously.
+* [#684](https://github.com/allora-network/allora-chain/pull/684) Avoid duplication of ABCI methods ordering. 
 
 ### Fixed
 

--- a/app/app.go
+++ b/app/app.go
@@ -13,29 +13,21 @@ import (
 
 	"cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/telemetry"
-	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/cosmos/cosmos-sdk/x/gov"
 	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
-
-	abci "github.com/cometbft/cometbft/abci/types"
-	dbm "github.com/cosmos/cosmos-db"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
-	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
 
 	"cosmossdk.io/core/appconfig"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	dbm "github.com/cosmos/cosmos-db"
 
 	storetypes "cosmossdk.io/store/types"
 	circuitkeeper "cosmossdk.io/x/circuit/keeper"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
-	upgradetypes "cosmossdk.io/x/upgrade/types"
 	emissionsKeeper "github.com/allora-network/allora-chain/x/emissions/keeper"
-	emissions "github.com/allora-network/allora-chain/x/emissions/types"
 	mintkeeper "github.com/allora-network/allora-chain/x/mint/keeper"
-	minttypes "github.com/allora-network/allora-chain/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -53,7 +45,6 @@ import (
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	consensuskeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
@@ -62,16 +53,12 @@ import (
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
-	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
-	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
 	icacontrollerkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/keeper"
 	icahostkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/keeper"
 	ibcfeekeeper "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/keeper"
-	ibcfeetypes "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/types"
 	ibctransferkeeper "github.com/cosmos/ibc-go/v8/modules/apps/transfer/keeper"
-	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	ibctestingtypes "github.com/cosmos/ibc-go/v8/testing/types"
 
@@ -247,39 +234,6 @@ func NewAlloraApp(
 	if err := app.RegisterStreamingServices(appOpts, app.kvStoreKeys()); err != nil {
 		return nil, err
 	}
-
-	/****  Module Options ****/
-	app.ModuleManager.SetOrderPreBlockers(
-		upgradetypes.ModuleName,
-	)
-
-	//begin_blockers: [capability, distribution, staking, mint, ibc, transfer, genutil, interchainaccounts, feeibc]
-	//end_blockers: [staking, ibc, transfer, capability, genutil, interchainaccounts, feeibc, emissions]
-	app.ModuleManager.SetOrderBeginBlockers(
-		capabilitytypes.ModuleName,
-		distrtypes.ModuleName,
-		slashingtypes.ModuleName,
-		stakingtypes.ModuleName,
-		upgradetypes.ModuleName,
-		minttypes.ModuleName,
-		ibcexported.ModuleName,
-		ibctransfertypes.ModuleName,
-		genutiltypes.ModuleName,
-		authz.ModuleName,
-		icatypes.ModuleName,
-		ibcfeetypes.ModuleName,
-	)
-	app.ModuleManager.SetOrderEndBlockers(
-		govtypes.ModuleName,
-		stakingtypes.ModuleName,
-		ibcexported.ModuleName,
-		ibctransfertypes.ModuleName,
-		capabilitytypes.ModuleName,
-		genutiltypes.ModuleName,
-		icatypes.ModuleName,
-		ibcfeetypes.ModuleName,
-		emissions.ModuleName,
-	)
 
 	// create the simulation manager and define the order of the modules for deterministic simulations
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing transactions

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -3,16 +3,56 @@ modules:
     config:
       "@type": cosmos.app.runtime.v1alpha1.Module
       app_name: AlloraApp
-      # During begin block slashing happens after distr.BeginBlocker so that
-      # there is nothing left over in the validator fee pool, so as to keep the CanWithdrawInvariant invariant.
-      # NOTE: staking module is required if HistoricalEntries param > 0
-      # order of emissions must come before distribution for reputers + workers take their rewards cut before validators cut
+
+      # Only modules providing a PreBlock func are listed here.
       pre_blockers: [ upgrade ]
-      begin_blockers: [capability, distribution, slashing, staking, upgrade, mint, ibc, transfer, genutil, authz, interchainaccounts, feeibc]
-      end_blockers: [gov, staking, ibc, transfer, capability, genutil, authz, interchainaccounts, feeibc, emissions]
-      # NOTE: The genutils module must occur after staking so that pools are properly initialized with tokens from genesis accounts.
-      # NOTE: The genutils module must also occur after auth so that it can access the params from auth.
-      init_genesis: [capability, auth, bank, distribution, staking, slashing, gov, mint, ibc, genutil, authz, transfer, interchainaccounts, feeibc, params, upgrade, consensus, circuit, emissions, allorastaking, allorarequests, allorarewards, allorapendingrewards, ecosystem]
+
+      # Only modules providing an BeginBlock func are listed here.
+      begin_blockers:
+        # capability must come before any modules using capabilities (e.g. IBC)
+        - capability
+        # During begin block slashing happens after distribution so that there is nothing left over in the validator fee
+        # pool, so as to keep the CanWithdrawInvariant invariant.
+        - distribution
+        - slashing
+        # staking module is required if HistoricalEntries param > 0
+        - staking
+        - mint
+        - ibc
+        - authz
+
+      # Only modules providing an EndBlock func are listed here.
+      end_blockers:
+        - gov
+        # staking must come after gov.
+        - staking
+        - emissions
+
+      # Only modules providing an InitGenesis func are listed here.
+      init_genesis:
+        # capability must come before any modules using capabilities (e.g. IBC)
+        - capability
+        - auth
+        - bank
+        - distribution
+        - staking
+        - slashing
+        - gov
+        - mint
+        - ibc
+        # The genutil module must occur:
+        # - after staking so that pools are properly initialized with tokens from genesis accounts;
+        # - after auth so that it can access the params from auth;
+        - genutil
+        - authz
+        - transfer
+        - interchainaccounts
+        - feeibc
+        - upgrade
+        - consensus
+        - circuit
+        - emissions
+
       override_store_keys:
         - module_name: auth
           kv_store_key: acc
@@ -29,7 +69,6 @@ modules:
         - account: not_bonded_tokens_pool
           permissions: [burner, staking]
         - account : allorastaking
-        - account : allorarequests
         - account : distribution
         - account : allorarewards
         - account : allorapendingrewards
@@ -46,7 +85,7 @@ modules:
     config:
       "@type": cosmos.bank.module.v1.Module
       blocked_module_accounts_override:
-        [auth, bonded_tokens_pool, not_bonded_tokens_pool, allorastaking, allorarequests, allorarewards, allorapendingrewards, distribution]
+        [auth, bonded_tokens_pool, not_bonded_tokens_pool, allorastaking, allorarewards, allorapendingrewards, distribution]
   - name: circuit
     config:
       "@type": cosmos.circuit.module.v1.Module


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Removes the ABCI methods ordering in the `app.go` that was redundant with the definition already present in the `app.yaml`, it's better to have a single source of truth.

I also took the opportunity to make sure that any ordering constraints are documented, and also remove from ordering lists the modules that doesn't provide the related func, this is not really the most common practice in the ecosystem but I believe it offers a better understanding and clarity over the app wiring, let me know your point of view on that.

Here's also some removals related to things that I believe doesn't exists anymore, let me know if it was a mistake:
- some `InitGenesis` modules: `allorastaking`, `allorarequests`, `allorarewards`, `allorapendingrewards`, `ecosystem`;
- the `allorarequests` module account;

I've only tested the chain is running locally.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

PROTO-2966

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
