### PR TITLE
Fix submission epoch boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * [#683](https://github.com/allora-network/allora-chain/pull/683) Added new strategy for reputer listening coefficients
 * [#668](https://github.com/allora-network/allora-chain/pull/668) Add stake nil amount validation + added tests + fixed other tests
+* [#687](https://github.com/allora-network/allora-chain/pull/687) Fix reputer nonce submission boundaries
 
 ### Security
 

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -3664,13 +3664,14 @@ func (k *Keeper) PruneReputerNonces(ctx context.Context, topicId uint64, blockHe
 
 // Return true if the nonce is within the worker submission window for the topic
 func (k *Keeper) BlockWithinWorkerSubmissionWindowOfNonce(topic types.Topic, nonce types.Nonce, blockHeight int64) bool {
-	return nonce.BlockHeight <= blockHeight && blockHeight < topic.WorkerSubmissionWindow+nonce.BlockHeight
+	return nonce.BlockHeight <= blockHeight && blockHeight <= topic.WorkerSubmissionWindow+nonce.BlockHeight
 }
 
 // Return true if the nonce is within the worker submission window for the topic
 func (k *Keeper) BlockWithinReputerSubmissionWindowOfNonce(topic types.Topic, nonce types.ReputerRequestNonce, blockHeight int64) bool {
 	return nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag <= blockHeight &&
-		blockHeight <= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag*2
+		// Reputer submission window is 2 gt_lag + between 1, 2 number of epochLengths. Assuming 2 EpochLengths as worst case
+		blockHeight <= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag+topic.EpochLength*2
 }
 
 func (k *Keeper) ValidateStringIsBech32(actor ActorId) error {

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -3663,15 +3663,17 @@ func (k *Keeper) PruneReputerNonces(ctx context.Context, topicId uint64, blockHe
 }
 
 // Return true if the nonce is within the worker submission window for the topic
+// Inclusive of the start block height and exclusive of the end block height
 func (k *Keeper) BlockWithinWorkerSubmissionWindowOfNonce(topic types.Topic, nonce types.Nonce, blockHeight int64) bool {
-	return nonce.BlockHeight <= blockHeight && blockHeight <= topic.WorkerSubmissionWindow+nonce.BlockHeight
+	return nonce.BlockHeight <= blockHeight && blockHeight < topic.WorkerSubmissionWindow+nonce.BlockHeight
 }
 
 // Return true if the nonce is within the worker submission window for the topic
+// Inclusive of the start block height and of the end block height
 func (k *Keeper) BlockWithinReputerSubmissionWindowOfNonce(topic types.Topic, nonce types.ReputerRequestNonce, blockHeight int64) bool {
+	extra_lag := topic.GroundTruthLag % topic.EpochLength
 	return nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag <= blockHeight &&
-		// Reputer submission window is 2 gt_lag + between 1, 2 number of epochLengths. Assuming 2 EpochLengths as worst case
-		blockHeight <= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag+topic.EpochLength*2
+		blockHeight <= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag+topic.EpochLength+extra_lag
 }
 
 func (k *Keeper) ValidateStringIsBech32(actor ActorId) error {

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -3671,9 +3671,9 @@ func (k *Keeper) BlockWithinWorkerSubmissionWindowOfNonce(topic types.Topic, non
 // Return true if the nonce is within the worker submission window for the topic
 // Inclusive of the start block height and of the end block height
 func (k *Keeper) BlockWithinReputerSubmissionWindowOfNonce(topic types.Topic, nonce types.ReputerRequestNonce, blockHeight int64) bool {
-	extra_lag := topic.GroundTruthLag % topic.EpochLength
+	extraLag := topic.GroundTruthLag % topic.EpochLength
 	return nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag <= blockHeight &&
-		blockHeight <= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag+topic.EpochLength+extra_lag
+		blockHeight <= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag+topic.EpochLength+extraLag
 }
 
 func (k *Keeper) ValidateStringIsBech32(actor ActorId) error {

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
@@ -66,7 +66,7 @@ func (ms msgServer) InsertReputerPayload(ctx context.Context, msg *types.InsertR
 		return nil, errorsmod.Wrapf(
 			types.ErrReputerNonceWindowNotAvailable,
 			"Reputer window not open for topic: %d, current block %d, start window: %d, end window: %d",
-			topicId, blockHeight, nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag, nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag*2,
+			topicId, blockHeight, nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag, nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag+topic.EpochLength*2,
 		)
 	}
 

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -64,6 +64,7 @@ func (ms msgServer) InsertWorkerPayload(ctx context.Context, msg *types.InsertWo
 		return nil, types.ErrUnfulfilledNonceNotFound
 	}
 
+	// Note: this is exclusive of the end block height
 	if !ms.k.BlockWithinWorkerSubmissionWindowOfNonce(topic, *nonce, blockHeight) {
 		return nil, errorsmod.Wrapf(
 			types.ErrWorkerNonceWindowNotAvailable,

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -90,6 +90,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 				}
 				for _, nonce := range nonces.Nonces {
 					// Skip rest of logic if the worker submission window is still open (i.e. don't close the window yet)
+					// Note: worker window exclusive of the end block height so we ensure the window is closed at this point.
 					if am.keeper.BlockWithinWorkerSubmissionWindowOfNonce(topic, *nonce, blockHeight) {
 						sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker %d: Worker window still open for topic: %d, nonce: %v", blockHeight, topicId, nonce))
 						continue


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* worker window: boundary block is exclusive of end block. Added comments where relevant.

* reputer window:
  * the upper boundary should be `gt_lag + (gt_lag%epochLength) + epochLength`, instead of `gt_lag*2`. The previous value would be inconsistent, especially in cases where `gt_lag is >> epochLength`.
  * added comments where relevant


## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [X] If tested, please describe how. If not, why tests are not needed. -- covered by unit tests and integration tests, also tested locally.
- [x] If documented, please describe where. If not, describe why docs are not needed. -- windows are documented in README.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

