### PR TITLE
Add the evidence module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [612](https://github.com/allora-network/allora-chain/pull/612) Load testnet state into local fork via in-place-testnet command 
+* [688](https://github.com/allora-network/allora-chain/pull/688) Add the `evidence` module.
 
 ### Security
 

--- a/app/app.go
+++ b/app/app.go
@@ -46,21 +46,22 @@ import (
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	metrics "github.com/hashicorp/go-metrics"
 
-	_ "cosmossdk.io/api/cosmos/tx/config/v1" // import for side-effects
-	_ "cosmossdk.io/x/circuit"               // import for side-effects
-	_ "cosmossdk.io/x/feegrant/module"       // import for side-effects
-	_ "cosmossdk.io/x/upgrade"
-	_ "github.com/allora-network/allora-chain/x/emissions/module"
-	_ "github.com/allora-network/allora-chain/x/mint/module" // import for side-effects
-	_ "github.com/cosmos/cosmos-sdk/x/auth"                  // import for side-effects
-	_ "github.com/cosmos/cosmos-sdk/x/auth/tx/config"        // import for side-effects
-	_ "github.com/cosmos/cosmos-sdk/x/authz/module"          // import for side-effects
-	_ "github.com/cosmos/cosmos-sdk/x/bank"                  // import for side-effects
-	_ "github.com/cosmos/cosmos-sdk/x/consensus"             // import for side-effects
-	_ "github.com/cosmos/cosmos-sdk/x/distribution"          // import for side-effects
-	_ "github.com/cosmos/cosmos-sdk/x/params"                // import for side-effects
-	_ "github.com/cosmos/cosmos-sdk/x/slashing"              // import for side-effects
-	_ "github.com/cosmos/cosmos-sdk/x/staking"               // import for side-effects
+	_ "cosmossdk.io/api/cosmos/tx/config/v1"                      // import for side-effects
+	_ "cosmossdk.io/x/circuit"                                    // import for side-effects
+	_ "cosmossdk.io/x/evidence"                                   // import for side-effects
+	_ "cosmossdk.io/x/feegrant/module"                            // import for side-effects
+	_ "cosmossdk.io/x/upgrade"                                    // import for side-effects
+	_ "github.com/allora-network/allora-chain/x/emissions/module" // import for side-effects
+	_ "github.com/allora-network/allora-chain/x/mint/module"      // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/auth"                       // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/auth/tx/config"             // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/authz/module"               // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/bank"                       // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/consensus"                  // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/distribution"               // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/params"                     // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/slashing"                   // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/staking"                    // import for side-effects
 
 	"github.com/allora-network/allora-chain/health"
 )

--- a/app/app.go
+++ b/app/app.go
@@ -179,6 +179,7 @@ func NewAlloraApp(
 		&app.ParamsKeeper,
 		&app.AuthzKeeper,
 		&app.CircuitBreakerKeeper,
+		&app.EvidenceKeeper,
 	); err != nil {
 		return nil, err
 	}

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -15,6 +15,7 @@ modules:
         # pool, so as to keep the CanWithdrawInvariant invariant.
         - distribution
         - slashing
+        - evidence
         # staking module is required if HistoricalEntries param > 0
         - staking
         - mint
@@ -47,6 +48,7 @@ modules:
         # - after staking so that pools are properly initialized with tokens from genesis accounts;
         # - after auth so that it can access the params from auth;
         - genutil
+        - evidence
         - authz
         - feegrant
         - transfer
@@ -134,3 +136,6 @@ modules:
   - name: feegrant
     config:
       "@type": cosmos.feegrant.module.v1.Module
+  - name: evidence
+    config:
+      "@type": cosmos.evidence.module.v1.Module

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	circuitkeeper "cosmossdk.io/x/circuit/keeper"
+	evidencekeeper "cosmossdk.io/x/evidence/keeper"
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
 	emissionsKeeper "github.com/allora-network/allora-chain/x/emissions/keeper"
@@ -43,6 +44,7 @@ type AppKeepers struct {
 	UpgradeKeeper         *upgradekeeper.Keeper
 	SlashingKeeper        slashingkeeper.Keeper
 	FeeGrantKeeper        feegrantkeeper.Keeper
+	EvidenceKeeper        evidencekeeper.Keeper
 
 	// IBC
 	IBCKeeper           *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly

--- a/app/upgrades/v0_7_0/upgrades.go
+++ b/app/upgrades/v0_7_0/upgrades.go
@@ -5,6 +5,7 @@ import (
 
 	cosmosmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
+	evidencetypes "cosmossdk.io/x/evidence/types"
 	"cosmossdk.io/x/feegrant"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/allora-network/allora-chain/app/keepers"
@@ -24,7 +25,9 @@ var Upgrade = upgrades.Upgrade{
 	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: storetypes.StoreUpgrades{
 		Added: []string{
-			feegrant.StoreKey, feemarkettypes.StoreKey,
+			feegrant.StoreKey,
+			feemarkettypes.StoreKey,
+			evidencetypes.StoreKey,
 		},
 		Renamed: nil,
 		Deleted: nil,


### PR DESCRIPTION
## Purpose of Changes and their Description

Add the evidence module in order to manage `DuplicateVoteEvidence` evidences provided by CometBFT and effectively slash concerned validators.

I've took the opportunity to add the `StoreUpgrades` notion to `Upgrade` to make reusable the logic attach to the addition/modification of stores.

Module wiring seems self-documented through the `app.yaml`, tested locally.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/PROTO-2964/add-the-evidence-module

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
