### PR TITLE
Add circuitbreaker ante decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#654](https://github.com/allora-network/allora-chain/pull/654) Reorganize Linter Folder, add linter to check fuzzer state transition probabilities add to 100 percent. (Integrated as part of #653)
 * [#685](https://github.com/allora-network/allora-chain/pull/685) Add burner permission to gov module
 * [#627](https://github.com/allora-network/allora-chain/pull/627) Add fee market and fee grant module
+* [#689](https://github.com/allora-network/allora-chain/pull/689) Add the `CircuitBreakerDecorator` to the `AnteHandler`
 
 ### Changed
 * [#652](https://github.com/allora-network/allora-chain/pull/652) Reduce code duplication, set local_testnet_upgrade_l1.sh using environment variables with local_testnet_l1.sh instead

--- a/app/ante.go
+++ b/app/ante.go
@@ -3,6 +3,7 @@ package app
 import (
 	errorsmod "cosmossdk.io/errors"
 
+	circuitante "cosmossdk.io/x/circuit/ante"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -19,6 +20,7 @@ type AnteHandlerOptions struct {
 	BankKeeper      feemarketante.BankKeeper
 	AccountKeeper   feemarketante.AccountKeeper
 	FeeMarketKeeper feemarketante.FeeMarketKeeper
+	CircuitKeeper   circuitante.CircuitBreaker
 }
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
@@ -47,6 +49,7 @@ func NewAnteHandler(options AnteHandlerOptions) (sdk.AnteHandler, error) {
 
 	anteDecorators := []sdk.AnteDecorator{
 		authante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		circuitante.NewCircuitBreakerDecorator(options.CircuitKeeper),
 		authante.NewExtensionOptionsDecorator(options.BaseOptions.ExtensionOptionChecker),
 		authante.NewValidateBasicDecorator(),
 		authante.NewTxTimeoutHeightDecorator(),

--- a/app/app.go
+++ b/app/app.go
@@ -229,6 +229,7 @@ func NewAlloraApp(
 		AccountKeeper:   app.AccountKeeper,
 		BankKeeper:      app.BankKeeper,
 		FeeMarketKeeper: app.FeeMarketKeeper,
+		CircuitKeeper:   &app.CircuitBreakerKeeper,
 	}
 	anteHandler, err := NewAnteHandler(anteOptions)
 	if err != nil {


### PR DESCRIPTION
## Purpose of Changes and their Description

Add the `CircuitBreakerDecorator` in our `AnteHandler` to prevent forbidden transactions submission (i.e. if any configured) earlier.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/PROTO-2965/custom-ante-handler

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
