### PR TITLE
Fix number of inferers considered in the reward cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#651](https://github.com/allora-network/allora-chain/pull/651) Refactor: Fuzzer rename invariants test to fuzz test
 * [#653](https://github.com/allora-network/allora-chain/pull/653) Fuzzer Bugfixes, Allow User to Set Fuzzer Transition Probability Distribution
 * [#686](https://github.com/allora-network/allora-chain/pull/686) CLI query commands alignment
+* [#691](https://github.com/allora-network/allora-chain/pull/691/files) Fix number of inferers considered in the reward cycle
 * [#693](https://github.com/allora-network/allora-chain/pull/693) Migration test updates
 
 ### Deprecated

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1112,19 +1112,13 @@ func (k *Keeper) AppendInference(
 		return errors.New("inference already submitted")
 	}
 
+	// Get active inferers for topic
 	workerAddresses, err := k.GetActiveInferersForTopic(ctx, topic.Id)
 	if err != nil {
 		return errorsmod.Wrap(err, "error getting active inferers for topic")
 	}
-	// If there are less than maxTopInferersToReward, add the current inferer
-	if uint64(len(workerAddresses)) < maxTopInferersToReward {
-		err := k.AddActiveInferer(ctx, topic.Id, inference.Inferer)
-		if err != nil {
-			return errorsmod.Wrap(err, "error adding active inferer")
-		}
-		return k.InsertInference(ctx, topic.Id, *inference)
-	}
 
+	// Get previous EMA score for the current inferer
 	previousEmaScore, err := k.GetInfererScoreEma(ctx, topic.Id, inference.Inferer)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Error getting inferer score ema")
@@ -1134,21 +1128,39 @@ func (k *Keeper) AppendInference(
 		return types.ErrCantUpdateEmaMoreThanOncePerWindow
 	}
 
+	// Get lowest inferer score ema for the topic
 	lowestEmaScore, found, err := k.GetLowestInfererScoreEma(ctx, topic.Id)
 	if err != nil {
 		return errorsmod.Wrap(err, "error getting lowest inferer score ema")
-		// If there are no lowest inferer score ema, calculate it
-	} else if !found {
-		lowestEmaScore, err = GetLowestScoreFromAllInferers(ctx, k, topic.Id, workerAddresses)
-		if err != nil {
-			return errorsmod.Wrap(err, "error getting lowest score from all inferers")
-		}
+	}
+	// If there are no lowest inferer score ema, it means it is the first inference for the topic
+	if !found {
+		lowestEmaScore = previousEmaScore
 		err = k.SetLowestInfererScoreEma(ctx, topic.Id, lowestEmaScore)
 		if err != nil {
 			return errorsmod.Wrap(err, "error setting lowest inferer score ema")
 		}
 	}
 
+	// If there are less than maxTopInferersToReward, add the current inferer, update the lowest inferer score ema if needed, and return
+	if uint64(len(workerAddresses)) < maxTopInferersToReward {
+		// Update lowest inferer score ema if needed
+		if uint64(len(workerAddresses)) == 0 || lowestEmaScore.Score.Gt(previousEmaScore.Score) {
+			err = k.SetLowestInfererScoreEma(ctx, topic.Id, previousEmaScore)
+			if err != nil {
+				return errorsmod.Wrap(err, "error setting lowest inferer score ema")
+			}
+		}
+
+		err = k.AddActiveInferer(ctx, topic.Id, inference.Inferer)
+		if err != nil {
+			return errorsmod.Wrap(err, "error adding active inferer")
+		}
+		return k.InsertInference(ctx, topic.Id, *inference)
+	}
+
+	// Else ...
+	// Checks if the inferer's previous EMA score is greater than the lowest EMA score
 	if previousEmaScore.Score.Gt(lowestEmaScore.Score) {
 		// Update EMA score for the lowest score inferer, who is not the current inferer
 		err = k.CalcAndSaveInfererScoreEmaWithLastSavedTopicQuantile(
@@ -1160,6 +1172,16 @@ func (k *Keeper) AppendInference(
 		if err != nil {
 			return errorsmod.Wrap(err, "error calculating and saving inferer score ema with last saved topic quantile")
 		}
+
+		// Check if the inferer with lowest score is active before removing it, because remove will not fail if the inferer is not active
+		isActive, err := k.IsActiveInferer(ctx, topic.Id, lowestEmaScore.Address)
+		if err != nil {
+			return errorsmod.Wrap(err, "error checking if inferer is active")
+		}
+		if !isActive {
+			return errors.New("inferer with lowest score is not active")
+		}
+
 		// Remove inferer with lowest score
 		err = k.RemoveActiveInferer(ctx, topic.Id, lowestEmaScore.Address)
 		if err != nil {

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1112,12 +1112,6 @@ func (k *Keeper) AppendInference(
 		return errors.New("inference already submitted")
 	}
 
-	// Get active inferers for topic
-	workerAddresses, err := k.GetActiveInferersForTopic(ctx, topic.Id)
-	if err != nil {
-		return errorsmod.Wrap(err, "error getting active inferers for topic")
-	}
-
 	// Get previous EMA score for the current inferer
 	previousEmaScore, err := k.GetInfererScoreEma(ctx, topic.Id, inference.Inferer)
 	if err != nil {
@@ -1129,17 +1123,15 @@ func (k *Keeper) AppendInference(
 	}
 
 	// Get lowest inferer score ema for the topic
-	lowestEmaScore, found, err := k.GetLowestInfererScoreEma(ctx, topic.Id)
+	lowestEmaScore, _, err := k.GetLowestInfererScoreEma(ctx, topic.Id)
 	if err != nil {
 		return errorsmod.Wrap(err, "error getting lowest inferer score ema")
 	}
-	// If there are no lowest inferer score ema, it means it is the first inference for the topic
-	if !found {
-		lowestEmaScore = previousEmaScore
-		err = k.SetLowestInfererScoreEma(ctx, topic.Id, lowestEmaScore)
-		if err != nil {
-			return errorsmod.Wrap(err, "error setting lowest inferer score ema")
-		}
+
+	// Get active inferers for topic
+	workerAddresses, err := k.GetActiveInferersForTopic(ctx, topic.Id)
+	if err != nil {
+		return errorsmod.Wrap(err, "error getting active inferers for topic")
 	}
 
 	// If there are less than maxTopInferersToReward, add the current inferer, update the lowest inferer score ema if needed, and return
@@ -1267,19 +1259,6 @@ func (k *Keeper) AppendForecast(
 		return errors.New("forecast already submitted")
 	}
 
-	forecasterAddresses, err := k.GetActiveForecastersForTopic(ctx, topic.Id)
-	if err != nil {
-		return errorsmod.Wrap(err, "error getting active forecasters for topic")
-	}
-	// If there are less than maxTopForecastersToReward, add the current forecaster
-	if uint64(len(forecasterAddresses)) < maxTopForecastersToReward {
-		err := k.AddActiveForecaster(ctx, topic.Id, forecast.Forecaster)
-		if err != nil {
-			return errorsmod.Wrap(err, "error adding active forecaster")
-		}
-		return k.InsertForecast(ctx, topic.Id, *forecast)
-	}
-
 	previousEmaScore, err := k.GetForecasterScoreEma(ctx, topic.Id, forecast.Forecaster)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Error getting forecaster score ema")
@@ -1289,18 +1268,30 @@ func (k *Keeper) AppendForecast(
 		return types.ErrCantUpdateEmaMoreThanOncePerWindow
 	}
 
-	lowestEmaScore, found, err := k.GetLowestForecasterScoreEma(ctx, topic.Id)
+	lowestEmaScore, _, err := k.GetLowestForecasterScoreEma(ctx, topic.Id)
 	if err != nil {
 		return errorsmod.Wrap(err, "error getting lowest forecaster score ema")
-	} else if !found {
-		lowestEmaScore, err = GetLowestScoreFromAllForecasters(ctx, k, topic.Id, forecasterAddresses)
-		if err != nil {
-			return errorsmod.Wrap(err, "error getting lowest score from all forecasters")
+	}
+
+	forecasterAddresses, err := k.GetActiveForecastersForTopic(ctx, topic.Id)
+	if err != nil {
+		return errorsmod.Wrap(err, "error getting active forecasters for topic")
+	}
+
+	// If there are less than maxTopForecastersToReward, add the current forecaster
+	if uint64(len(forecasterAddresses)) < maxTopForecastersToReward {
+		if uint64(len(forecasterAddresses)) == 0 || lowestEmaScore.Score.Gt(previousEmaScore.Score) {
+			err = k.SetLowestForecasterScoreEma(ctx, topic.Id, previousEmaScore)
+			if err != nil {
+				return errorsmod.Wrap(err, "error setting lowest forecaster score ema")
+			}
 		}
-		err = k.SetLowestForecasterScoreEma(ctx, topic.Id, lowestEmaScore)
+
+		err = k.AddActiveForecaster(ctx, topic.Id, forecast.Forecaster)
 		if err != nil {
-			return errorsmod.Wrap(err, "error setting lowest forecaster score ema")
+			return errorsmod.Wrap(err, "error adding active forecaster")
 		}
+		return k.InsertForecast(ctx, topic.Id, *forecast)
 	}
 
 	if previousEmaScore.Score.Gt(lowestEmaScore.Score) {
@@ -1314,6 +1305,16 @@ func (k *Keeper) AppendForecast(
 		if err != nil {
 			return errorsmod.Wrap(err, "error calculating and saving forecaster score ema with last saved topic quantile")
 		}
+
+		// Check if the forecaster with lowest score is active before removing it, because remove will not fail if the forecaster is not active
+		isActive, err := k.IsActiveForecaster(ctx, topic.Id, lowestEmaScore.Address)
+		if err != nil {
+			return errorsmod.Wrap(err, "error checking if forecaster is active")
+		}
+		if !isActive {
+			return errors.New("forecaster with lowest score is not active")
+		}
+
 		// Remove forecaster with lowest score
 		err = k.RemoveActiveForecaster(ctx, topic.Id, lowestEmaScore.Address)
 		if err != nil {
@@ -1453,19 +1454,6 @@ func (k *Keeper) AppendReputerLoss(
 		return errors.New("reputer loss already submitted")
 	}
 
-	reputerAddresses, err := k.GetActiveReputersForTopic(ctx, topic.Id)
-	if err != nil {
-		return errorsmod.Wrap(err, "error getting active reputers for topic")
-	}
-	// If there are less than maxTopReputersToReward, add the current reputer
-	if uint64(len(reputerAddresses)) < moduleParams.MaxTopReputersToReward {
-		err := k.AddActiveReputer(ctx, topic.Id, reputerLoss.ValueBundle.Reputer)
-		if err != nil {
-			return errorsmod.Wrap(err, "error adding active reputer")
-		}
-		return k.InsertReputerLoss(ctx, topic.Id, *reputerLoss)
-	}
-
 	previousEmaScore, err := k.GetReputerScoreEma(ctx, topic.Id, reputerLoss.ValueBundle.Reputer)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Error getting reputer score ema")
@@ -1475,18 +1463,29 @@ func (k *Keeper) AppendReputerLoss(
 		return types.ErrCantUpdateEmaMoreThanOncePerWindow
 	}
 
-	lowestEmaScore, found, err := k.GetLowestReputerScoreEma(ctx, topic.Id)
+	lowestEmaScore, _, err := k.GetLowestReputerScoreEma(ctx, topic.Id)
 	if err != nil {
 		return errorsmod.Wrap(err, "error getting lowest reputer score ema")
-	} else if !found {
-		lowestEmaScore, err = GetLowestScoreFromAllReputers(ctx, k, topic.Id, reputerAddresses)
-		if err != nil {
-			return errorsmod.Wrap(err, "error getting lowest score from all reputers")
+	}
+
+	reputerAddresses, err := k.GetActiveReputersForTopic(ctx, topic.Id)
+	if err != nil {
+		return errorsmod.Wrap(err, "error getting active reputers for topic")
+	}
+	// If there are less than maxTopReputersToReward, add the current reputer
+	if uint64(len(reputerAddresses)) < moduleParams.MaxTopReputersToReward {
+		if uint64(len(reputerAddresses)) == 0 || lowestEmaScore.Score.Gt(previousEmaScore.Score) {
+			err = k.SetLowestReputerScoreEma(ctx, topic.Id, previousEmaScore)
+			if err != nil {
+				return errorsmod.Wrap(err, "error setting lowest reputer score ema")
+			}
 		}
-		err = k.SetLowestReputerScoreEma(ctx, topic.Id, lowestEmaScore)
+
+		err = k.AddActiveReputer(ctx, topic.Id, reputerLoss.ValueBundle.Reputer)
 		if err != nil {
-			return errorsmod.Wrap(err, "error setting lowest reputer score ema")
+			return errorsmod.Wrap(err, "error adding active reputer")
 		}
+		return k.InsertReputerLoss(ctx, topic.Id, *reputerLoss)
 	}
 
 	if previousEmaScore.Score.Gt(lowestEmaScore.Score) {
@@ -1500,6 +1499,16 @@ func (k *Keeper) AppendReputerLoss(
 		if err != nil {
 			return errorsmod.Wrap(err, "error calculating and saving reputer score ema with last saved topic quantile")
 		}
+
+		// Check if the reputer with lowest score is active before removing it, because remove will not fail if the reputer is not active
+		isActive, err := k.IsActiveReputer(ctx, topic.Id, lowestEmaScore.Address)
+		if err != nil {
+			return errorsmod.Wrap(err, "error checking if reputer is active")
+		}
+		if !isActive {
+			return errors.New("reputer with lowest score is not active")
+		}
+
 		// Remove reputer with lowest score
 		err = k.RemoveActiveReputer(ctx, topic.Id, lowestEmaScore.Address)
 		if err != nil {

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -3768,6 +3768,119 @@ func (s *KeeperTestSuite) TestAppendInference() {
 	s.Require().Equal(updateAttemptForWorker2.BlockHeight, updatedWorker2Score.BlockHeight, "unchanged height")
 }
 
+func getNewAddress() string {
+	addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+	return addr.String()
+}
+
+func (s *KeeperTestSuite) TestAppendInferenceWithResetActiveWorkers() {
+	ctx := s.ctx
+	k := s.emissionsKeeper
+	// Topic IDs
+	topicId := s.CreateOneTopic(10801)
+	nonce := types.Nonce{BlockHeight: 10}
+	blockHeightInferences := int64(10)
+
+	// Set previous topic quantile inferer score ema
+	err := k.SetPreviousTopicQuantileInfererScoreEma(ctx, topicId, alloraMath.MustNewDecFromString("1000"))
+	s.Require().NoError(err)
+
+	topic, err := k.GetTopic(ctx, topicId)
+	s.Require().NoError(err)
+
+	worker1 := getNewAddress()
+	worker2 := getNewAddress()
+	worker3 := getNewAddress()
+	worker4 := getNewAddress()
+	worker5 := getNewAddress()
+	worker6 := getNewAddress()
+	// score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker1, Score: alloraMath.NewDecFromInt64(91)}
+	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker2, Score: alloraMath.NewDecFromInt64(92)}
+	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker3, Score: alloraMath.NewDecFromInt64(93)}
+	score4 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker4, Score: alloraMath.NewDecFromInt64(94)}
+	score5 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker5, Score: alloraMath.NewDecFromInt64(95)}
+	score6 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker6, Score: alloraMath.NewDecFromInt64(96)}
+	// err = k.SetInfererScoreEma(ctx, topicId, worker1, score1)
+	// s.Require().NoError(err)
+	err = k.SetInfererScoreEma(ctx, topicId, worker2, score2)
+	s.Require().NoError(err)
+	err = k.SetInfererScoreEma(ctx, topicId, worker3, score3)
+	s.Require().NoError(err)
+	err = k.SetInfererScoreEma(ctx, topicId, worker4, score4)
+	s.Require().NoError(err)
+	err = k.SetInfererScoreEma(ctx, topicId, worker5, score5)
+	s.Require().NoError(err)
+	err = k.SetInfererScoreEma(ctx, topicId, worker6, score6)
+	s.Require().NoError(err)
+
+	// Ensure that the number of top inferers is capped at the max top inferers to reward
+	// New high-score entrant should replace earlier low-score entrant
+	params := types.DefaultParams()
+	params.MaxTopInferersToReward = 4
+	err = k.SetParams(ctx, params)
+	s.Require().NoError(err)
+
+	allInferences := types.Inferences{
+		Inferences: []*types.Inference{
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.11")},
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.12")},
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.13")},
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.14")},
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker5, Value: alloraMath.MustNewDecFromString("0.15")},
+		},
+	}
+	for _, inference := range allInferences.Inferences {
+		err = k.AppendInference(ctx, topic, nonce.BlockHeight, inference, params.MaxTopInferersToReward)
+		s.Require().NoError(err)
+	}
+
+	activeInferers, err := k.GetActiveInferersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(params.MaxTopInferersToReward, uint64(len(activeInferers)))
+
+	lowestEmaScore, found, err := k.GetLowestInfererScoreEma(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().True(found)
+	s.Require().Equal(lowestEmaScore.Address, worker2)
+
+	err = k.ResetActiveWorkersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+
+	activeInferers, err = k.GetActiveInferersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Empty(activeInferers)
+
+	lowestEmaScore, found, err = k.GetLowestInfererScoreEma(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().True(found)
+	s.Require().Equal(lowestEmaScore.Address, worker2)
+
+	blockHeightInferences = blockHeightInferences + topic.EpochLength
+	allInferences = types.Inferences{
+		Inferences: []*types.Inference{
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.22")},
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.23")},
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.24")},
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker5, Value: alloraMath.MustNewDecFromString("0.25")},
+			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker6, Value: alloraMath.MustNewDecFromString("0.26")},
+		},
+	}
+	nonce.BlockHeight++
+	for _, inference := range allInferences.Inferences {
+		err = k.AppendInference(ctx, topic, nonce.BlockHeight, inference, params.MaxTopInferersToReward)
+		s.Require().NoError(err)
+	}
+
+	activeInferers, err = k.GetActiveInferersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(params.MaxTopInferersToReward, uint64(len(activeInferers)))
+
+	lowestEmaScore, found, err = k.GetLowestInfererScoreEma(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().True(found)
+	s.Require().Equal(lowestEmaScore.Address, worker3)
+}
+
 func mockUninitializedParams() types.Params {
 	return types.Params{
 		Version:                             "v2",

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -4068,6 +4068,154 @@ func (s *KeeperTestSuite) TestAppendForecast() {
 	s.Require().Equal(params.MaxTopForecastersToReward, uint64(len(activeForecasters)))
 }
 
+func (s *KeeperTestSuite) TestAppendForecastWithResetActiveForecasters() {
+
+	ctx := s.ctx
+	k := s.emissionsKeeper
+	topicId := s.CreateOneTopic(10800)
+	nonce := types.Nonce{BlockHeight: 10}
+	blockHeightInferences := int64(10)
+
+	worker1 := s.addrsStr[0]
+	worker2 := s.addrsStr[1]
+	worker3 := s.addrsStr[2]
+	worker4 := s.addrsStr[3]
+	worker5 := s.addrsStr[4]
+
+	score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker1, Score: alloraMath.NewDecFromInt64(95)}
+	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker2, Score: alloraMath.NewDecFromInt64(90)}
+	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker3, Score: alloraMath.NewDecFromInt64(99)}
+	score4 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker4, Score: alloraMath.NewDecFromInt64(91)}
+	score5 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker5, Score: alloraMath.NewDecFromInt64(96)}
+	err := k.SetForecasterScoreEma(ctx, topicId, worker1, score1)
+	s.Require().NoError(err)
+	err = k.SetForecasterScoreEma(ctx, topicId, worker2, score2)
+	s.Require().NoError(err)
+	err = k.SetForecasterScoreEma(ctx, topicId, worker3, score3)
+	s.Require().NoError(err)
+	err = k.SetForecasterScoreEma(ctx, topicId, worker4, score4)
+	s.Require().NoError(err)
+	err = k.SetForecasterScoreEma(ctx, topicId, worker5, score5)
+	s.Require().NoError(err)
+
+	params := mockUninitializedParams()
+	params.MaxTopForecastersToReward = 4
+	err = k.SetParams(ctx, params)
+	s.Require().NoError(err)
+
+	allForecasts := types.Forecasts{
+		Forecasts: []*types.Forecast{
+			{
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+				Forecaster:  worker1,
+				ForecastElements: []*types.ForecastElement{
+					{
+						Inferer: worker1,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+					{
+						Inferer: worker2,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+				},
+			},
+			{
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+				Forecaster:  worker2,
+				ForecastElements: []*types.ForecastElement{
+					{
+						Inferer: worker1,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+					{
+						Inferer: worker2,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+				},
+			},
+			{
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+				Forecaster:  worker3,
+				ForecastElements: []*types.ForecastElement{
+					{
+						Inferer: worker1,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+					{
+						Inferer: worker2,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+				},
+			},
+			{
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+				Forecaster:  worker4,
+				ForecastElements: []*types.ForecastElement{
+					{
+						Inferer: worker1,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+					{
+						Inferer: worker2,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+				},
+			},
+			{
+				TopicId:     topicId,
+				BlockHeight: blockHeightInferences,
+				Forecaster:  worker5,
+				ForecastElements: []*types.ForecastElement{
+					{
+						Inferer: worker1,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+					{
+						Inferer: worker2,
+						Value:   alloraMath.MustNewDecFromString("0.52"),
+					},
+				},
+			},
+		},
+	}
+
+	topic, err := k.GetTopic(ctx, topicId)
+	s.Require().NoError(err)
+	for _, forecast := range allForecasts.Forecasts {
+		err = k.AppendForecast(ctx, topic, nonce.BlockHeight, forecast, params.MaxTopForecastersToReward)
+		s.Require().NoError(err)
+	}
+
+	activeForecasters, err := k.GetActiveForecastersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(params.MaxTopForecastersToReward, uint64(len(activeForecasters)))
+
+	// Reset active forecasters
+	err = k.ResetActiveWorkersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+
+	activeForecasters, err = k.GetActiveForecastersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Empty(activeForecasters)
+
+	topic, err = k.GetTopic(ctx, topicId)
+	s.Require().NoError(err)
+
+	nonce.BlockHeight++
+	for _, forecast := range allForecasts.Forecasts {
+		err = k.AppendForecast(ctx, topic, nonce.BlockHeight, forecast, params.MaxTopForecastersToReward)
+		s.Require().NoError(err)
+	}
+
+	activeForecasters, err = k.GetActiveForecastersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(params.MaxTopForecastersToReward, uint64(len(activeForecasters)))
+}
+
 func (s *KeeperTestSuite) TestAppendReputerLoss() {
 	ctx := s.ctx
 	k := s.emissionsKeeper
@@ -4230,6 +4378,183 @@ func (s *KeeperTestSuite) TestAppendReputerLoss() {
 	}
 	err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, &reputerValueBundle5)
 	s.Require().NoError(err)
+	activeReputers, err = k.GetActiveReputersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(params.MaxTopReputersToReward, uint64(len(activeReputers)))
+}
+
+func (s *KeeperTestSuite) TestAppendReputerLossWithResetActiveReputers() {
+	ctx := s.ctx
+	k := s.emissionsKeeper
+	topicId := s.CreateOneTopic(10800)
+	blockHeight := int64(10)
+	nonce := types.Nonce{BlockHeight: blockHeight}
+	reputerRequestNonce := &types.ReputerRequestNonce{
+		ReputerNonce: &types.Nonce{BlockHeight: blockHeight},
+	}
+
+	reputer1 := s.addrsStr[0]
+	reputer2 := s.addrsStr[1]
+	reputer3 := s.addrsStr[2]
+	reputer4 := s.addrsStr[3]
+	reputer5 := s.addrsStr[4]
+
+	score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer1, Score: alloraMath.NewDecFromInt64(95)}
+	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer2, Score: alloraMath.NewDecFromInt64(90)}
+	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer3, Score: alloraMath.NewDecFromInt64(99)}
+	score4 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer4, Score: alloraMath.NewDecFromInt64(91)}
+	score5 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer5, Score: alloraMath.NewDecFromInt64(96)}
+	err := k.SetReputerScoreEma(ctx, topicId, reputer1, score1)
+	s.Require().NoError(err)
+	err = k.SetReputerScoreEma(ctx, topicId, reputer2, score2)
+	s.Require().NoError(err)
+	err = k.SetReputerScoreEma(ctx, topicId, reputer3, score3)
+	s.Require().NoError(err)
+	err = k.SetReputerScoreEma(ctx, topicId, reputer4, score4)
+	s.Require().NoError(err)
+	err = k.SetReputerScoreEma(ctx, topicId, reputer5, score5)
+	s.Require().NoError(err)
+
+	params := types.DefaultParams()
+	params.MaxTopReputersToReward = 4
+	err = k.SetParams(ctx, params)
+	s.Require().NoError(err)
+
+	valueBundleReputer1 := types.ValueBundle{
+		Reputer:                       reputer1,
+		CombinedValue:                 alloraMath.MustNewDecFromString(".0000117005278862668"),
+		ReputerRequestNonce:           reputerRequestNonce,
+		TopicId:                       topicId,
+		ExtraData:                     nil,
+		InfererValues:                 nil,
+		ForecasterValues:              nil,
+		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
+		OneOutInfererValues:           nil,
+		OneOutForecasterValues:        nil,
+		OneInForecasterValues:         nil,
+		OneOutInfererForecasterValues: nil,
+	}
+	signature := s.signValueBundle(&valueBundleReputer1, s.privKeys[0])
+	reputerValueBundle1 := types.ReputerValueBundle{
+		ValueBundle: &valueBundleReputer1,
+		Signature:   signature,
+		Pubkey:      s.pubKeyHexStr[0],
+	}
+	valueBundleReputer2 := types.ValueBundle{
+		Reputer:                       reputer2,
+		CombinedValue:                 alloraMath.MustNewDecFromString(".00000962701954026944"),
+		ReputerRequestNonce:           reputerRequestNonce,
+		TopicId:                       topicId,
+		ExtraData:                     nil,
+		InfererValues:                 nil,
+		ForecasterValues:              nil,
+		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
+		OneOutInfererValues:           nil,
+		OneOutForecasterValues:        nil,
+		OneInForecasterValues:         nil,
+		OneOutInfererForecasterValues: nil,
+	}
+	signature = s.signValueBundle(&valueBundleReputer2, s.privKeys[1])
+	reputerValueBundle2 := types.ReputerValueBundle{
+		ValueBundle: &valueBundleReputer2,
+		Signature:   signature,
+		Pubkey:      s.pubKeyHexStr[1],
+	}
+	valueBundleReputer3 := types.ValueBundle{
+		Reputer:                       reputer3,
+		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
+		ReputerRequestNonce:           reputerRequestNonce,
+		TopicId:                       topicId,
+		ExtraData:                     nil,
+		InfererValues:                 nil,
+		ForecasterValues:              nil,
+		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
+		OneOutInfererValues:           nil,
+		OneOutForecasterValues:        nil,
+		OneInForecasterValues:         nil,
+		OneOutInfererForecasterValues: nil,
+	}
+	signature = s.signValueBundle(&valueBundleReputer3, s.privKeys[2])
+	reputerValueBundle3 := types.ReputerValueBundle{
+		ValueBundle: &valueBundleReputer3,
+		Signature:   signature,
+		Pubkey:      s.pubKeyHexStr[2],
+	}
+	valueBundleReputer4 := types.ValueBundle{
+		Reputer:                       reputer4,
+		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
+		ReputerRequestNonce:           reputerRequestNonce,
+		TopicId:                       topicId,
+		ExtraData:                     nil,
+		InfererValues:                 nil,
+		ForecasterValues:              nil,
+		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
+		OneOutInfererValues:           nil,
+		OneOutForecasterValues:        nil,
+		OneInForecasterValues:         nil,
+		OneOutInfererForecasterValues: nil,
+	}
+	signature = s.signValueBundle(&valueBundleReputer4, s.privKeys[3])
+	reputerValueBundle4 := types.ReputerValueBundle{
+		ValueBundle: &valueBundleReputer4,
+		Signature:   signature,
+		Pubkey:      s.pubKeyHexStr[3],
+	}
+	valueBundleReputer5 := types.ValueBundle{
+		Reputer:                       reputer5,
+		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
+		ReputerRequestNonce:           reputerRequestNonce,
+		TopicId:                       topicId,
+		ExtraData:                     nil,
+		InfererValues:                 nil,
+		ForecasterValues:              nil,
+		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
+		OneOutInfererValues:           nil,
+		OneOutForecasterValues:        nil,
+		OneInForecasterValues:         nil,
+		OneOutInfererForecasterValues: nil,
+	}
+	signature = s.signValueBundle(&valueBundleReputer5, s.privKeys[4])
+	reputerValueBundle5 := types.ReputerValueBundle{
+		ValueBundle: &valueBundleReputer5,
+		Signature:   signature,
+		Pubkey:      s.pubKeyHexStr[4],
+	}
+
+	allReputerLosses := types.ReputerValueBundles{
+		ReputerValueBundles: []*types.ReputerValueBundle{
+			&reputerValueBundle1,
+			&reputerValueBundle2,
+			&reputerValueBundle3,
+			&reputerValueBundle4,
+			&reputerValueBundle5,
+		},
+	}
+
+	topic, err := k.GetTopic(ctx, topicId)
+	s.Require().NoError(err)
+	for _, reputerValueBundle := range allReputerLosses.ReputerValueBundles {
+		err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, reputerValueBundle)
+		s.Require().NoError(err)
+	}
+
+	activeReputers, err := k.GetActiveReputersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(params.MaxTopReputersToReward, uint64(len(activeReputers)))
+
+	err = k.ResetActiveReputersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+
+	activeReputers, err = k.GetActiveReputersForTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Empty(activeReputers)
+
+	nonce.BlockHeight++
+	for _, reputerValueBundle := range allReputerLosses.ReputerValueBundles {
+		err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, reputerValueBundle)
+		s.Require().NoError(err)
+	}
+
 	activeReputers, err = k.GetActiveReputersForTopic(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(params.MaxTopReputersToReward, uint64(len(activeReputers)))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

`k.lowestInfererScoreEma` was not being updated on a new Epoch. Then, after the 32 slots get filled up, and when the 33rd inference arrives, it was checked against the value in `k.lowestInfererScoreEma` from previous Epoch.

If the new inferer has a greater score, it gets added and the old one gets removed. But since the old one was from the previous epoch (that is, the worker in the stored `Score` struct of lowest score), it does not exist anymore, and the function that removes the inferer won't return and error if it does not exist. So we don't remove any inferer, and we add a new one. That's how we end up with 33.

This PR effectively resets that stored lowest score (stored by topic) upon the start of a new worker submission window. Therefore, whenever one attempts to move a worker out of the active set, we can be assured the worker is actually a part of the topic's current active set.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/PROTO-2851/fix-number-of-inferers-considered-in-the-reward-cycle

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
   - Unit tests provided
- [x] If documented, please describe where. If not, describe why docs are not needed.
   - Evident in the code and its comments
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
   - Added to stanza of next release

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
