### PR TITLE
Adapt install script to new release assets naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* [#699](https://github.com/allora-network/allora-chain/pull/699) Make install script manage new release assets naming
+
 ## v0.7.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Binary can be Installed for Linux or Mac (check releases for Windows)
 Specify a version to install if desired. 
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/allora-network/allora-chain/main/install.sh | bash -s -- v0.0.8
+curl -sSL https://raw.githubusercontent.com/allora-network/allora-chain/main/install.sh | bash -s -- v0.7.0
 ```
 
 Ensure `~/.local/bin` is in your PATH.

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 APP_NAME="allorad"
 
 # Check for a version argument, otherwise set a default version
-VERSION=${1:-"v0.2.8"}
+VERSION=${1:-"v0.7.0"}
 
 # Define the base URL using the specified or default version
 BASE_URL="https://github.com/allora-network/allora-chain/releases/download/$VERSION"
@@ -27,7 +27,7 @@ case $ARCH in
 esac
 
 # Construct the download URL
-URL="${BASE_URL}/${APP_NAME}_${OS}_${ARCH}"
+URL="${BASE_URL}/allora-chain_${VERSION#v}_${OS}_${ARCH}"
 
 # Define the target directory
 TARGET_DIR="$HOME/.local/bin"


### PR DESCRIPTION
## Purpose of Changes and their Description

Update the `install.sh` script according to the new release assets name template, for instance:
`allorad_${OS}_${ARCH}` => `allora-chain_${VERSION_DIGITS}_${OS}_${ARCH}`

The installed binary is still `allorad`.

I took the opportunity to update the default version installed to the current latest (i.e. `0.7.0`).

Can be tested before merging with:
```bash
curl -sSL https://raw.githubusercontent.com/allora-network/allora-chain/arnaud%2Fadapt-install-script/install.sh | bash -s -- v0.7.0
```

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?