### PR TITLE
Register old proto messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* [#700](https://github.com/allora-network/allora-chain/pull/700) Allow clients to unmarshall old transactions
+
 ## v0.7.0
 
 ### Added

--- a/x/emissions/api/emissions/v2/codec.go
+++ b/x/emissions/api/emissions/v2/codec.go
@@ -1,0 +1,28 @@
+package emissionsv2
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// nolint: exhaustruct
+func RegisterInterfaces(registry types.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+		&MsgCreateNewTopic{},
+		&MsgRegister{},
+		&MsgRemoveRegistration{},
+		&MsgAddStake{},
+		&MsgRemoveStake{},
+		&MsgCancelRemoveStake{},
+		&MsgDelegateStake{},
+		&MsgRewardDelegateStake{},
+		&MsgRemoveDelegateStake{},
+		&MsgCancelRemoveDelegateStake{},
+		&MsgFundTopic{},
+		&MsgAddToWhitelistAdmin{},
+		&MsgRemoveFromWhitelistAdmin{},
+		&MsgInsertWorkerPayload{},
+		&MsgInsertReputerPayload{},
+	)
+}

--- a/x/emissions/api/emissions/v3/codec.go
+++ b/x/emissions/api/emissions/v3/codec.go
@@ -1,0 +1,28 @@
+package emissionsv3
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// nolint: exhaustruct
+func RegisterInterfaces(registry types.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+		&MsgCreateNewTopic{},
+		&MsgRegister{},
+		&MsgRemoveRegistration{},
+		&MsgAddStake{},
+		&MsgRemoveStake{},
+		&MsgCancelRemoveStake{},
+		&MsgDelegateStake{},
+		&MsgRewardDelegateStake{},
+		&MsgRemoveDelegateStake{},
+		&MsgCancelRemoveDelegateStake{},
+		&MsgFundTopic{},
+		&MsgAddToWhitelistAdmin{},
+		&MsgRemoveFromWhitelistAdmin{},
+		&MsgInsertWorkerPayload{},
+		&MsgInsertReputerPayload{},
+	)
+}

--- a/x/emissions/api/emissions/v4/codec.go
+++ b/x/emissions/api/emissions/v4/codec.go
@@ -1,0 +1,28 @@
+package emissionsv4
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// nolint: exhaustruct
+func RegisterInterfaces(registry types.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&UpdateParamsRequest{},
+		&CreateNewTopicRequest{},
+		&RegisterRequest{},
+		&RemoveRegistrationRequest{},
+		&AddStakeRequest{},
+		&RemoveStakeRequest{},
+		&CancelRemoveStakeRequest{},
+		&DelegateStakeRequest{},
+		&RewardDelegateStakeRequest{},
+		&RemoveDelegateStakeRequest{},
+		&CancelRemoveDelegateStakeRequest{},
+		&FundTopicRequest{},
+		&AddToWhitelistAdminRequest{},
+		&RemoveFromWhitelistAdminRequest{},
+		&InsertWorkerPayloadRequest{},
+		&InsertReputerPayloadRequest{},
+	)
+}

--- a/x/emissions/api/emissions/v5/codec.go
+++ b/x/emissions/api/emissions/v5/codec.go
@@ -1,0 +1,28 @@
+package emissionsv5
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// nolint: exhaustruct
+func RegisterInterfaces(registry types.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&UpdateParamsRequest{},
+		&CreateNewTopicRequest{},
+		&RegisterRequest{},
+		&RemoveRegistrationRequest{},
+		&AddStakeRequest{},
+		&RemoveStakeRequest{},
+		&CancelRemoveStakeRequest{},
+		&DelegateStakeRequest{},
+		&RewardDelegateStakeRequest{},
+		&RemoveDelegateStakeRequest{},
+		&CancelRemoveDelegateStakeRequest{},
+		&FundTopicRequest{},
+		&AddToWhitelistAdminRequest{},
+		&RemoveFromWhitelistAdminRequest{},
+		&InsertWorkerPayloadRequest{},
+		&InsertReputerPayloadRequest{},
+	)
+}

--- a/x/emissions/api/emissions/v6/codec.go
+++ b/x/emissions/api/emissions/v6/codec.go
@@ -1,0 +1,40 @@
+package emissionsv6
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// nolint: exhaustruct
+func RegisterInterfaces(registry types.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&UpdateParamsRequest{},
+		&CreateNewTopicRequest{},
+		&RegisterRequest{},
+		&RemoveRegistrationRequest{},
+		&AddStakeRequest{},
+		&RemoveStakeRequest{},
+		&CancelRemoveStakeRequest{},
+		&DelegateStakeRequest{},
+		&RewardDelegateStakeRequest{},
+		&RemoveDelegateStakeRequest{},
+		&CancelRemoveDelegateStakeRequest{},
+		&FundTopicRequest{},
+		&AddToWhitelistAdminRequest{},
+		&RemoveFromWhitelistAdminRequest{},
+		&InsertWorkerPayloadRequest{},
+		&InsertReputerPayloadRequest{},
+		&AddToGlobalWhitelistRequest{},
+		&RemoveFromGlobalWhitelistRequest{},
+		&EnableTopicWorkerWhitelistRequest{},
+		&DisableTopicWorkerWhitelistRequest{},
+		&EnableTopicReputerWhitelistRequest{},
+		&DisableTopicReputerWhitelistRequest{},
+		&AddToTopicCreatorWhitelistRequest{},
+		&RemoveFromTopicCreatorWhitelistRequest{},
+		&AddToTopicWorkerWhitelistRequest{},
+		&RemoveFromTopicWorkerWhitelistRequest{},
+		&AddToTopicReputerWhitelistRequest{},
+		&RemoveFromTopicReputerWhitelistRequest{},
+	)
+}

--- a/x/emissions/module/module.go
+++ b/x/emissions/module/module.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 
 	"cosmossdk.io/core/appmodule"
+	v2 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v2"
+	v3 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v3"
+	v4 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v4"
+	v5 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v5"
 	keeper "github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
 	"github.com/allora-network/allora-chain/x/emissions/keeper/queryserver"
@@ -65,6 +69,10 @@ func (AppModule) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *gwrunt
 // RegisterInterfaces registers interfaces and implementations of the state module.
 func (AppModule) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	types.RegisterInterfaces(registry)
+	v2.RegisterInterfaces(registry)
+	v3.RegisterInterfaces(registry)
+	v4.RegisterInterfaces(registry)
+	v5.RegisterInterfaces(registry)
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.

--- a/x/emissions/types/codec.go
+++ b/x/emissions/types/codec.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	types "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 

--- a/x/mint/api/mint/v1beta1/codec.go
+++ b/x/mint/api/mint/v1beta1/codec.go
@@ -1,0 +1,13 @@
+package mintv1beta1
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// nolint: exhaustruct
+func RegisterInterfaces(registry types.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+	)
+}

--- a/x/mint/api/mint/v2/codec.go
+++ b/x/mint/api/mint/v2/codec.go
@@ -1,0 +1,14 @@
+package mintv2
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// nolint: exhaustruct
+func RegisterInterfaces(registry types.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&UpdateParamsRequest{},
+		&RecalculateTargetEmissionRequest{},
+	)
+}

--- a/x/mint/module/module.go
+++ b/x/mint/module/module.go
@@ -9,6 +9,7 @@ import (
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/depinject"
 	modulev1 "github.com/allora-network/allora-chain/x/mint/api/mint/module/v1"
+	v1beta1 "github.com/allora-network/allora-chain/x/mint/api/mint/v1beta1"
 	"github.com/allora-network/allora-chain/x/mint/keeper"
 	"github.com/allora-network/allora-chain/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -50,6 +51,7 @@ func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 // RegisterInterfaces registers the module's interface types
 func (b AppModuleBasic) RegisterInterfaces(r cdctypes.InterfaceRegistry) {
 	types.RegisterInterfaces(r)
+	v1beta1.RegisterInterfaces(r)
 }
 
 // DefaultGenesis returns default genesis state as raw bytes for the mint


### PR DESCRIPTION
## Purpose of Changes and their Description

Solve the unmarshalling issues of `sdk.Msg` implementations of previous `x/emissions` and `x/mint` versions by registering related types in the `InterfaceRegistry`.

This change is not consensus breaking as these messages are never manipulated in state mutations, there is no need to update validator nodes with this fix.

It'll allow to query transactions containing old versions of proto messages, for example the query below was returning an error:
```bash
> allorad --node "https://allora-rpc.testnet.allora.network" query tx 74E327C59995366ECF6009AE68122EB60B24815C78B636B01B52B2E96772932C
Error: unable to resolve type URL /emissions.v5.InsertWorkerPayloadRequest: tx parse error
Usage:
  allorad query tx --type=[hash|acc_seq|signature] [hash|acc_seq|signature] [flags]

Flags:
      --grpc-addr string   the gRPC endpoint to use for this chain
      --grpc-insecure      allow gRPC over insecure channels, if not the server must use TLS
      --height int         Use a specific height to query state at (this can error if the node is pruning state)
  -h, --help               help for tx
      --node string        <host>:<port> to CometBFT RPC interface for this chain (default "tcp://localhost:26657")
  -o, --output string      Output format (text|json) (default "text")
      --type string        The type to be used when querying tx, can be one of "hash", "acc_seq", "signature" (default "hash")

Global Flags:
      --home string         directory for config and data (default "/Users/arnaud/.allorad")
      --log_format string   The logging format (json|plain) (default "plain")
      --log_level string    The logging level (trace|debug|info|warn|error|fatal|panic|disabled or '*:<level>,<key>:<level>') (default "info")
      --log_no_color        Disable colored logs
      --trace               print out full stack trace on errors

unable to resolve type URL /emissions.v5.InsertWorkerPayloadRequest: tx parse error [cosmos/cosmos-sdk@v0.50.10/x/auth/tx/decoder.go:44]
```

I'll mention this in the upgrade checklist so we do the same for future versions.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/PROTO-3030/investigate-issue-when-querying-transactions-in-testnet

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
