### PR TITLE
Correct Discrepancies with Whitepaper modified reward fractions vs plain EMA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.X.X
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
 ### Fixed
 
 * [#699](https://github.com/allora-network/allora-chain/pull/699) Make install script manage new release assets naming
+* [#704](https://github.com/allora-network/allora-chain/pull/704) Correct Discrepancies with Whitepaper modified reward fractions vs plain EMA
+
+### Security
+
+## [Released]
 
 ## v0.7.0
 
@@ -103,8 +118,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 * [#682](https://github.com/allora-network/allora-chain/pull/682) Ensure IBC `MsgTransfer` funds are received
-
-## [Released]
 
 ## v0.6.0
 

--- a/x/emissions/module/rewards/reputer_rewards.go
+++ b/x/emissions/module/rewards/reputer_rewards.go
@@ -83,22 +83,21 @@ func GetReputerTaskEntropy(
 	if len(emaRewardFractions) == 0 {
 		return alloraMath.Dec{}, errors.Wrapf(types.ErrInvalidReward, "invalid reward fractions after EMA")
 	}
-	// Calculate modified reward fractions and persist for next round
-	numberRatio, err := NumberRatio(emaRewardFractions)
-	if err != nil {
-		return alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate reputer number ratio")
-	}
-	modifiedRewardFractions, err := ModifiedRewardFractions(emaRewardFractions)
-	if err != nil {
-		return alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate modified reward fractions")
-	}
 	for i, reputer := range reputers {
-		err := k.SetPreviousReputerRewardFraction(ctx, topicId, reputer, modifiedRewardFractions[i])
+		err := k.SetPreviousReputerRewardFraction(ctx, topicId, reputer, emaRewardFractions[i])
 		if err != nil {
 			return alloraMath.Dec{}, errors.Wrapf(err, "failed to set previous reputer reward fraction")
 		}
 	}
-
+	// Calculate modified reward fractions and persist for next round
+	modifiedRewardFractions, err := ModifiedRewardFractions(emaRewardFractions)
+	if err != nil {
+		return alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate modified reward fractions")
+	}
+	numberRatio, err := NumberRatio(modifiedRewardFractions)
+	if err != nil {
+		return alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate reputer number ratio")
+	}
 	if numReputers > 1 {
 		entropy, err = Entropy(
 			modifiedRewardFractions,

--- a/x/emissions/module/rewards/worker_rewards.go
+++ b/x/emissions/module/rewards/worker_rewards.go
@@ -182,29 +182,29 @@ func getInferenceOrForecastTaskEntropy(
 	if len(emaRewardFractions) == 0 {
 		return alloraMath.Dec{}, errors.Wrapf(types.ErrInvalidReward, "invalid reward fractions after EMA calculation")
 	}
-	// Calculate modified reward fractions and persist for next round
-	numberRatio, err := NumberRatio(emaRewardFractions)
-	if err != nil {
-		return alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate number ratio")
-	}
-	modifiedRewardFractions, err := ModifiedRewardFractions(emaRewardFractions)
-	if err != nil {
-		return alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate modified reward fractions")
-	}
 	if which == taskInference {
 		for i, worker := range workers {
-			err := k.SetPreviousInferenceRewardFraction(ctx, topicId, worker, modifiedRewardFractions[i])
+			err := k.SetPreviousInferenceRewardFraction(ctx, topicId, worker, emaRewardFractions[i])
 			if err != nil {
 				return alloraMath.Dec{}, errors.Wrapf(err, "failed to set previous inference reward fraction")
 			}
 		}
 	} else { // taskForecast
 		for i, worker := range workers {
-			err := k.SetPreviousForecastRewardFraction(ctx, topicId, worker, modifiedRewardFractions[i])
+			err := k.SetPreviousForecastRewardFraction(ctx, topicId, worker, emaRewardFractions[i])
 			if err != nil {
 				return alloraMath.Dec{}, errors.Wrapf(err, "failed to set previous forecast reward fraction")
 			}
 		}
+	}
+	// Calculate modified reward fractions and persist for next round
+	modifiedRewardFractions, err := ModifiedRewardFractions(emaRewardFractions)
+	if err != nil {
+		return alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate modified reward fractions")
+	}
+	numberRatio, err := NumberRatio(modifiedRewardFractions)
+	if err != nil {
+		return alloraMath.Dec{}, errors.Wrapf(err, "failed to calculate number ratio")
 	}
 
 	if numWorkers > 1 {


### PR DESCRIPTION
## Purpose of Changes and their Description

Really all credit for this PR goes to @cal-hawk who did the hard work of finding the bug and tracing the actual lines of code related to it.

He found a discrepancy between the whitepaper and the allora-chain codebase where u-tilde (inferer, reputer, forecaster reward fractions) were being used for numberRatio calculations when it should be using f (the modifiedRewardFractions). And then also the reverse for setting the previous EMA score - we were using f instead of u-tilde in that case.

and in the other case it's:

f being used where it should be u-tilde

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

PROTO-3039, RES-579

## Are these changes tested and documented?

To be quite honest I don't know of an easy way to test this in a unit test and show that the fixed code addresses issues other than just pointing to the whitepaper and saying read these formulas. The existing unit test suite at least will cover that directionally these changes do not break any major functionality of the chain.