### PR TITLE
PROTO-3076: add back the TopicInitialRegretSetEvent

### DIFF
--- a/x/emissions/keeper/inference_synthesis/network_regrets.go
+++ b/x/emissions/keeper/inference_synthesis/network_regrets.go
@@ -421,6 +421,9 @@ func GetCalcSetNetworkRegrets(args GetCalcSetNetworkRegretsArgs) error {
 		if err != nil {
 			return errorsmod.Wrapf(err, "Error updating topic initial regret")
 		}
+
+		// For batch event emission
+		emissions.EmitNewTopicInitialRegretSetEvent(args.Ctx, args.TopicId, blockHeight, updatedTopicInitialRegret)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
Added event emission for topic initial regret updates. This change enables external monitoring of when and how topic initial regrets are modified. 
Note, event was removed by mistake in v0.7.0.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
https://linear.app/alloralabs/issue/PROTO-3076/add-back-the-topicinitialregretsetevent-to-the-chain

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
   - The event emission uses an existing event type and follows the same pattern as other event emissions in the codebase, and is already tested.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo
N/A
