### PR TITLE
Add sortition penalties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#703](https://github.com/allora-network/allora-chain/pull/703) Add outlier detection to inferences
 * [#714](https://github.com/allora-network/allora-chain/pull/714) Add initialization of actors' EMA scores
 * [#716](https://github.com/allora-network/allora-chain/pull/716) Add global workers, reputers, admins + bulk operations
+* [#712](https://github.com/allora-network/allora-chain/pull/712) Apply sortition penalties based on liveness
 
 ### Changed
 

--- a/math/utils_test.go
+++ b/math/utils_test.go
@@ -63,6 +63,78 @@ func TestCalcEmaWithNaN(t *testing.T) {
 	require.ErrorIs(t, err, alloraMath.ErrNaN)
 }
 
+func TestNCalcEma(t *testing.T) {
+	cases := []struct {
+		name           string
+		alpha          alloraMath.Dec
+		update         alloraMath.Dec
+		score          alloraMath.Dec
+		n              uint64
+		expectedResult alloraMath.Dec
+		expectedErr    error
+	}{
+		{
+			name:           "n=1",
+			alpha:          alloraMath.MustNewDecFromString("0.1"),
+			update:         alloraMath.MustNewDecFromString("300"),
+			score:          alloraMath.MustNewDecFromString("200"),
+			n:              1,
+			expectedResult: alloraMath.MustNewDecFromString("210"),
+			expectedErr:    nil,
+		},
+		{
+			name:           "n=4",
+			alpha:          alloraMath.MustNewDecFromString("0.1"),
+			update:         alloraMath.MustNewDecFromString("300"),
+			score:          alloraMath.MustNewDecFromString("200"),
+			n:              4,
+			expectedResult: alloraMath.MustNewDecFromString("234.39"),
+			expectedErr:    nil,
+		},
+		{
+			name:           "error alpha NaN",
+			alpha:          alloraMath.NewNaN(),
+			update:         alloraMath.MustNewDecFromString("300"),
+			score:          alloraMath.MustNewDecFromString("200"),
+			n:              3,
+			expectedResult: alloraMath.ZeroDec(),
+			expectedErr:    alloraMath.ErrNaN,
+		},
+		{
+			name:           "error update NaN",
+			alpha:          alloraMath.MustNewDecFromString("0.1"),
+			update:         alloraMath.NewNaN(),
+			score:          alloraMath.MustNewDecFromString("200"),
+			n:              3,
+			expectedResult: alloraMath.ZeroDec(),
+			expectedErr:    alloraMath.ErrNaN,
+		},
+		{
+			name:           "error score NaN",
+			alpha:          alloraMath.MustNewDecFromString("0.1"),
+			update:         alloraMath.MustNewDecFromString("300"),
+			score:          alloraMath.NewNaN(),
+			n:              3,
+			expectedResult: alloraMath.ZeroDec(),
+			expectedErr:    alloraMath.ErrNaN,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := alloraMath.NCalcEma(tc.alpha, tc.update, tc.score, tc.n)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				inDelta, err := alloraMath.InDelta(tc.expectedResult, result, alloraMath.MustNewDecFromString("0.0001"))
+				require.NoError(t, err)
+				require.True(t, inDelta, "expected %s, got %s", tc.expectedResult.String(), result.String())
+			}
+		})
+	}
+}
+
 func TestStdDev(t *testing.T) {
 	tests := []struct {
 		name string

--- a/x/emissions/keeper/actor_penalties.go
+++ b/x/emissions/keeper/actor_penalties.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -133,6 +134,7 @@ func CountReputerContiguousMissedEpochs(topic types.Topic, lastSubmittedNonce in
 }
 
 func countContiguousMissedEpochs(prevEpochStart, epochLength, lastSubmittedNonce int64) int64 {
+	lastSubmittedNonce = math.Max(lastSubmittedNonce, 0)
 	if lastSubmittedNonce >= prevEpochStart {
 		return 0
 	}

--- a/x/emissions/keeper/actor_penalties.go
+++ b/x/emissions/keeper/actor_penalties.go
@@ -1,9 +1,6 @@
 package keeper
 
 import (
-	"errors"
-
-	"cosmossdk.io/collections"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -20,7 +17,7 @@ func (k *Keeper) MayPenaliseInferer(
 	return MayPenaliseActor(
 		CountWorkerContiguousMissedEpochs,
 		func(topicId TopicId) (alloraMath.Dec, error) {
-			return k.initialInfererEmaScore.Get(ctx, topicId)
+			return k.GetTopicInitialInfererEmaScore(ctx, topicId)
 		},
 		func(topicId TopicId, score types.Score) error {
 			return k.SetInfererScoreEma(ctx, topicId, score.Address, score)
@@ -42,7 +39,7 @@ func (k *Keeper) MayPenaliseForecaster(
 	return MayPenaliseActor(
 		CountWorkerContiguousMissedEpochs,
 		func(topicId TopicId) (alloraMath.Dec, error) {
-			return k.initialForecasterEmaScore.Get(ctx, topicId)
+			return k.GetTopicInitialForecasterEmaScore(ctx, topicId)
 		},
 		func(topicId TopicId, score types.Score) error {
 			return k.SetForecasterScoreEma(ctx, topicId, score.Address, score)
@@ -64,7 +61,7 @@ func (k *Keeper) MayPenaliseReputer(
 	return MayPenaliseActor(
 		CountReputerContiguousMissedEpochs,
 		func(topicId TopicId) (alloraMath.Dec, error) {
-			return k.initialReputerEmaScore.Get(ctx, topicId)
+			return k.GetTopicInitialReputerEmaScore(ctx, topicId)
 		},
 		func(topicId TopicId, score types.Score) error {
 			return k.SetReputerScoreEma(ctx, topicId, score.Address, score)
@@ -90,10 +87,6 @@ func MayPenaliseActor(
 	}
 
 	penalty, err := getPenaltyFn(topic.Id)
-	// No penalty set, no penalty
-	if errors.Is(err, collections.ErrNotFound) {
-		return emaScore, nil
-	}
 	if err != nil {
 		return types.Score{}, err
 	}

--- a/x/emissions/keeper/actor_penalties.go
+++ b/x/emissions/keeper/actor_penalties.go
@@ -73,7 +73,7 @@ func (k *Keeper) MayPenaliseReputer(
 }
 
 func MayPenaliseActor(
-	missedEpochsFn func(topic types.Topic, lastSubmissionHeight int64) int64,
+	missedEpochsFn func(topic types.Topic, lastSubmittedNonce int64) int64,
 	getPenaltyFn func(topicId TopicId) (alloraMath.Dec, error),
 	setScoreFn func(topicId TopicId, score types.Score) error,
 	topic types.Topic,
@@ -107,22 +107,22 @@ func applyPenalty(topic types.Topic, penalty, emaScore alloraMath.Dec, missedEpo
 
 // CountWorkerContiguousMissedEpochs counts the number of contiguous missed epochs prior to the given nonce, given the
 // actor last submission.
-func CountWorkerContiguousMissedEpochs(topic types.Topic, lastSubmissionHeight int64) int64 {
+func CountWorkerContiguousMissedEpochs(topic types.Topic, lastSubmittedNonce int64) int64 {
 	prevEpochStart := topic.EpochLastEnded - topic.EpochLength
-	return countContiguousMissedEpochs(prevEpochStart, topic.EpochLength, lastSubmissionHeight)
+	return countContiguousMissedEpochs(prevEpochStart, topic.EpochLength, lastSubmittedNonce)
 }
 
 // CountReputerContiguousMissedEpochs counts the number of contiguous missed epochs prior to the given nonce, given the
 // actor last submission.
-func CountReputerContiguousMissedEpochs(topic types.Topic, lastSubmissionHeight int64) int64 {
-	prevEpochStart := topic.EpochLastEnded - topic.EpochLength + topic.WorkerSubmissionWindow + topic.GroundTruthLag
-	return countContiguousMissedEpochs(prevEpochStart, topic.EpochLength, lastSubmissionHeight)
+func CountReputerContiguousMissedEpochs(topic types.Topic, lastSubmittedNonce int64) int64 {
+	prevEpochStart := topic.EpochLastEnded - topic.EpochLength - topic.GroundTruthLag
+	return countContiguousMissedEpochs(prevEpochStart, topic.EpochLength, lastSubmittedNonce)
 }
 
-func countContiguousMissedEpochs(prevEpochStart, epochLength, lastSubmissionHeight int64) int64 {
-	if lastSubmissionHeight >= prevEpochStart {
+func countContiguousMissedEpochs(prevEpochStart, epochLength, lastSubmittedNonce int64) int64 {
+	if lastSubmittedNonce >= prevEpochStart {
 		return 0
 	}
 
-	return (prevEpochStart-1-lastSubmissionHeight)/epochLength + 1
+	return (prevEpochStart-1-lastSubmittedNonce)/epochLength + 1
 }

--- a/x/emissions/keeper/actor_penalties.go
+++ b/x/emissions/keeper/actor_penalties.go
@@ -15,7 +15,7 @@ func (k *Keeper) ApplyLivenessPenaltyToInferer(
 	nonceBlockHeight types.BlockHeight,
 	emaScore types.Score,
 ) (types.Score, error) {
-	return ApplyLivenessPenaltyTo(
+	return ApplyLivenessPenaltyToActor(
 		ctx,
 		CountWorkerContiguousMissedEpochs,
 		func(topicId TopicId) (alloraMath.Dec, error) {
@@ -38,7 +38,7 @@ func (k *Keeper) ApplyLivenessPenaltyToForecaster(
 	nonceBlockHeight types.BlockHeight,
 	emaScore types.Score,
 ) (types.Score, error) {
-	return ApplyLivenessPenaltyTo(
+	return ApplyLivenessPenaltyToActor(
 		ctx,
 		CountWorkerContiguousMissedEpochs,
 		func(topicId TopicId) (alloraMath.Dec, error) {
@@ -61,7 +61,7 @@ func (k *Keeper) ApplyLivenessPenaltyToReputer(
 	nonceBlockHeight types.BlockHeight,
 	emaScore types.Score,
 ) (types.Score, error) {
-	return ApplyLivenessPenaltyTo(
+	return ApplyLivenessPenaltyToActor(
 		ctx,
 		CountReputerContiguousMissedEpochs,
 		func(topicId TopicId) (alloraMath.Dec, error) {
@@ -76,7 +76,7 @@ func (k *Keeper) ApplyLivenessPenaltyToReputer(
 	)
 }
 
-func ApplyLivenessPenaltyTo(
+func ApplyLivenessPenaltyToActor(
 	ctx sdk.Context,
 	missedEpochsFn func(topic types.Topic, lastSubmittedNonce int64) int64,
 	getAsymptoteFn func(topicId TopicId) (alloraMath.Dec, error),
@@ -135,6 +135,9 @@ func CountReputerContiguousMissedEpochs(topic types.Topic, lastSubmittedNonce in
 
 func countContiguousMissedEpochs(prevEpochStart, epochLength, lastSubmittedNonce int64) int64 {
 	lastSubmittedNonce = math.Max(lastSubmittedNonce, 0)
+	prevEpochStart = math.Max(prevEpochStart, 0)
+	epochLength = math.Max(epochLength, 0)
+
 	if lastSubmittedNonce >= prevEpochStart {
 		return 0
 	}

--- a/x/emissions/keeper/actor_penalties.go
+++ b/x/emissions/keeper/actor_penalties.go
@@ -73,8 +73,7 @@ func mayPenaliseWorker(
 		return types.Score{}, err
 	}
 	emaScore.BlockHeight = block
-	// TODO: Provide the limit as the initial score
-	emaScore.Score, err = applyPenalty(topic, penalty, alloraMath.ZeroDec(), emaScore.Score, missedEpochs)
+	emaScore.Score, err = applyPenalty(topic, penalty, emaScore.Score, missedEpochs)
 	if err != nil {
 		return types.Score{}, err
 	}
@@ -84,20 +83,8 @@ func mayPenaliseWorker(
 }
 
 // applyPenalty applies the penalty to the EMA score for the given number of missed epochs while staying above provided limit.
-func applyPenalty(topic types.Topic, penalty, limit, emaScore alloraMath.Dec, missedEpochs int64) (alloraMath.Dec, error) {
-	for i := int64(0); i < missedEpochs; i++ {
-		penalisedScore, err := alloraMath.CalcEma(topic.MeritSortitionAlpha, penalty, emaScore, false)
-		if err != nil {
-			return alloraMath.ZeroDec(), err
-		}
-
-		if penalisedScore.Lt(limit) {
-			break
-		}
-		emaScore = penalisedScore
-	}
-
-	return emaScore, nil
+func applyPenalty(topic types.Topic, penalty, emaScore alloraMath.Dec, missedEpochs int64) (alloraMath.Dec, error) {
+	return alloraMath.NCalcEma(topic.MeritSortitionAlpha, penalty, emaScore, uint64(missedEpochs))
 }
 
 // CountWorkerContiguousMissedEpochs counts the number of contiguous missed epochs prior to the given nonce, given the

--- a/x/emissions/keeper/actor_penalties.go
+++ b/x/emissions/keeper/actor_penalties.go
@@ -1,0 +1,73 @@
+package keeper
+
+import (
+	"errors"
+
+	"cosmossdk.io/collections"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// MayPenaliseInferer penalises an inferer for missing previous epochs. It saves and returns the new EMA score.
+// If the inferer didn't miss any epochs this is a no-op, the EMA score is returned as is.
+func (k *Keeper) MayPenaliseInferer(
+	ctx sdk.Context,
+	topic types.Topic,
+	block types.BlockHeight,
+	emaScore types.Score,
+) (types.Score, error) {
+	missedEpochs := countWorkerContiguousMissedEpochs(topic, emaScore.BlockHeight)
+	// No missed epochs == no penalty
+	if missedEpochs == 0 {
+		return emaScore, nil
+	}
+
+	penalty, err := k.initialInfererEmaScore.Get(ctx, topic.Id)
+	// No penalty set, no penalty
+	if errors.Is(err, collections.ErrNotFound) {
+		return emaScore, nil
+	}
+	if err != nil {
+		return types.Score{}, err
+	}
+	emaScore.BlockHeight = block
+	// TODO: Provide the limit as the initial score
+	emaScore.Score, err = applyPenalty(topic, penalty, alloraMath.ZeroDec(), emaScore.Score, missedEpochs)
+	if err != nil {
+		return types.Score{}, err
+	}
+
+	// Save the penalised EMA score
+	return emaScore, k.SetInfererScoreEma(ctx, topic.Id, emaScore.Address, emaScore)
+}
+
+// applyPenalty applies the penalty to the EMA score for the given number of missed epochs while staying above provided limit.
+func applyPenalty(topic types.Topic, penalty, limit, emaScore alloraMath.Dec, missedEpochs uint32) (alloraMath.Dec, error) {
+	for i := uint32(0); i < missedEpochs; i++ {
+		penalisedScore, err := alloraMath.CalcEma(topic.MeritSortitionAlpha, penalty, emaScore, false)
+		if err != nil {
+			return alloraMath.ZeroDec(), err
+		}
+
+		if penalisedScore.Lt(limit) {
+			break
+		}
+		emaScore = penalisedScore
+	}
+
+	return emaScore, nil
+}
+
+// CountWorkerContiguousMissedEpochs counts the number of contiguous missed epochs prior to the given nonce, given the
+// last worker submission and the current block heights.
+func countWorkerContiguousMissedEpochs(topic types.Topic, lastSubmissionHeight int64) uint32 {
+	count := uint32(0)
+	prevEpochStart := topic.EpochLastEnded - topic.EpochLength
+	for lastSubmissionHeight < prevEpochStart {
+		count++
+		prevEpochStart -= topic.EpochLength
+	}
+
+	return count
+}

--- a/x/emissions/keeper/actor_penalties_test.go
+++ b/x/emissions/keeper/actor_penalties_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // nolint: exhaustruct
-func (s *KeeperTestSuite) TestMayPenaliseInferer() {
+func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInferer() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 
@@ -31,7 +31,7 @@ func (s *KeeperTestSuite) TestMayPenaliseInferer() {
 	}
 	s.Require().NoError(keeper.SetTopicInitialInfererEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
 
-	newScore, err := keeper.MayPenaliseInferer(ctx, givenTopic, 105, givenPreviousScore)
+	newScore, err := keeper.ApplyLivenessPenaltyToInferer(ctx, givenTopic, 105, givenPreviousScore)
 	s.Require().NoError(err)
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
@@ -46,7 +46,7 @@ func (s *KeeperTestSuite) TestMayPenaliseInferer() {
 }
 
 // nolint: exhaustruct
-func (s *KeeperTestSuite) TestMayPenaliseForecaster() {
+func (s *KeeperTestSuite) TestApplyLivenessPenaltyToForecaster() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 
@@ -64,7 +64,7 @@ func (s *KeeperTestSuite) TestMayPenaliseForecaster() {
 	}
 	s.Require().NoError(keeper.SetTopicInitialForecasterEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
 
-	newScore, err := keeper.MayPenaliseForecaster(ctx, givenTopic, 105, givenPreviousScore)
+	newScore, err := keeper.ApplyLivenessPenaltyToForecaster(ctx, givenTopic, 105, givenPreviousScore)
 	s.Require().NoError(err)
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
@@ -79,7 +79,7 @@ func (s *KeeperTestSuite) TestMayPenaliseForecaster() {
 }
 
 // nolint: exhaustruct
-func (s *KeeperTestSuite) TestMayPenaliseReputer() {
+func (s *KeeperTestSuite) TestApplyLivenessPenaltyToReputer() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 
@@ -98,7 +98,7 @@ func (s *KeeperTestSuite) TestMayPenaliseReputer() {
 	}
 	s.Require().NoError(keeper.SetTopicInitialReputerEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
 
-	newScore, err := keeper.MayPenaliseReputer(ctx, givenTopic, 105, givenPreviousScore)
+	newScore, err := keeper.ApplyLivenessPenaltyToReputer(ctx, givenTopic, 105, givenPreviousScore)
 	s.Require().NoError(err)
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
@@ -113,7 +113,7 @@ func (s *KeeperTestSuite) TestMayPenaliseReputer() {
 }
 
 // nolint: exhaustruct
-func TestMayPenaliseActor(t *testing.T) {
+func TestApplyLivenessPenaltyToActor(t *testing.T) {
 	ctx := testutil.DefaultContextWithDB(t, storetypes.NewKVStoreKey("emissions"), storetypes.NewTransientStoreKey("transient_test")).Ctx
 	givenTopic := types.Topic{
 		Id:                  uint64(1),
@@ -162,7 +162,7 @@ func TestMayPenaliseActor(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			newScore, err := keeper.MayPenaliseActor(
+			newScore, err := keeper.ApplyLivenessPenaltyTo(
 				ctx,
 				// Mock missed epochs calculation
 				func(topic types.Topic, _ int64) int64 {

--- a/x/emissions/keeper/actor_penalties_test.go
+++ b/x/emissions/keeper/actor_penalties_test.go
@@ -162,7 +162,7 @@ func TestApplyLivenessPenaltyToActor(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			newScore, err := keeper.ApplyLivenessPenaltyTo(
+			newScore, err := keeper.ApplyLivenessPenaltyToActor(
 				ctx,
 				// Mock missed epochs calculation
 				func(topic types.Topic, _ int64) int64 {

--- a/x/emissions/keeper/actor_penalties_test.go
+++ b/x/emissions/keeper/actor_penalties_test.go
@@ -36,7 +36,7 @@ func (s *KeeperTestSuite) TestMayPenaliseInferer() {
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
 	s.Require().Equal(int64(105), newScore.BlockHeight)
-	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("365.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
+	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("265.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
 	s.Require().NoError(err)
 	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
 
@@ -69,7 +69,7 @@ func (s *KeeperTestSuite) TestMayPenaliseForecaster() {
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
 	s.Require().Equal(int64(105), newScore.BlockHeight)
-	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("365.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
+	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("265.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
 	s.Require().NoError(err)
 	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
 
@@ -84,12 +84,11 @@ func (s *KeeperTestSuite) TestMayPenaliseReputer() {
 	keeper := s.emissionsKeeper
 
 	givenTopic := types.Topic{
-		Id:                     uint64(1),
-		MeritSortitionAlpha:    alloraMath.MustNewDecFromString("0.1"),
-		EpochLastEnded:         95,
-		EpochLength:            10,
-		WorkerSubmissionWindow: 2,
-		GroundTruthLag:         3,
+		Id:                  uint64(1),
+		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
+		EpochLastEnded:      105,
+		EpochLength:         10,
+		GroundTruthLag:      5,
 	}
 	givenPreviousScore := types.Score{
 		TopicId:     givenTopic.Id,
@@ -104,7 +103,7 @@ func (s *KeeperTestSuite) TestMayPenaliseReputer() {
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
 	s.Require().Equal(int64(105), newScore.BlockHeight)
-	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("365.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
+	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("265.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
 	s.Require().NoError(err)
 	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
 
@@ -137,11 +136,6 @@ func TestMayPenaliseActor(t *testing.T) {
 		{
 			name:          "no missed epochs",
 			missedEpochs:  0,
-			expectedScore: &givenPreviousScore,
-		},
-		{
-			name:          "no penalty to apply",
-			missedEpochs:  4,
 			expectedScore: &givenPreviousScore,
 		},
 		{
@@ -277,7 +271,7 @@ func TestCountWorkerContiguousMissedEpochs(t *testing.T) {
 // nolint: exhaustruct
 func TestCountReputerContiguousMissedEpochs(t *testing.T) {
 	topic := types.Topic{
-		EpochLastEnded: 95,
+		EpochLastEnded: 105,
 		EpochLength:    10,
 		GroundTruthLag: 5,
 	}

--- a/x/emissions/keeper/actor_penalties_test.go
+++ b/x/emissions/keeper/actor_penalties_test.go
@@ -1,0 +1,337 @@
+package keeper_test
+
+import (
+	"fmt"
+	"testing"
+
+	"cosmossdk.io/collections"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+	"github.com/stretchr/testify/require"
+)
+
+// nolint: exhaustruct
+func (s *KeeperTestSuite) TestMayPenaliseInferer() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+
+	givenTopic := types.Topic{
+		Id:                  uint64(1),
+		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
+		EpochLastEnded:      100,
+		EpochLength:         10,
+	}
+	givenPreviousScore := types.Score{
+		TopicId:     givenTopic.Id,
+		BlockHeight: int64(55),
+		Address:     "allo1l6nc88z4uqs00nnnaqkwjvlk4lxq3k4und7kzy",
+		Score:       alloraMath.MustNewDecFromString("300"),
+	}
+	s.Require().NoError(keeper.SetTopicInitialInfererEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
+
+	newScore, err := keeper.MayPenaliseInferer(ctx, givenTopic, 105, givenPreviousScore)
+	s.Require().NoError(err)
+	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
+	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
+	s.Require().Equal(int64(105), newScore.BlockHeight)
+	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("365.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
+	s.Require().NoError(err)
+	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
+
+	scoreFromStore, err := keeper.GetInfererScoreEma(ctx, givenTopic.Id, givenPreviousScore.Address)
+	s.Require().NoError(err)
+	s.Require().Equal(newScore, scoreFromStore)
+}
+
+// nolint: exhaustruct
+func (s *KeeperTestSuite) TestMayPenaliseForecaster() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+
+	givenTopic := types.Topic{
+		Id:                  uint64(1),
+		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
+		EpochLastEnded:      100,
+		EpochLength:         10,
+	}
+	givenPreviousScore := types.Score{
+		TopicId:     givenTopic.Id,
+		BlockHeight: int64(55),
+		Address:     "allo1l6nc88z4uqs00nnnaqkwjvlk4lxq3k4und7kzy",
+		Score:       alloraMath.MustNewDecFromString("300"),
+	}
+	s.Require().NoError(keeper.SetTopicInitialForecasterEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
+
+	newScore, err := keeper.MayPenaliseForecaster(ctx, givenTopic, 105, givenPreviousScore)
+	s.Require().NoError(err)
+	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
+	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
+	s.Require().Equal(int64(105), newScore.BlockHeight)
+	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("365.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
+	s.Require().NoError(err)
+	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
+
+	scoreFromStore, err := keeper.GetForecasterScoreEma(ctx, givenTopic.Id, givenPreviousScore.Address)
+	s.Require().NoError(err)
+	s.Require().Equal(newScore, scoreFromStore)
+}
+
+// nolint: exhaustruct
+func (s *KeeperTestSuite) TestMayPenaliseReputer() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+
+	givenTopic := types.Topic{
+		Id:                     uint64(1),
+		MeritSortitionAlpha:    alloraMath.MustNewDecFromString("0.1"),
+		EpochLastEnded:         95,
+		EpochLength:            10,
+		WorkerSubmissionWindow: 2,
+		GroundTruthLag:         3,
+	}
+	givenPreviousScore := types.Score{
+		TopicId:     givenTopic.Id,
+		BlockHeight: int64(55),
+		Address:     "allo1l6nc88z4uqs00nnnaqkwjvlk4lxq3k4und7kzy",
+		Score:       alloraMath.MustNewDecFromString("300"),
+	}
+	s.Require().NoError(keeper.SetTopicInitialReputerEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
+
+	newScore, err := keeper.MayPenaliseReputer(ctx, givenTopic, 105, givenPreviousScore)
+	s.Require().NoError(err)
+	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
+	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
+	s.Require().Equal(int64(105), newScore.BlockHeight)
+	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("365.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
+	s.Require().NoError(err)
+	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
+
+	scoreFromStore, err := keeper.GetReputerScoreEma(ctx, givenTopic.Id, givenPreviousScore.Address)
+	s.Require().NoError(err)
+	s.Require().Equal(newScore, scoreFromStore)
+}
+
+// nolint: exhaustruct
+func TestMayPenaliseActor(t *testing.T) {
+	givenTopic := types.Topic{
+		Id:                  uint64(1),
+		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
+	}
+	givenPreviousScore := types.Score{
+		TopicId:     givenTopic.Id,
+		BlockHeight: int64(100),
+		Address:     "address",
+		Score:       alloraMath.MustNewDecFromString("300"),
+	}
+
+	cases := []struct {
+		name              string
+		missedEpochs      int64
+		withPenalty       bool
+		withGetPenaltyErr error
+		withSetScoreErr   error
+		expectedScore     *types.Score
+	}{
+		{
+			name:          "no missed epochs",
+			missedEpochs:  0,
+			withPenalty:   true,
+			expectedScore: &givenPreviousScore,
+		},
+		{
+			name:          "no penalty to apply",
+			missedEpochs:  4,
+			withPenalty:   false,
+			expectedScore: &givenPreviousScore,
+		},
+		{
+			name:         "apply penalty",
+			missedEpochs: 4,
+			withPenalty:  true,
+			expectedScore: &types.Score{
+				TopicId:     givenPreviousScore.TopicId,
+				BlockHeight: int64(200),
+				Address:     givenPreviousScore.Address,
+				Score:       alloraMath.MustNewDecFromString("265.61"),
+			},
+		},
+		{
+			name:              "get penalty error",
+			missedEpochs:      2,
+			withPenalty:       true,
+			withGetPenaltyErr: fmt.Errorf("oups"),
+		},
+		{
+			name:            "set score error",
+			missedEpochs:    2,
+			withPenalty:     true,
+			withSetScoreErr: fmt.Errorf("oups"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			newScore, err := keeper.MayPenaliseActor(
+				// Mock missed epochs calculation
+				func(topic types.Topic, _ int64) int64 {
+					require.Equal(t, givenTopic, topic)
+					return tc.missedEpochs
+				},
+				// Mock penalty retrieval
+				func(topicId keeper.TopicId) (alloraMath.Dec, error) {
+					require.Equal(t, givenTopic.Id, topicId)
+					if tc.withGetPenaltyErr != nil {
+						return alloraMath.ZeroDec(), tc.withGetPenaltyErr
+					}
+					if tc.withPenalty {
+						return alloraMath.MustNewDecFromString("200"), nil
+					}
+					return alloraMath.ZeroDec(), collections.ErrNotFound
+				},
+				// Mock new EMA score setter
+				func(topicId keeper.TopicId, score types.Score) error {
+					require.Equal(t, givenTopic.Id, topicId)
+					if tc.withSetScoreErr != nil {
+						return tc.withSetScoreErr
+					}
+
+					require.Equal(t, tc.expectedScore.TopicId, score.TopicId, "expected %d, got %d", tc.expectedScore.TopicId, score.TopicId)
+					require.Equal(t, tc.expectedScore.Address, score.Address, "expected %s, got %s", tc.expectedScore.Address, score.Address)
+					require.Equal(t, tc.expectedScore.BlockHeight, score.BlockHeight, "expected %d, got %d", tc.expectedScore.BlockHeight, score.BlockHeight)
+					inDelta, err := alloraMath.InDelta(tc.expectedScore.Score, score.Score, alloraMath.MustNewDecFromString("0.0001"))
+					require.NoError(t, err)
+					require.True(t, inDelta, "expected %s, got %s", tc.expectedScore.Score.String(), score.Score.String())
+					return nil
+				},
+				givenTopic,
+				200,
+				givenPreviousScore,
+			)
+
+			if tc.withGetPenaltyErr != nil {
+				require.ErrorIs(t, tc.withGetPenaltyErr, err)
+			} else if tc.withSetScoreErr != nil {
+				require.ErrorIs(t, tc.withSetScoreErr, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedScore.TopicId, newScore.TopicId, "expected %d, got %d", tc.expectedScore.TopicId, newScore.TopicId)
+				require.Equal(t, tc.expectedScore.Address, newScore.Address, "expected %s, got %s", tc.expectedScore.Address, newScore.Address)
+				require.Equal(t, tc.expectedScore.BlockHeight, newScore.BlockHeight, "expected %d, got %d", tc.expectedScore.BlockHeight, newScore.BlockHeight)
+				inDelta, err := alloraMath.InDelta(tc.expectedScore.Score, newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
+				require.NoError(t, err)
+				require.True(t, inDelta, "expected %s, got %s", tc.expectedScore.Score.String(), newScore.Score.String())
+			}
+		})
+	}
+}
+
+// nolint: exhaustruct
+func TestCountWorkerContiguousMissedEpochs(t *testing.T) {
+	topic := types.Topic{
+		EpochLastEnded: 100,
+		EpochLength:    10,
+	}
+
+	cases := []struct {
+		name                 string
+		lastSubmissionHeight int64
+		expectedMissedEpochs int64
+	}{
+		{
+			name:                 "in last epoch",
+			lastSubmissionHeight: 95,
+			expectedMissedEpochs: 0,
+		},
+		{
+			name:                 "after last epoch",
+			lastSubmissionHeight: 105,
+			expectedMissedEpochs: 0,
+		},
+		{
+			name:                 "one missed epoch",
+			lastSubmissionHeight: 85,
+			expectedMissedEpochs: 1,
+		},
+		{
+			name:                 "four missed epoch",
+			lastSubmissionHeight: 55,
+			expectedMissedEpochs: 4,
+		},
+		{
+			name:                 "on the edge of last epoch",
+			lastSubmissionHeight: 90,
+			expectedMissedEpochs: 0,
+		},
+		{
+			name:                 "on the edge of an epoch",
+			lastSubmissionHeight: 60,
+			expectedMissedEpochs: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			missedEpochs := keeper.CountWorkerContiguousMissedEpochs(topic, tc.lastSubmissionHeight)
+			if missedEpochs != tc.expectedMissedEpochs {
+				require.Equal(t, tc.expectedMissedEpochs, missedEpochs, "expected %d, got %d", tc.expectedMissedEpochs, missedEpochs)
+			}
+		})
+	}
+}
+
+// nolint: exhaustruct
+func TestCountReputerContiguousMissedEpochs(t *testing.T) {
+	topic := types.Topic{
+		EpochLastEnded:         95,
+		EpochLength:            10,
+		WorkerSubmissionWindow: 2,
+		GroundTruthLag:         3,
+	}
+
+	cases := []struct {
+		name                 string
+		lastSubmissionHeight int64
+		expectedMissedEpochs int64
+	}{
+		{
+			name:                 "in last epoch",
+			lastSubmissionHeight: 95,
+			expectedMissedEpochs: 0,
+		},
+		{
+			name:                 "after last epoch",
+			lastSubmissionHeight: 105,
+			expectedMissedEpochs: 0,
+		},
+		{
+			name:                 "one missed epoch",
+			lastSubmissionHeight: 85,
+			expectedMissedEpochs: 1,
+		},
+		{
+			name:                 "four missed epoch",
+			lastSubmissionHeight: 55,
+			expectedMissedEpochs: 4,
+		},
+		{
+			name:                 "on the edge of last epoch",
+			lastSubmissionHeight: 90,
+			expectedMissedEpochs: 0,
+		},
+		{
+			name:                 "on the edge of an epoch",
+			lastSubmissionHeight: 60,
+			expectedMissedEpochs: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			missedEpochs := keeper.CountReputerContiguousMissedEpochs(topic, tc.lastSubmissionHeight)
+			if missedEpochs != tc.expectedMissedEpochs {
+				require.Equal(t, tc.expectedMissedEpochs, missedEpochs, "expected %d, got %d", tc.expectedMissedEpochs, missedEpochs)
+			}
+		})
+	}
+}

--- a/x/emissions/keeper/actor_penalties_test.go
+++ b/x/emissions/keeper/actor_penalties_test.go
@@ -235,44 +235,44 @@ func TestCountWorkerContiguousMissedEpochs(t *testing.T) {
 
 	cases := []struct {
 		name                 string
-		lastSubmissionHeight int64
+		lastSubmittedNonce   int64
 		expectedMissedEpochs int64
 	}{
 		{
 			name:                 "in last epoch",
-			lastSubmissionHeight: 95,
+			lastSubmittedNonce:   95,
 			expectedMissedEpochs: 0,
 		},
 		{
 			name:                 "after last epoch",
-			lastSubmissionHeight: 105,
+			lastSubmittedNonce:   105,
 			expectedMissedEpochs: 0,
 		},
 		{
 			name:                 "one missed epoch",
-			lastSubmissionHeight: 85,
+			lastSubmittedNonce:   85,
 			expectedMissedEpochs: 1,
 		},
 		{
 			name:                 "four missed epoch",
-			lastSubmissionHeight: 55,
+			lastSubmittedNonce:   55,
 			expectedMissedEpochs: 4,
 		},
 		{
 			name:                 "on the edge of last epoch",
-			lastSubmissionHeight: 90,
+			lastSubmittedNonce:   90,
 			expectedMissedEpochs: 0,
 		},
 		{
 			name:                 "on the edge of an epoch",
-			lastSubmissionHeight: 60,
+			lastSubmittedNonce:   60,
 			expectedMissedEpochs: 3,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			missedEpochs := keeper.CountWorkerContiguousMissedEpochs(topic, tc.lastSubmissionHeight)
+			missedEpochs := keeper.CountWorkerContiguousMissedEpochs(topic, tc.lastSubmittedNonce)
 			if missedEpochs != tc.expectedMissedEpochs {
 				require.Equal(t, tc.expectedMissedEpochs, missedEpochs, "expected %d, got %d", tc.expectedMissedEpochs, missedEpochs)
 			}
@@ -283,52 +283,51 @@ func TestCountWorkerContiguousMissedEpochs(t *testing.T) {
 // nolint: exhaustruct
 func TestCountReputerContiguousMissedEpochs(t *testing.T) {
 	topic := types.Topic{
-		EpochLastEnded:         95,
-		EpochLength:            10,
-		WorkerSubmissionWindow: 2,
-		GroundTruthLag:         3,
+		EpochLastEnded: 95,
+		EpochLength:    10,
+		GroundTruthLag: 5,
 	}
 
 	cases := []struct {
 		name                 string
-		lastSubmissionHeight int64
+		lastSubmittedNonce   int64
 		expectedMissedEpochs int64
 	}{
 		{
 			name:                 "in last epoch",
-			lastSubmissionHeight: 95,
+			lastSubmittedNonce:   95,
 			expectedMissedEpochs: 0,
 		},
 		{
 			name:                 "after last epoch",
-			lastSubmissionHeight: 105,
+			lastSubmittedNonce:   105,
 			expectedMissedEpochs: 0,
 		},
 		{
 			name:                 "one missed epoch",
-			lastSubmissionHeight: 85,
+			lastSubmittedNonce:   85,
 			expectedMissedEpochs: 1,
 		},
 		{
 			name:                 "four missed epoch",
-			lastSubmissionHeight: 55,
+			lastSubmittedNonce:   55,
 			expectedMissedEpochs: 4,
 		},
 		{
 			name:                 "on the edge of last epoch",
-			lastSubmissionHeight: 90,
+			lastSubmittedNonce:   90,
 			expectedMissedEpochs: 0,
 		},
 		{
 			name:                 "on the edge of an epoch",
-			lastSubmissionHeight: 60,
+			lastSubmittedNonce:   60,
 			expectedMissedEpochs: 3,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			missedEpochs := keeper.CountReputerContiguousMissedEpochs(topic, tc.lastSubmissionHeight)
+			missedEpochs := keeper.CountReputerContiguousMissedEpochs(topic, tc.lastSubmittedNonce)
 			if missedEpochs != tc.expectedMissedEpochs {
 				require.Equal(t, tc.expectedMissedEpochs, missedEpochs, "expected %d, got %d", tc.expectedMissedEpochs, missedEpochs)
 			}

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1310,6 +1310,12 @@ func (k *Keeper) AppendInference(
 		}
 	}
 
+	// Penalise the inferer if needed
+	previousEmaScore, err = k.MayPenaliseInferer(ctx, topic, nonceBlockHeight, previousEmaScore)
+	if err != nil {
+		return errorsmod.Wrap(err, "error setting bad reputer in nonce")
+	}
+
 	// Get lowest inferer score ema for the topic
 	lowestEmaScore, _, err := k.GetLowestInfererScoreEma(ctx, topic.Id)
 	if err != nil {

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1292,6 +1292,12 @@ func (k *Keeper) AppendInference(
 		return types.ErrCantUpdateEmaMoreThanOncePerWindow
 	}
 
+	// Penalise the inferer if needed
+	previousEmaScore, err = k.MayPenaliseInferer(ctx, topic, nonceBlockHeight, previousEmaScore)
+	if err != nil {
+		return errorsmod.Wrap(err, "error trying to penalise inferer")
+	}
+
 	// Check if the inferer is new and set initial EMA score
 	if previousEmaScore.BlockHeight == 0 {
 		initialEmaScore, err := k.GetTopicInitialInfererEmaScore(ctx, topic.Id)
@@ -1308,12 +1314,6 @@ func (k *Keeper) AppendInference(
 		if err != nil {
 			return errorsmod.Wrap(err, "error setting initial inferer score ema")
 		}
-	}
-
-	// Penalise the inferer if needed
-	previousEmaScore, err = k.MayPenaliseInferer(ctx, topic, nonceBlockHeight, previousEmaScore)
-	if err != nil {
-		return errorsmod.Wrap(err, "error setting bad reputer in nonce")
 	}
 
 	// Get lowest inferer score ema for the topic
@@ -1462,6 +1462,12 @@ func (k *Keeper) AppendForecast(
 	// Only calc and save if there's a new update
 	if previousEmaScore.BlockHeight >= nonceBlockHeight {
 		return types.ErrCantUpdateEmaMoreThanOncePerWindow
+	}
+
+	// Penalise the forecaster if needed
+	previousEmaScore, err = k.MayPenaliseForecaster(ctx, topic, nonceBlockHeight, previousEmaScore)
+	if err != nil {
+		return errorsmod.Wrap(err, "error trying to penalise forecaster")
 	}
 
 	// Check if the forecaster is new and set initial EMA score

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1293,7 +1293,7 @@ func (k *Keeper) AppendInference(
 	}
 
 	// Penalise the inferer if needed
-	previousEmaScore, err = k.MayPenaliseInferer(ctx, topic, nonceBlockHeight, previousEmaScore)
+	previousEmaScore, err = k.ApplyLivenessPenaltyToInferer(ctx, topic, nonceBlockHeight, previousEmaScore)
 	if err != nil {
 		return errorsmod.Wrap(err, "error trying to penalise inferer")
 	}
@@ -1465,7 +1465,7 @@ func (k *Keeper) AppendForecast(
 	}
 
 	// Penalise the forecaster if needed
-	previousEmaScore, err = k.MayPenaliseForecaster(ctx, topic, nonceBlockHeight, previousEmaScore)
+	previousEmaScore, err = k.ApplyLivenessPenaltyToForecaster(ctx, topic, nonceBlockHeight, previousEmaScore)
 	if err != nil {
 		return errorsmod.Wrap(err, "error trying to penalise forecaster")
 	}
@@ -1684,7 +1684,7 @@ func (k *Keeper) AppendReputerLoss(
 	}
 
 	// Penalise the reputer if needed
-	previousEmaScore, err = k.MayPenaliseReputer(ctx, topic, nonceBlockHeight, previousEmaScore)
+	previousEmaScore, err = k.ApplyLivenessPenaltyToReputer(ctx, topic, nonceBlockHeight, previousEmaScore)
 	if err != nil {
 		return errorsmod.Wrap(err, "error trying to penalise reputer")
 	}

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1683,6 +1683,12 @@ func (k *Keeper) AppendReputerLoss(
 		return types.ErrCantUpdateEmaMoreThanOncePerWindow
 	}
 
+	// Penalise the reputer if needed
+	previousEmaScore, err = k.MayPenaliseReputer(ctx, topic, nonceBlockHeight, previousEmaScore)
+	if err != nil {
+		return errorsmod.Wrap(err, "error trying to penalise reputer")
+	}
+
 	// Check if the reputer is new and set initial EMA score
 	if previousEmaScore.BlockHeight == 0 {
 		initialEmaScore, err := k.GetTopicInitialReputerEmaScore(ctx, topic.Id)

--- a/x/emissions/migrations/v7/migrate_test.go
+++ b/x/emissions/migrations/v7/migrate_test.go
@@ -131,7 +131,7 @@ func (s *EmissionsV6MigrationTestSuite) TestMigrateParams() {
 	// TO BE ADDED VIA DEFAULT PARAMS:
 	// - InferenceOutlierDetectionThreshold
 	// - InferenceOutlierDetectionAlpha
-
+	// - LambdaInitialScore
 	paramsExpected := defaultParams
 
 	params, err := s.emissionsKeeper.GetParams(s.ctx)

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -538,7 +538,7 @@ func CalculateTopicInitialEmaScore(
 	}
 	lambda := params.LambdaInitialScore
 
-	// Calculate standard deviation of EMA scores in active set
+	// Calculate lowest and standard deviation of EMA scores in active set
 	var emaScores []alloraMath.Dec
 	lowestScore := activeScores[0]
 	for _, score := range activeScores {


### PR DESCRIPTION
## Purpose of Changes and their Description

Penalise underperforming actors that are missing epochs when they become live again.

A penalty will be applied to their EMA score, the penalty used in the initial EMA score, it is applied as many times as the number of previously missed epochs towards the initial score.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/PROTO-3089/add-sortition-penalties

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?