### PR TITLE
Fix typos

### DIFF
--- a/test/fuzz/common_test.go
+++ b/test/fuzz/common_test.go
@@ -53,7 +53,7 @@ type Actor struct {
 }
 
 // stringer for actor
-func (an Actor) String() string {
+func (a Actor) String() string {
 	return a.name
 }
 

--- a/test/fuzz/common_test.go
+++ b/test/fuzz/common_test.go
@@ -53,7 +53,7 @@ type Actor struct {
 }
 
 // stringer for actor
-func (a Actor) String() string {
+func (an Actor) String() string {
 	return a.name
 }
 

--- a/x/emissions/keeper/ema_scores.go
+++ b/x/emissions/keeper/ema_scores.go
@@ -9,7 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// Calculates and saves the EMA scores for a active set worker and topic.
+// Calculates and saves the EMA scores for an active set worker and topic.
 // By assuming worker is in active set, we know to calculate the EMA with a new, passed-in score.
 func (k *Keeper) CalcAndSaveInfererScoreEmaForActiveSet(
 	ctx context.Context,
@@ -45,7 +45,7 @@ func (k *Keeper) CalcAndSaveInfererScoreEmaForActiveSet(
 	return emaScore, nil
 }
 
-// Calculates and saves the EMA scores for a active set worker and topic.
+// Calculates and saves the EMA scores for an active set worker and topic.
 // By assuming worker is in active set, we know to calculate the EMA with a new, passed-in score.
 func (k *Keeper) CalcAndSaveForecasterScoreEmaForActiveSet(
 	ctx context.Context,

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
@@ -11,7 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// A tx function that accepts a individual loss and possibly returns an error
+// A tx function that accepts an individual loss and possibly returns an error
 func (ms msgServer) InsertReputerPayload(ctx context.Context, msg *types.InsertReputerPayloadRequest) (_ *types.InsertReputerPayloadResponse, err error) {
 	defer metrics.RecordMetrics("InsertReputerPayload", time.Now(), &err)
 

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -11,7 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// A tx function that accepts a individual inference and forecast and possibly returns an error
+// A tx function that accepts an individual inference and forecast and possibly returns an error
 // Need to call this once per forecaster per topic inference solicitation round because protobuf does not nested repeated fields
 // Only 1 payload per registered worker is kept, ignore the rest. In particular, take the first payload from each
 // registered worker and none from any unregistered actor.


### PR DESCRIPTION
This pull request addresses minor typos in the following files:
- `common_test.go`: Corrected the use of "a" to "an" for "Actor" in the `String()` method.
- `ema_scores.go`: Fixed "a active set worker" to "an active set worker" for grammatical accuracy.
- `msg_server_reputer_payload.go`: Corrected "a individual loss" to "an individual loss".
- `msg_server_worker_payload.go`: Fixed "a individual inference" to "an individual inference".

These changes ensure proper grammar usage and improve code clarity.
