### PR TITLE
fix: adapt missed epoch calculation on worker activity

### DIFF
--- a/x/emissions/keeper/actor_penalties.go
+++ b/x/emissions/keeper/actor_penalties.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"fmt"
-
 	"cosmossdk.io/math"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
@@ -80,7 +78,6 @@ func ApplyLivenessPenaltyToActor(
 	missedEpochs := missedEpochsFn(topic, emaScore.BlockHeight)
 	// No missed epochs == no penalty
 	if missedEpochs == 0 {
-		fmt.Println("--- NO PENALTY FOR ACTOR ---", nonceBlockHeight, emaScore)
 		ctx.Logger().Debug("no liveness penalty on actor",
 			"nonce", nonceBlockHeight,
 			"score", emaScore,
@@ -99,11 +96,6 @@ func ApplyLivenessPenaltyToActor(
 		return types.Score{}, err
 	}
 
-	fmt.Println("--- APPLY PENALTY TO ACTOR ---", "nonce", nonceBlockHeight,
-		"missed", missedEpochs,
-		"penalty", penalty,
-		"before", beforePenalty,
-		"after", emaScore)
 	ctx.Logger().Debug("apply liveness penalty on actor",
 		"nonce", nonceBlockHeight,
 		"missed", missedEpochs,

--- a/x/emissions/keeper/actor_penalties.go
+++ b/x/emissions/keeper/actor_penalties.go
@@ -103,8 +103,6 @@ func ApplyLivenessPenaltyToActor(
 		"before", beforePenalty,
 		"after", emaScore,
 	)
-
-	// Save the penalised EMA score
 	return emaScore, nil
 }
 

--- a/x/emissions/keeper/actor_penalties_test.go
+++ b/x/emissions/keeper/actor_penalties_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
 	"testing"
 
 	storetypes "cosmossdk.io/store/types"
@@ -13,7 +12,7 @@ import (
 )
 
 // nolint: exhaustruct
-func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInactiveInferer() {
+func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInferer() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 
@@ -22,7 +21,6 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInactiveInferer() {
 		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
 		EpochLastEnded:      100,
 		EpochLength:         10,
-		GroundTruthLag:      5,
 	}
 	givenPreviousScore := types.Score{
 		TopicId:     givenTopic.Id,
@@ -36,53 +34,14 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInactiveInferer() {
 	s.Require().NoError(err)
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
-	s.Require().Equal(int64(105), newScore.BlockHeight)
+	s.Require().Equal(int64(55), newScore.BlockHeight)
 	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("265.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
 	s.Require().NoError(err)
 	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
-
-	scoreFromStore, err := keeper.GetInfererScoreEma(ctx, givenTopic.Id, givenPreviousScore.Address)
-	s.Require().NoError(err)
-	s.Require().Equal(newScore, scoreFromStore)
 }
 
 // nolint: exhaustruct
-func (s *KeeperTestSuite) TestApplyLivenessPenaltyToActiveInferer() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-
-	givenTopic := types.Topic{
-		Id:                  uint64(1),
-		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
-		EpochLastEnded:      105,
-		EpochLength:         10,
-		GroundTruthLag:      5,
-	}
-	givenPreviousScore := types.Score{
-		TopicId:     givenTopic.Id,
-		BlockHeight: int64(55),
-		Address:     "allo1l6nc88z4uqs00nnnaqkwjvlk4lxq3k4und7kzy",
-		Score:       alloraMath.MustNewDecFromString("300"),
-	}
-	s.Require().NoError(keeper.SetTopicInitialInfererEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
-	s.Require().NoError(keeper.AddActiveInferer(ctx, givenTopic.Id, givenPreviousScore.Address))
-
-	newScore, err := keeper.ApplyLivenessPenaltyToInferer(ctx, givenTopic, 105, givenPreviousScore)
-	s.Require().NoError(err)
-	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
-	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
-	s.Require().Equal(int64(105), newScore.BlockHeight)
-	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("265.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
-	s.Require().NoError(err)
-	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
-
-	scoreFromStore, err := keeper.GetInfererScoreEma(ctx, givenTopic.Id, givenPreviousScore.Address)
-	s.Require().NoError(err)
-	s.Require().Equal(newScore, scoreFromStore)
-}
-
-// nolint: exhaustruct
-func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInactiveForecaster() {
+func (s *KeeperTestSuite) TestApplyLivenessPenaltyToForecaster() {
 	ctx := s.ctx
 	keeper := s.emissionsKeeper
 
@@ -91,7 +50,6 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInactiveForecaster() {
 		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
 		EpochLastEnded:      100,
 		EpochLength:         10,
-		GroundTruthLag:      5,
 	}
 	givenPreviousScore := types.Score{
 		TopicId:     givenTopic.Id,
@@ -105,49 +63,10 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInactiveForecaster() {
 	s.Require().NoError(err)
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
-	s.Require().Equal(int64(105), newScore.BlockHeight)
+	s.Require().Equal(int64(55), newScore.BlockHeight)
 	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("265.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
 	s.Require().NoError(err)
 	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
-
-	scoreFromStore, err := keeper.GetForecasterScoreEma(ctx, givenTopic.Id, givenPreviousScore.Address)
-	s.Require().NoError(err)
-	s.Require().Equal(newScore, scoreFromStore)
-}
-
-// nolint: exhaustruct
-func (s *KeeperTestSuite) TestApplyLivenessPenaltyToActiveForecaster() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-
-	givenTopic := types.Topic{
-		Id:                  uint64(1),
-		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
-		EpochLastEnded:      105,
-		EpochLength:         10,
-		GroundTruthLag:      5,
-	}
-	givenPreviousScore := types.Score{
-		TopicId:     givenTopic.Id,
-		BlockHeight: int64(55),
-		Address:     "allo1l6nc88z4uqs00nnnaqkwjvlk4lxq3k4und7kzy",
-		Score:       alloraMath.MustNewDecFromString("300"),
-	}
-	s.Require().NoError(keeper.SetTopicInitialForecasterEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
-	s.Require().NoError(keeper.AddActiveForecaster(ctx, givenTopic.Id, givenPreviousScore.Address))
-
-	newScore, err := keeper.ApplyLivenessPenaltyToForecaster(ctx, givenTopic, 105, givenPreviousScore)
-	s.Require().NoError(err)
-	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
-	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
-	s.Require().Equal(int64(105), newScore.BlockHeight)
-	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("265.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
-	s.Require().NoError(err)
-	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
-
-	scoreFromStore, err := keeper.GetForecasterScoreEma(ctx, givenTopic.Id, givenPreviousScore.Address)
-	s.Require().NoError(err)
-	s.Require().Equal(newScore, scoreFromStore)
 }
 
 // nolint: exhaustruct
@@ -158,9 +77,9 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToReputer() {
 	givenTopic := types.Topic{
 		Id:                  uint64(1),
 		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
-		EpochLastEnded:      105,
+		EpochLastEnded:      110,
 		EpochLength:         10,
-		GroundTruthLag:      5,
+		GroundTruthLag:      10,
 	}
 	givenPreviousScore := types.Score{
 		TopicId:     givenTopic.Id,
@@ -174,14 +93,10 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToReputer() {
 	s.Require().NoError(err)
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
-	s.Require().Equal(int64(105), newScore.BlockHeight)
+	s.Require().Equal(int64(55), newScore.BlockHeight)
 	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("265.61"), newScore.Score, alloraMath.MustNewDecFromString("0.0001"))
 	s.Require().NoError(err)
 	s.Require().True(inDelta, "expected %s, got %s", alloraMath.MustNewDecFromString("265.61"), newScore.Score)
-
-	scoreFromStore, err := keeper.GetReputerScoreEma(ctx, givenTopic.Id, givenPreviousScore.Address)
-	s.Require().NoError(err)
-	s.Require().Equal(newScore, scoreFromStore)
 }
 
 // nolint: exhaustruct
@@ -215,20 +130,10 @@ func TestApplyLivenessPenaltyToActor(t *testing.T) {
 			missedEpochs: 4,
 			expectedScore: &types.Score{
 				TopicId:     givenPreviousScore.TopicId,
-				BlockHeight: int64(200),
+				BlockHeight: givenPreviousScore.BlockHeight, // Only applying score penalty, not updating block height
 				Address:     givenPreviousScore.Address,
 				Score:       alloraMath.MustNewDecFromString("265.61"),
 			},
-		},
-		{
-			name:              "get penalty error",
-			missedEpochs:      2,
-			withGetPenaltyErr: fmt.Errorf("oups"),
-		},
-		{
-			name:            "set score error",
-			missedEpochs:    2,
-			withSetScoreErr: fmt.Errorf("oups"),
 		},
 	}
 
@@ -249,21 +154,6 @@ func TestApplyLivenessPenaltyToActor(t *testing.T) {
 					}
 					return alloraMath.MustNewDecFromString("200"), nil
 				},
-				// Mock new EMA score setter
-				func(topicId keeper.TopicId, score types.Score) error {
-					require.Equal(t, givenTopic.Id, topicId)
-					if tc.withSetScoreErr != nil {
-						return tc.withSetScoreErr
-					}
-
-					require.Equal(t, tc.expectedScore.TopicId, score.TopicId, "expected %d, got %d", tc.expectedScore.TopicId, score.TopicId)
-					require.Equal(t, tc.expectedScore.Address, score.Address, "expected %s, got %s", tc.expectedScore.Address, score.Address)
-					require.Equal(t, tc.expectedScore.BlockHeight, score.BlockHeight, "expected %d, got %d", tc.expectedScore.BlockHeight, score.BlockHeight)
-					inDelta, err := alloraMath.InDelta(tc.expectedScore.Score, score.Score, alloraMath.MustNewDecFromString("0.0001"))
-					require.NoError(t, err)
-					require.True(t, inDelta, "expected %s, got %s", tc.expectedScore.Score.String(), score.Score.String())
-					return nil
-				},
 				givenTopic,
 				200,
 				givenPreviousScore,
@@ -271,8 +161,6 @@ func TestApplyLivenessPenaltyToActor(t *testing.T) {
 
 			if tc.withGetPenaltyErr != nil {
 				require.ErrorIs(t, tc.withGetPenaltyErr, err)
-			} else if tc.withSetScoreErr != nil {
-				require.ErrorIs(t, tc.withSetScoreErr, err)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedScore.TopicId, newScore.TopicId, "expected %d, got %d", tc.expectedScore.TopicId, newScore.TopicId)
@@ -287,7 +175,7 @@ func TestApplyLivenessPenaltyToActor(t *testing.T) {
 }
 
 // nolint: exhaustruct
-func TestCountInactiveWorkerContiguousMissedEpochs(t *testing.T) {
+func TestCountWorkerContiguousMissedEpochs(t *testing.T) {
 	topic := types.Topic{
 		EpochLastEnded: 100,
 		EpochLength:    10,
@@ -332,62 +220,7 @@ func TestCountInactiveWorkerContiguousMissedEpochs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			missedEpochs := keeper.CountInactiveWorkerContiguousMissedEpochs(topic, tc.lastSubmittedNonce)
-			if missedEpochs != tc.expectedMissedEpochs {
-				require.Equal(t, tc.expectedMissedEpochs, missedEpochs, "expected %d, got %d", tc.expectedMissedEpochs, missedEpochs)
-			}
-		})
-	}
-}
-
-// nolint: exhaustruct
-func TestCountActiveWorkerContiguousMissedEpochs(t *testing.T) {
-	topic := types.Topic{
-		EpochLastEnded: 105,
-		EpochLength:    10,
-		GroundTruthLag: 5,
-	}
-
-	cases := []struct {
-		name                 string
-		lastSubmittedNonce   int64
-		expectedMissedEpochs int64
-	}{
-		{
-			name:                 "in last epoch",
-			lastSubmittedNonce:   95,
-			expectedMissedEpochs: 0,
-		},
-		{
-			name:                 "after last epoch",
-			lastSubmittedNonce:   105,
-			expectedMissedEpochs: 0,
-		},
-		{
-			name:                 "one missed epoch",
-			lastSubmittedNonce:   85,
-			expectedMissedEpochs: 1,
-		},
-		{
-			name:                 "four missed epoch",
-			lastSubmittedNonce:   55,
-			expectedMissedEpochs: 4,
-		},
-		{
-			name:                 "on the edge of last epoch",
-			lastSubmittedNonce:   90,
-			expectedMissedEpochs: 0,
-		},
-		{
-			name:                 "on the edge of an epoch",
-			lastSubmittedNonce:   60,
-			expectedMissedEpochs: 3,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			missedEpochs := keeper.CountActiveWorkerContiguousMissedEpochs(topic, tc.lastSubmittedNonce)
+			missedEpochs := keeper.CountWorkerContiguousMissedEpochs(topic, tc.lastSubmittedNonce)
 			if missedEpochs != tc.expectedMissedEpochs {
 				require.Equal(t, tc.expectedMissedEpochs, missedEpochs, "expected %d, got %d", tc.expectedMissedEpochs, missedEpochs)
 			}
@@ -398,50 +231,93 @@ func TestCountActiveWorkerContiguousMissedEpochs(t *testing.T) {
 // nolint: exhaustruct
 func TestCountReputerContiguousMissedEpochs(t *testing.T) {
 	topic := types.Topic{
-		EpochLastEnded: 105,
+		EpochLastEnded: 110,
 		EpochLength:    10,
-		GroundTruthLag: 5,
 	}
 
 	cases := []struct {
 		name                 string
+		groundTruthLag       int64
 		lastSubmittedNonce   int64
 		expectedMissedEpochs int64
 	}{
 		{
 			name:                 "in last epoch",
+			groundTruthLag:       10,
 			lastSubmittedNonce:   95,
 			expectedMissedEpochs: 0,
 		},
 		{
+			name:                 "in last epoch (big gt-lag)",
+			groundTruthLag:       30,
+			lastSubmittedNonce:   75,
+			expectedMissedEpochs: 0,
+		},
+		{
 			name:                 "after last epoch",
-			lastSubmittedNonce:   105,
+			groundTruthLag:       10,
+			lastSubmittedNonce:   95,
+			expectedMissedEpochs: 0,
+		},
+		{
+			name:                 "after last epoch (big gt-lag)",
+			groundTruthLag:       30,
+			lastSubmittedNonce:   75,
 			expectedMissedEpochs: 0,
 		},
 		{
 			name:                 "one missed epoch",
+			groundTruthLag:       10,
 			lastSubmittedNonce:   85,
 			expectedMissedEpochs: 1,
 		},
 		{
+			name:                 "one missed epoch (big gt-lag)",
+			groundTruthLag:       30,
+			lastSubmittedNonce:   65,
+			expectedMissedEpochs: 1,
+		},
+		{
 			name:                 "four missed epoch",
+			groundTruthLag:       10,
 			lastSubmittedNonce:   55,
 			expectedMissedEpochs: 4,
 		},
 		{
+			name:                 "four missed epoch (big gt-lag)",
+			groundTruthLag:       30,
+			lastSubmittedNonce:   35,
+			expectedMissedEpochs: 4,
+		},
+		{
 			name:                 "on the edge of last epoch",
+			groundTruthLag:       10,
 			lastSubmittedNonce:   90,
 			expectedMissedEpochs: 0,
 		},
 		{
+			name:                 "on the edge of last epoch (big gt-lag)",
+			groundTruthLag:       30,
+			lastSubmittedNonce:   70,
+			expectedMissedEpochs: 0,
+		},
+		{
 			name:                 "on the edge of an epoch",
+			groundTruthLag:       10,
 			lastSubmittedNonce:   60,
+			expectedMissedEpochs: 3,
+		},
+		{
+			name:                 "on the edge of an epoch (big gt-lag)",
+			groundTruthLag:       30,
+			lastSubmittedNonce:   40,
 			expectedMissedEpochs: 3,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			topic.GroundTruthLag = tc.groundTruthLag
 			missedEpochs := keeper.CountReputerContiguousMissedEpochs(topic, tc.lastSubmittedNonce)
 			if missedEpochs != tc.expectedMissedEpochs {
 				require.Equal(t, tc.expectedMissedEpochs, missedEpochs, "expected %d, got %d", tc.expectedMissedEpochs, missedEpochs)

--- a/x/emissions/keeper/ema_scores.go
+++ b/x/emissions/keeper/ema_scores.go
@@ -14,7 +14,6 @@ import (
 func (k *Keeper) CalcAndSaveInfererScoreEmaForActiveSet(
 	ctx context.Context,
 	topic types.Topic,
-	block types.BlockHeight,
 	worker ActorId,
 	newScore types.Score,
 ) (types.Score, error) {
@@ -34,7 +33,7 @@ func (k *Keeper) CalcAndSaveInfererScoreEmaForActiveSet(
 	}
 	emaScore := types.Score{
 		TopicId:     topic.Id,
-		BlockHeight: block,
+		BlockHeight: previousScore.BlockHeight,
 		Address:     worker,
 		Score:       emaScoreDec,
 	}
@@ -50,7 +49,6 @@ func (k *Keeper) CalcAndSaveInfererScoreEmaForActiveSet(
 func (k *Keeper) CalcAndSaveForecasterScoreEmaForActiveSet(
 	ctx context.Context,
 	topic types.Topic,
-	block types.BlockHeight,
 	worker ActorId,
 	newScore types.Score,
 ) (types.Score, error) {
@@ -70,7 +68,7 @@ func (k *Keeper) CalcAndSaveForecasterScoreEmaForActiveSet(
 	}
 	emaScore := types.Score{
 		TopicId:     topic.Id,
-		BlockHeight: block,
+		BlockHeight: previousScore.BlockHeight,
 		Address:     worker,
 		Score:       emaScoreDec,
 	}
@@ -86,7 +84,6 @@ func (k *Keeper) CalcAndSaveForecasterScoreEmaForActiveSet(
 func (k *Keeper) CalcAndSaveReputerScoreEmaForActiveSet(
 	ctx context.Context,
 	topic types.Topic,
-	block types.BlockHeight,
 	reputer ActorId,
 	newScore types.Score,
 ) (types.Score, error) {
@@ -106,7 +103,7 @@ func (k *Keeper) CalcAndSaveReputerScoreEmaForActiveSet(
 	}
 	emaScore := types.Score{
 		TopicId:     topic.Id,
-		BlockHeight: block,
+		BlockHeight: previousScore.BlockHeight,
 		Address:     reputer,
 		Score:       emaScoreDec,
 	}

--- a/x/emissions/keeper/ema_scores_test.go
+++ b/x/emissions/keeper/ema_scores_test.go
@@ -38,7 +38,7 @@ func (s *KeeperTestSuite) TestCalcAndSaveInfererScoreEmaIfNewUpdate() {
 		Address:     worker,
 		Score:       alloraMath.MustNewDecFromString("0.2"),
 	}
-	emaScore, err := keeper.CalcAndSaveInfererScoreEmaForActiveSet(ctx, topic, block, worker, newScore)
+	emaScore, err := keeper.CalcAndSaveInfererScoreEmaForActiveSet(ctx, topic, worker, newScore)
 	s.Require().NoError(err)
 	s.Require().Equal("0.2", emaScore.Score.String())
 
@@ -47,16 +47,16 @@ func (s *KeeperTestSuite) TestCalcAndSaveInfererScoreEmaIfNewUpdate() {
 	s.Require().NoError(err)
 	s.Require().Equal(newScore.Score, savedScore.Score)
 
-	// Test case 2: Update blockheight of score
+	// Test case 2: Don't update blockheight of score
 	newScore.BlockHeight = block + 5
-	emaScore, err = keeper.CalcAndSaveInfererScoreEmaForActiveSet(ctx, topic, newScore.BlockHeight, worker, newScore)
+	emaScore, err = keeper.CalcAndSaveInfererScoreEmaForActiveSet(ctx, topic, worker, newScore)
 	s.Require().NoError(err)
 	s.Require().Equal("0.2", emaScore.Score.String())
 
-	// Verify the EMA score was not updated
-	savedScore, err = keeper.GetInfererScoreEma(ctx, topic.Id, worker)
+	// Verify the blockheight of the EMA score was not updated
+	savedScoreAgain, err := keeper.GetInfererScoreEma(ctx, topic.Id, worker)
 	s.Require().NoError(err)
-	s.Require().Equal(newScore.BlockHeight, savedScore.BlockHeight)
+	s.Require().Equal(savedScore.BlockHeight, savedScoreAgain.BlockHeight)
 }
 
 func (s *KeeperTestSuite) TestCalcAndSaveForecasterScoreEmaIfNewUpdate() {
@@ -92,7 +92,7 @@ func (s *KeeperTestSuite) TestCalcAndSaveForecasterScoreEmaIfNewUpdate() {
 		Address:     worker,
 		Score:       alloraMath.MustNewDecFromString("0.5"),
 	}
-	emaScore, err := keeper.CalcAndSaveForecasterScoreEmaForActiveSet(ctx, topic, block, worker, newScore)
+	emaScore, err := keeper.CalcAndSaveForecasterScoreEmaForActiveSet(ctx, topic, worker, newScore)
 	s.Require().NoError(err)
 	s.Require().Equal("0.5", emaScore.Score.String())
 
@@ -101,16 +101,16 @@ func (s *KeeperTestSuite) TestCalcAndSaveForecasterScoreEmaIfNewUpdate() {
 	s.Require().NoError(err)
 	s.Require().Equal(newScore.Score, savedScore.Score)
 
-	// Test case 2: Update blockheight of score
+	// Test case 2: Not update blockheight of score
 	newScore.BlockHeight = block + 5
-	emaScore, err = keeper.CalcAndSaveForecasterScoreEmaForActiveSet(ctx, topic, newScore.BlockHeight, worker, newScore)
+	emaScore, err = keeper.CalcAndSaveForecasterScoreEmaForActiveSet(ctx, topic, worker, newScore)
 	s.Require().NoError(err)
 	s.Require().Equal("0.5", emaScore.Score.String())
 
-	// Verify the EMA score was not updated
-	savedScore, err = keeper.GetForecasterScoreEma(ctx, topic.Id, worker)
+	// Verify the blockheight of the EMA score was not updated
+	savedScoreAgain, err := keeper.GetForecasterScoreEma(ctx, topic.Id, worker)
 	s.Require().NoError(err)
-	s.Require().Equal(newScore.BlockHeight, savedScore.BlockHeight)
+	s.Require().Equal(savedScore.BlockHeight, savedScoreAgain.BlockHeight)
 }
 
 func (s *KeeperTestSuite) TestCalcAndSaveReputerScoreEmaIfNewUpdate() {
@@ -146,7 +146,7 @@ func (s *KeeperTestSuite) TestCalcAndSaveReputerScoreEmaIfNewUpdate() {
 		Address:     reputer,
 		Score:       alloraMath.MustNewDecFromString("0.5"),
 	}
-	emaScore, err := keeper.CalcAndSaveReputerScoreEmaForActiveSet(ctx, topic, block, reputer, newScore)
+	emaScore, err := keeper.CalcAndSaveReputerScoreEmaForActiveSet(ctx, topic, reputer, newScore)
 	s.Require().NoError(err)
 	s.Require().Equal("0.5", emaScore.Score.String())
 
@@ -155,16 +155,16 @@ func (s *KeeperTestSuite) TestCalcAndSaveReputerScoreEmaIfNewUpdate() {
 	s.Require().NoError(err)
 	s.Require().Equal(newScore.Score, savedScore.Score)
 
-	// Test case 2: Update blockheight of score
+	// Test case 2: Don't update blockheight of score
 	newScore.BlockHeight = block + 10
-	emaScore, err = keeper.CalcAndSaveReputerScoreEmaForActiveSet(ctx, topic, newScore.BlockHeight, reputer, newScore)
+	emaScore, err = keeper.CalcAndSaveReputerScoreEmaForActiveSet(ctx, topic, reputer, newScore)
 	s.Require().NoError(err)
 	s.Require().Equal("0.5", emaScore.Score.String())
 
-	// Verify the EMA score was not updated
-	savedScore, err = keeper.GetReputerScoreEma(ctx, topic.Id, reputer)
+	// Verify the blockheight of the EMA score was not updated
+	savedScoreAgain, err := keeper.GetReputerScoreEma(ctx, topic.Id, reputer)
 	s.Require().NoError(err)
-	s.Require().Equal(newScore.BlockHeight, savedScore.BlockHeight)
+	s.Require().Equal(savedScore.BlockHeight, savedScoreAgain.BlockHeight)
 }
 
 func (s *KeeperTestSuite) TestCalcAndSaveInfererScoreEmaWithLastSavedTopicQuantile() {

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1302,7 +1302,9 @@ func (k *Keeper) AppendInference(
 	}
 
 	// Check if the inferer is new and set initial EMA score
+	firstSubmission := false
 	if previousEmaScore.BlockHeight == 0 {
+		firstSubmission = true
 		initialEmaScore, err := k.GetTopicInitialInfererEmaScore(ctx, topic.Id)
 		if err != nil {
 			return errorsmod.Wrap(err, "error getting topic initial ema score")
@@ -1394,7 +1396,7 @@ func (k *Keeper) AppendInference(
 		return k.InsertInference(ctx, topic.Id, *inference)
 	} else {
 		// Update EMA score for the current inferer, who is the lowest score inferer
-		if previousEmaScore.BlockHeight != 0 { // Only update if not a new inferer
+		if !firstSubmission { // Only update if not a new inferer
 			err = k.CalcAndSaveInfererScoreEmaWithLastSavedTopicQuantile(ctx, topic, nonceBlockHeight, previousEmaScore)
 			if err != nil {
 				return errorsmod.Wrap(err, "error calculating and saving inferer score ema with last saved topic quantile")
@@ -1474,7 +1476,9 @@ func (k *Keeper) AppendForecast(
 	}
 
 	// Check if the forecaster is new and set initial EMA score
+	firstSubmission := false
 	if previousEmaScore.BlockHeight == 0 {
+		firstSubmission = true
 		initialEmaScore, err := k.GetTopicInitialForecasterEmaScore(ctx, topic.Id)
 		if err != nil {
 			return errorsmod.Wrap(err, "error getting topic initial ema score")
@@ -1560,7 +1564,7 @@ func (k *Keeper) AppendForecast(
 		return k.InsertForecast(ctx, topic.Id, *forecast)
 	} else {
 		// Update EMA score for the current forecaster, who is the lowest score forecaster
-		if previousEmaScore.BlockHeight != 0 {
+		if !firstSubmission {
 			err = k.CalcAndSaveForecasterScoreEmaWithLastSavedTopicQuantile(ctx, topic, nonceBlockHeight, previousEmaScore)
 			if err != nil {
 				return errorsmod.Wrap(err, "error calculating and saving forecaster score ema with last saved topic quantile")
@@ -1693,7 +1697,9 @@ func (k *Keeper) AppendReputerLoss(
 	}
 
 	// Check if the reputer is new and set initial EMA score
+	firstSubmission := false
 	if previousEmaScore.BlockHeight == 0 {
+		firstSubmission = true
 		initialEmaScore, err := k.GetTopicInitialReputerEmaScore(ctx, topic.Id)
 		if err != nil {
 			return errorsmod.Wrap(err, "error getting topic initial ema score")
@@ -1778,7 +1784,7 @@ func (k *Keeper) AppendReputerLoss(
 		return k.InsertReputerLoss(ctx, topic.Id, *reputerLoss)
 	} else {
 		// Update EMA score for the current reputer, who is the lowest score reputer
-		if previousEmaScore.BlockHeight != 0 {
+		if !firstSubmission {
 			err = k.CalcAndSaveReputerScoreEmaWithLastSavedTopicQuantile(ctx, topic, nonceBlockHeight, previousEmaScore)
 			if err != nil {
 				return errorsmod.Wrap(err, "error calculating and saving reputer score ema with last saved topic quantile")

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1295,12 +1295,6 @@ func (k *Keeper) AppendInference(
 		return types.ErrCantUpdateEmaMoreThanOncePerWindow
 	}
 
-	// Penalise the inferer if needed
-	previousEmaScore, err = k.ApplyLivenessPenaltyToInferer(ctx, topic, nonceBlockHeight, previousEmaScore)
-	if err != nil {
-		return errorsmod.Wrap(err, "error trying to penalise inferer")
-	}
-
 	// Check if the inferer is new and set initial EMA score
 	firstSubmission := false
 	if previousEmaScore.BlockHeight == 0 {
@@ -1318,6 +1312,19 @@ func (k *Keeper) AppendInference(
 		err = k.SetInfererScoreEma(ctx, topic.Id, inference.Inferer, previousEmaScore)
 		if err != nil {
 			return errorsmod.Wrap(err, "error setting initial inferer score ema")
+		}
+	} else {
+		// If not new: Penalise the inferer if needed
+		previousEmaScore, err = k.ApplyLivenessPenaltyToInferer(ctx, topic, nonceBlockHeight, previousEmaScore)
+		if err != nil {
+			return errorsmod.Wrap(err, "error trying to penalise inferer")
+		}
+
+		// Update score nonce for liveness tracking
+		previousEmaScore.BlockHeight = nonceBlockHeight
+		err = k.SetInfererScoreEma(ctx, topic.Id, inference.Inferer, previousEmaScore)
+		if err != nil {
+			return errorsmod.Wrap(err, "error setting penalised inferer score ema")
 		}
 	}
 
@@ -1469,12 +1476,6 @@ func (k *Keeper) AppendForecast(
 		return types.ErrCantUpdateEmaMoreThanOncePerWindow
 	}
 
-	// Penalise the forecaster if needed
-	previousEmaScore, err = k.ApplyLivenessPenaltyToForecaster(ctx, topic, nonceBlockHeight, previousEmaScore)
-	if err != nil {
-		return errorsmod.Wrap(err, "error trying to penalise forecaster")
-	}
-
 	// Check if the forecaster is new and set initial EMA score
 	firstSubmission := false
 	if previousEmaScore.BlockHeight == 0 {
@@ -1491,6 +1492,19 @@ func (k *Keeper) AppendForecast(
 		})
 		if err != nil {
 			return errorsmod.Wrap(err, "error setting forecaster score ema")
+		}
+	} else {
+		// If not new: Penalise the forecaster if needed
+		previousEmaScore, err = k.ApplyLivenessPenaltyToForecaster(ctx, topic, nonceBlockHeight, previousEmaScore)
+		if err != nil {
+			return errorsmod.Wrap(err, "error trying to penalise forecaster")
+		}
+
+		// Update score nonce for liveness tracking
+		previousEmaScore.BlockHeight = nonceBlockHeight
+		err = k.SetForecasterScoreEma(ctx, topic.Id, previousEmaScore.Address, previousEmaScore)
+		if err != nil {
+			return errorsmod.Wrap(err, "error setting penalised forecaster score ema")
 		}
 	}
 
@@ -1690,12 +1704,6 @@ func (k *Keeper) AppendReputerLoss(
 		return types.ErrCantUpdateEmaMoreThanOncePerWindow
 	}
 
-	// Penalise the reputer if needed
-	previousEmaScore, err = k.ApplyLivenessPenaltyToReputer(ctx, topic, nonceBlockHeight, previousEmaScore)
-	if err != nil {
-		return errorsmod.Wrap(err, "error trying to penalise reputer")
-	}
-
 	// Check if the reputer is new and set initial EMA score
 	firstSubmission := false
 	if previousEmaScore.BlockHeight == 0 {
@@ -1712,6 +1720,19 @@ func (k *Keeper) AppendReputerLoss(
 		})
 		if err != nil {
 			return errorsmod.Wrap(err, "error setting initial reputer score ema")
+		}
+	} else {
+		// If not new: Penalise the reputer if needed
+		previousEmaScore, err = k.ApplyLivenessPenaltyToReputer(ctx, topic, nonceBlockHeight, previousEmaScore)
+		if err != nil {
+			return errorsmod.Wrap(err, "error trying to penalise reputer")
+		}
+
+		// Update score nonce for liveness tracking
+		previousEmaScore.BlockHeight = nonceBlockHeight
+		err = k.SetReputerScoreEma(ctx, topic.Id, previousEmaScore.Address, previousEmaScore)
+		if err != nil {
+			return errorsmod.Wrap(err, "error setting penalised reputer score ema")
 		}
 	}
 

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -5372,12 +5372,13 @@ func (s *KeeperTestSuite) TestFirstSubmissionDoesNotUpdateEMAUsingQuantile() {
 	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
-	for i := 0; i < int(params.MaxTopInferersToReward); i++ {
+	//nolint: gosec
+	for i := int64(0); i < int64(params.MaxTopInferersToReward); i++ {
 		score := types.Score{
 			TopicId:     topicId,
 			Address:     s.addrsStr[i],
 			BlockHeight: 1,
-			Score:       alloraMath.NewDecFromInt64(90 + int64(i)),
+			Score:       alloraMath.NewDecFromInt64(90 + i),
 		}
 		err := k.SetInfererScoreEma(ctx, topicId, s.addrsStr[i], score)
 		s.Require().NoError(err)

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -5460,7 +5460,8 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendInference() {
 	err = k.AppendInference(ctx, topic, blockHeight, inference, 4)
 	s.Require().NoError(err)
 
-	// Verify the worker received the initial EMA score
+	// Verify the worker's EMA score trended toward the topic initial score especially when there is a lapse in their
+	// liveness
 	score, err := k.GetInfererScoreEma(ctx, topic.Id, worker)
 	s.Require().NoError(err)
 	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("82.805"), score.Score, alloraMath.MustNewDecFromString("0.0001"))
@@ -5515,7 +5516,8 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendForecast() {
 	s.Require().NoError(err)
 	s.Require().NoError(err)
 
-	// Verify the worker received the initial EMA score
+	// Verify the worker's EMA score trended toward the topic initial score especially when there is a lapse in their
+	// liveness
 	score, err := k.GetForecasterScoreEma(ctx, topic.Id, worker)
 	s.Require().NoError(err)
 	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("82.805"), score.Score, alloraMath.MustNewDecFromString("0.0001"))
@@ -5580,7 +5582,8 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendReputerLoss() {
 	err = k.AppendReputerLoss(ctx, topic, types.DefaultParams(), blockHeight, &reputerValueBundle)
 	s.Require().NoError(err)
 
-	// Verify the worker received the initial EMA score
+	// Verify the reputer's EMA score trended toward the topic initial score especially when there is a lapse in their
+	// liveness
 	score, err := k.GetReputerScoreEma(ctx, topic.Id, reputer)
 	s.Require().NoError(err)
 	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("86.450"), score.Score, alloraMath.MustNewDecFromString("0.0001"))

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -146,7 +146,7 @@ func GenerateReputerScores(
 			return []types.Score{}, errors.Wrapf(err, "Error inserting reputer score")
 		}
 
-		emaScore, err := keeper.CalcAndSaveReputerScoreEmaForActiveSet(ctx, topic, block, reputer, instantScore)
+		emaScore, err := keeper.CalcAndSaveReputerScoreEmaForActiveSet(ctx, topic, reputer, instantScore)
 		if err != nil {
 			return []types.Score{}, errors.Wrapf(err, "Error calculating and saving reputer score ema")
 		}
@@ -237,7 +237,7 @@ func GenerateInferenceScores(
 			return []types.Score{}, errors.Wrapf(err, "Error inserting worker inference score")
 		}
 
-		emaScore, err := keeper.CalcAndSaveInfererScoreEmaForActiveSet(ctx, topic, block, oneOutLoss.Worker, instantScore)
+		emaScore, err := keeper.CalcAndSaveInfererScoreEmaForActiveSet(ctx, topic, oneOutLoss.Worker, instantScore)
 		if err != nil {
 			return []types.Score{}, errors.Wrapf(err, "Error calculating and saving inferer score ema")
 		}
@@ -352,7 +352,7 @@ func GenerateForecastScores(
 			return []types.Score{}, errors.Wrapf(err, "Error inserting worker forecast score")
 		}
 
-		emaScore, err := keeper.CalcAndSaveForecasterScoreEmaForActiveSet(ctx, topic, block, oneInNaiveLoss.Worker, instantScore)
+		emaScore, err := keeper.CalcAndSaveForecasterScoreEmaForActiveSet(ctx, topic, oneInNaiveLoss.Worker, instantScore)
 		if err != nil {
 			return []types.Score{}, errors.Wrapf(err, "Error calculating and saving forecaster score ema")
 		}


### PR DESCRIPTION
## Purpose of Changes and their Description

Brings two fix to the penalty calculation introduced by https://github.com/allora-network/allora-chain/pull/712:

1. When a participant submits for the first time he is penalised because we assign it a score with the block height of 0, this is now checked to avoid the penalty

2. As scores of participants in the active set are updated when we compute the rewards, active workers are penalised when they shouldn't, we now change the missed epoch calculation depending on active or not

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/PROTO-3089/add-sortition-penalties

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?
