### PR TITLE
Use reputer nonce as latestAvailable

### DIFF
--- a/x/emissions/keeper/queryserver/query_server_inferences.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences.go
@@ -322,7 +322,7 @@ func (qs queryServer) getLatestAvailableNetworkInferencesBase(
 	}, nil
 }
 
-// Original function converts result to response
+// Gets the latest available network inferences with data from the last reputer commit
 func (qs queryServer) GetLatestAvailableNetworkInferences(
 	ctx context.Context,
 	req *emissionstypes.GetLatestAvailableNetworkInferencesRequest,

--- a/x/emissions/keeper/queryserver/query_server_inferences.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences.go
@@ -274,11 +274,6 @@ func (qs queryServer) getLatestAvailableNetworkInferencesBase(
 ) (out *NetworkInferencesResult, err error) {
 	defer metrics.RecordMetrics("GetLatestAvailableNetworkInferences", time.Now(), &err)
 
-	lastWorkerCommit, err := qs.k.GetWorkerTopicLastCommit(params.ctx, params.topicId)
-	if err != nil {
-		return nil, err
-	}
-
 	lastReputerCommit, err := qs.k.GetReputerTopicLastCommit(params.ctx, params.topicId)
 	if err != nil {
 		return nil, err
@@ -288,7 +283,7 @@ func (qs queryServer) getLatestAvailableNetworkInferencesBase(
 		sdk.UnwrapSDKContext(params.ctx),
 		qs.k,
 		params.topicId,
-		&lastWorkerCommit.Nonce.BlockHeight,
+		&lastReputerCommit.Nonce.BlockHeight,
 		params.outlierResistant,
 	)
 	if err != nil {
@@ -320,8 +315,8 @@ func (qs queryServer) getLatestAvailableNetworkInferencesBase(
 		networkInferences:                result.NetworkInferences,
 		infererWeights:                   synth.ConvertWeightsToArrays(inferers, result.InfererToWeight),
 		forecasterWeights:                synth.ConvertWeightsToArrays(forecasters, result.ForecasterToWeight),
-		inferenceBlockHeight:             lastWorkerCommit.Nonce.BlockHeight,
-		lossBlockHeight:                  lastReputerCommit.Nonce.BlockHeight,
+		inferenceBlockHeight:             lastReputerCommit.Nonce.BlockHeight,
+		lossBlockHeight:                  result.LossBlockHeight,
 		confidenceIntervalRawPercentiles: ciRawPercentiles,
 		confidenceIntervalValues:         ciValues,
 	}, nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

`GetLatestAvailableNetworkInferences` currently gets the latest inferences in `allInferences` but doesn't check if there are losses set for that particular nonce (it does check if there is _some_ reputer nonce set in the past though)
This PR changes it to get the network inferences from the latest reputer token, which changes the `Available` concept to those having had reputation.
Not sure if this is the expected behaviour, so leaving impl as `Draft` with a test that is not yet working, will fix when we align here.


## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
