### PR TITLE
fix: prevent git stash errors when no changes are present

### DIFF
--- a/Dockerfile.upgrade
+++ b/Dockerfile.upgrade
@@ -11,7 +11,7 @@ ADD . /src
 WORKDIR /src
 
 # Save the uncommited changes
-RUN git stash -u -m "$GIT_STASH_MESSAGE"
+RUN git diff-index --quiet HEAD || git stash -u -m "$GIT_STASH_MESSAGE"
 # Switch to the baseline version
 RUN git checkout $BASELINE_VERSION_TAG
 


### PR DESCRIPTION
- Added a check before running 'git stash' to avoid errors when no changes exist.
* Ensures smooth build process without unnecessary failures.
* Improves the stability of Docker builds by handling edge cases correctly.

