### PR TITLE
fix: Typos and Broken Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Here is a [guide](https://blog.cosmos.network/cosmos-sdk-state-sync-guide-99e4cf
 
 To use statesync, you need:
 
-1. Peers with state snapshots enabled. Allora [peers](https://github.com/allora-network/networks/blob/main/testnet-1/peers.txt) have enabled snapshots for every 1000 blocks.
+1. Peers with state snapshots enabled. Allora [peers](https://github.com/allora-network/networks/blob/main/allora-testnet-1/peers.txt) have enabled snapshots for every 1000 blocks.
 2. 2 RPC endpoints, you can use any synced full nodes for this purpose.
 
 **NOTE:** To enable state snapshots, you just need to pass `--state-sync.snapshot-keep-recent=X` and `--state-sync.snapshot-interval=Y` to the `allorad start` command.

--- a/test/integration/upgrade_test.go
+++ b/test/integration/upgrade_test.go
@@ -169,7 +169,7 @@ func UpgradeChecks(m testCommon.TestConfig) {
 	proposalId, proposalHeight := proposeUpgrade(m)
 	m.T.Logf("--- Vote on Upgrade Proposal %d ---", proposalId)
 	voteOnProposal(m, proposalId)
-	m.T.Logf("--- Wating for Proposal %d to Pass ---", proposalId)
+	m.T.Logf("--- Waiting for Proposal %d to Pass ---", proposalId)
 	waitForProposalPass(m, proposalId)
 	m.T.Logf("--- Waiting for Upgrade to %s at height %d ---", versionName, proposalHeight)
 	waitForUpgrade(m, proposalHeight)

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1277,7 +1277,7 @@ func (k *Keeper) AppendInference(
 	inference *types.Inference,
 	maxTopInferersToReward uint64,
 ) error {
-	// Check if the inferers already submited the inference
+	// Check if the inferers already submitted the inference
 	isActive, err := k.IsActiveInferer(ctx, topic.Id, inference.Inferer)
 	if err != nil {
 		return errorsmod.Wrap(err, "error checking if worker already submitted inference")

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -120,7 +120,7 @@ func GenerateReputerScores(
 		return []types.Score{}, errors.Wrapf(err, "Error getting GetAllReputersOutput")
 	}
 
-	// Insert new coeffients and scores
+	// Insert new coefficients and scores
 	var instantScores []types.Score
 	var emaScores []types.Score
 	activeArr := make(map[string]bool)


### PR DESCRIPTION
Hey! This PR fixes a few typos in the code and updates a broken link in `README.md`. Just some cleanup—nothing major.

### Changes:
- **README.md** – Fixed a broken link to the peers file.
- **upgrade_test.go** – Fixed a typo in logs (`Wating` → `Waiting`).
- **keeper.go** – Fixed a misspelling (`submited` → `submitted`).
- **scores.go** – Fixed a typo (`coeffients` → `coefficients`).
