### PR TITLE
Make VERSION work with non-annotated tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMMIT := $(shell git log -1 --format='%H')
 
 # don't override user values
 ifeq (,$(VERSION))
-  VERSION := $(shell git describe --exact-match 2>/dev/null)
+  VERSION := $(shell git describe --exact-match --tags 2>/dev/null)
   # if VERSION is empty, then populate it with branch's name and raw commit hash
   ifeq (,$(VERSION))
     VERSION := $(BRANCH)-$(COMMIT)


### PR DESCRIPTION
## Purpose of Changes and their Description

`v0.8.3` is not annotated tag so the `VERSION` variable in the Makefile always fails

```
source/allora-network/allora-chain (tags/v0.8.3?) $ git describe --exact-match
fatal: no tag exactly matches 'cab7882d7d460813c0424b155b8f77979a3c4007'
```

non-annotated tags are generally not recommended, but if you want to make them work, you need to provide `--tags`

```
allora-network/allora-chain (tags/v0.8.3?) $ git describe --exact-match --tags
v0.8.3
```



## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://github.com/allora-network/allora-chain/issues/751

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

before

```
source/allora-network/allora-chain (tags/v0.8.3?) $ git describe --exact-match
fatal: no tag exactly matches 'cab7882d7d460813c0424b155b8f77979a3c4007'
```

after

```
allora-network/allora-chain (tags/v0.8.3?) $ git describe --exact-match --tags
v0.8.3
```

```
source/allora-network/allora-chain (dev*?) $ git tag wooooot
```
```
BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
COMMIT := $(shell git log -1 --format='%H')

# don't override user values
ifeq (,$(VERSION))
  VERSION := $(shell git describe --exact-match --tags 2>/dev/null)
  # if VERSION is empty, then populate it with branch's name and raw commit hash
  ifeq (,$(VERSION))
    VERSION := $(BRANCH)-$(COMMIT)
  endif
endif

woot:
	echo $(VERSION)
```
```
source/allora-network/allora-chain (dev*?) $ make woot
echo wooooot
wooooot
```

## Still Left Todo


