### PR TITLE
Fix error message inconsistency in whitelist.go

### DIFF
--- a/x/emissions/keeper/whitelist.go
+++ b/x/emissions/keeper/whitelist.go
@@ -43,77 +43,77 @@ func (k *Keeper) DisableTopicReputerWhitelist(ctx context.Context, topicId Topic
 
 func (k *Keeper) AddToGlobalWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.globalWhitelist.Set(ctx, actor)
 }
 
 func (k *Keeper) RemoveFromGlobalWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.globalWhitelist.Remove(ctx, actor)
 }
 
 func (k *Keeper) AddToGlobalWorkerWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.globalWorkerWhitelist.Set(ctx, actor)
 }
 
 func (k *Keeper) RemoveFromGlobalWorkerWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.globalWorkerWhitelist.Remove(ctx, actor)
 }
 
 func (k *Keeper) AddToGlobalReputerWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.globalReputerWhitelist.Set(ctx, actor)
 }
 
 func (k *Keeper) RemoveFromGlobalReputerWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.globalReputerWhitelist.Remove(ctx, actor)
 }
 
 func (k *Keeper) AddToGlobalAdminWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.globalAdminWhitelist.Set(ctx, actor)
 }
 
 func (k *Keeper) RemoveFromGlobalAdminWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.globalAdminWhitelist.Remove(ctx, actor)
 }
 
 func (k *Keeper) AddToTopicCreatorWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.topicCreatorWhitelist.Set(ctx, actor)
 }
 
 func (k *Keeper) RemoveFromTopicCreatorWhitelist(ctx context.Context, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	return k.topicCreatorWhitelist.Remove(ctx, actor)
 }
 
 func (k *Keeper) AddToTopicWorkerWhitelist(ctx context.Context, topicId TopicId, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	key := collections.Join(topicId, actor)
 	return k.topicWorkerWhitelist.Set(ctx, key)
@@ -121,7 +121,7 @@ func (k *Keeper) AddToTopicWorkerWhitelist(ctx context.Context, topicId TopicId,
 
 func (k *Keeper) RemoveFromTopicWorkerWhitelist(ctx context.Context, topicId TopicId, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	key := collections.Join(topicId, actor)
 	return k.topicWorkerWhitelist.Remove(ctx, key)
@@ -129,7 +129,7 @@ func (k *Keeper) RemoveFromTopicWorkerWhitelist(ctx context.Context, topicId Top
 
 func (k *Keeper) AddToTopicReputerWhitelist(ctx context.Context, topicId TopicId, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	key := collections.Join(topicId, actor)
 	return k.topicReputerWhitelist.Set(ctx, key)
@@ -137,7 +137,7 @@ func (k *Keeper) AddToTopicReputerWhitelist(ctx context.Context, topicId TopicId
 
 func (k *Keeper) RemoveFromTopicReputerWhitelist(ctx context.Context, topicId TopicId, actor ActorId) error {
 	if err := types.ValidateBech32(actor); err != nil {
-		return errorsmod.Wrap(err, "error validating admin id")
+		return errorsmod.Wrap(err, "error validating actor id")
 	}
 	key := collections.Join(topicId, actor)
 	return k.topicReputerWhitelist.Remove(ctx, key)


### PR DESCRIPTION
Corrected error messages in whitelist functions to properly reference "actor id" instead of "admin id" in validation error messages. This improves error clarity and consistency when validating actor identifiers.