### PR TITLE
chore: fixed unquoted curl parameters to avoid errors

### DIFF
--- a/scripts/l1_node.sh
+++ b/scripts/l1_node.sh
@@ -66,8 +66,8 @@ if [ ! -f $INIT_FLAG ]; then
 fi
 echo "Node is initialized"
 
-SEEDS=$(curl -Ls ${SEEDS_URL})
-PEERS=$(curl -Ls ${PEERS_URL})
+SEEDS=$(curl -Ls "${SEEDS_URL}")
+PEERS=$(curl -Ls "${PEERS_URL}")
 
 if [ "x${STATE_SYNC_RPC1}" != "x" ]; then
     echo "Enable state sync"


### PR DESCRIPTION
## Purpose of Changes and their Description  
I fixed a potential issue with the curl commands where unquoted URL variables could lead to errors, particularly if they contained spaces or special characters. The updated code now properly quotes the URLs to prevent these issues.  

```bash
SEEDS=$(curl -Ls "${SEEDS_URL}")
PEERS=$(curl -Ls "${PEERS_URL}")
```

## Link(s) to Ticket(s) or Issue(s) resolved by this PR  
N/A

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`? 