### PR TITLE
ENGN-3256 totalsumprevioustopicweights can be set to any value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#757](https://github.com/allora-network/allora-chain/pull/757) Incoming value limiting
 * [#761](https://github.com/allora-network/allora-chain/pull/761) Fix close worker nonce boundaries
+* [#760](https://github.com/allora-network/allora-chain/pull/760) Fix topic low-weight inactive topic weight vulnerability
 
 ### Security
 

--- a/x/emissions/keeper/topic_activation.go
+++ b/x/emissions/keeper/topic_activation.go
@@ -279,7 +279,7 @@ func (k *Keeper) ActivateTopic(ctx context.Context, topicId TopicId) error {
 	epochEndBlock := currentBlock + topic.EpochLength
 
 	err = k.activateTopicAndResetLowestWeightAtBlock(ctx, topicId, epochEndBlock)
-	if errors.IsOf(err, types.ErrTopicAlreadyActive) || errors.IsOf(err, types.ErrTopicCannotBeActivated) {
+	if errors.IsOf(err, types.ErrTopicAlreadyActive, types.ErrTopicCannotBeActivated) {
 		sdkCtx.Logger().Info(fmt.Sprintf("Failed to add topic at next epoch %d, %d, %v", topicId, epochEndBlock, err))
 		return nil
 	}

--- a/x/emissions/keeper/topic_activation.go
+++ b/x/emissions/keeper/topic_activation.go
@@ -116,7 +116,7 @@ func (k *Keeper) inactivateTopicWithoutMinWeightReset(ctx context.Context, topic
 		return errors.Wrap(err, "failed to check if topic exists")
 	}
 	if !topicExists {
-		return nil
+		return types.ErrTopicDoesNotExist
 	}
 
 	// Check if this topic is activated or not
@@ -191,22 +191,22 @@ func (k *Keeper) addTopicToActiveSetRespectingLimitsWithoutMinWeightReset(
 	ctx context.Context,
 	topicId TopicId,
 	block BlockHeight,
-) (bool, error) {
+) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	params, err := k.GetParams(ctx)
 	if err != nil {
-		return false, err
+		return err
 	}
 	topicIdsActiveAtBlock, err := k.GetActiveTopicIdsAtBlock(ctx, block)
 	if err != nil {
-		return false, err
+		return err
 	}
 	existingActiveTopics := topicIdsActiveAtBlock.TopicIds
 
 	// If the topic is already active at the block, no op
 	for _, id := range existingActiveTopics {
 		if id == topicId {
-			return false, nil
+			return types.ErrTopicAlreadyActive
 		}
 	}
 
@@ -215,21 +215,21 @@ func (k *Keeper) addTopicToActiveSetRespectingLimitsWithoutMinWeightReset(
 		// Remove the topic with the lowest weight
 		lowestWeight, _, err := k.GetLowestActiveTopicWeightAtBlock(ctx, block)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		weight, err := k.GetTopicWeightFromTopicId(ctx, topicId)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		if weight.Lt(lowestWeight.Weight) {
 			sdkCtx.Logger().Warn(fmt.Sprintf("Topic %d cannot be activated due to less than lowest weight at block %d", topicId, block))
-			return false, nil
+			return types.ErrTopicCannotBeActivated
 		}
 		err = k.inactivateTopicWithoutMinWeightReset(ctx, lowestWeight.TopicId)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		// Remove the lowest weight topic from the active topics at the block
@@ -246,9 +246,9 @@ func (k *Keeper) addTopicToActiveSetRespectingLimitsWithoutMinWeightReset(
 	newActiveTopicIds := types.TopicIds{TopicIds: existingActiveTopics}
 	err = k.SetBlockToActiveTopics(ctx, block, newActiveTopicIds)
 	if err != nil {
-		return false, err
+		return err
 	}
-	return true, nil
+	return nil
 }
 
 // Set a topic to active if the topic exists, else does nothing
@@ -279,6 +279,10 @@ func (k *Keeper) ActivateTopic(ctx context.Context, topicId TopicId) error {
 	epochEndBlock := currentBlock + topic.EpochLength
 
 	err = k.activateTopicAndResetLowestWeightAtBlock(ctx, topicId, epochEndBlock)
+	if errors.IsOf(err, types.ErrTopicAlreadyActive) || errors.IsOf(err, types.ErrTopicCannotBeActivated) {
+		sdkCtx.Logger().Info(fmt.Sprintf("Failed to add topic at next epoch %d, %d, %v", topicId, epochEndBlock, err))
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err, "failed to activate topic and reset lowest weight at block")
 	}
@@ -339,7 +343,10 @@ func (k *Keeper) AttemptTopicReactivation(ctx context.Context, topicId TopicId) 
 	}
 
 	err = k.activateTopicAndResetLowestWeightAtBlock(ctx, topicId, epochEndBlock)
-	if err != nil {
+	if errors.IsOf(err, types.ErrTopicAlreadyActive) || errors.IsOf(err, types.ErrTopicCannotBeActivated) {
+		sdkCtx.Logger().Info(fmt.Sprintf("Failed to add topic at next epoch %d, %d, %v", topicId, epochEndBlock, err))
+		return nil
+	} else if err != nil {
 		return errors.Wrap(err, "failed to activate topic and reset lowest weight at block")
 	}
 
@@ -375,14 +382,9 @@ func (k *Keeper) removeCurrentTopicFromBlock(ctx context.Context, topicId TopicI
 func (k *Keeper) activateTopicAndResetLowestWeightAtBlock(ctx context.Context, topicId TopicId, epochEndBlock BlockHeight) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	// Add to next epoch end block if greater than lowest weight
-	isAdded, err := k.addTopicToActiveSetRespectingLimitsWithoutMinWeightReset(ctx, topicId, epochEndBlock)
+	err := k.addTopicToActiveSetRespectingLimitsWithoutMinWeightReset(ctx, topicId, epochEndBlock)
 	if err != nil {
-		sdkCtx.Logger().Warn(fmt.Sprintf("Failed to add topic at next epoch %d, %d", topicId, epochEndBlock))
 		return errors.Wrap(err, "failed to add topic to active set respecting limits without min weight reset")
-	}
-	if !isAdded {
-		sdkCtx.Logger().Info(fmt.Sprintf("Failed to add topic at next epoch %d, %d", topicId, epochEndBlock))
-		return nil
 	}
 
 	err = k.SetTopicToNextPossibleChurningBlock(ctx, topicId, epochEndBlock)

--- a/x/emissions/keeper/topic_activation.go
+++ b/x/emissions/keeper/topic_activation.go
@@ -343,7 +343,7 @@ func (k *Keeper) AttemptTopicReactivation(ctx context.Context, topicId TopicId) 
 	}
 
 	err = k.activateTopicAndResetLowestWeightAtBlock(ctx, topicId, epochEndBlock)
-	if errors.IsOf(err, types.ErrTopicAlreadyActive) || errors.IsOf(err, types.ErrTopicCannotBeActivated) {
+	if errors.IsOf(err, types.ErrTopicAlreadyActive, types.ErrTopicCannotBeActivated) {
 		sdkCtx.Logger().Info(fmt.Sprintf("Failed to add topic at next epoch %d, %d, %v", topicId, epochEndBlock, err))
 		return nil
 	} else if err != nil {

--- a/x/emissions/types/errors.go
+++ b/x/emissions/types/errors.go
@@ -95,4 +95,6 @@ var (
 	ErrNotPermittedToAddStake                    = errors.Register(ModuleName, 90, "not permitted to add stake")
 	ErrNotPermittedToUpdateWhitelistAdmins       = errors.Register(ModuleName, 91, "not permitted to update whitelist admins")
 	ErrMaxWhitelistInputArrayLengthExceeded      = errors.Register(ModuleName, 92, "max whitelist input array length exceeded")
+	ErrTopicAlreadyActive                        = errors.Register(ModuleName, 93, "topic already active")
+	ErrTopicCannotBeActivated                    = errors.Register(ModuleName, 94, "topic cannot be activated")
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Fix vulnerability: if topic has not been (re)activated, then the topic weights should not change.
* Change `isAdded, error` for just `error` on `addTopicToActiveSetRespectingLimitsWithoutMinWeightReset`, adding some error types. The flag was not really adding value, while not processing the flag would lead to a vulnerability like the one found.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- existing unit tests 
- [x] If documented, please describe where. If not, describe why docs are not needed. -- no need, changes in functions not user-facing.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?


