### PR TITLE
owner should be paid worker rewards not inference sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* [#762](https://github.com/allora-network/allora-chain/pull/762) Worker node owner should get compensated, not sender of inferences
+
 ### Deprecated
 
 ### Removed

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -633,10 +633,17 @@ func payoutRewards(
 				ret = append(ret, errors.Wrapf(err, "failed to decode payout address: %s", reward.Address))
 				continue
 			}
+
+			nodeInfo, err := k.GetWorkerInfo(ctx, reward.Address)
+			if err != nil {
+				ret = append(ret, errors.Wrapf(err, "failed to get worker info: %s", reward.Address))
+				continue
+			}
+
 			err = k.SendCoinsFromModuleToAccount(
 				ctx,
 				types.AlloraRewardsAccountName,
-				reward.Address,
+				nodeInfo.Owner,
 				coins,
 			)
 			if err != nil {
@@ -644,7 +651,7 @@ func payoutRewards(
 					err,
 					"failed to send coins from rewards module to payout address %s, %s",
 					types.AlloraRewardsAccountName,
-					reward.Address,
+					nodeInfo.Owner,
 				))
 				continue
 			}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

The owner of a worker should be paid not the sender of inferences. This allows other addresses to be compensated for worker participation. It also contributes to the ability for x/feegrant to pay for worker fees.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/ENGN-3547/the-owner-of-a-worker-should-be-paid-not-the-sender

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

Decide if we want to also send reputer rewards to reputer wallets as opposed to augment their stake.