### PR TITLE
topicRewardAlpha using weekly cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* [#764](https://github.com/allora-network/allora-chain/pull/764) TopicRewardAlpha using weekly cadence
+
 ### Deprecated
 
 ### Removed

--- a/math/utils.go
+++ b/math/utils.go
@@ -669,3 +669,43 @@ func MedianAbsoluteDeviation(data []Dec) (medianAbsoluteDeviation Dec, median De
 
 	return medianAbsoluteDeviation, median, nil
 }
+
+// GetSmoothedAlpha computes a smoothing factor based on a given interval,
+// adjusting the exponential moving average update rate.
+// It generalizes the per-topic alpha calculation from Equation 54.
+func GetSmoothedAlpha(epochLength int64, baseIntervalDec Dec, baseAlpha Dec) (Dec, error) {
+	// Ensure epochLength and baseInterval are positive
+	if epochLength <= 0 {
+		return ZeroDec(), errorsmod.Wrap(ErrOutOfRange, "epochLength and baseInterval must be positive")
+	}
+	if baseIntervalDec.Lte(ZeroDec()) {
+		return ZeroDec(), errorsmod.Wrap(ErrOutOfRange, "baseInterval must be positive")
+	}
+
+	epochLengthDec := NewDecFromInt64(epochLength)
+	// Compute scaling factor (EpochLength / BaseInterval)
+	scalingFactor, err := epochLengthDec.Quo(baseIntervalDec)
+	if err != nil {
+		return ZeroDec(), errorsmod.Wrap(err, "error computing scaling factor")
+	}
+
+	// Compute (1 - baseAlpha)
+	oneMinusBaseAlpha, err := OneDec().Sub(baseAlpha)
+	if err != nil {
+		return ZeroDec(), errorsmod.Wrap(err, "error computing (1 - baseAlpha)")
+	}
+
+	// Compute (1 - baseAlpha)^(EpochLength / BaseInterval)
+	expTerm, err := Pow(oneMinusBaseAlpha, scalingFactor)
+	if err != nil {
+		return ZeroDec(), errorsmod.Wrap(err, "error computing exponentiation")
+	}
+
+	// Compute smoothed alpha: 1 - (1 - baseAlpha)^(EpochLength / BaseInterval)
+	smoothedAlpha, err := OneDec().Sub(expTerm)
+	if err != nil {
+		return ZeroDec(), errorsmod.Wrap(err, "error computing smoothed alpha")
+	}
+
+	return smoothedAlpha, nil
+}

--- a/math/utils.go
+++ b/math/utils.go
@@ -676,7 +676,7 @@ func MedianAbsoluteDeviation(data []Dec) (medianAbsoluteDeviation Dec, median De
 func GetSmoothedAlpha(epochLength int64, baseIntervalDec Dec, baseAlpha Dec) (Dec, error) {
 	// Ensure epochLength and baseInterval are positive
 	if epochLength <= 0 {
-		return ZeroDec(), errorsmod.Wrap(ErrOutOfRange, "epochLength and baseInterval must be positive")
+		return ZeroDec(), errorsmod.Wrap(ErrOutOfRange, "epochLength must be positive")
 	}
 	if baseIntervalDec.Lte(ZeroDec()) {
 		return ZeroDec(), errorsmod.Wrap(ErrOutOfRange, "baseInterval must be positive")

--- a/math/utils_test.go
+++ b/math/utils_test.go
@@ -930,3 +930,103 @@ func TestMedianAbsoluteDeviation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSmoothedAlpha(t *testing.T) {
+	testCases := []struct {
+		name         string
+		epochLength  int64
+		baseInterval alloraMath.Dec
+		baseAlpha    alloraMath.Dec
+		expected     alloraMath.Dec
+		expectError  bool
+		epsilon      alloraMath.Dec
+	}{
+		{
+			name:         "Standard case - weekly updates",
+			epochLength:  1000,
+			baseInterval: alloraMath.MustNewDecFromString("50000"),
+			baseAlpha:    alloraMath.MustNewDecFromString("0.5"),
+			expected:     alloraMath.MustNewDecFromString("0.013"),
+			expectError:  false,
+			epsilon:      alloraMath.MustNewDecFromString("0.001"),
+		},
+		{
+			name:         "Short epoch, updates fast",
+			epochLength:  100,
+			baseInterval: alloraMath.MustNewDecFromString("50000"),
+			baseAlpha:    alloraMath.MustNewDecFromString("0.5"),
+			expected:     alloraMath.MustNewDecFromString("0.0013"),
+			expectError:  false,
+			epsilon:      alloraMath.MustNewDecFromString("0.001"),
+		},
+		{
+			name:         "Long epoch, slow updates",
+			epochLength:  100000,
+			baseInterval: alloraMath.MustNewDecFromString("50000"),
+			baseAlpha:    alloraMath.MustNewDecFromString("0.5"),
+			expected:     alloraMath.MustNewDecFromString("0.75"),
+			expectError:  false,
+			epsilon:      alloraMath.MustNewDecFromString("0.01"),
+		},
+		{
+			name:         "Monthly-like smoothing",
+			epochLength:  100000,
+			baseInterval: alloraMath.MustNewDecFromString("50000"),
+			baseAlpha:    alloraMath.MustNewDecFromString("0.9375"),
+			expected:     alloraMath.MustNewDecFromString("0.996"),
+			expectError:  false,
+			epsilon:      alloraMath.MustNewDecFromString("0.001"),
+		},
+		{
+			name:         "Edge case - very short epoch",
+			epochLength:  1,
+			baseInterval: alloraMath.MustNewDecFromString("50000"),
+			baseAlpha:    alloraMath.MustNewDecFromString("0.5"),
+			expected:     alloraMath.MustNewDecFromString("0.0000198"),
+			expectError:  false,
+			epsilon:      alloraMath.MustNewDecFromString("0.001"),
+		},
+		{
+			name:         "Edge case - very long epoch",
+			epochLength:  500000,
+			baseInterval: alloraMath.MustNewDecFromString("50000"),
+			baseAlpha:    alloraMath.MustNewDecFromString("0.5"),
+			expected:     alloraMath.MustNewDecFromString("0.999"),
+			expectError:  false,
+			epsilon:      alloraMath.MustNewDecFromString("0.001"),
+		},
+		{
+			name:         "Invalid input - zero epoch length",
+			epochLength:  0,
+			baseInterval: alloraMath.MustNewDecFromString("50000"),
+			baseAlpha:    alloraMath.MustNewDecFromString("0.5"),
+			expected:     alloraMath.ZeroDec(),
+			expectError:  true,
+			epsilon:      alloraMath.MustNewDecFromString("0.001"),
+		},
+		{
+			name:         "Invalid input - zero base interval",
+			epochLength:  1000,
+			baseInterval: alloraMath.ZeroDec(),
+			baseAlpha:    alloraMath.MustNewDecFromString("0.5"),
+			expected:     alloraMath.ZeroDec(),
+			expectError:  true,
+			epsilon:      alloraMath.MustNewDecFromString("0.001"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := alloraMath.GetSmoothedAlpha(tc.epochLength, tc.baseInterval, tc.baseAlpha)
+			if tc.expectError {
+				require.Error(t, err, "Expected an error but got none")
+			} else {
+				require.NoError(t, err, "Unexpected error: %v", err)
+				inDelta, err := alloraMath.InDelta(tc.expected, result, tc.epsilon)
+				require.NoError(t, err)
+				require.True(t, inDelta,
+					"Unexpected result for %s: got %s, want %s", tc.name, result.String(), tc.expected.String())
+			}
+		})
+	}
+}

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -3170,7 +3170,7 @@ func (k *Keeper) AddTopicFeeRevenue(ctx context.Context, topicId TopicId, amount
 
 // return the blocks per week
 // defined as the blocks per month divided by 4.345
-func calculateBlocksPerWeek(ctx sdk.Context, k Keeper) (alloraMath.Dec, error) {
+func (k *Keeper) calculateBlocksPerWeek(ctx context.Context) (alloraMath.Dec, error) {
 	moduleParams, err := k.GetParams(ctx)
 	if err != nil {
 		return alloraMath.Dec{}, errorsmod.Wrap(err, "error getting params")
@@ -3243,7 +3243,7 @@ func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topicId TopicId, block Blo
 		ctx.Logger().Warn(fmt.Sprintf("Blocks per epoch is zero for topic %d. Skipping fee revenue drip.", topicId))
 		return nil
 	}
-	blocksPerWeek, err := calculateBlocksPerWeek(ctx, *k)
+	blocksPerWeek, err := k.calculateBlocksPerWeek(ctx)
 	if err != nil {
 		return errorsmod.Wrap(err, "error calculating blocks per week")
 	}

--- a/x/emissions/keeper/msgserver/msg_server_demand_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand_test.go
@@ -130,3 +130,92 @@ func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
 
 	s.Require().Equal(topic2Weight.Gt(topicWeight), true, "Topic1 weight should be greater than Topic2 weight")
 }
+
+func (s *MsgServerTestSuite) TestTopicWeightChangesWithDifferentEpochLengths() {
+	senderAddr := s.addrs[0]
+	sender := s.addrsStr[0]
+	reputer := s.addrsStr[1]
+
+	// Create two topics with different epoch lengths
+	topic1 := s.CreateCustomEpochTopic(125) // Longer epoch
+	topic2 := s.CreateCustomEpochTopic(50)  // Shorter epoch
+
+	// Put same stake in both topics
+	err := s.emissionsKeeper.AddReputerStake(s.ctx, topic1.Id, reputer, cosmosMath.NewInt(500000))
+	s.Require().NoError(err)
+	err = s.emissionsKeeper.InactivateTopic(s.ctx, topic1.Id)
+	s.Require().NoError(err)
+
+	err = s.emissionsKeeper.AddReputerStake(s.ctx, topic2.Id, reputer, cosmosMath.NewInt(500000))
+	s.Require().NoError(err)
+	err = s.emissionsKeeper.InactivateTopic(s.ctx, topic2.Id)
+	s.Require().NoError(err)
+
+	// Set up funding amounts
+	var initialStake int64 = 10000
+	var initialStake2 int64 = 10000
+	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake+initialStake2)))
+	err = s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
+	s.Require().NoError(err)
+	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, senderAddr, initialStakeCoins)
+	s.Require().NoError(err)
+
+	// Create funding requests
+	r := types.FundTopicRequest{
+		Sender:  sender,
+		TopicId: topic1.Id,
+		Amount:  cosmosMath.NewInt(initialStake),
+	}
+	r2 := types.FundTopicRequest{
+		Sender:  sender,
+		TopicId: topic2.Id,
+		Amount:  cosmosMath.NewInt(initialStake2),
+	}
+
+	// Get params for weight calculation
+	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	s.Require().NoError(err, "GetParams should not return an error")
+
+	// Fund both topics
+	response, err := s.msgServer.FundTopic(s.ctx, &r)
+	s.Require().NoError(err, "FundTopic should not return an error")
+	s.Require().NotNil(response, "Response should not be nil")
+
+	response2, err := s.msgServer.FundTopic(s.ctx, &r2)
+	s.Require().NoError(err, "FundTopic should not return an error")
+	s.Require().NotNil(response2, "Response should not be nil")
+
+	// Check if both topics are activated
+	res, err := s.emissionsKeeper.IsTopicActive(s.ctx, r.TopicId)
+	s.Require().NoError(err)
+	s.Require().Equal(true, res, "Topic1 is not activated")
+
+	res2, err := s.emissionsKeeper.IsTopicActive(s.ctx, r2.TopicId)
+	s.Require().NoError(err)
+	s.Require().Equal(true, res2, "Topic2 is not activated")
+
+	// Get weights for both topics
+	topicWeight1, _, err := s.emissionsKeeper.GetCurrentTopicWeight(
+		s.ctx,
+		r.TopicId,
+		125,
+		params.TopicRewardAlpha,
+		params.TopicRewardStakeImportance,
+		params.TopicRewardFeeRevenueImportance,
+	)
+	s.Require().NoError(err)
+
+	topicWeight2, _, err := s.emissionsKeeper.GetCurrentTopicWeight(
+		s.ctx,
+		r2.TopicId,
+		50,
+		params.TopicRewardAlpha,
+		params.TopicRewardStakeImportance,
+		params.TopicRewardFeeRevenueImportance,
+	)
+	s.Require().NoError(err)
+
+	// Topic2 should have higher weight due to higher funding, despite shorter epoch
+	s.Require().Equal(topicWeight2.Gt(topicWeight1), true, "Topic2 weight should be greater than Topic1 weight because it has a shorter epoch length")
+
+}

--- a/x/emissions/keeper/msgserver/msg_server_demand_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand_test.go
@@ -3,6 +3,7 @@ package msgserver_test
 import (
 	cosmosMath "cosmossdk.io/math"
 	"github.com/allora-network/allora-chain/app/params"
+	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -137,8 +138,10 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 	reputer := s.addrsStr[1]
 
 	// Create two topics with different epoch lengths
-	topic1 := s.CreateCustomEpochTopic(125) // Longer epoch
-	topic2 := s.CreateCustomEpochTopic(50)  // Shorter epoch
+	epochLength1 := int64(125)
+	epochLength2 := int64(50)
+	topic1 := s.CreateCustomEpochTopic(epochLength1) // Longer epoch
+	topic2 := s.CreateCustomEpochTopic(epochLength2) // Shorter epoch
 
 	// Put same stake in both topics
 	err := s.emissionsKeeper.AddReputerStake(s.ctx, topic1.Id, reputer, cosmosMath.NewInt(500000))
@@ -198,7 +201,7 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 	topicWeight1, _, err := s.emissionsKeeper.GetCurrentTopicWeight(
 		s.ctx,
 		r.TopicId,
-		125,
+		epochLength1,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
@@ -208,14 +211,42 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 	topicWeight2, _, err := s.emissionsKeeper.GetCurrentTopicWeight(
 		s.ctx,
 		r2.TopicId,
-		50,
+		epochLength2,
+		params.TopicRewardAlpha,
+		params.TopicRewardStakeImportance,
+		params.TopicRewardFeeRevenueImportance,
+	)
+	s.Require().NoError(err)
+	// Topics should have equal weights at this point because their previous topic weight is still zero
+	s.Require().Equal(topicWeight2.Equal(topicWeight1), true, "Topic2 weight should be equal to Topic1 weight if no previous topic weight is set")
+
+	// Setting previous topic weights
+	err = s.emissionsKeeper.SetPreviousTopicWeight(s.ctx, r.TopicId, alloraMath.MustNewDecFromString("100"))
+	s.Require().NoError(err)
+	err = s.emissionsKeeper.SetPreviousTopicWeight(s.ctx, r2.TopicId, alloraMath.MustNewDecFromString("100"))
+	s.Require().NoError(err)
+
+	// Recalculate having set previous topic weights
+	topicWeight1, _, err = s.emissionsKeeper.GetCurrentTopicWeight(
+		s.ctx,
+		r.TopicId,
+		epochLength1,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
 	)
 	s.Require().NoError(err)
 
-	// Topic2 should have higher weight due to higher funding, despite shorter epoch
-	s.Require().Equal(topicWeight2.Equal(topicWeight1), true, "Topic2 weight should be greater than Topic1 weight because it has a shorter epoch length")
+	topicWeight2, _, err = s.emissionsKeeper.GetCurrentTopicWeight(
+		s.ctx,
+		r2.TopicId,
+		epochLength2,
+		params.TopicRewardAlpha,
+		params.TopicRewardStakeImportance,
+		params.TopicRewardFeeRevenueImportance,
+	)
+	s.Require().NoError(err)
+	// Topics should have equal weights because the target weight is not affected by the epoch length
+	s.Require().Equal(topicWeight1.Gt(topicWeight2), true, "Topic1 weight should > Topic2 weight because prev topic weights are smaller than current ones and Topic1 has a longer epoch length")
 
 }

--- a/x/emissions/keeper/msgserver/msg_server_demand_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand_test.go
@@ -131,7 +131,7 @@ func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
 	s.Require().Equal(topic2Weight.Gt(topicWeight), true, "Topic1 weight should be greater than Topic2 weight")
 }
 
-func (s *MsgServerTestSuite) TestTopicWeightChangesWithDifferentEpochLengths() {
+func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengths() {
 	senderAddr := s.addrs[0]
 	sender := s.addrsStr[0]
 	reputer := s.addrsStr[1]
@@ -216,6 +216,6 @@ func (s *MsgServerTestSuite) TestTopicWeightChangesWithDifferentEpochLengths() {
 	s.Require().NoError(err)
 
 	// Topic2 should have higher weight due to higher funding, despite shorter epoch
-	s.Require().Equal(topicWeight2.Gt(topicWeight1), true, "Topic2 weight should be greater than Topic1 weight because it has a shorter epoch length")
+	s.Require().Equal(topicWeight2.Equal(topicWeight1), true, "Topic2 weight should be greater than Topic1 weight because it has a shorter epoch length")
 
 }

--- a/x/emissions/keeper/topic_weight.go
+++ b/x/emissions/keeper/topic_weight.go
@@ -42,6 +42,11 @@ func (k *Keeper) GetCurrentTopicWeight(
 	stakeImportance alloraMath.Dec,
 	feeImportance alloraMath.Dec,
 ) (weight alloraMath.Dec, topicRevenue cosmosMath.Int, err error) {
+	blocksPerWeek, err := k.calculateBlocksPerWeek(ctx)
+	if err != nil {
+		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to calculate blocks per week")
+	}
+
 	topicStake, err := k.GetTopicStake(ctx, topicId)
 	if err != nil {
 		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get topic stake")
@@ -80,12 +85,17 @@ func (k *Keeper) GetCurrentTopicWeight(
 		if err != nil {
 			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get previous topic weight")
 		}
-		weight, err = alloraMath.CalcEma(topicRewardAlpha, targetWeight, previousTopicWeight, noPrior)
+
+		// Calculate alpha
+		topicSmoothedAlpha, err := alloraMath.GetSmoothedAlpha(topicEpochLength, blocksPerWeek, topicRewardAlpha)
+		if err != nil {
+			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get smoothed alpha")
+		}
+		weightNew, err := alloraMath.CalcEma(topicSmoothedAlpha, targetWeight, previousTopicWeight, noPrior)
 		if err != nil {
 			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to calculate EMA")
 		}
-
-		return weight, topicFeeRevenue, nil
+		return weightNew, topicFeeRevenue, nil
 	}
 
 	return alloraMath.ZeroDec(), topicFeeRevenue, nil

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -2,7 +2,6 @@ package rewards_test
 
 import (
 	"fmt"
-	l "log"
 	"testing"
 	"time"
 
@@ -758,7 +757,7 @@ func (s *RewardsTestSuite) getRewardsDistribution(
 
 	// Move to end of this epoch block
 	nextBlock, _, err := s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId)
-	s.T().Logf("Next block: %v", nextBlock)
+	s.T().Logf("Moving nonce for TopicId: %d, Next block: %v", topicId, nextBlock)
 	s.Require().NoError(err)
 	blockHeight := nextBlock
 	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(blockHeight)
@@ -2311,6 +2310,10 @@ func (s *RewardsTestSuite) SetParamsForTest() {
 		MinEpochLength:          []int64{1},
 		RegistrationFee:         []cosmosMath.Int{cosmosMath.NewInt(6)},
 		MaxActiveTopicsPerBlock: []uint64{2},
+		BlocksPerMonth:          []uint64{864000},
+		// Exaggerated TopicRewardAlpha to compensate the effect of latest topic reward alpha vs
+		// the dripping effect and separate epochs running multiple topics.
+		TopicRewardAlpha: []alloraMath.Dec{alloraMath.MustNewDecFromString("0.999375")},
 		// the following fields are not set
 		Version:                             nil,
 		MaxSerializedMsgLength:              nil,
@@ -2325,7 +2328,6 @@ func (s *RewardsTestSuite) SetParamsForTest() {
 		MaxUnfulfilledReputerRequests:       nil,
 		TopicRewardStakeImportance:          nil,
 		TopicRewardFeeRevenueImportance:     nil,
-		TopicRewardAlpha:                    nil,
 		TaskRewardAlpha:                     nil,
 		ValidatorsVsAlloraPercentReward:     nil,
 		MaxSamplesToScaleScores:             nil,
@@ -2336,7 +2338,6 @@ func (s *RewardsTestSuite) SetParamsForTest() {
 		DefaultPageLimit:                    nil,
 		MaxPageLimit:                        nil,
 		MinEpochLengthRecordLimit:           nil,
-		BlocksPerMonth:                      nil,
 		PRewardInference:                    nil,
 		PRewardForecast:                     nil,
 		PRewardReputer:                      nil,
@@ -3129,7 +3130,8 @@ func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
 	reputer5_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[2]])
 	require.NoError(err)
 
-	// do work on the topics to earn rewards
+	// do work on the topics to earn rewards. Beware: there are moving of blocks, so it's different epochs where
+	// topicId0 and topicId1 get their action done.
 	s.getRewardsDistribution(
 		topicId0,
 		workerValues,
@@ -3177,28 +3179,22 @@ func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
 	require.NoError(err)
 
 	worker1InclusionNum, err := s.emissionsKeeper.GetCountInfererInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[0]])
-	l.Println("worker1InclusionNum", worker1InclusionNum)
 	require.NoError(err)
 	require.Equal(uint64(1), worker1InclusionNum)
 	worker2InclusionNum, err := s.emissionsKeeper.GetCountInfererInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[1]])
-	l.Println("worker2InclusionNum", worker2InclusionNum)
 	require.NoError(err)
 	require.Equal(uint64(1), worker2InclusionNum)
 	worker3InclusionNum, err := s.emissionsKeeper.GetCountInfererInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[2]])
-	l.Println("worker3InclusionNum", worker3InclusionNum)
 	require.Equal(uint64(1), worker3InclusionNum)
 	require.NoError(err)
 
 	worker1InclusionNum, err = s.emissionsKeeper.GetCountForecasterInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[0]])
-	l.Println("worker1InclusionNum", worker1InclusionNum)
 	require.NoError(err)
 	require.Equal(uint64(1), worker1InclusionNum)
 	worker2InclusionNum, err = s.emissionsKeeper.GetCountForecasterInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[1]])
-	l.Println("worker2InclusionNum", worker2InclusionNum)
 	require.NoError(err)
 	require.Equal(uint64(1), worker2InclusionNum)
 	worker3InclusionNum, err = s.emissionsKeeper.GetCountForecasterInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[2]])
-	l.Println("worker3InclusionNum", worker3InclusionNum)
 	require.Equal(uint64(1), worker3InclusionNum)
 	require.NoError(err)
 	const topicFundAmount int64 = 1000
@@ -3243,11 +3239,12 @@ func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
 
 	require.Equal(topic0RewardTotal0, topic1RewardTotal0)
 
-	// Now, in second trial, increase stake for first reputer in topic1
-	s.MintTokensToAddress(s.addrs[reputerIndexes[0]], stake)
+	// Now, in second trial, significantly increase stake for first reputer in topic1
+	stakeIncrease := cosmosMath.NewInt(1000).Mul(stake)
+	s.MintTokensToAddress(s.addrs[reputerIndexes[0]], stakeIncrease)
 	_, err = s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
 		Sender:  s.addrsStr[reputerIndexes[0]],
-		Amount:  stake,
+		Amount:  stakeIncrease,
 		TopicId: topicId1,
 	})
 	require.NoError(err)
@@ -3261,7 +3258,8 @@ func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
 	block++
 	s.ctx = s.ctx.WithBlockHeight(block)
 
-	// do work on the topics to earn rewards
+	// do work on the topics to earn rewards. Beware: there are moving of blocks, so it's different epochs where
+	// topicId0 and topicId1 get their action done.
 	s.getRewardsDistribution(
 		topicId0,
 		workerValues,
@@ -3270,8 +3268,7 @@ func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
 		"0.1",
 		"0.1",
 	)
-
-	s.getRewardsDistribution(
+	taskRewards1 := s.getRewardsDistribution(
 		topicId1,
 		workerValues,
 		reputerValues,
@@ -3279,6 +3276,27 @@ func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
 		"0.1",
 		"0.1",
 	)
+
+	// Get and check the rewards for the reputer after the stake increase
+	var taskRewardsReputer3AfterStakeIncrease,
+		taskRewardsReputer4AfterStakeIncrease,
+		taskRewardsReputer5AfterStakeIncrease types.TaskReward
+
+	for _, reward := range taskRewards1 {
+		if reward.Type == types.ReputerAndDelegatorRewardType {
+			if reward.Address == s.addrsStr[reputerIndexes[0]] {
+				taskRewardsReputer3AfterStakeIncrease = reward
+			}
+			if reward.Address == s.addrsStr[reputerIndexes[1]] {
+				taskRewardsReputer4AfterStakeIncrease = reward
+			}
+			if reward.Address == s.addrsStr[reputerIndexes[2]] {
+				taskRewardsReputer5AfterStakeIncrease = reward
+			}
+		}
+	}
+	require.True(taskRewardsReputer3AfterStakeIncrease.Reward.Gt(taskRewardsReputer4AfterStakeIncrease.Reward))
+	require.True(taskRewardsReputer3AfterStakeIncrease.Reward.Gt(taskRewardsReputer5AfterStakeIncrease.Reward))
 
 	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
 
@@ -3302,11 +3320,11 @@ func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
 	reputer5_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[2]])
 	require.NoError(err)
 
-	// calculate rewards
+	// calculate rewards (topic 0)
 	reputer0_Reward1 := reputer0_Stake2.Sub(reputer0_Stake1)
 	reputer1_Reward1 := reputer1_Stake2.Sub(reputer1_Stake1)
 	reputer2_Reward1 := reputer2_Stake2.Sub(reputer2_Stake1)
-
+	// calculate rewards (topic 1)
 	reputer3_Reward1 := reputer3_Stake2.Sub(reputer3_Stake1)
 	reputer4_Reward1 := reputer4_Stake2.Sub(reputer4_Stake1)
 	reputer5_Reward1 := reputer5_Stake2.Sub(reputer5_Stake1)
@@ -3315,14 +3333,38 @@ func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
 	topic0RewardTotal1 := reputer0_Reward1.Add(reputer1_Reward1).Add(reputer2_Reward1)
 	topic1RewardTotal1 := reputer3_Reward1.Add(reputer4_Reward1).Add(reputer5_Reward1)
 
+	topic0Total0Dec, err := alloraMath.NewDecFromSdkInt(topic0RewardTotal0)
+	require.NoError(err)
+	topic1Total0Dec, err := alloraMath.NewDecFromSdkInt(topic1RewardTotal0)
+	require.NoError(err)
+	topic0Total1Dec, err := alloraMath.NewDecFromSdkInt(topic0RewardTotal1)
+	require.NoError(err)
+	topic1Total1Dec, err := alloraMath.NewDecFromSdkInt(topic1RewardTotal1)
+	require.NoError(err)
+
+	// Normalize to the amount of rewards given in each cycle and check the ratios of the whole rewards,
+	// instead of absolute values (since rewards amount is different in each cycle).
+	totalRewardsEpoch0, err := topic0Total0Dec.Add(topic1Total0Dec)
+	require.NoError(err)
+	totalRewardsEpoch1, err := topic0Total1Dec.Add(topic1Total1Dec)
+	require.NoError(err)
+
+	topic0RewardTotal0Normalized, err := topic0Total0Dec.Quo(totalRewardsEpoch0)
+	require.NoError(err)
+	topic1RewardTotal0Normalized, err := topic1Total0Dec.Quo(totalRewardsEpoch0)
+	require.NoError(err)
+	topic0RewardTotal1Normalized, err := topic0Total1Dec.Quo(totalRewardsEpoch1)
+	require.NoError(err)
+	topic1RewardTotal1Normalized, err := topic1Total1Dec.Quo(totalRewardsEpoch1)
+
 	// in the first round, the rewards should be equal for each topic
-	require.True(topic0RewardTotal0.Equal(topic1RewardTotal0), "%s != %s", topic0RewardTotal0, topic1RewardTotal0)
+	require.True(topic0RewardTotal0Normalized.Equal(topic1RewardTotal0Normalized), "%s != %s", topic0RewardTotal0Normalized, topic1RewardTotal0Normalized)
 	// for topic 0, the rewards should be less in the second round
-	require.True(topic0RewardTotal0.GT(topic0RewardTotal1), "%s <= %s", topic0RewardTotal0, topic0RewardTotal1)
+	require.True(topic0RewardTotal0Normalized.Gte(topic1RewardTotal0Normalized), "%s <= %s", topic0RewardTotal0Normalized, topic1RewardTotal0Normalized)
 	// in the second round, the rewards should be greater for topic 1
-	require.True(topic0RewardTotal1.LT(topic1RewardTotal1), "%s >= %s", topic0RewardTotal1, topic1RewardTotal1)
+	require.True(topic0RewardTotal1Normalized.Lte(topic1RewardTotal1Normalized), "%s >= %s", topic0RewardTotal1Normalized, topic1RewardTotal1Normalized)
 	// the rewards for topic 1 should be greater in the second round
-	require.True(topic1RewardTotal0.LT(topic1RewardTotal1), "%s >= %s", topic1RewardTotal0, topic1RewardTotal1)
+	require.True(topic1RewardTotal0Normalized.Lt(topic1RewardTotal1Normalized), "%s >= %s", topic1RewardTotal0Normalized, topic1RewardTotal1Normalized)
 }
 
 func (s *RewardsTestSuite) TestReputerAboveConsensusGetsLessRewards() {
@@ -3789,6 +3831,7 @@ func (s *RewardsTestSuite) TestRewardIncreaseContiouslyAfterTopicReactivated() {
 	require.Equal(len(rewardsDistribution0_1), len(rewardsDistribution0_0))
 }
 
+// Generates slice of consecutive numbers
 func (s *RewardsTestSuite) returnIndexes(start, count int) []int {
 	res := make([]int, count)
 	for ind := start; ind < start+count; ind++ {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* TopicRewardAlpha to follow the whitepaper weekly cadence
* Generic function `GetSmoothedAlpha` to model equation 54, used to model equation 57's weekly cadence, but which can be used also in the scenario of any EMA-based cadence change. 

IMPACT: smoother weight change to topics.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
Adapted existing unit tests and create new ones. 
- [x] If documented, please describe where. If not, describe why docs are not needed. -- no need, just follows the whitepaper better.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

