### PR TITLE
fix sort by weight instead of topic id; rm excess sort logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * [#762](https://github.com/allora-network/allora-chain/pull/762) Worker node owner should get compensated, not sender of inferences
+* [#766](https://github.com/allora-network/allora-chain/pull/766) Fix sort by weight instead of topic id. Remove excess sort logic
 
 ### Deprecated
 

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -63,7 +63,6 @@ func UpdateNoncesOfActiveTopics(
 		ctx,
 		weights,
 		moduleParams.MaxActiveTopicsPerBlock,
-		block,
 	)
 	if err != nil {
 		return errors.Wrapf(err, "failed to skim top topics by weight")

--- a/x/emissions/module/rewards/topic_skimming.go
+++ b/x/emissions/module/rewards/topic_skimming.go
@@ -2,51 +2,15 @@ package rewards
 
 import (
 	"fmt"
-	"math/rand"
 	"sort"
 
-	"cosmossdk.io/errors"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// A structure to hold the original value and a random tiebreaker
-type SortableTopicId struct {
-	Value      TopicId
-	Weight     *alloraMath.Dec
-	Tiebreaker uint32
-}
-
-// Sorts the given slice of topics in descending order according to their corresponding return, using pseudorandom tiebreaker
-// e.g. ([]uint64{1, 2, 3}, map[uint64]uint64{1: 2, 2: 2, 3: 3}, 0) -> [3, 1, 2] or [3, 2, 1]
-func SortTopicsByWeightDescWithRandomTiebreaker(topicIds []TopicId, weights map[TopicId]*alloraMath.Dec, randSeed BlockHeight) ([]TopicId, error) {
-	// Convert the slice of Ts to a slice of SortableItems, each with a random tiebreaker
-	r := rand.New(rand.NewSource(randSeed)) //nolint:gosec // G404: Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand)
-	items := make([]SortableTopicId, len(topicIds))
-	for i, topicId := range topicIds {
-		items[i] = SortableTopicId{topicId, weights[topicId], r.Uint32()}
-	}
-
-	// Sort the slice of SortableItems
-	// If the values are equal, the tiebreaker will decide their order
-	sort.Slice(items, func(i, j int) bool {
-		if items[i].Value == items[j].Value {
-			return items[i].Tiebreaker > items[j].Tiebreaker
-		}
-		return (*items[i].Weight).Gt(*items[j].Weight)
-	})
-
-	// Extract and print the sorted values to demonstrate the sorting
-	sortedValues := make([]TopicId, len(topicIds))
-	for i, item := range items {
-		sortedValues[i] = item.Value
-	}
-	return sortedValues, nil
-}
-
 // Returns a map of topicId to weights of the top N topics by weight in descending order
 // It is assumed that topicIds is of a reasonable size, throttled by perhaps MaxTopicsPerBlock global param
-func SkimTopTopicsByWeightDesc(ctx sdk.Context, weights map[TopicId]*alloraMath.Dec, N uint64, block BlockHeight) (map[TopicId]*alloraMath.Dec, []TopicId, error) {
+func SkimTopTopicsByWeightDesc(ctx sdk.Context, weights map[TopicId]*alloraMath.Dec, N uint64) (map[TopicId]*alloraMath.Dec, []TopicId, error) {
 	topicIds := make([]TopicId, 0, len(weights))
 	for topicId := range weights { // nolint: maprange // reason: iteration to array before sorting
 		topicIds = append(topicIds, topicId)
@@ -58,26 +22,22 @@ func SkimTopTopicsByWeightDesc(ctx sdk.Context, weights map[TopicId]*alloraMath.
 		}
 		return (*weights[topicIds[i]]).Gt(*weights[topicIds[j]])
 	})
-	sortedTopicIds, err := SortTopicsByWeightDescWithRandomTiebreaker(topicIds, weights, block)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to sort topics by weight desc with random tiebreaker")
-	}
 
 	numberToAdd := N
-	if (uint64)(len(sortedTopicIds)) < N {
-		numberToAdd = (uint64)(len(sortedTopicIds))
+	if (uint64)(len(topicIds)) < N {
+		numberToAdd = (uint64)(len(topicIds))
 	}
 
 	weightsOfTopN := make(map[TopicId]*alloraMath.Dec, numberToAdd)
 	listOfTopN := make([]TopicId, numberToAdd)
 	for i := uint64(0); i < numberToAdd; i++ {
-		weightsOfTopN[sortedTopicIds[i]] = weights[sortedTopicIds[i]]
-		listOfTopN[i] = sortedTopicIds[i]
+		weightsOfTopN[topicIds[i]] = weights[topicIds[i]]
+		listOfTopN[i] = topicIds[i]
 	}
 
 	Logger(ctx).Debug(
 		fmt.Sprintf("SkimTopTopicsByWeightDesc took top %d topics out of %d",
-			numberToAdd, len(sortedTopicIds)))
+			numberToAdd, len(topicIds)))
 
 	return weightsOfTopN, listOfTopN, nil
 }

--- a/x/emissions/module/rewards/topic_skimming_test.go
+++ b/x/emissions/module/rewards/topic_skimming_test.go
@@ -6,40 +6,22 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 )
 
-func (s *RewardsTestSuite) TestSortTopicsByWeightDescWithRandomTiebreakerSimple() {
-	var unsortedTopicIds = []uint64{1, 2, 3, 4, 5}
-	var weightsPerTopic = []int64{100, 300, 700, 400, 200}
-	var weights = map[uint64]*alloraMath.Dec{}
-	for i, topicId := range unsortedTopicIds {
-		weight := alloraMath.NewDecFromInt64(weightsPerTopic[i])
-		weights[topicId] = &weight
-	}
-	sortedList, err := rewards.SortTopicsByWeightDescWithRandomTiebreaker(unsortedTopicIds, weights, 0)
-	s.Require().NoError(err)
-
-	s.Require().Equal(len(unsortedTopicIds), len(sortedList), "SortTopicsByWeightDescWithRandomTiebreaker should return the same length list")
-	s.Require().Equal(uint64(3), sortedList[0], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
-	s.Require().Equal(uint64(4), sortedList[1], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
-	s.Require().Equal(uint64(2), sortedList[2], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
-	s.Require().Equal(uint64(5), sortedList[3], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
-	s.Require().Equal(uint64(1), sortedList[4], "SortTopicsByWeightDescWithRandomTiebreaker should return the expected sorted list")
-}
-
 func (s *RewardsTestSuite) TestSkimTopTopicsByWeightDescSimple() {
 	var unsortedTopicIds = []uint64{1, 2, 3, 4, 5}
-	var weightsPerTopic = []int64{100, 300, 700, 400, 200}
+	var weightsPerTopic = []int64{100, 300, 400, 400, 200}
+	// Tiebreaker is topic id. Intended order of topics => 3 > 4 > 2 > 5 > 1
 	var weights = map[uint64]*alloraMath.Dec{}
 	for i, topicId := range unsortedTopicIds {
 		weight := alloraMath.NewDecFromInt64(weightsPerTopic[i])
 		weights[topicId] = &weight
 	}
 	N := uint64(3)
-	mapOfTopN, listOfTopN, err := rewards.SkimTopTopicsByWeightDesc(s.ctx, weights, N, 0)
+	mapOfTopN, listOfTopN, err := rewards.SkimTopTopicsByWeightDesc(s.ctx, weights, N)
 	s.Require().NoError(err)
 
 	// Check that mapOfTopN has the expected keys
 	s.Require().Equal(N, uint64(len(mapOfTopN)), "SkimTopTopicsByWeightDesc should return a map with N keys")
-	s.Require().Equal("700", mapOfTopN[3].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
+	s.Require().Equal("400", mapOfTopN[3].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
 	s.Require().Equal("400", mapOfTopN[4].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
 	s.Require().Equal("300", mapOfTopN[2].String(), "SkimTopTopicsByWeightDesc should return the expected sorted list")
 	// Check that mapOfTopN does not have any other keys


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Difference in sorting order across `UpdateNoncesOfActiveTopics` and `EmitRewards` was resolved. Code in former sorted on the wrong condition resulting in unintended functionality, possibly including giving rewards to the wrong topics when the number of active topics exceeds `MaxActiveTopicsPerBlock`.

Was able to remove some excess logic as well.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/ENGN-3518/171-difference-in-sorting-order-across-updatenoncesofactivetopics-and

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
   - Unit tests
- [x] If documented, please describe where. If not, describe why docs are not needed.
   - Executes intended functionality as explained in code comments
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
