### PR TITLE
Fix delegators funds lost if reputer leaves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
 * [#799](https://github.com/allora-network/allora-chain/pull/799) Correct Monthly PreviousPercentageRewardToStakedReputers Calculation
+* [#770](https://github.com/allora-network/allora-chain/pull/770) Allow delegate stake management after reputer unregister
 
 ### Security
 
@@ -106,7 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* [#803](https://github.com/allora-network/allora-chain/pull/803) Add reset/cleanup functions to defer in CloseReputerNonce 
+* [#803](https://github.com/allora-network/allora-chain/pull/803) Add reset/cleanup functions to defer in CloseReputerNonce
 * [#804](https://github.com/allora-network/allora-chain/pull/804) Additional validations + use inferenceBlockheight in NetworkInferences
 * [#805](https://github.com/allora-network/allora-chain/pull/805) An invalid bundle gets ignored on networkLoss calc
 
@@ -116,7 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Removed
 
-#### Added 
+#### Added
 
 #### Changed
 

--- a/x/emissions/keeper/msgserver/msg_server_stake.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake.go
@@ -217,13 +217,6 @@ func (ms msgServer) RemoveDelegateStake(ctx context.Context, msg *types.RemoveDe
 		return nil, types.ErrTopicDoesNotExist
 	}
 
-	isRegistered, err := ms.k.IsReputerRegisteredInTopic(ctx, msg.TopicId, msg.Reputer)
-	if err != nil {
-		return nil, err
-	} else if !isRegistered {
-		return nil, errorsmod.Wrap(types.ErrAddressIsNotRegisteredInThisTopic, "reputer address")
-	}
-
 	// Check the delegator has enough stake already placed on the topic to remove the stake
 	delegateStakePlaced, err := ms.k.GetDelegateStakePlacement(ctx, msg.TopicId, msg.Sender, msg.Reputer)
 	if err != nil {
@@ -299,13 +292,6 @@ func (ms msgServer) CancelRemoveDelegateStake(ctx context.Context, msg *types.Ca
 		return nil, types.ErrTopicDoesNotExist
 	}
 
-	isRegistered, err := ms.k.IsReputerRegisteredInTopic(ctx, msg.TopicId, msg.Reputer)
-	if err != nil {
-		return nil, err
-	} else if !isRegistered {
-		return nil, errorsmod.Wrap(types.ErrAddressIsNotRegisteredInThisTopic, "reputer address")
-	}
-
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	removal, found, err := ms.k.GetDelegateStakeRemovalForDelegatorReputerAndTopicId(
 		sdkCtx, msg.Sender, msg.Reputer, msg.TopicId,
@@ -344,13 +330,6 @@ func (ms msgServer) RewardDelegateStake(ctx context.Context, msg *types.RewardDe
 		return nil, err
 	} else if !topicExists {
 		return nil, types.ErrTopicDoesNotExist
-	}
-
-	isRegistered, err := ms.k.IsReputerRegisteredInTopic(ctx, msg.TopicId, msg.Reputer)
-	if err != nil {
-		return nil, err
-	} else if !isRegistered {
-		return nil, errorsmod.Wrap(types.ErrAddressIsNotRegisteredInThisTopic, "reputer address")
 	}
 
 	delegateInfo, err := ms.k.GetDelegateStakePlacement(ctx, msg.TopicId, msg.Sender, msg.Reputer)

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -1709,9 +1709,7 @@ func (s *MsgServerTestSuite) TestRewardDelegateStake() {
 func (s *MsgServerTestSuite) TestRewardDelegateStakeOnUnregisteredReputer() {
 	ctx := s.ctx
 	require := s.Require()
-	keeper := s.emissionsKeeper
 	block := int64(1003)
-	newBlock := int64(1004)
 	score := alloraMath.MustNewDecFromString("17.53436")
 
 	delegator := s.addrsStr[0]
@@ -1720,18 +1718,13 @@ func (s *MsgServerTestSuite) TestRewardDelegateStakeOnUnregisteredReputer() {
 	reputerAddr := s.addrs[1]
 	worker := s.addrsStr[2]
 	workerAddr := s.addrs[2]
-	delegator2 := s.addrsStr[3]
-	delegator2Addr := s.addrs[3]
 	stakeAmount := cosmosMath.NewInt(500000)
 	registrationInitialBalance := cosmosMath.NewInt(1000)
 	delegatorStakeAmount := cosmosMath.NewInt(500)
-	delegatorStakeAmount2 := cosmosMath.NewInt(500)
-	delegator2StakeAmount := cosmosMath.NewInt(5000)
 
 	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
-	s.MintTokensToAddress(delegator2Addr, cosmosMath.NewInt(1000000))
 
 	addStakeMsg := &types.AddStakeRequest{
 		Sender:  reputer,
@@ -1750,29 +1743,10 @@ func (s *MsgServerTestSuite) TestRewardDelegateStakeOnUnregisteredReputer() {
 		Amount:  delegatorStakeAmount,
 	}
 
-	msg2 := &types.DelegateStakeRequest{
-		Sender:  delegator2,
-		TopicId: topicId,
-		Reputer: reputer,
-		Amount:  delegator2StakeAmount,
-	}
-
-	reputerStake, err := s.emissionsKeeper.GetStakeReputerAuthority(ctx, topicId, reputer)
-	require.NoError(err)
-	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
-
-	amount0, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegator, reputer)
-	require.NoError(err)
-	require.Equal(alloraMath.NewDecFromInt64(0), amount0.Amount)
-
 	// Perform the stake delegation
 	responseDelegator, err := s.msgServer.DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(responseDelegator, "Response should not be nil after successful delegation")
-
-	responseDelegator2, err := s.msgServer.DelegateStake(ctx, msg2)
-	require.NoError(err)
-	require.NotNil(responseDelegator2, "Response should not be nil after successful delegation")
 
 	var reputerValueBundles types.ReputerValueBundles
 	scoreToAdd := types.Score{
@@ -1787,12 +1761,17 @@ func (s *MsgServerTestSuite) TestRewardDelegateStakeOnUnregisteredReputer() {
 	reputerValueBundle := &types.ReputerValueBundle{
 		Pubkey: s.pubKeyHexStr[1],
 		ValueBundle: &types.ValueBundle{
-			TopicId:                       topicId,
-			ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
-			Reputer:                       reputer,
-			ExtraData:                     nil,
-			CombinedValue:                 alloraMath.MustNewDecFromString("1500.0"),
-			InfererValues:                 nil,
+			TopicId:             topicId,
+			ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
+			Reputer:             reputer,
+			ExtraData:           nil,
+			CombinedValue:       alloraMath.MustNewDecFromString("1500.0"),
+			InfererValues: []*types.WorkerAttributedValue{
+				{
+					Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+					Value:  alloraMath.MustNewDecFromString("1"),
+				},
+			},
 			ForecasterValues:              nil,
 			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
 			OneOutInfererValues:           nil,
@@ -1830,97 +1809,18 @@ func (s *MsgServerTestSuite) TestRewardDelegateStakeOnUnregisteredReputer() {
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(reputerRewards))
 
-	msg3 := &types.DelegateStakeRequest{
-		Sender:  delegator,
-		TopicId: topicId,
-		Reputer: reputer,
-		Amount:  delegatorStakeAmount2,
-	}
-
-	responseDelegator3, err := s.msgServer.DelegateStake(ctx, msg3)
-	require.NoError(err)
-	require.NotNil(responseDelegator3, "Response should not be nil after successful delegation")
-
-	var newReputerValueBundles types.ReputerValueBundles
-	newScoreToAdd := types.Score{
-		TopicId:     topicId,
-		BlockHeight: newBlock,
-		Address:     reputer,
-		Score:       score,
-	}
-	err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, newBlock, newScoreToAdd)
-	s.Require().NoError(err)
-
-	newReputerValueBundle := &types.ReputerValueBundle{
-		ValueBundle: &types.ValueBundle{
-			TopicId:                       topicId,
-			ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: newBlock}},
-			Reputer:                       reputer,
-			ExtraData:                     nil,
-			CombinedValue:                 alloraMath.MustNewDecFromString("1500.0"),
-			InfererValues:                 nil,
-			ForecasterValues:              nil,
-			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
-			OneOutInfererValues:           nil,
-			OneOutForecasterValues:        nil,
-			OneInForecasterValues:         nil,
-			OneOutInfererForecasterValues: nil,
-		},
-		Signature: []byte{},
-		Pubkey:    s.pubKeyHexStr[1],
-	}
-	newReputerValueBundles.ReputerValueBundles = append(newReputerValueBundles.ReputerValueBundles, newReputerValueBundle)
-	err = s.emissionsKeeper.InsertActiveReputerLosses(s.ctx, topicId, newBlock, newReputerValueBundles)
-	s.Require().NoError(err)
-
-	// Calculate and Set the reputer scores
-	scores, err = rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
-	s.Require().NoError(err)
-
-	// Generate new rewards
-	reputers, reputersRewardFractions, err = rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
-		topicId,
-		alloraMath.OneDec(),
-		scores,
-	)
-	s.Require().NoError(err)
-	newReputerRewards, err := rewards.GetRewardPerReputer(
-		s.ctx,
-		s.emissionsKeeper,
-		topicId,
-		alloraMath.MustNewDecFromString("1020.5559072418691"),
-		reputers,
-		reputersRewardFractions,
-	)
-	s.Require().NoError(err)
-	s.Require().Equal(1, len(newReputerRewards))
-
 	beforeBalance := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	s.Require().NoError(s.emissionsKeeper.RemoveReputer(ctx, topicId, reputer))
+
 	rewardMsg := &types.RewardDelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
 		Reputer: reputer,
 	}
-
-	s.Require().NoError(s.emissionsKeeper.RemoveReputer(ctx, topicId, reputer))
-
 	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
 	afterBalance := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	s.Require().NoError(err)
 	s.Require().Greater(afterBalance.Amount.Uint64(), beforeBalance.Amount.Uint64(), "Balance must be increased")
-
-	beforeBalance2 := s.bankKeeper.GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
-	rewardMsg2 := &types.RewardDelegateStakeRequest{
-		Sender:  delegator2,
-		TopicId: topicId,
-		Reputer: reputer,
-	}
-	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg2)
-	afterBalance2 := s.bankKeeper.GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
-	s.Require().NoError(err)
-	s.Require().Greater(afterBalance2.Amount.Uint64(), beforeBalance2.Amount.Uint64(), "Balance must be increased")
 }
 
 func (s *MsgServerTestSuite) insertValueBundlesAndGetRewards(

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -770,6 +770,65 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStake() {
 	require.NotNil(removalInfo[0])
 }
 
+func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeOnUnregisteredReputer() {
+	ctx := s.ctx
+	require := s.Require()
+	keeper := s.emissionsKeeper
+
+	delegatorAddr := s.addrs[0]
+	delegator := s.addrsStr[0]
+	reputer := s.addrsStr[1]
+	topic := s.CreateOneTopic()
+	stakeAmount := cosmosMath.NewInt(50)
+	moduleParams, err := keeper.GetParams(ctx)
+	require.NoError(err)
+	removalDelay := moduleParams.RemoveStakeDelayWindow
+
+	reputerInfo := types.OffchainNode{
+		Owner:       s.addrsStr[0],
+		NodeAddress: reputer,
+	}
+
+	err = keeper.InsertReputer(ctx, topic.Id, reputer, reputerInfo)
+	require.NoError(err)
+
+	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
+
+	msg := &types.DelegateStakeRequest{
+		Sender:  delegator,
+		TopicId: topic.Id,
+		Reputer: reputer,
+		Amount:  stakeAmount,
+	}
+
+	// Perform the stake delegation
+	response, err := s.msgServer.DelegateStake(ctx, msg)
+	require.NoError(err)
+	require.NotNil(response, "Response should not be nil after successful delegation")
+
+	err = keeper.RemoveReputer(ctx, topic.Id, reputer)
+	require.NoError(err)
+
+	// Perform the stake removal initiation
+	msg2 := &types.RemoveDelegateStakeRequest{
+		Sender:  delegator,
+		Reputer: reputer,
+		TopicId: topic.Id,
+		Amount:  stakeAmount,
+	}
+	response2, err := s.msgServer.RemoveDelegateStake(ctx, msg2)
+	require.NoError(err)
+	require.NotNil(response2, "Response should not be nil after successful stake removal initiation")
+
+	// Verification: Check if the removal has been queued
+	removeBlock := ctx.BlockHeight() + removalDelay
+	removalInfo, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, removeBlock, 100)
+	require.NoError(err)
+	require.False(limitHit)
+	require.Len(removalInfo, 1)
+	require.NotNil(removalInfo[0])
+}
+
 func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeError() {
 	ctx := s.ctx
 	require := s.Require()
@@ -1647,6 +1706,223 @@ func (s *MsgServerTestSuite) TestRewardDelegateStake() {
 	s.Require().Greater(afterBalance2.Amount.Uint64(), beforeBalance2.Amount.Uint64(), "Balance must be increased")
 }
 
+func (s *MsgServerTestSuite) TestRewardDelegateStakeOnUnregisteredReputer() {
+	ctx := s.ctx
+	require := s.Require()
+	keeper := s.emissionsKeeper
+	block := int64(1003)
+	newBlock := int64(1004)
+	score := alloraMath.MustNewDecFromString("17.53436")
+
+	delegator := s.addrsStr[0]
+	delegatorAddr := s.addrs[0]
+	reputer := s.addrsStr[1]
+	reputerAddr := s.addrs[1]
+	worker := s.addrsStr[2]
+	workerAddr := s.addrs[2]
+	delegator2 := s.addrsStr[3]
+	delegator2Addr := s.addrs[3]
+	stakeAmount := cosmosMath.NewInt(500000)
+	registrationInitialBalance := cosmosMath.NewInt(1000)
+	delegatorStakeAmount := cosmosMath.NewInt(500)
+	delegatorStakeAmount2 := cosmosMath.NewInt(500)
+	delegator2StakeAmount := cosmosMath.NewInt(5000)
+
+	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
+	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
+	s.MintTokensToAddress(delegator2Addr, cosmosMath.NewInt(1000000))
+
+	addStakeMsg := &types.AddStakeRequest{
+		Sender:  reputer,
+		TopicId: topicId,
+		Amount:  stakeAmount,
+	}
+
+	response, err := s.msgServer.AddStake(ctx, addStakeMsg)
+	require.NoError(err, "AddStake should not return an error")
+	require.NotNil(response)
+
+	msg := &types.DelegateStakeRequest{
+		Sender:  delegator,
+		TopicId: topicId,
+		Reputer: reputer,
+		Amount:  delegatorStakeAmount,
+	}
+
+	msg2 := &types.DelegateStakeRequest{
+		Sender:  delegator2,
+		TopicId: topicId,
+		Reputer: reputer,
+		Amount:  delegator2StakeAmount,
+	}
+
+	reputerStake, err := s.emissionsKeeper.GetStakeReputerAuthority(ctx, topicId, reputer)
+	require.NoError(err)
+	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
+
+	amount0, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegator, reputer)
+	require.NoError(err)
+	require.Equal(alloraMath.NewDecFromInt64(0), amount0.Amount)
+
+	// Perform the stake delegation
+	responseDelegator, err := s.msgServer.DelegateStake(ctx, msg)
+	require.NoError(err)
+	require.NotNil(responseDelegator, "Response should not be nil after successful delegation")
+
+	responseDelegator2, err := s.msgServer.DelegateStake(ctx, msg2)
+	require.NoError(err)
+	require.NotNil(responseDelegator2, "Response should not be nil after successful delegation")
+
+	var reputerValueBundles types.ReputerValueBundles
+	scoreToAdd := types.Score{
+		TopicId:     topicId,
+		BlockHeight: block,
+		Address:     reputer,
+		Score:       score,
+	}
+	err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, block, scoreToAdd)
+	s.Require().NoError(err)
+
+	reputerValueBundle := &types.ReputerValueBundle{
+		Pubkey: s.pubKeyHexStr[1],
+		ValueBundle: &types.ValueBundle{
+			TopicId:                       topicId,
+			ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
+			Reputer:                       reputer,
+			ExtraData:                     nil,
+			CombinedValue:                 alloraMath.MustNewDecFromString("1500.0"),
+			InfererValues:                 nil,
+			ForecasterValues:              nil,
+			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
+			OneOutInfererValues:           nil,
+			OneOutForecasterValues:        nil,
+			OneInForecasterValues:         nil,
+			OneOutInfererForecasterValues: nil,
+		},
+		Signature: []byte{},
+	}
+	reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, reputerValueBundle)
+	err = s.emissionsKeeper.InsertActiveReputerLosses(s.ctx, topicId, block, reputerValueBundles)
+	s.Require().NoError(err)
+
+	// Calculate and Set the reputer scores
+	scores, err := rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	s.Require().NoError(err)
+
+	// Generate rewards
+	reputers, reputersRewardFractions, err := rewards.GetReputersRewardFractions(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		alloraMath.OneDec(),
+		scores,
+	)
+	s.Require().NoError(err)
+	reputerRewards, err := rewards.GetRewardPerReputer(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		alloraMath.MustNewDecFromString("1017.5559072418691"),
+		reputers,
+		reputersRewardFractions,
+	)
+	s.Require().NoError(err)
+	s.Require().Equal(1, len(reputerRewards))
+
+	msg3 := &types.DelegateStakeRequest{
+		Sender:  delegator,
+		TopicId: topicId,
+		Reputer: reputer,
+		Amount:  delegatorStakeAmount2,
+	}
+
+	responseDelegator3, err := s.msgServer.DelegateStake(ctx, msg3)
+	require.NoError(err)
+	require.NotNil(responseDelegator3, "Response should not be nil after successful delegation")
+
+	var newReputerValueBundles types.ReputerValueBundles
+	newScoreToAdd := types.Score{
+		TopicId:     topicId,
+		BlockHeight: newBlock,
+		Address:     reputer,
+		Score:       score,
+	}
+	err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, newBlock, newScoreToAdd)
+	s.Require().NoError(err)
+
+	newReputerValueBundle := &types.ReputerValueBundle{
+		ValueBundle: &types.ValueBundle{
+			TopicId:                       topicId,
+			ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: newBlock}},
+			Reputer:                       reputer,
+			ExtraData:                     nil,
+			CombinedValue:                 alloraMath.MustNewDecFromString("1500.0"),
+			InfererValues:                 nil,
+			ForecasterValues:              nil,
+			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
+			OneOutInfererValues:           nil,
+			OneOutForecasterValues:        nil,
+			OneInForecasterValues:         nil,
+			OneOutInfererForecasterValues: nil,
+		},
+		Signature: []byte{},
+		Pubkey:    s.pubKeyHexStr[1],
+	}
+	newReputerValueBundles.ReputerValueBundles = append(newReputerValueBundles.ReputerValueBundles, newReputerValueBundle)
+	err = s.emissionsKeeper.InsertActiveReputerLosses(s.ctx, topicId, newBlock, newReputerValueBundles)
+	s.Require().NoError(err)
+
+	// Calculate and Set the reputer scores
+	scores, err = rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	s.Require().NoError(err)
+
+	// Generate new rewards
+	reputers, reputersRewardFractions, err = rewards.GetReputersRewardFractions(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		alloraMath.OneDec(),
+		scores,
+	)
+	s.Require().NoError(err)
+	newReputerRewards, err := rewards.GetRewardPerReputer(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		alloraMath.MustNewDecFromString("1020.5559072418691"),
+		reputers,
+		reputersRewardFractions,
+	)
+	s.Require().NoError(err)
+	s.Require().Equal(1, len(newReputerRewards))
+
+	beforeBalance := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	rewardMsg := &types.RewardDelegateStakeRequest{
+		Sender:  delegator,
+		TopicId: topicId,
+		Reputer: reputer,
+	}
+
+	s.Require().NoError(s.emissionsKeeper.RemoveReputer(ctx, topicId, reputer))
+
+	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
+	afterBalance := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	s.Require().NoError(err)
+	s.Require().Greater(afterBalance.Amount.Uint64(), beforeBalance.Amount.Uint64(), "Balance must be increased")
+
+	beforeBalance2 := s.bankKeeper.GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
+	rewardMsg2 := &types.RewardDelegateStakeRequest{
+		Sender:  delegator2,
+		TopicId: topicId,
+		Reputer: reputer,
+	}
+	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg2)
+	afterBalance2 := s.bankKeeper.GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
+	s.Require().NoError(err)
+	s.Require().Greater(afterBalance2.Amount.Uint64(), beforeBalance2.Amount.Uint64(), "Balance must be increased")
+}
+
 func (s *MsgServerTestSuite) insertValueBundlesAndGetRewards(
 	reputerPrivKey secp256k1.PrivKey,
 	reputer string,
@@ -2160,6 +2436,51 @@ func (s *MsgServerTestSuite) TestCancelRemoveDelegateStake() {
 	}
 	err := s.emissionsKeeper.SetDelegateStakeRemoval(ctx, stakeToRemove)
 	require.NoError(err)
+
+	// Call CancelRemoveDelegateStake
+	msg := &types.CancelRemoveDelegateStakeRequest{
+		Sender:    delegator,
+		Reputer:   reputer,
+		TopicId:   topicId,
+		Delegator: delegator,
+	}
+	_, err = s.msgServer.CancelRemoveDelegateStake(ctx, msg)
+	require.NoError(err)
+
+	// Verify that the stake removal is deleted
+	_, found, err := s.emissionsKeeper.
+		GetDelegateStakeRemovalForDelegatorReputerAndTopicId(ctx, delegator, reputer, topicId)
+	require.NoError(err)
+	require.False(found, "Stake removal should be deleted")
+}
+
+func (s *MsgServerTestSuite) TestCancelRemoveDelegateStakeOnUnregisteredReputer() {
+	ctx := s.ctx
+	require := s.Require()
+	// Set up test data
+	delegator := s.addrsStr[0]
+	reputer := s.addrsStr[1]
+	reputerAddr := s.addrs[1]
+	worker := s.addrsStr[2]
+	workerAddr := s.addrs[2]
+	registrationInitialBalance := cosmosMath.NewInt(10000)
+	amount := cosmosMath.NewInt(50)
+
+	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+
+	// Add a delegate stake removal
+	stakeToRemove := types.DelegateStakeRemovalInfo{
+		BlockRemovalStarted:   10,
+		TopicId:               topicId,
+		Reputer:               reputer,
+		Delegator:             delegator,
+		Amount:                amount,
+		BlockRemovalCompleted: 20,
+	}
+	err := s.emissionsKeeper.SetDelegateStakeRemoval(ctx, stakeToRemove)
+	require.NoError(err)
+
+	s.Require().NoError(s.emissionsKeeper.RemoveReputer(ctx, topicId, reputer))
 
 	// Call CancelRemoveDelegateStake
 	msg := &types.CancelRemoveDelegateStakeRequest{


### PR DESCRIPTION
## Purpose of Changes and their Description

Allow reputer delegators to operate their stake even is the reputer is not registered anymore, the concerned operations are:
- `RemoveDelegateStake`
- `CancelRemoveDelegateStake`
- `RewardDelegateStake`

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/ENGN-3495/103-delegators-funds-will-be-lost-if-reputer-leaves

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
