### PR TITLE
Fix: ensure consistent content in reputer value bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+# v0.12.0
+
+### Added
+
+### Changed
+
+* [#774](https://github.com/allora-network/allora-chain/pull/774) Add validation checks upon reputer value bundles
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+### API Breaking Changes
+
+#### Removed
+
+#### Added 
+
+#### Changed
+
+# [Released]
+
 # v0.11.0
 
 ### Added
@@ -79,7 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* [#803](https://github.com/allora-network/allora-chain/pull/803) Add reset/cleanup functions to defer in CloseReputerNonce 
+* [#803](https://github.com/allora-network/allora-chain/pull/803) Add reset/cleanup functions to defer in CloseReputerNonce
 * [#804](https://github.com/allora-network/allora-chain/pull/804) Additional validations + use inferenceBlockheight in NetworkInferences
 * [#805](https://github.com/allora-network/allora-chain/pull/805) An invalid bundle gets ignored on networkLoss calc
 
@@ -89,11 +115,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Removed
 
-#### Added 
+#### Added
 
 #### Changed
-
-# [Released]
 
 # v0.10.0
 

--- a/utils/fn/fn.go
+++ b/utils/fn/fn.go
@@ -7,3 +7,19 @@ func Map[S []InType, U []OutType, InType any, OutType any](in S, fn func(InType)
 	}
 	return out
 }
+
+func ElementsMatch[S []InType, InType comparable](a, b S) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[InType]struct{}, len(a))
+	for i := range a {
+		seen[a[i]] = struct{}{}
+	}
+	for i := range b {
+		if _, ok := seen[b[i]]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/utils/fn/fn_test.go
+++ b/utils/fn/fn_test.go
@@ -1,0 +1,25 @@
+package fn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestElementsMatch(t *testing.T) {
+	tcs := []struct {
+		a, b []int
+		want bool
+	}{
+		{[]int{1, 2, 3}, []int{1, 2, 4}, false},
+		{[]int{1, 2, 3}, []int{1, 2}, false},
+		{[]int{1}, []int{1}, true},
+		{[]int{1, 2, 3}, []int{1, 2, 3}, true},
+		{[]int{1, 2, 3}, []int{3, 2, 1}, true},
+		{[]int{1, 2, 3}, []int{2, 3, 1}, true},
+	}
+
+	for _, tc := range tcs {
+		require.Equal(t, tc.want, ElementsMatch(tc.a, tc.b))
+	}
+}

--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -333,49 +333,33 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 
 	// Filter out values submitted by unaccepted workers
 	acceptedInfererValues := make([]*types.WorkerAttributedValue, 0)
-	infererAlreadySeen := make(map[string]bool)
 	for _, workerVal := range reputerValueBundle.ValueBundle.InfererValues {
 		if _, ok := acceptedInferersOfBatch[workerVal.Worker]; ok {
-			if _, ok := infererAlreadySeen[workerVal.Worker]; !ok {
-				acceptedInfererValues = append(acceptedInfererValues, workerVal)
-				infererAlreadySeen[workerVal.Worker] = true // Mark as seen => no duplicates
-			}
+			acceptedInfererValues = append(acceptedInfererValues, workerVal)
 		}
 	}
 
 	acceptedForecasterValues := make([]*types.WorkerAttributedValue, 0)
-	forecasterAlreadySeen := make(map[string]bool)
 	for _, workerVal := range reputerValueBundle.ValueBundle.ForecasterValues {
 		if _, ok := acceptedForecastersOfBatch[workerVal.Worker]; ok {
-			if _, ok := forecasterAlreadySeen[workerVal.Worker]; !ok {
-				acceptedForecasterValues = append(acceptedForecasterValues, workerVal)
-				forecasterAlreadySeen[workerVal.Worker] = true // Mark as seen => no duplicates
-			}
+			acceptedForecasterValues = append(acceptedForecasterValues, workerVal)
 		}
 	}
 
 	acceptedOneOutInfererValues := make([]*types.WithheldWorkerAttributedValue, 0)
 	// If 1 or fewer inferers, there's no one-out inferer data to receive
 	if len(acceptedInfererValues) > 1 {
-		oneOutInfererAlreadySeen := make(map[string]bool)
 		for _, workerVal := range reputerValueBundle.ValueBundle.OneOutInfererValues {
 			if _, ok := acceptedInferersOfBatch[workerVal.Worker]; ok {
-				if _, ok := oneOutInfererAlreadySeen[workerVal.Worker]; !ok {
-					acceptedOneOutInfererValues = append(acceptedOneOutInfererValues, workerVal)
-					oneOutInfererAlreadySeen[workerVal.Worker] = true // Mark as seen => no duplicates
-				}
+				acceptedOneOutInfererValues = append(acceptedOneOutInfererValues, workerVal)
 			}
 		}
 	}
 
 	acceptedOneOutForecasterValues := make([]*types.WithheldWorkerAttributedValue, 0)
-	oneOutForecasterAlreadySeen := make(map[string]bool)
 	for _, workerVal := range reputerValueBundle.ValueBundle.OneOutForecasterValues {
 		if _, ok := acceptedForecastersOfBatch[workerVal.Worker]; ok {
-			if _, ok := oneOutForecasterAlreadySeen[workerVal.Worker]; !ok {
-				acceptedOneOutForecasterValues = append(acceptedOneOutForecasterValues, workerVal)
-				oneOutForecasterAlreadySeen[workerVal.Worker] = true // Mark as seen => no duplicates
-			}
+			acceptedOneOutForecasterValues = append(acceptedOneOutForecasterValues, workerVal)
 		}
 	}
 
@@ -384,13 +368,9 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 		if _, ok := acceptedForecastersOfBatch[forecasterVal.Forecaster]; ok {
 			// Filter out unaccepted workers for this forecaster
 			acceptedWorkers := make([]*types.WithheldWorkerAttributedValue, 0)
-			workerAlreadySeen := make(map[string]bool)
 			for _, workerVal := range forecasterVal.OneOutInfererValues {
 				if _, ok := acceptedInferersOfBatch[workerVal.Worker]; ok {
-					if _, ok := workerAlreadySeen[workerVal.Worker]; !ok {
-						acceptedWorkers = append(acceptedWorkers, workerVal)
-						workerAlreadySeen[workerVal.Worker] = true // Mark as seen => no duplicates
-					}
+					acceptedWorkers = append(acceptedWorkers, workerVal)
 				}
 			}
 			// Only add forecaster if it has at least one accepted worker
@@ -404,13 +384,9 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 	}
 
 	acceptedOneInForecasterValues := make([]*types.WorkerAttributedValue, 0)
-	oneInForecasterAlreadySeen := make(map[string]bool)
 	for _, workerVal := range reputerValueBundle.ValueBundle.OneInForecasterValues {
 		if _, ok := acceptedForecastersOfBatch[workerVal.Worker]; ok {
-			if _, ok := oneInForecasterAlreadySeen[workerVal.Worker]; !ok {
-				acceptedOneInForecasterValues = append(acceptedOneInForecasterValues, workerVal)
-				oneInForecasterAlreadySeen[workerVal.Worker] = true // Mark as seen => no duplicates
-			}
+			acceptedOneInForecasterValues = append(acceptedOneInForecasterValues, workerVal)
 		}
 	}
 

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"strings"
 
 	errorsmod "cosmossdk.io/errors"
 	"github.com/pkg/errors"
@@ -2019,15 +2018,6 @@ func (k *Keeper) InsertActiveReputerLosses(
 	if err := types.ValidateBlockHeight(block); err != nil {
 		return errorsmod.Wrap(err, "block height validation failed")
 	}
-	if err := reputerLossBundles.Validate(); err != nil {
-		// in the singular case of a bundle that has been filtered, we allow
-		// the signature validation to fail. This is secure because we already do
-		// bundle validation in CloseReputerNonce before calling this function
-		// however this should be well and truly fixed by PROTO-2369
-		if !strings.Contains(err.Error(), "signature verification failed") {
-			return errorsmod.Wrap(err, "reputer loss bundles validation failed")
-		}
-	}
 	key := collections.Join(topicId, block)
 	return k.allLossBundles.Set(ctx, key, reputerLossBundles)
 }
@@ -2057,9 +2047,6 @@ func (k *Keeper) InsertNetworkLossBundleAtBlock(
 	}
 	if err := types.ValidateBlockHeight(block); err != nil {
 		return errorsmod.Wrap(err, "block height validation failed")
-	}
-	if err := lossBundle.Validate(); err != nil {
-		return errorsmod.Wrap(err, "loss bundle validation failed")
 	}
 	key := collections.Join(topicId, block)
 	return k.networkLossBundles.Set(ctx, key, lossBundle)

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
@@ -23,7 +23,7 @@ func (ms msgServer) InsertReputerPayload(ctx context.Context, msg *types.InsertR
 	if err != nil {
 		return nil, errorsmod.Wrapf(err, "Error getting params for reputer: %v", &msg.ReputerValueBundle.ValueBundle.Reputer)
 	}
-	rvb, err := types.NewInputReputerValueBundleFromInput(msg.ReputerValueBundle)
+	rvb, err := types.NewReputerValueBundleFromInput(msg.ReputerValueBundle)
 	if err != nil {
 		return nil, errorsmod.Wrapf(err,
 			"Reputer bad data format for block: %d", blockHeight)

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
@@ -100,8 +100,13 @@ func (s *MsgServerTestSuite) setUpMsgReputerPayload(
 				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
 			},
 		},
-		NaiveValue:          alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-		OneOutInfererValues: []*types.InputWithheldWorkerAttributedValue{},
+		NaiveValue: alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
+		OneOutInfererValues: []*types.InputWithheldWorkerAttributedValue{
+			{
+				Worker: workerAddr.String(),
+				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
+			},
+		},
 		OneOutForecasterValues: []*types.InputWithheldWorkerAttributedValue{
 			{
 				Worker: workerAddr.String(),

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
@@ -119,7 +119,17 @@ func (s *MsgServerTestSuite) setUpMsgReputerPayload(
 				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
 			},
 		},
-		OneOutInfererForecasterValues: nil,
+		OneOutInfererForecasterValues: []*types.InputOneOutInfererForecasterValues{
+			{
+				Forecaster: workerAddr.String(),
+				OneOutInfererValues: []*types.InputWithheldWorkerAttributedValue{
+					{
+						Worker: workerAddr.String(),
+						Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
+					},
+				},
+			},
+		},
 	}
 
 	return reputerValueBundle, expectedInferences, expectedForecasts, topicId

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -2265,7 +2265,7 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionWithOneInfererAndOneReputer
 		NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0116")),
 		InfererValues:                 []*types.InputWorkerAttributedValue{{Worker: s.addrsStr[worker], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0112"))}},
 		ForecasterValues:              []*types.InputWorkerAttributedValue{},
-		OneOutInfererValues:           []*types.InputWithheldWorkerAttributedValue{},
+		OneOutInfererValues:           []*types.InputWithheldWorkerAttributedValue{{Worker: s.addrsStr[worker], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0112"))}},
 		OneOutForecasterValues:        []*types.InputWithheldWorkerAttributedValue{},
 		OneInForecasterValues:         []*types.InputWorkerAttributedValue{},
 		OneOutInfererForecasterValues: nil,

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -1058,7 +1058,12 @@ func generateLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64,
 			OneOutInfererValues:           make([]*types.InputWithheldWorkerAttributedValue, len(workers)),
 			OneOutForecasterValues:        make([]*types.InputWithheldWorkerAttributedValue, len(workers)),
 			OneInForecasterValues:         make([]*types.InputWorkerAttributedValue, len(workers)),
-			OneOutInfererForecasterValues: nil,
+			OneOutInfererForecasterValues: make([]*types.InputOneOutInfererForecasterValues, len(workers)),
+		}
+
+		oneOutInferers := make([]*types.InputWithheldWorkerAttributedValue, 0, len(workers))
+		for j, worker := range workers {
+			oneOutInferers = append(oneOutInferers, &types.InputWithheldWorkerAttributedValue{Worker: worker.String(), Value: reputersInfererOneOutLosses[i][j]})
 		}
 
 		for j, worker := range workers {
@@ -1067,6 +1072,7 @@ func generateLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64,
 			valueBundle.OneOutInfererValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: worker.String(), Value: reputersInfererOneOutLosses[i][j]}
 			valueBundle.OneOutForecasterValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: worker.String(), Value: reputersForecasterOneOutLosses[i][j]}
 			valueBundle.OneInForecasterValues[j] = &types.InputWorkerAttributedValue{Worker: worker.String(), Value: reputersOneInNaiveLosses[i][j]}
+			valueBundle.OneOutInfererForecasterValues[j] = &types.InputOneOutInfererForecasterValues{Forecaster: worker.String(), OneOutInfererValues: oneOutInferers}
 		}
 
 		sig, err := signInputValueBundle(valueBundle, s.privKeys[reputerIndex])
@@ -1118,7 +1124,12 @@ func generateHugeLossBundles(
 			OneOutInfererValues:           make([]*types.InputWithheldWorkerAttributedValue, len(workerIndexes)),
 			OneOutForecasterValues:        make([]*types.InputWithheldWorkerAttributedValue, len(workerIndexes)),
 			OneInForecasterValues:         make([]*types.InputWorkerAttributedValue, len(workerIndexes)),
-			OneOutInfererForecasterValues: nil,
+			OneOutInfererForecasterValues: make([]*types.InputOneOutInfererForecasterValues, len(workerIndexes)),
+		}
+
+		oneOutInferers := make([]*types.InputWithheldWorkerAttributedValue, 0, len(workerIndexes))
+		for j, workerIndex := range workerIndexes {
+			oneOutInferers = append(oneOutInferers, &types.InputWithheldWorkerAttributedValue{Worker: s.addrsStr[workerIndex], Value: alloraMath.MustNewBoundedExp40Dec(reputersInfererOneOutLosses[i][j])})
 		}
 
 		for j, workerIndex := range workerIndexes {
@@ -1127,6 +1138,7 @@ func generateHugeLossBundles(
 			valueBundle.OneOutInfererValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: s.addrsStr[workerIndex], Value: alloraMath.MustNewBoundedExp40Dec(reputersInfererOneOutLosses[i][j])}
 			valueBundle.OneOutForecasterValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: s.addrsStr[workerIndex], Value: alloraMath.MustNewBoundedExp40Dec(reputersForecasterOneOutLosses[i][j])}
 			valueBundle.OneInForecasterValues[j] = &types.InputWorkerAttributedValue{Worker: s.addrsStr[workerIndex], Value: alloraMath.MustNewBoundedExp40Dec(reputersOneInNaiveLosses[i][j])}
+			valueBundle.OneOutInfererForecasterValues[j] = &types.InputOneOutInfererForecasterValues{Forecaster: s.addrsStr[workerIndex], OneOutInfererValues: oneOutInferers}
 		}
 
 		sig, err := signInputValueBundle(valueBundle, s.privKeys[reputerIndex])
@@ -1730,7 +1742,18 @@ func generateSimpleLossBundles(
 			OneOutInfererValues:           make([]*types.InputWithheldWorkerAttributedValue, countValues),
 			OneOutForecasterValues:        make([]*types.InputWithheldWorkerAttributedValue, countValues),
 			OneInForecasterValues:         make([]*types.InputWorkerAttributedValue, countValues),
-			OneOutInfererForecasterValues: nil,
+			OneOutInfererForecasterValues: make([]*types.InputOneOutInfererForecasterValues, countValues),
+		}
+
+		oneOutInferers := make([]*types.InputWithheldWorkerAttributedValue, 0, len(workerValues))
+		for i, inferer := range workerValues {
+			if i >= len(reputerValues) {
+				break
+			}
+			oneOutInferers = append(oneOutInferers, &types.InputWithheldWorkerAttributedValue{
+				Worker: s.addrsStr[inferer.Index],
+				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputerValues[i].Value)),
+			})
 		}
 
 		for j, worker := range workerValues {
@@ -1748,6 +1771,10 @@ func generateSimpleLossBundles(
 				}
 				valueBundle.OneOutForecasterValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: s.addrsStr[worker.Index], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputerValues[j].Value))}
 				valueBundle.OneInForecasterValues[j] = &types.InputWorkerAttributedValue{Worker: s.addrsStr[worker.Index], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputerValues[j].Value))}
+				valueBundle.OneOutInfererForecasterValues[j] = &types.InputOneOutInfererForecasterValues{
+					Forecaster:          s.addrsStr[worker.Index],
+					OneOutInfererValues: oneOutInferers,
+				}
 			}
 		}
 

--- a/x/emissions/module/rewards/worker_rewards_test.go
+++ b/x/emissions/module/rewards/worker_rewards_test.go
@@ -686,6 +686,29 @@ func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.
 		},
 	}
 
+	oneOutInfererForecasterLosses := []*types.OneOutInfererForecasterValues{
+		{
+			Forecaster:          s.addrs[0].String(),
+			OneOutInfererValues: oneOutInfererLosses,
+		},
+		{
+			Forecaster:          s.addrs[1].String(),
+			OneOutInfererValues: oneOutInfererLosses,
+		},
+		{
+			Forecaster:          s.addrs[2].String(),
+			OneOutInfererValues: oneOutInfererLosses,
+		},
+		{
+			Forecaster:          s.addrs[3].String(),
+			OneOutInfererValues: oneOutInfererLosses,
+		},
+		{
+			Forecaster:          s.addrs[4].String(),
+			OneOutInfererValues: oneOutInfererLosses,
+		},
+	}
+
 	networkLosses := types.ValueBundle{
 		TopicId:                       topicId,
 		ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
@@ -698,7 +721,7 @@ func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.
 		OneOutInfererValues:           oneOutInfererLosses,
 		OneOutForecasterValues:        oneOutForecasterLosses,
 		OneInForecasterValues:         oneInNaiveLosses,
-		OneOutInfererForecasterValues: nil,
+		OneOutInfererForecasterValues: oneOutInfererForecasterLosses,
 	}
 
 	// Persist network losses
@@ -775,6 +798,21 @@ func mockSimpleNetworkLosses(
 		},
 	}
 
+	oneOutInfererForecasterLosses := []*types.OneOutInfererForecasterValues{
+		{
+			Forecaster:          s.addrs[0].String(),
+			OneOutInfererValues: genericLossesWithheld,
+		},
+		{
+			Forecaster:          s.addrs[1].String(),
+			OneOutInfererValues: genericLossesWithheld,
+		},
+		{
+			Forecaster:          s.addrs[2].String(),
+			OneOutInfererValues: genericLossesWithheld,
+		},
+	}
+
 	networkLosses := types.ValueBundle{
 		TopicId:                       topicId,
 		ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
@@ -787,7 +825,7 @@ func mockSimpleNetworkLosses(
 		OneOutInfererValues:           genericLossesWithheld,
 		OneOutForecasterValues:        genericLossesWithheld,
 		OneInForecasterValues:         genericLosses,
-		OneOutInfererForecasterValues: nil,
+		OneOutInfererForecasterValues: oneOutInfererForecasterLosses,
 	}
 
 	err := s.emissionsKeeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, block, networkLosses)

--- a/x/emissions/module/rewards/worker_rewards_test.go
+++ b/x/emissions/module/rewards/worker_rewards_test.go
@@ -594,6 +594,29 @@ func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.
 		},
 	}
 
+	forecasterValues := []*types.WorkerAttributedValue{
+		{
+			Worker: s.addrs[0].String(),
+			Value:  alloraMath.MustNewDecFromString("10"),
+		},
+		{
+			Worker: s.addrs[1].String(),
+			Value:  alloraMath.MustNewDecFromString("10"),
+		},
+		{
+			Worker: s.addrs[2].String(),
+			Value:  alloraMath.MustNewDecFromString("10"),
+		},
+		{
+			Worker: s.addrs[3].String(),
+			Value:  alloraMath.MustNewDecFromString("10"),
+		},
+		{
+			Worker: s.addrs[4].String(),
+			Value:  alloraMath.MustNewDecFromString("10"),
+		},
+	}
+
 	oneOutInfererLosses := []*types.WithheldWorkerAttributedValue{
 		{
 			Worker: s.addrs[0].String(),
@@ -670,7 +693,7 @@ func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.
 		ExtraData:                     nil,
 		CombinedValue:                 alloraMath.MustNewDecFromString("0.013481256018186383"),
 		InfererValues:                 infererValues,
-		ForecasterValues:              nil,
+		ForecasterValues:              forecasterValues,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.01344474872292"),
 		OneOutInfererValues:           oneOutInfererLosses,
 		OneOutForecasterValues:        oneOutForecasterLosses,
@@ -708,6 +731,20 @@ func mockSimpleNetworkLosses(
 		},
 	}
 
+	forecasterValues := []*types.WorkerAttributedValue{
+		{
+			Worker: s.addrs[0].String(),
+			Value:  alloraMath.MustNewDecFromString("0.2"),
+		},
+		{
+			Worker: s.addrs[1].String(),
+			Value:  alloraMath.MustNewDecFromString("0.3"),
+		},
+		{
+			Worker: s.addrs[2].String(),
+			Value:  alloraMath.MustNewDecFromString("0.4"),
+		},
+	}
 	genericLossesWithheld := []*types.WithheldWorkerAttributedValue{
 		{
 			Worker: s.addrs[0].String(),
@@ -745,7 +782,7 @@ func mockSimpleNetworkLosses(
 		ExtraData:                     nil,
 		CombinedValue:                 alloraMath.MustNewDecFromString("0.05"),
 		InfererValues:                 infererValues,
-		ForecasterValues:              nil,
+		ForecasterValues:              forecasterValues,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.05"),
 		OneOutInfererValues:           genericLossesWithheld,
 		OneOutForecasterValues:        genericLossesWithheld,

--- a/x/emissions/types/conversions.go
+++ b/x/emissions/types/conversions.go
@@ -285,8 +285,8 @@ func NewValueBundleFromInput(bvb *InputValueBundle) (*ValueBundle, error) {
 	return valueBundle, nil
 }
 
-// NewInputReputerValueBundleFromInput converts InputReputerValueBundle to ReputerValueBundle
-func NewInputReputerValueBundleFromInput(brvb *InputReputerValueBundle) (*ReputerValueBundle, error) {
+// NewReputerValueBundleFromInput converts InputReputerValueBundle to ReputerValueBundle
+func NewReputerValueBundleFromInput(brvb *InputReputerValueBundle) (*ReputerValueBundle, error) {
 	if brvb == nil {
 		return nil, ErrInvalidValue
 	}

--- a/x/emissions/types/conversions_test.go
+++ b/x/emissions/types/conversions_test.go
@@ -498,6 +498,105 @@ func TestInputValueBundleConvert(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid forecasters len in OneOutInfererForecasterValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneInForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid inferers len in OneOutInfererForecasterValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneInForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{
+					{
+						Forecaster:          "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						OneOutInfererValues: []*InputWithheldWorkerAttributedValue{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "invalid inferers in OneOutInfererValues",
 			input: &InputValueBundle{
 				TopicId: 1,

--- a/x/emissions/types/conversions_test.go
+++ b/x/emissions/types/conversions_test.go
@@ -279,7 +279,7 @@ func TestInputValueBundleConvert(t *testing.T) {
 				},
 				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
 					{
-						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
 						Value:  mustNewBoundedExp40Dec(t, "7.89"),
 					},
 				},
@@ -300,7 +300,7 @@ func TestInputValueBundleConvert(t *testing.T) {
 						Forecaster: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
 						OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
 							{
-								Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+								Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
 								Value:  mustNewBoundedExp40Dec(t, "7.89"),
 							},
 						},
@@ -308,6 +308,456 @@ func TestInputValueBundleConvert(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "duplicate inferer",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues:              []*InputWorkerAttributedValue{},
+				OneOutInfererValues:           []*InputWithheldWorkerAttributedValue{},
+				OneOutForecasterValues:        []*InputWithheldWorkerAttributedValue{},
+				OneInForecasterValues:         []*InputWorkerAttributedValue{},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate forecaster",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererValues:           []*InputWithheldWorkerAttributedValue{},
+				OneOutForecasterValues:        []*InputWithheldWorkerAttributedValue{},
+				OneInForecasterValues:         []*InputWorkerAttributedValue{},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid inferers len in OneOutInfererValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneInForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid forecasters len in OneOutForecasterValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{},
+				OneInForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid forecasters len in OneInForecasterValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneInForecasterValues:         []*InputWorkerAttributedValue{},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid inferers in OneOutInfererValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+					{
+						Worker: "allo14m0d2gqk67hwlkhd6jjzdmtqv86h8f9jk39rmx",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneInForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid forecasters in OneOutForecasterValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+					{
+						Worker: "allo14m0d2gqk67hwlkhd6jjzdmtqv86h8f9jk39rmx",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneInForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid forecasters in OneInForecasterValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneInForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+					{
+						Worker: "allo14m0d2gqk67hwlkhd6jjzdmtqv86h8f9jk39rmx",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid forecaster in OneOutInfererForecasterValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneInForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{
+					{
+						Forecaster:          "allo14m0d2gqk67hwlkhd6jjzdmtqv86h8f9jk39rmx",
+						OneOutInfererValues: []*InputWithheldWorkerAttributedValue{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid inferer in OneOutInfererForecasterValues",
+			input: &InputValueBundle{
+				TopicId: 1,
+				ReputerRequestNonce: &ReputerRequestNonce{
+					ReputerNonce: &Nonce{
+						BlockHeight: 1,
+					},
+				},
+				Reputer:       "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec",
+				ExtraData:     []byte("extra"),
+				CombinedValue: mustNewBoundedExp40Dec(t, "1.23"),
+				NaiveValue:    mustNewBoundedExp40Dec(t, "4.56"),
+				InfererValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				ForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.23"),
+					},
+				},
+				OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutForecasterValues: []*InputWithheldWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneInForecasterValues: []*InputWorkerAttributedValue{
+					{
+						Worker: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						Value:  mustNewBoundedExp40Dec(t, "1.25"),
+					},
+				},
+				OneOutInfererForecasterValues: []*InputOneOutInfererForecasterValues{
+					{
+						Forecaster: "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh",
+						OneOutInfererValues: []*InputWithheldWorkerAttributedValue{
+							{
+								Worker: "allo14m0d2gqk67hwlkhd6jjzdmtqv86h8f9jk39rmx",
+								Value:  mustNewBoundedExp40Dec(t, "1.25"),
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
 		},
 	}
 

--- a/x/emissions/types/validations.go
+++ b/x/emissions/types/validations.go
@@ -580,12 +580,16 @@ func (bundle *ValueBundle) Validate() error {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "value bundle inferer values cannot be nil")
 	}
 
+	inferers := make(map[string]struct{}, len(bundle.InfererValues))
+	forecasters := make(map[string]struct{}, len(bundle.ForecasterValues))
+
 	// nil values for bundle.InfererValues are interpreted to mean that there
 	// are no inferer values for this bundle, and are allowed
 	for _, infererValue := range bundle.InfererValues {
 		if err := infererValue.Validate(); err != nil {
 			return errors.Wrap(err, "value bundle inferer value is invalid")
 		}
+		inferers[infererValue.Worker] = struct{}{}
 	}
 
 	// nil values for bundle.ForecasterValues are interpreted to mean that there
@@ -594,10 +598,23 @@ func (bundle *ValueBundle) Validate() error {
 		if err := forecasterValue.Validate(); err != nil {
 			return errors.Wrap(err, "value bundle forecaster value is invalid")
 		}
+		forecasters[forecasterValue.Worker] = struct{}{}
 	}
 
 	if err := ValidateDec(bundle.NaiveValue); err != nil {
 		return errors.Wrap(err, "value bundle naive value is invalid")
+	}
+
+	infererCount := len(inferers)
+	forecasterCount := len(forecasters)
+	if len(bundle.InfererValues) != infererCount ||
+		len(bundle.OneOutInfererValues) != infererCount {
+		return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle must concern same inferer set")
+	}
+	if len(bundle.ForecasterValues) != forecasterCount ||
+		len(bundle.OneOutForecasterValues) != forecasterCount ||
+		len(bundle.OneInForecasterValues) != forecasterCount {
+		return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle must concern same forecaster set")
 	}
 
 	// nil values for bundle.OneOutInfererValues are interpreted to mean that there
@@ -605,6 +622,9 @@ func (bundle *ValueBundle) Validate() error {
 	for _, oneOutInfererValue := range bundle.OneOutInfererValues {
 		if err := oneOutInfererValue.Validate(); err != nil {
 			return errors.Wrap(err, "value bundle one out inferer value is invalid")
+		}
+		if _, ok := inferers[oneOutInfererValue.Worker]; !ok {
+			return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle one out inferer value not in provided inferer set")
 		}
 	}
 
@@ -614,6 +634,9 @@ func (bundle *ValueBundle) Validate() error {
 		if err := oneOutForecasterValue.Validate(); err != nil {
 			return errors.Wrap(err, "value bundle one out forecaster value is invalid")
 		}
+		if _, ok := forecasters[oneOutForecasterValue.Worker]; !ok {
+			return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle one out forecaster value not in provided forecaster set")
+		}
 	}
 
 	// nil values for bundle.OneInForecasterValues are interpreted to mean that there
@@ -622,6 +645,9 @@ func (bundle *ValueBundle) Validate() error {
 		if err := oneInForecasterValue.Validate(); err != nil {
 			return errors.Wrap(err, "value bundle one in forecaster value is invalid")
 		}
+		if _, ok := forecasters[oneInForecasterValue.Worker]; !ok {
+			return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle one in forecaster value not in provided forecaster set")
+		}
 	}
 
 	// nil values for bundle.OneOutInfererForecasterValues are interpreted to mean that there
@@ -629,6 +655,18 @@ func (bundle *ValueBundle) Validate() error {
 	for _, oneOutInfererForecaster := range bundle.OneOutInfererForecasterValues {
 		if err := oneOutInfererForecaster.Validate(); err != nil {
 			return errors.Wrap(err, "value bundle one out inferer forecaster value is invalid")
+		}
+
+		// Check the forecaster is part of the bundle
+		if _, ok := forecasters[oneOutInfererForecaster.Forecaster]; !ok {
+			return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle one out inferer forecaster value not in provided forecaster set")
+		}
+
+		// Check the inferers are part of the bundle
+		for _, oneOutInfererValue := range oneOutInfererForecaster.OneOutInfererValues {
+			if _, ok := inferers[oneOutInfererValue.Worker]; !ok {
+				return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle one out inferer forecaster value not in provided inferer set")
+			}
 		}
 	}
 	return nil

--- a/x/emissions/types/validations.go
+++ b/x/emissions/types/validations.go
@@ -613,7 +613,8 @@ func (bundle *ValueBundle) Validate() error {
 	}
 	if len(bundle.ForecasterValues) != forecasterCount ||
 		len(bundle.OneOutForecasterValues) != forecasterCount ||
-		len(bundle.OneInForecasterValues) != forecasterCount {
+		len(bundle.OneInForecasterValues) != forecasterCount ||
+		len(bundle.OneOutInfererForecasterValues) != forecasterCount {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle must concern same forecaster set")
 	}
 
@@ -663,6 +664,9 @@ func (bundle *ValueBundle) Validate() error {
 		}
 
 		// Check the inferers are part of the bundle
+		if len(oneOutInfererForecaster.OneOutInfererValues) != infererCount {
+			return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle one out inferer forecaster must concern same inferer set")
+		}
 		for _, oneOutInfererValue := range oneOutInfererForecaster.OneOutInfererValues {
 			if _, ok := inferers[oneOutInfererValue.Worker]; !ok {
 				return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle one out inferer forecaster value not in provided inferer set")


### PR DESCRIPTION
## Purpose of Changes and their Description

Add some checks upon reputer `ValueBundle`, please review carefully these added checks to ensure they don't prevent allowed inputs.

Here are the added stateless validations when constructing the bundle:
- No duplicate inferers;
- No duplicate forecasters;
- Identical inferers in `InfererValues` and `OneOutInfererValues`;
- Identical forecasters in `ForecasterValues`, `OneOutForecasterValues` and `OneInForecasterValues`;
- `OneOutInfererForecasterValues` contains all forecasters, and all inferers for each;

As these checks ensured upon submission, I've removed some validations that were made in the reputer nonce closing.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?