### PR TITLE
target weight: rm div by topic epochLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#762](https://github.com/allora-network/allora-chain/pull/762) Worker node owner should get compensated, not sender of inferences
 * [#766](https://github.com/allora-network/allora-chain/pull/766) Fix sort by weight instead of topic id. Remove excess sort logic
+* [#776](https://github.com/allora-network/allora-chain/pull/776) Target weight: rm div by topic epochLength
 
 ### Deprecated
 

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -3497,54 +3497,60 @@ func (s *KeeperTestSuite) TestGetTargetWeight() {
 		s.T().Fatalf("Failed to get parameters: %v", err)
 	}
 
-	dec, err := alloraMath.NewDecFromString("22.36067977499789696409173668731276")
+	// Value for full calculation
+	dec, err := alloraMath.NewDecFromString("70.71067811865475244008443621048490")
 	s.Require().NoError(err)
 
 	testCases := []struct {
-		name             string
-		topicStake       alloraMath.Dec
-		topicEpochLength int64
-		topicFeeRevenue  alloraMath.Dec
-		stakeImportance  alloraMath.Dec
-		feeImportance    alloraMath.Dec
-		want             alloraMath.Dec
-		expectError      bool
+		name            string
+		topicStake      alloraMath.Dec
+		topicFeeRevenue alloraMath.Dec
+		stakeImportance alloraMath.Dec
+		feeImportance   alloraMath.Dec
+		want            alloraMath.Dec
+		expectError     bool
 	}{
 		{
-			name:             "Basic valid inputs",
-			topicStake:       alloraMath.NewDecFromInt64(100),
-			topicEpochLength: 10,
-			topicFeeRevenue:  alloraMath.NewDecFromInt64(50),
-			stakeImportance:  params.TopicRewardStakeImportance,
-			feeImportance:    params.TopicRewardFeeRevenueImportance,
-			want:             dec,
-			expectError:      false,
+			name:            "Basic valid inputs",
+			topicStake:      alloraMath.NewDecFromInt64(100),
+			topicFeeRevenue: alloraMath.NewDecFromInt64(50),
+			stakeImportance: params.TopicRewardStakeImportance,
+			feeImportance:   params.TopicRewardFeeRevenueImportance,
+			want:            dec,
+			expectError:     false,
 		},
 		{
-			name:             "Zero epoch length",
-			topicStake:       alloraMath.NewDecFromInt64(100),
-			topicEpochLength: 0,
-			topicFeeRevenue:  alloraMath.NewDecFromInt64(50),
-			stakeImportance:  params.TopicRewardStakeImportance,
-			feeImportance:    params.TopicRewardFeeRevenueImportance,
-			want:             alloraMath.Dec{},
-			expectError:      true,
+			name:            "Zero topic Fee revenue should return stake only",
+			topicStake:      alloraMath.NewDecFromInt64(100),
+			topicFeeRevenue: alloraMath.ZeroDec(),
+			stakeImportance: params.TopicRewardStakeImportance,
+			feeImportance:   params.TopicRewardFeeRevenueImportance,
+			want:            alloraMath.ZeroDec(),
+			expectError:     false,
 		},
 		{
-			name:             "Negative stake",
-			topicStake:       alloraMath.NewDecFromInt64(-100),
-			topicEpochLength: 10,
-			topicFeeRevenue:  alloraMath.NewDecFromInt64(50),
-			stakeImportance:  params.TopicRewardStakeImportance,
-			feeImportance:    params.TopicRewardFeeRevenueImportance,
-			want:             alloraMath.Dec{},
-			expectError:      true,
+			name:            "Zero topic stake should return fee only",
+			topicStake:      alloraMath.ZeroDec(),
+			topicFeeRevenue: alloraMath.NewDecFromInt64(50),
+			stakeImportance: params.TopicRewardStakeImportance,
+			feeImportance:   params.TopicRewardFeeRevenueImportance,
+			want:            alloraMath.ZeroDec(),
+			expectError:     false,
+		},
+		{
+			name:            "Negative stake",
+			topicStake:      alloraMath.NewDecFromInt64(-100),
+			topicFeeRevenue: alloraMath.NewDecFromInt64(50),
+			stakeImportance: params.TopicRewardStakeImportance,
+			feeImportance:   params.TopicRewardFeeRevenueImportance,
+			want:            alloraMath.Dec{},
+			expectError:     true,
 		},
 	}
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			got, err := s.emissionsKeeper.GetTargetWeight(tc.topicStake, tc.topicEpochLength, tc.topicFeeRevenue, tc.stakeImportance, tc.feeImportance)
+			got, err := s.emissionsKeeper.GetTargetWeight(tc.topicStake, tc.topicFeeRevenue, tc.stakeImportance, tc.feeImportance)
 			if tc.expectError {
 				s.Require().Error(err, "Expected an error for case: %s", tc.name)
 			} else {

--- a/x/emissions/keeper/topic_weight.go
+++ b/x/emissions/keeper/topic_weight.go
@@ -19,7 +19,6 @@ import (
 // μ, ν are global constants with fiduciary values of 0.5 and 0.5
 func (k *Keeper) GetTargetWeight(
 	topicStake alloraMath.Dec,
-	topicEpochLength int64,
 	topicFeeRevenue alloraMath.Dec,
 	stakeImportance alloraMath.Dec,
 	feeImportance alloraMath.Dec,
@@ -28,12 +27,7 @@ func (k *Keeper) GetTargetWeight(
 	if err != nil {
 		return alloraMath.Dec{}, err
 	}
-	c := alloraMath.NewDecFromInt64(topicEpochLength)
-	feePerEpoch, err := topicFeeRevenue.Quo(c)
-	if err != nil {
-		return alloraMath.Dec{}, err
-	}
-	p, err := alloraMath.Pow(feePerEpoch, feeImportance)
+	p, err := alloraMath.Pow(topicFeeRevenue, feeImportance)
 	if err != nil {
 		return alloraMath.Dec{}, err
 	}
@@ -73,7 +67,6 @@ func (k *Keeper) GetCurrentTopicWeight(
 	if !topicFeeRevenueDec.Equal(alloraMath.ZeroDec()) {
 		targetWeight, err := k.GetTargetWeight(
 			topicStakeDec,
-			topicEpochLength,
 			topicFeeRevenueDec,
 			stakeImportance,
 			feeImportance,

--- a/x/emissions/migrations/v3/migrate.go
+++ b/x/emissions/migrations/v3/migrate.go
@@ -185,7 +185,6 @@ func MigrateTopics(
 			params.TopicRewardAlpha,
 			params.TopicRewardStakeImportance,
 			params.TopicRewardFeeRevenueImportance,
-			emissionsKeeper,
 		)
 		if err != nil {
 			topicsToChange[string(iterator.Key())] = getNewTopic(oldMsg)
@@ -325,6 +324,35 @@ func ResetMapsWithNonNumericValues(ctx sdk.Context, store storetypes.KVStore, cd
 	return nil
 }
 
+// Return the target weight of a topic
+// ^w_{t,i} = S^{μ}_{t,i} * (P/C)^{ν}_{t,i}
+// where S_{t,i} is the stake of of topic t in the last reward epoch i
+// and (P/C)_{t,i} is the fee revenue collected for performing inference per topic epoch
+// requests for topic t in the last reward epoch i
+// μ, ν are global constants with fiduciary values of 0.5 and 0.5
+func getTargetWeight(
+	topicStake alloraMath.Dec,
+	topicEpochLength int64,
+	topicFeeRevenue alloraMath.Dec,
+	stakeImportance alloraMath.Dec,
+	feeImportance alloraMath.Dec,
+) (alloraMath.Dec, error) {
+	s, err := alloraMath.Pow(topicStake, stakeImportance)
+	if err != nil {
+		return alloraMath.Dec{}, err
+	}
+	c := alloraMath.NewDecFromInt64(topicEpochLength)
+	feePerEpoch, err := topicFeeRevenue.Quo(c)
+	if err != nil {
+		return alloraMath.Dec{}, err
+	}
+	p, err := alloraMath.Pow(feePerEpoch, feeImportance)
+	if err != nil {
+		return alloraMath.Dec{}, err
+	}
+	return s.Mul(p)
+}
+
 func getTopicWeight(
 	feeRevenue, stake cosmosMath.Int,
 	previousWeight alloraMath.Dec,
@@ -332,7 +360,6 @@ func getTopicWeight(
 	topicRewardAlpha alloraMath.Dec,
 	stakeImportance alloraMath.Dec,
 	feeImportance alloraMath.Dec,
-	emissionsKeeper keeper.Keeper,
 ) (alloraMath.Dec, error) {
 	feeRevenueDec, err := alloraMath.NewDecFromSdkInt(feeRevenue)
 	if err != nil {
@@ -343,8 +370,9 @@ func getTopicWeight(
 		return alloraMath.ZeroDec(), err
 	}
 	if !feeRevenueDec.Equal(alloraMath.ZeroDec()) {
-		targetWeight, err := emissionsKeeper.GetTargetWeight(
+		targetWeight, err := getTargetWeight(
 			topicStakeDec,
+			topicEpochLength,
 			feeRevenueDec,
 			stakeImportance,
 			feeImportance,

--- a/x/emissions/migrations/v3/migrate.go
+++ b/x/emissions/migrations/v3/migrate.go
@@ -345,7 +345,6 @@ func getTopicWeight(
 	if !feeRevenueDec.Equal(alloraMath.ZeroDec()) {
 		targetWeight, err := emissionsKeeper.GetTargetWeight(
 			topicStakeDec,
-			topicEpochLength,
 			feeRevenueDec,
 			stakeImportance,
 			feeImportance,

--- a/x/emissions/module/rewards/topic_rewards_test.go
+++ b/x/emissions/module/rewards/topic_rewards_test.go
@@ -31,6 +31,8 @@ func mockTopic(s *RewardsTestSuite) types.Topic {
 	}
 }
 
+// Forces dripping of two topics, which initially has two active topics, but next round
+// leads to one of them not reaching the MinTopicWeight thus being inactivated.
 func (s *RewardsTestSuite) TestGetAndUpdateActiveTopicWeights() {
 	ctx := s.ctx
 	maxActiveTopicsNum := uint64(2)
@@ -38,9 +40,10 @@ func (s *RewardsTestSuite) TestGetAndUpdateActiveTopicWeights() {
 	params.BlocksPerMonth = 864000
 	params.MaxActiveTopicsPerBlock = maxActiveTopicsNum
 	params.MaxPageLimit = uint64(100)
+	params.MinTopicWeight = alloraMath.MustNewDecFromString("100")
 	params.TopicRewardAlpha = alloraMath.MustNewDecFromString("0.5")
 	params.TopicRewardStakeImportance = alloraMath.OneDec()
-	params.TopicRewardFeeRevenueImportance = alloraMath.MustNewDecFromString("1")
+	params.TopicRewardFeeRevenueImportance = alloraMath.OneDec()
 	err := s.emissionsKeeper.SetParams(ctx, params)
 	s.Require().NoError(err, "Setting parameters should not fail")
 
@@ -67,7 +70,7 @@ func (s *RewardsTestSuite) TestGetAndUpdateActiveTopicWeights() {
 	totalSumPreviousTopicWeights, err := s.emissionsKeeper.GetTotalSumPreviousTopicWeights(ctx)
 	s.Require().NoError(err)
 	s.Require().Equal(totalSumPreviousTopicWeights, alloraMath.ZeroDec(), "Total sum of previous topic weights at start should be zero")
-	setTopicWeight(topic1.Id, 150, 10)
+	setTopicWeight(topic1.Id, 10, 10)
 	err = s.emissionsKeeper.SetTopic(ctx, topic1.Id, topic1)
 	s.Require().NoError(err)
 	err = s.emissionsKeeper.ActivateTopic(ctx, topic1.Id)
@@ -75,9 +78,9 @@ func (s *RewardsTestSuite) TestGetAndUpdateActiveTopicWeights() {
 
 	totalSumPreviousTopicWeights, err = s.emissionsKeeper.GetTotalSumPreviousTopicWeights(ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(totalSumPreviousTopicWeights, alloraMath.MustNewDecFromString("0"), "Total sum of previous topic weights should still be 0 bc previous topic weight is not set")
+	s.Require().Equal(totalSumPreviousTopicWeights, alloraMath.ZeroDec(), "Total sum of previous topic weights should still be 0 bc previous topic weight is not set")
 
-	setTopicWeight(topic2.Id, 300, 10)
+	setTopicWeight(topic2.Id, 30, 10)
 	err = s.emissionsKeeper.SetTopic(ctx, topic2.Id, topic2)
 	s.Require().NoError(err)
 	err = s.emissionsKeeper.ActivateTopic(ctx, topic2.Id)
@@ -92,12 +95,12 @@ func (s *RewardsTestSuite) TestGetAndUpdateActiveTopicWeights() {
 	totalSumPreviousTopicWeights, err = s.emissionsKeeper.GetTotalSumPreviousTopicWeights(ctx)
 	s.T().Logf("totalSumPreviousTopicWeights: %v", totalSumPreviousTopicWeights)
 	s.Require().NoError(err)
-	s.Require().Equal(totalSumPreviousTopicWeights, alloraMath.MustNewDecFromString("0"), "Total sum of previous topic weights should not be 0 after settings topic weights")
+	s.Require().Equal(totalSumPreviousTopicWeights, alloraMath.ZeroDec(), "Total sum of previous topic weights should not be 0 after settings topic weights")
 
 	previousTopicWeights, _, err := s.emissionsKeeper.GetPreviousTopicWeight(ctx, topic1.Id)
 	s.T().Logf("topic1 previousTopicWeights: %v", previousTopicWeights)
 	s.Require().NoError(err)
-	s.Require().Equal(previousTopicWeights, alloraMath.MustNewDecFromString("0"), "Previous topic weights should still be 0 after settings topic weights")
+	s.Require().Equal(previousTopicWeights, alloraMath.ZeroDec(), "Previous topic weights should still be 0 after settings topic weights")
 
 	block = 16
 	ctx = s.ctx.WithBlockHeight(int64(block))

--- a/x/emissions/types/params.go
+++ b/x/emissions/types/params.go
@@ -13,7 +13,7 @@ import (
 func DefaultParams() Params {
 	return Params{
 		Version:                             "v7",                                         // version of the protocol should be in lockstep with github release tag version
-		MinTopicWeight:                      alloraMath.MustNewDecFromString("100"),       // total weight for a topic < this => don't run inference solicatation or loss update
+		MinTopicWeight:                      alloraMath.MustNewDecFromString("100"),       // total weight for a topic < this => don't run inference solicitation or loss update
 		RequiredMinimumStake:                cosmosMath.NewInt(10000),                     // minimum stake required to be a worker or reputer
 		RemoveStakeDelayWindow:              int64((60 * 60 * 24 * 7 * 3) / 3),            // ~approx 3 weeks assuming 3 second block time, number of blocks to wait before finalizing a stake withdrawal
 		MinEpochLength:                      12,                                           // shortest number of blocks per epoch topics are allowed to set as their cadence


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Fix problem: topics with shorter epochLengths got higher target weights, but there's no justification for this. 
* Alignment with whitepaper: target weights are not dependent on epochLength.
* Added / modified tests.
* v3 migration contains a call to this `getTargetWeight` function. Previous impl of the function has been internalized in the migration.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- Unit tests fixed 
- [x] If documented, please describe where. If not, describe why docs are not needed. -- No need, just aligment with whitepaper.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?


