### PR TITLE
Allow forecasts with unregistered inferers to proceed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* [#777](https://github.com/allora-network/allora-chain/pull/777) Allow forecasts with unregistered inferers to proceed
 
 ### Deprecated
 

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -142,8 +142,8 @@ func (ms msgServer) InsertWorkerPayload(ctx context.Context, msg *types.InsertWo
 				return nil, err
 			}
 			if !isInfererRegistered {
-				return nil, errorsmod.Wrapf(err,
-					"Error forecasted inferer address is not registered in this topic")
+				sdkCtx.Logger().Info("Skipping unregistered inferer", "inferer", el.Inferer)
+				continue
 			}
 
 			notAlreadySeen := !seenInferers[el.Inferer]

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -136,16 +136,6 @@ func (ms msgServer) InsertWorkerPayload(ctx context.Context, msg *types.InsertWo
 		acceptedForecastElements := make([]*types.ForecastElement, 0)
 		seenInferers := make(map[string]bool)
 		for _, el := range forecast.ForecastElements {
-			// Check if the forecasted inferer is registered in the topic
-			isInfererRegistered, err := ms.k.IsWorkerRegisteredInTopic(ctx, topicId, el.Inferer)
-			if err != nil {
-				return nil, err
-			}
-			if !isInfererRegistered {
-				sdkCtx.Logger().Info("Skipping unregistered inferer", "inferer", el.Inferer)
-				continue
-			}
-
 			notAlreadySeen := !seenInferers[el.Inferer]
 			_, isTopInferer := topNInferer[el.Inferer]
 			if notAlreadySeen && isTopInferer {

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
@@ -963,3 +963,52 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadForecastIncludesSelf() {
 	require.Equal(workerAddr, forecastsAtBlock.ForecastElements[0].Inferer)
 	require.Equal(otherInferer, forecastsAtBlock.ForecastElements[1].Inferer)
 }
+func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadSucceedsWithUnregisteredForecastedInferer() {
+	ctx, msgServer := s.ctx, s.msgServer
+	require := s.Require()
+
+	workerPrivateKey := secp256k1.GenPrivKey()
+
+	// Set up a worker payload message and get the topic ID
+	workerMsg, topicId := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
+
+	// Count the number of forecast elements before we make any changes
+	originalElementCount := len(workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.ForecastElements)
+	require.Greater(originalElementCount, 1, "Test needs multiple forecast elements")
+
+	// Select one of the inferers from the forecast elements to unregister
+	infererToUnregister := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.ForecastElements[1].Inferer
+
+	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
+
+	// Whitelist the worker for the topic so they can submit forecasts
+	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	require.NoError(err)
+
+	// Unregister the inferer
+	unregisterMsg := &types.RemoveRegistrationRequest{
+		Sender:    infererToUnregister,
+		TopicId:   topicId,
+		IsReputer: false,
+	}
+	_, err = msgServer.RemoveRegistration(ctx, unregisterMsg)
+	require.NoError(err)
+
+	// Verify that the inferer was successfully unregistered from the topic
+	isRegistered, err := s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topicId, infererToUnregister)
+	require.NoError(err)
+	require.False(isRegistered, "Inferer should be unregistered")
+
+	// IMPORTANT: Verify that there are no forecasts for this topic/block at the start of the test
+	// This establishes a clean baseline to verify our test's effects
+	forecastsCount0 := s.getCountForecastsAtBlock(topicId, blockHeight)
+	require.Equal(forecastsCount0, 0, "No forecasts should exist before submitting the payload")
+
+	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
+
+	// Set the block height context so that we're within the worker submission window
+	ctx = ctx.WithBlockHeight(blockHeight)
+
+	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	require.NoError(err, "InsertWorkerPayload should succeed by skipping the unregistered inferer")
+}

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
@@ -1010,5 +1010,5 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadSucceedsWithUnregisteredF
 	ctx = ctx.WithBlockHeight(blockHeight)
 
 	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
-	require.NoError(err, "InsertWorkerPayload should succeed by skipping the unregistered inferer")
+	require.NoError(err, "InsertWorkerPayload should succeed with an unregistered inferer")
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

This addresses the vulnerability where inferer deregistrations would  cause a forecaster's entire submission to fail. Now, when an inferer is not registered in a topic, we skip that specific inferer in the forecast rather than failing the whole transaction.

- Modified message handler to continue processing when an inferer is unregistered
- Added test case to verify the fix works correctly

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/ENGN-3519/172-inferer-de-registrations-will-cause-forecasting-submission-to

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
