### PR TITLE
Fix max distant value in stake weighted calc

### DIFF
--- a/x/emissions/module/rewards/rewards_internal.go
+++ b/x/emissions/module/rewards/rewards_internal.go
@@ -292,12 +292,9 @@ func GetStakeWeightedLossMatrix(
 				return nil, nil, err
 			}
 
-			absoluteDifference := distance
-			if distance.IsNegative() {
-				absoluteDifference, err = distance.Abs()
-				if err != nil {
-					return nil, nil, err
-				}
+			absoluteDifference, err := distance.Abs()
+			if err != nil {
+				return nil, nil, err
 			}
 
 			// Update the most distant value if this is the first valid distance

--- a/x/emissions/module/rewards/rewards_internal.go
+++ b/x/emissions/module/rewards/rewards_internal.go
@@ -299,7 +299,7 @@ func GetStakeWeightedLossMatrix(
 					return nil, nil, err
 				}
 			}
-	
+
 			// Update the most distant value if this is the first valid distance
 			// or if this distance is greater than the current maximum
 			if !hasFoundValidDistance || absoluteDifference.Gt(maxDistance) {

--- a/x/emissions/module/rewards/rewards_internal.go
+++ b/x/emissions/module/rewards/rewards_internal.go
@@ -294,7 +294,7 @@ func GetStakeWeightedLossMatrix(
 
 			absoluteDifference := distance
 			if distance.IsNegative() {
-				absoluteDifference, err = distance.Mul(alloraMath.MustNewDecFromString("-1"))
+				absoluteDifference, err = distance.Abs()
 				if err != nil {
 					return nil, nil, err
 				}

--- a/x/emissions/module/rewards/rewards_internal.go
+++ b/x/emissions/module/rewards/rewards_internal.go
@@ -279,10 +279,8 @@ func GetStakeWeightedLossMatrix(
 		stakeWeightedLoss[j] = sum
 
 		// Find most distant value from consensus value
-		maxDistance, err := alloraMath.OneDec().Mul(alloraMath.MustNewDecFromString("-1")) // Initialize with an impossible value
-		if err != nil {
-			return nil, nil, err
-		}
+		maxDistance := alloraMath.ZeroDec()
+		hasFoundValidDistance := false
 		for _, losses := range reputersReportedLosses {
 			// Skip if loss is NaN
 			if losses[j].IsNaN() {
@@ -293,9 +291,21 @@ func GetStakeWeightedLossMatrix(
 			if err != nil {
 				return nil, nil, err
 			}
-			if distance.Gt(maxDistance) {
-				maxDistance = distance
+
+			absoluteDifference := distance
+			if distance.IsNegative() {
+				absoluteDifference, err = distance.Mul(alloraMath.MustNewDecFromString("-1"))
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+	
+			// Update the most distant value if this is the first valid distance
+			// or if this distance is greater than the current maximum
+			if !hasFoundValidDistance || absoluteDifference.Gt(maxDistance) {
+				maxDistance = absoluteDifference
 				mostDistantValues[j] = losses[j]
+				hasFoundValidDistance = true
 			}
 		}
 	}

--- a/x/emissions/module/rewards/rewards_internal_test.go
+++ b/x/emissions/module/rewards/rewards_internal_test.go
@@ -630,6 +630,100 @@ func TestGetStakeWeightedLoss(t *testing.T) {
 	}
 }
 
+func TestGetStakeWeightedLossMatrixAbsoluteDifference(t *testing.T) {
+	tests := []struct {
+		name                string
+		stakes              []alloraMath.Dec
+		losses              [][]alloraMath.Dec
+		expectedConsensus   []alloraMath.Dec
+		expectedMostDistant []alloraMath.Dec
+	}{
+		{
+			name: "Most distant value below consensus",
+			stakes: []alloraMath.Dec{
+				alloraMath.NewDecFromInt64(1),
+				alloraMath.NewDecFromInt64(1),
+				alloraMath.NewDecFromInt64(1),
+			},
+			losses: [][]alloraMath.Dec{
+				{alloraMath.NewDecFromInt64(5)},
+				{alloraMath.NewDecFromInt64(5)},
+				{alloraMath.NewDecFromInt64(2)},
+			},
+			expectedConsensus:   []alloraMath.Dec{alloraMath.NewDecFromInt64(4)},
+			expectedMostDistant: []alloraMath.Dec{alloraMath.NewDecFromInt64(2)},
+		},
+		{
+			name: "Most distant value above consensus",
+			stakes: []alloraMath.Dec{
+				alloraMath.NewDecFromInt64(1),
+				alloraMath.NewDecFromInt64(1),
+				alloraMath.NewDecFromInt64(1),
+			},
+			losses: [][]alloraMath.Dec{
+				{alloraMath.NewDecFromInt64(2)},
+				{alloraMath.NewDecFromInt64(2)},
+				{alloraMath.NewDecFromInt64(8)},
+			},
+			expectedConsensus:   []alloraMath.Dec{alloraMath.NewDecFromInt64(4)},
+			expectedMostDistant: []alloraMath.Dec{alloraMath.NewDecFromInt64(8)},
+		},
+		{
+			name: "Equal absolute distances",
+			stakes: []alloraMath.Dec{
+				alloraMath.NewDecFromInt64(1),
+				alloraMath.NewDecFromInt64(1),
+				alloraMath.NewDecFromInt64(1),
+			},
+			losses: [][]alloraMath.Dec{
+				{alloraMath.NewDecFromInt64(0)},
+				{alloraMath.NewDecFromInt64(5)},
+				{alloraMath.NewDecFromInt64(10)},
+			},
+			expectedConsensus:   []alloraMath.Dec{alloraMath.NewDecFromInt64(5)},
+			expectedMostDistant: []alloraMath.Dec{alloraMath.NewDecFromInt64(10)},
+		},
+		{
+			name: "With NaN values",
+			stakes: []alloraMath.Dec{
+				alloraMath.NewDecFromInt64(1),
+				alloraMath.NewDecFromInt64(1),
+				alloraMath.NewDecFromInt64(1),
+			},
+			losses: [][]alloraMath.Dec{
+				{alloraMath.NewDecFromInt64(1)},
+				{alloraMath.NewNaN()},
+				{alloraMath.NewDecFromInt64(7)},
+			},
+			expectedConsensus:   []alloraMath.Dec{alloraMath.NewDecFromInt64(4)},
+			expectedMostDistant: []alloraMath.Dec{alloraMath.NewDecFromInt64(1)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			consensus, mostDistant, err := rewards.GetStakeWeightedLossMatrix(tc.stakes, tc.losses)
+			require.NoError(t, err)
+
+			// Check consensus values
+			for i, v := range consensus {
+				inDelta, err := alloraMath.InDelta(tc.expectedConsensus[i], v, alloraMath.MustNewDecFromString("0.00001"))
+				require.NoError(t, err)
+				if !inDelta {
+					t.Errorf("GetStakeWeightedLoss() got = %v, want %v", consensus, tc.expectedConsensus)
+				}
+			}
+
+			// Check most distant values
+			require.Equal(t, len(tc.expectedMostDistant), len(mostDistant))
+			for i, v := range mostDistant {
+				require.True(t, tc.expectedMostDistant[i].Equal(v),
+					"mostDistant[%d]: expected %s, got %s", i, tc.expectedMostDistant[i], v)
+			}
+		})
+	}
+}
+
 func TestGetFinalWorkerPerformanceScore(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
This PR improves the implementation of GetStakeWeightedLossMatrix to correctly identify the most distant value from the consensus using absolute differences. The function is used to calculate stake-weighted loss matrices and identify outliers in reported losses.

- Modified the logic in GetStakeWeightedLossMatrix to properly calculate absolute differences by taking the absolute value of the distance between each value and the consensus
- Updated tests to verify the correct behavior with values both above and below consensus

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
https://linear.app/alloralabs/issue/ENGN-3540/182-incorrect-maxdistant-value-causes-reputers-who-havent-submitted
