### PR TITLE
Remove fmt.Sprintf from logs, added check-log-sprintf linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -41,3 +41,6 @@ jobs:
       - name: check-fuzz-transitions
         run: go run ./linter/fuzz-transitions
         timeout-minutes: 10
+      - name: check-log-sprintf
+        run: go run ./linter/logging ./...
+        timeout-minutes: 10

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -42,5 +42,5 @@ jobs:
         run: go run ./linter/fuzz-transitions
         timeout-minutes: 10
       - name: check-log-sprintf
-        run: go run ./linter/logging ./...
+        run: go run ./linter/log-sprintf ./...
         timeout-minutes: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* [#764](https://github.com/allora-network/allora-chain/pull/764) TopicRewardAlpha using weekly cadence
-
 ### Deprecated
 
 ### Removed
@@ -69,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#762](https://github.com/allora-network/allora-chain/pull/762) Worker node owner should get compensated, not sender of inferences
 * [#766](https://github.com/allora-network/allora-chain/pull/766) Fix sort by weight instead of topic id. Remove excess sort logic
 * [#776](https://github.com/allora-network/allora-chain/pull/776) Target weight: rm div by topic epochLength
+* [#764](https://github.com/allora-network/allora-chain/pull/764) TopicRewardAlpha using weekly cadence
 
 ### Deprecated
 
@@ -81,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#761](https://github.com/allora-network/allora-chain/pull/761) Fix close worker nonce boundaries
 * [#760](https://github.com/allora-network/allora-chain/pull/760) Fix topic low-weight inactive topic weight vulnerability
 * [#771](https://github.com/allora-network/allora-chain/pull/771) Fix reputer/worker window boundaries
+* [#782](https://github.com/allora-network/allora-chain/pull/782) More efficient logging, added check-log-sprintf linter
 
 ### Security
 

--- a/linter/log-sprintf/main.go
+++ b/linter/log-sprintf/main.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/tools/go/analysis/singlechecker"
 )
 
-var Analyzer = &analysis.Analyzer{
+var Analyzer = &analysis.Analyzer{ //nolint: exhaustruct
 	Name: "log_sprintf",
 	Doc:  "checks for inefficient use of fmt.Sprintf inside logging functions",
 	Run:  run,
@@ -60,7 +60,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return true
 		})
 	}
-	return nil, nil
+	return nil, nil //nolint: nilnil
 }
 
 func main() {

--- a/linter/log-sprintf/main.go
+++ b/linter/log-sprintf/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 var Analyzer = &analysis.Analyzer{
-	Name: "log-sprintf",
+	Name: "log_sprintf",
 	Doc:  "checks for inefficient use of fmt.Sprintf inside logging functions",
 	Run:  run,
 }

--- a/linter/logging/main.go
+++ b/linter/logging/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "log-sprintf",
+	Doc:  "checks for inefficient use of fmt.Sprintf inside logging functions",
+	Run:  run,
+}
+
+var loggingFuncs = map[string]bool{
+	"Debug": true,
+	"Info":  true,
+	"Warn":  true,
+	"Error": true,
+	"Fatal": true,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			callExpr, ok := n.(*ast.CallExpr)
+			if !ok || len(callExpr.Args) == 0 {
+				return true
+			}
+
+			// Check if the function being called is a SelectorExpr (e.g., logger.Debug)
+			selExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+
+			// Match known logging method names (regardless of object)
+			if !loggingFuncs[selExpr.Sel.Name] {
+				return true
+			}
+
+			// Check if first argument is fmt.Sprintf(...)
+			firstArg, ok := callExpr.Args[0].(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			innerSel, ok := firstArg.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+
+			pkgIdent, ok := innerSel.X.(*ast.Ident)
+			if !ok || pkgIdent.Name != "fmt" || innerSel.Sel.Name != "Sprintf" {
+				return true
+			}
+
+			pass.Reportf(firstArg.Pos(), "avoid using fmt.Sprintf inside log.%s: use logger formatting instead", selExpr.Sel.Name)
+			return true
+		})
+	}
+	return nil, nil
+}
+
+func main() {
+	singlechecker.Main(Analyzer)
+}

--- a/math/bounded_dec.go
+++ b/math/bounded_dec.go
@@ -12,6 +12,18 @@ const (
 	DataLimitExponent = 40
 )
 
+var (
+	// Pre-computed boundary values
+	minBoundValue Dec
+	maxBoundValue Dec
+)
+
+// Initialize the boundary values for performance
+func init() {
+	minBoundValue = MustNewDecFromString(fmt.Sprintf("1e-%d", DataLimitExponent))
+	maxBoundValue = MustNewDecFromString(fmt.Sprintf("1e%d", DataLimitExponent))
+}
+
 // BoundedExp40Dec represents a decimal with enforced value boundaries.
 // It wraps the base Dec type and enforces limits during marshaling/unmarshaling.
 type BoundedExp40Dec struct {
@@ -34,16 +46,11 @@ func validateBounds(d Dec) error {
 		return errorsmod.Wrap(err, "failed to get absolute value")
 	}
 
-	// Create boundary values for the magnitude
-	baseString := "1e"
-	minValue, _ := NewDecFromString(baseString + fmt.Sprintf("-%d", DataLimitExponent))
-	maxValue, _ := NewDecFromString(baseString + fmt.Sprintf("%d", DataLimitExponent))
-
 	// Check magnitude boundaries
-	if absValue.Lt(minValue) {
+	if absValue.Lt(minBoundValue) {
 		return errorsmod.Wrapf(ErrOutOfRange, "value %s cannot have higher precision than %d", d, DataLimitExponent)
 	}
-	if absValue.Gt(maxValue) {
+	if absValue.Gt(maxBoundValue) {
 		return errorsmod.Wrapf(ErrOutOfRange, "value %s cannot be greater than ±1e%d", d, DataLimitExponent)
 	}
 

--- a/test/fuzz/invariants.patch
+++ b/test/fuzz/invariants.patch
@@ -1,8 +1,12 @@
 diff --git a/x/emissions/module/abci.go b/x/emissions/module/abci.go
-index 8ff85b13..88779b6e 100644
+index aab2b38..ff19d79 100644
 --- a/x/emissions/module/abci.go
 +++ b/x/emissions/module/abci.go
-@@ -6,6 +6,7 @@ import (
+@@ -2,9 +2,11 @@ package module
+ 
+ import (
+ 	"context"
++	"fmt"
  	"time"
  
  	"cosmossdk.io/errors"
@@ -10,7 +14,7 @@ index 8ff85b13..88779b6e 100644
  	allorautils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
  	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
  	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
-@@ -17,6 +18,10 @@ func EndBlocker(ctx context.Context, am AppModule) error {
+@@ -16,6 +18,10 @@ func EndBlocker(ctx context.Context, am AppModule) error {
  	defer telemetry.ModuleMeasureSince(emissionstypes.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
  
  	sdkCtx := sdk.UnwrapSDKContext(ctx)
@@ -19,13 +23,13 @@ index 8ff85b13..88779b6e 100644
 +		panic(fmt.Sprintf("Invariants broken: %s", invariantMessage))
 +	}
  	blockHeight := sdkCtx.BlockHeight()
- 	sdkCtx.Logger().Debug(
- 		fmt.Sprintf("\n ---------------- Emissions EndBlock %d ------------------- \n",
+ 	sdkCtx.Logger().Debug("---------------- Emissions EndBlock -------------------", "blockHeight", blockHeight)
+ 	moduleParams, err := am.keeper.GetParams(sdkCtx)
 diff --git a/x/emissions/module/module.go b/x/emissions/module/module.go
-index f8ddae02..0a8cc692 100644
+index 0550bed..1121734 100644
 --- a/x/emissions/module/module.go
 +++ b/x/emissions/module/module.go
-@@ -22,6 +22,15 @@ import (
+@@ -33,6 +33,15 @@ import (
  	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
  )
  
@@ -41,7 +45,7 @@ index f8ddae02..0a8cc692 100644
  var (
  	_ module.AppModuleBasic   = AppModule{} // nolint: exhaustruct
  	_ module.HasGenesis       = AppModule{} // nolint: exhaustruct
-@@ -135,14 +144,6 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
+@@ -178,14 +187,6 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
  
  // EndBlock returns the end blocker for the emissions module.
  func (am AppModule) EndBlock(ctx context.Context) error {

--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -3,7 +3,6 @@ package actorutils
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 
 	"cosmossdk.io/collections"
@@ -119,7 +118,7 @@ func CloseReputerNonce(
 		return err
 	}
 
-	ctx.Logger().Debug(fmt.Sprintf("Reputer Nonce %d Network Loss Bundle %v", &nonce.BlockHeight, networkLossBundle))
+	ctx.Logger().Debug("Reputer Nonce", "blockHeight", &nonce.BlockHeight, "networkLossBundle", networkLossBundle)
 
 	err = k.InsertNetworkLossBundleAtBlock(ctx, topic.Id, nonce.BlockHeight, networkLossBundle)
 	if err != nil {
@@ -244,7 +243,7 @@ func CloseReputerNonce(
 	}
 
 	types.EmitNewReputerLastCommitSetEvent(ctx, topic.Id, blockHeight, &nonce)
-	ctx.Logger().Info(fmt.Sprintf("Closed reputer nonce for topic: %d, nonce: %v", topic.Id, nonce))
+	ctx.Logger().Info("Closed reputer nonce", "topicId", topic.Id, "nonce", nonce)
 	return nil
 }
 

--- a/x/emissions/keeper/actor_utils/worker.go
+++ b/x/emissions/keeper/actor_utils/worker.go
@@ -1,7 +1,6 @@
 package actorutils
 
 import (
-	"fmt"
 	"sort"
 
 	keeper "github.com/allora-network/allora-chain/x/emissions/keeper"
@@ -104,7 +103,7 @@ func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonc
 	}
 
 	types.EmitNewWorkerLastCommitSetEvent(ctx, topic.Id, blockHeight, &nonce)
-	ctx.Logger().Info(fmt.Sprintf("Closed worker nonce for topic: %d, nonce: %v", topic.Id, nonce))
+	ctx.Logger().Info("Closed worker nonce", "topicId", topic.Id, "nonce", nonce)
 	// Return an empty response as the operation was successful
 	return nil
 }

--- a/x/emissions/keeper/inference_synthesis/forecast_implied.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied.go
@@ -1,8 +1,6 @@
 package inferencesynthesis
 
 import (
-	"fmt"
-
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	alloraMath "github.com/allora-network/allora-chain/math"
@@ -39,7 +37,7 @@ func CalcForecastImpliedInferences(args CalcForecastImpliedInferencesArgs) (
 	forecasterToRegretOut map[Forecaster]*Regret,
 	err error,
 ) {
-	args.Logger.Debug(fmt.Sprintf("Calculating forecast-implied inferences for topic %v", args.TopicId))
+	args.Logger.Debug("Calculating forecast-implied inferences", "topicId", args.TopicId)
 	// "k" here is the forecaster's address
 	// For each forecast, and for each forecast element, calculate forecast-implied inferences I_ik
 	forecasterToForecastImpliedInference = make(map[Forecaster]*emissionstypes.Inference, len(args.Forecasters))
@@ -199,6 +197,5 @@ func CalcForecastImpliedInferences(args CalcForecastImpliedInferencesArgs) (
 		}
 	}
 
-	args.Logger.Debug(fmt.Sprintf("Forecast-implied inferences: %v", forecasterToForecastImpliedInference))
 	return forecasterToForecastImpliedInference, infererToRegretOut, forecasterToRegretOut, nil
 }

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder.go
@@ -2,7 +2,6 @@ package inferencesynthesis
 
 import (
 	"context"
-	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
@@ -33,7 +32,7 @@ type GetCombinedInferenceArgs struct {
 // Calculates the network combined inference I_i, Equation 9
 func GetCombinedInference(args GetCombinedInferenceArgs) (
 	weights RegretInformedWeights, combinedInference InferenceValue, err error) {
-	args.Logger.Debug(fmt.Sprintf("Calculating combined inference for topic %v", args.TopicId))
+	args.Logger.Debug("Calculating combined inference", "topicId", args.TopicId)
 
 	weights, err = CalcWeightsGivenWorkers(
 		CalcWeightsGivenWorkersArgs{
@@ -68,7 +67,7 @@ func GetCombinedInference(args GetCombinedInferenceArgs) (
 		return RegretInformedWeights{}, InferenceValue{}, errorsmod.Wrap(err, "GetCombinedInference() error calculating combined inference")
 	}
 
-	args.Logger.Debug(fmt.Sprintf("Combined inference calculated for topic %v is %v", args.TopicId, combinedInference))
+	args.Logger.Debug("Combined inference calculated", "topicId", args.TopicId)
 	return weights, combinedInference, nil
 }
 
@@ -96,7 +95,7 @@ func getForecastImpliedInferences(
 	forecastImpliedInferences = make([]*emissions.WorkerAttributedValue, 0)
 	for _, forecaster := range forecasters {
 		if forecasterToForecastImpliedInference[forecaster] == nil {
-			logger.Warn(fmt.Sprintf("getForecastImpliedInferences() no forecast-implied inference for forecaster %s", forecaster))
+			logger.Warn("getForecastImpliedInferences() no forecast-implied inference", "forecaster", forecaster)
 			continue
 		}
 		forecastImpliedInferences = append(forecastImpliedInferences, &emissions.WorkerAttributedValue{
@@ -128,7 +127,7 @@ type GetNaiveInferenceArgs struct {
 
 // Calculates the network naive inference I^-_i
 func GetNaiveInference(args GetNaiveInferenceArgs) (naiveInference alloraMath.Dec, err error) {
-	args.Logger.Debug(fmt.Sprintf("Calculating naive inference for topic %v", args.TopicId))
+	args.Logger.Debug("Calculating naive inference", "topicId", args.TopicId)
 
 	// Get inferer naive regrets
 	infererToRegret := make(map[string]*alloraMath.Dec)
@@ -173,7 +172,7 @@ func GetNaiveInference(args GetNaiveInferenceArgs) (naiveInference alloraMath.De
 		return alloraMath.Dec{}, errorsmod.Wrap(err, "GetNaiveInference() error calculating naive inference")
 	}
 
-	args.Logger.Debug(fmt.Sprintf("Naive inference calculated for topic %v is %v", args.TopicId, naiveInference))
+	args.Logger.Debug("Naive inference calculated", "topicId", args.TopicId)
 	return naiveInference, nil
 }
 
@@ -204,8 +203,7 @@ func calcOneOutInfererInference(args CalcOneOutInfererInferenceArgs) (
 	oneOutNetworkInferenceWithoutInferer alloraMath.Dec,
 	err error,
 ) {
-	args.Logger.Debug(fmt.Sprintf(
-		"calcOneOutInfererInference() calculating one-out inference for topic %v withheld inferer %s", args.TopicId, args.WithheldInferer))
+	args.Logger.Debug("calcOneOutInfererInference() calculating one-out inference", "topicId", args.TopicId, "withheldInferer", args.WithheldInferer)
 
 	// To calculate one out, remove the inferer from the list of inferers
 	remainingInferers := make([]Worker, 0)
@@ -217,7 +215,7 @@ func calcOneOutInfererInference(args CalcOneOutInfererInferenceArgs) (
 			remainingInferers = append(remainingInferers, inferer)
 			inference, ok := args.InfererToInference[inferer]
 			if !ok {
-				args.Logger.Debug(fmt.Sprintf("calcOneOutInfererInference() cannot find inferer in InferenceByWorker in args.InfererToInference %v", inferer))
+				args.Logger.Debug("calcOneOutInfererInference() cannot find inferer in InferenceByWorker in args.InfererToInference", "inferer", inferer)
 				continue
 			}
 			remainingInfererToInference[inferer] = inference
@@ -298,7 +296,7 @@ func calcOneOutInfererInference(args CalcOneOutInfererInferenceArgs) (
 		return alloraMath.Dec{}, errorsmod.Wrapf(err, "calcOneOutInfererInference() error calculating one-out inference for inferer")
 	}
 
-	args.Logger.Debug(fmt.Sprintf("One-out inference calculated for topic %v withheld inferer %s is %v", args.TopicId, args.WithheldInferer, oneOutNetworkInferenceWithoutInferer))
+	args.Logger.Debug("One-out inference calculated", "topicId", args.TopicId, "withheldInferer", args.WithheldInferer, "oneOutNetworkInferenceWithoutInferer", oneOutNetworkInferenceWithoutInferer)
 	return oneOutNetworkInferenceWithoutInferer, nil
 }
 
@@ -331,11 +329,7 @@ func GetOneOutInfererInferences(args GetOneOutInfererInferencesArgs) (
 	oneOutInfererInferences []*emissions.WithheldWorkerAttributedValue,
 	err error,
 ) {
-	args.Logger.Debug(fmt.Sprintf(
-		"Calculating one-out inferer inferences for topic %v with %v inferers",
-		args.TopicId,
-		len(args.Inferers),
-	))
+	args.Logger.Debug("Calculating one-out inferer inferences", "topicId", args.TopicId, "numInferers", len(args.Inferers))
 	// Calculate the one-out inferences per inferer
 	oneOutInferences := make([]*emissions.WithheldWorkerAttributedValue, 0)
 	for _, worker := range args.Inferers {
@@ -370,7 +364,7 @@ func GetOneOutInfererInferences(args GetOneOutInfererInferencesArgs) (
 		})
 	}
 
-	args.Logger.Debug(fmt.Sprintf("One-out inferer inferences calculated for topic %v", args.TopicId))
+	args.Logger.Debug("One-out inferer inferences calculated", "topicId", args.TopicId)
 	return oneOutInferences, nil
 }
 
@@ -400,7 +394,7 @@ func calcOneOutForecasterInference(args CalcOneOutForecasterInferenceArgs) (
 	oneOutNetworkInferenceWithoutInferer alloraMath.Dec,
 	err error,
 ) {
-	args.Logger.Debug(fmt.Sprintf("Calculating one-out inference for topic %v withheld forecaster %s", args.TopicId, args.WithheldForecaster))
+	args.Logger.Debug("Calculating one-out inference", "topicId", args.TopicId, "withheldForecaster", args.WithheldForecaster)
 
 	// To calculate one out, remove the withheldForecaster from the list of forecasters
 	remainingForecasters := make([]Forecaster, 0)
@@ -467,7 +461,7 @@ func calcOneOutForecasterInference(args CalcOneOutForecasterInferenceArgs) (
 		return alloraMath.Dec{}, errorsmod.Wrapf(err, "calcOneOutForecasterInference() error calculating one-out inference for inferer")
 	}
 
-	args.Logger.Debug(fmt.Sprintf("One-out inference calculated for topic %v withheld forecaster %s is %v", args.TopicId, args.WithheldForecaster, oneOutNetworkInferenceWithoutInferer))
+	args.Logger.Debug("One-out inference calculated", "topicId", args.TopicId, "withheldForecaster", args.WithheldForecaster, "oneOutNetworkInferenceWithoutInferer", oneOutNetworkInferenceWithoutInferer)
 	return oneOutNetworkInferenceWithoutInferer, nil
 }
 
@@ -499,7 +493,7 @@ func GetOneOutForecasterInferences(args GetOneOutForecasterInferencesArgs) (
 	oneOutForecasterInferences []*emissions.WithheldWorkerAttributedValue,
 	err error,
 ) {
-	args.Logger.Debug(fmt.Sprintf("Calculating one-out forecaster inferences for topic %v with %v forecasters", args.TopicId, len(args.Forecasters)))
+	args.Logger.Debug("Calculating one-out forecaster inferences", "topicId", args.TopicId, "numForecasters", len(args.Forecasters))
 	// Calculate the one-out forecast-implied inferences per forecaster
 	oneOutForecasterInferences = make([]*emissions.WithheldWorkerAttributedValue, 0)
 	// If there is only one forecaster, there's no need to calculate one-out inferences
@@ -533,7 +527,7 @@ func GetOneOutForecasterInferences(args GetOneOutForecasterInferencesArgs) (
 				Value:  oneOutInference,
 			})
 		}
-		args.Logger.Debug(fmt.Sprintf("One-out forecaster inferences calculated for topic %v", args.TopicId))
+		args.Logger.Debug("One-out forecaster inferences calculated", "topicId", args.TopicId)
 	}
 	return oneOutForecasterInferences, nil
 }
@@ -562,7 +556,7 @@ func calcOneInValue(args calcOneInValueArgs) (
 	oneInInference alloraMath.Dec,
 	err error,
 ) {
-	args.Logger.Debug(fmt.Sprintf("Calculating one-in inference for forecaster: %s", args.OneInForecaster))
+	args.Logger.Debug("Calculating one-in inference", "forecaster", args.OneInForecaster)
 
 	// In each loop, remove all forecast-implied inferences except one
 	singleForecastImpliedInference := make(map[Worker]*emissions.Inference, 1)
@@ -595,7 +589,7 @@ func calcOneInValue(args calcOneInValueArgs) (
 
 		inference, ok := args.InfererToInference[inferer]
 		if !ok {
-			args.Logger.Debug(fmt.Sprintf("CalcOneInValue() cannot find inferer in InferenceByWorker %v", inferer))
+			args.Logger.Debug("CalcOneInValue() cannot find inferer in InferenceByWorker", "inferer", inferer)
 			continue
 		}
 		infererToInferenceForSingleForecaster[inferer] = inference

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -1,8 +1,6 @@
 package inferencesynthesis
 
 import (
-	"fmt"
-
 	"cosmossdk.io/collections"
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -253,7 +251,7 @@ func GetCalcNetworkInferenceArgs(
 			return CalcNetworkInferencesArgs{}, errorsmod.Wrapf(err, "GetCalcNetworkInferenceArgs: error getting inferer regret")
 		}
 
-		logger.Debug(fmt.Sprintf("Inferer %v has regret %v", inferer, regret.Value))
+		logger.Debug("Inferer has regret", "inferer", inferer, "regret", regret.Value)
 		infererToRegret[inferer] = &regret.Value
 	}
 
@@ -264,7 +262,7 @@ func GetCalcNetworkInferenceArgs(
 			return CalcNetworkInferencesArgs{}, errorsmod.Wrapf(err, "GetCalcNetworkInferenceArgs: error getting forecaster regret")
 		}
 
-		logger.Debug(fmt.Sprintf("Forecaster %v has regret %v", forecaster, regret.Value))
+		logger.Debug("Forecaster has regret", "forecaster", forecaster, "regret", regret.Value)
 		forecasterToRegret[forecaster] = &regret.Value
 	}
 
@@ -273,7 +271,7 @@ func GetCalcNetworkInferenceArgs(
 	if err != nil {
 		return CalcNetworkInferencesArgs{}, errorsmod.Wrap(err, "CalcNetworkInferences() error getting latest regret stdnorm")
 	}
-	logger.Info(fmt.Sprintf("GetCalcNetworkInferenceArgs: StdDevPlusEpsilon: %v", stdDevPlusEpsilon))
+	logger.Info("GetCalcNetworkInferenceArgs: StdDevPlusEpsilon", "stdDevPlusEpsilon", stdDevPlusEpsilon)
 
 	forecastImpliedInferencesByWorker, _, _, err := CalcForecastImpliedInferences(
 		CalcForecastImpliedInferencesArgs{

--- a/x/emissions/keeper/inference_synthesis/weight.go
+++ b/x/emissions/keeper/inference_synthesis/weight.go
@@ -1,8 +1,6 @@
 package inferencesynthesis
 
 import (
-	"fmt"
-
 	"cosmossdk.io/log"
 
 	errorsmod "cosmossdk.io/errors"
@@ -167,7 +165,7 @@ func CalcWeightsGivenWorkers(args CalcWeightsGivenWorkersArgs) (RegretInformedWe
 	for _, worker := range args.Inferers {
 		regret, ok := args.InfererToRegret[worker]
 		if !ok {
-			args.Logger.Debug(fmt.Sprintf("Cannot find worker in InfererRegrets in CalcWeightsGivenWorkers %v", worker))
+			args.Logger.Debug("Cannot find worker in InfererRegrets in CalcWeightsGivenWorkers", "worker", worker)
 			continue
 		}
 		regretFrac, err := regret.Quo(stdDevRegretsPlusEpsilon)
@@ -188,7 +186,7 @@ func CalcWeightsGivenWorkers(args CalcWeightsGivenWorkersArgs) (RegretInformedWe
 		for _, worker := range args.Forecasters {
 			regret, ok := args.ForecasterToRegret[worker]
 			if !ok {
-				args.Logger.Debug(fmt.Sprintf("Cannot find worker in ForecasterRegrets in CalcWeightsGivenWorkers %v", worker))
+				args.Logger.Debug("Cannot find worker in ForecasterRegrets in CalcWeightsGivenWorkers", "worker", worker)
 				continue
 			}
 			regretFrac, err := regret.Quo(stdDevRegretsPlusEpsilon)
@@ -274,17 +272,17 @@ func calcWeightedInference(args calcWeightedInferenceArgs) (InferenceValue, erro
 		for _, inferer := range args.inferers {
 			inferenceByWorker, exists := args.workerToInference[inferer]
 			if !exists {
-				args.logger.Debug(fmt.Sprintf("Cannot find inferer in InferenceByWorker in CalcWeightedInference %v", inferer))
+				args.logger.Debug("Cannot find inferer in InferenceByWorker in CalcWeightedInference", "inferer", inferer)
 				continue
 			}
 			infererWeight, exists := args.weights.Inferers[inferer]
 			if !exists {
-				args.logger.Debug(fmt.Sprintf("Cannot find inferer in weights.inferers in CalcWeightedInference %v", inferer))
+				args.logger.Debug("Cannot find inferer in weights.inferers in CalcWeightedInference", "inferer", inferer)
 				continue
 			}
 			_, exists = args.infererToRegret[inferer]
 			if !exists {
-				args.logger.Debug(fmt.Sprintf("Cannot find inferer in InfererRegrets in CalcWeightedInference %v", inferer))
+				args.logger.Debug("Cannot find inferer in InfererRegrets in CalcWeightedInference", "inferer", inferer)
 				continue
 			}
 			runningUnnormalizedI_i, sumWeights, err = accumulateWeights(
@@ -301,17 +299,17 @@ func calcWeightedInference(args calcWeightedInferenceArgs) (InferenceValue, erro
 		for _, forecaster := range args.forecasters {
 			workerForecastImpliedInference, exists := args.forecasterToForecastImpliedInference[forecaster]
 			if !exists {
-				args.logger.Debug(fmt.Sprintf("Cannot find forecaster in ForecastImpliedInferenceByWorker in CalcWeightedInference %v", forecaster))
+				args.logger.Debug("Cannot find forecaster in ForecastImpliedInferenceByWorker in CalcWeightedInference", "forecaster", forecaster)
 				continue
 			}
 			forecasterWeight, exists := args.weights.Forecasters[forecaster]
 			if !exists {
-				args.logger.Debug(fmt.Sprintf("Cannot find forecaster in weights.forecasters in CalcWeightedInference %v", forecaster))
+				args.logger.Debug("Cannot find forecaster in weights.forecasters in CalcWeightedInference", "forecaster", forecaster)
 				continue
 			}
 			_, exists = args.forecasterToRegret[forecaster]
 			if !exists {
-				args.logger.Debug(fmt.Sprintf("Cannot find forecaster in ForecasterRegrets in CalcWeightedInference %v", forecaster))
+				args.logger.Debug("Cannot find forecaster in ForecasterRegrets in CalcWeightedInference", "forecaster", forecaster)
 				continue
 			}
 			runningUnnormalizedI_i, sumWeights, err = accumulateWeights(
@@ -353,7 +351,7 @@ func getInfererRegretsSlice(
 	for _, inferer := range inferers {
 		regret, ok := infererToRegret[inferer]
 		if !ok {
-			logger.Debug(fmt.Sprintf("Cannot find inferer in InfererRegrets in GetInfererRegretsSlice %v", inferer))
+			logger.Debug("Cannot find inferer in InfererRegrets in GetInfererRegretsSlice", "inferer", inferer)
 			continue
 		}
 		regrets = append(regrets, *regret)
@@ -376,7 +374,7 @@ func getForecasterRegretsSlice(
 	for _, forecaster := range forecasters {
 		regret, ok := forecasterToRegret[forecaster]
 		if !ok {
-			logger.Debug(fmt.Sprintf("Cannot find forecaster in ForecasterRegrets in GetForecasterRegretsSlice %v", forecaster))
+			logger.Debug("Cannot find forecaster in ForecasterRegrets in GetForecasterRegretsSlice", "forecaster", forecaster)
 			continue
 		}
 		regrets = append(regrets, *regret)

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -1200,7 +1200,7 @@ func (k *Keeper) UpdateNetworkInferencesOutlierMetrics(
 	topicId TopicId,
 	inferenceBlockHeight BlockHeight,
 ) error {
-	ctx.Logger().Debug(fmt.Sprintf("Updating network inferences outlier metrics for topic %d, block height %d", topicId, inferenceBlockHeight))
+	ctx.Logger().Debug("Updating network inferences outlier metrics", "topicId", topicId, "blockHeight", inferenceBlockHeight)
 	// Get all inferences at the block height
 	inferences, err := k.GetInferencesAtBlock(ctx, topicId, inferenceBlockHeight, false)
 	if err != nil {
@@ -1208,7 +1208,7 @@ func (k *Keeper) UpdateNetworkInferencesOutlierMetrics(
 	}
 	if len(inferences.Inferences) == 0 {
 		// If there are no inferences, do not update the metrics
-		ctx.Logger().Info(fmt.Sprintf("no inferences found, skipping update of outlier metrics, topicId: %d blockHeight: %d", topicId, inferenceBlockHeight))
+		ctx.Logger().Info("no inferences found, skipping update of outlier metrics", "topicId", topicId, "blockHeight", inferenceBlockHeight)
 		return nil
 	}
 
@@ -1252,7 +1252,7 @@ func (k *Keeper) UpdateNetworkInferencesOutlierMetrics(
 		}
 	}
 
-	ctx.Logger().Info(fmt.Sprintf("Setting new outlier-resistant mad %s, median %s for topic %d", newMad, median, topicId))
+	ctx.Logger().Info("Setting new outlier-resistant mad", "newMad", newMad, "median", median, "topicId", topicId)
 
 	// Set last mad inferences
 	err = k.SetMadInferences(ctx, topicId, newMad)
@@ -3240,7 +3240,7 @@ func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topicId TopicId, block Blo
 	}
 	blocksPerEpoch := alloraMath.NewDecFromInt64(topic.EpochLength)
 	if blocksPerEpoch.IsZero() {
-		ctx.Logger().Warn(fmt.Sprintf("Blocks per epoch is zero for topic %d. Skipping fee revenue drip.", topicId))
+		ctx.Logger().Warn("Blocks per epoch is zero for topic", "topicId", topicId)
 		return nil
 	}
 	blocksPerWeek, err := k.calculateBlocksPerWeek(ctx)
@@ -3253,7 +3253,7 @@ func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topicId TopicId, block Blo
 	}
 	if epochsPerWeek.IsZero() {
 		// Log a warning
-		ctx.Logger().Warn(fmt.Sprintf("Epochs per week is zero for topic %d. Skipping fee revenue drip.", topicId))
+		ctx.Logger().Warn("Epochs per week is zero for topic", "topicId", topicId)
 		return nil
 	}
 	// this delta is the drip per epoch

--- a/x/emissions/keeper/topic_activation.go
+++ b/x/emissions/keeper/topic_activation.go
@@ -394,7 +394,7 @@ func (k *Keeper) activateTopicAndResetLowestWeightAtBlock(ctx context.Context, t
 	// Reset lowest weight
 	err = k.ResetLowestActiveTopicWeightAtBlock(ctx, epochEndBlock)
 	if err != nil {
-		sdkCtx.Logger().Warn("Failed to reset lowest weight at next epoch", "topicId", topicId, "epochEndBlock", epochEndBlock)
+		sdkCtx.Logger().Warn("Failed to reset lowest weight at next epoch", "topicId", topicId, "epochEndBlock", epochEndBlock, "error", err)
 		return errors.Wrap(err, "failed to reset lowest weight at block")
 	}
 

--- a/x/emissions/keeper/topic_activation.go
+++ b/x/emissions/keeper/topic_activation.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"fmt"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
@@ -224,7 +223,7 @@ func (k *Keeper) addTopicToActiveSetRespectingLimitsWithoutMinWeightReset(
 		}
 
 		if weight.Lt(lowestWeight.Weight) {
-			sdkCtx.Logger().Warn(fmt.Sprintf("Topic %d cannot be activated due to less than lowest weight at block %d", topicId, block))
+			sdkCtx.Logger().Warn("Topic cannot be activated due to less than lowest weight at block", "topicId", topicId, "block", block)
 			return types.ErrTopicCannotBeActivated
 		}
 		err = k.inactivateTopicWithoutMinWeightReset(ctx, lowestWeight.TopicId)
@@ -280,7 +279,7 @@ func (k *Keeper) ActivateTopic(ctx context.Context, topicId TopicId) error {
 
 	err = k.activateTopicAndResetLowestWeightAtBlock(ctx, topicId, epochEndBlock)
 	if errors.IsOf(err, types.ErrTopicAlreadyActive, types.ErrTopicCannotBeActivated) {
-		sdkCtx.Logger().Info(fmt.Sprintf("Failed to add topic at next epoch %d, %d, %v", topicId, epochEndBlock, err))
+		sdkCtx.Logger().Info("Failed to add topic at next epoch", "topicId", topicId, "epochEndBlock", epochEndBlock, "error", err)
 		return nil
 	}
 	if err != nil {
@@ -293,7 +292,7 @@ func (k *Keeper) ActivateTopic(ctx context.Context, topicId TopicId) error {
 		return errors.Wrap(err, "failed to set active topics")
 	}
 
-	sdkCtx.Logger().Info(fmt.Sprintf("Topic %d activated at block %d", topicId, currentBlock))
+	sdkCtx.Logger().Info("Topic activated at block", "topicId", topicId, "block", currentBlock)
 	// This topic was activated, so we need to add its previous weight if any to the total sum of previous topic weights
 	topicWeight, noPrior, err := k.GetPreviousTopicWeight(ctx, topicId)
 	if err != nil {
@@ -338,19 +337,19 @@ func (k *Keeper) AttemptTopicReactivation(ctx context.Context, topicId TopicId) 
 	// Remove current active topic from block
 	err = k.removeCurrentTopicFromBlock(ctx, topicId, currentBlock)
 	if err != nil {
-		sdkCtx.Logger().Warn(fmt.Sprintf("Failed to remove current active topic from block %d", topicId))
+		sdkCtx.Logger().Warn("Failed to remove current active topic", "topicId", topicId, "block", currentBlock)
 		return errors.Wrap(err, "failed to remove current active topic from block")
 	}
 
 	err = k.activateTopicAndResetLowestWeightAtBlock(ctx, topicId, epochEndBlock)
 	if errors.IsOf(err, types.ErrTopicAlreadyActive, types.ErrTopicCannotBeActivated) {
-		sdkCtx.Logger().Info(fmt.Sprintf("Failed to add topic at next epoch %d, %d, %v", topicId, epochEndBlock, err))
+		sdkCtx.Logger().Info("Failed to add topic at next epoch", "topicId", topicId, "epochEndBlock", epochEndBlock, "error", err)
 		return nil
 	} else if err != nil {
 		return errors.Wrap(err, "failed to activate topic and reset lowest weight at block")
 	}
 
-	sdkCtx.Logger().Debug(fmt.Sprintf("Topic %d reactivated at next epoch %d", topicId, epochEndBlock))
+	sdkCtx.Logger().Debug("Topic reactivated at next epoch", "topicId", topicId, "epochEndBlock", epochEndBlock)
 	return nil
 }
 
@@ -395,7 +394,7 @@ func (k *Keeper) activateTopicAndResetLowestWeightAtBlock(ctx context.Context, t
 	// Reset lowest weight
 	err = k.ResetLowestActiveTopicWeightAtBlock(ctx, epochEndBlock)
 	if err != nil {
-		sdkCtx.Logger().Warn(fmt.Sprintf("Failed to reset lowest weight at next epoch %d, %d", topicId, epochEndBlock))
+		sdkCtx.Logger().Warn("Failed to reset lowest weight at next epoch", "topicId", topicId, "epochEndBlock", epochEndBlock)
 		return errors.Wrap(err, "failed to reset lowest weight at block")
 	}
 

--- a/x/emissions/keeper/topic_activation.go
+++ b/x/emissions/keeper/topic_activation.go
@@ -337,7 +337,7 @@ func (k *Keeper) AttemptTopicReactivation(ctx context.Context, topicId TopicId) 
 	// Remove current active topic from block
 	err = k.removeCurrentTopicFromBlock(ctx, topicId, currentBlock)
 	if err != nil {
-		sdkCtx.Logger().Warn("Failed to remove current active topic", "topicId", topicId, "block", currentBlock)
+		sdkCtx.Logger().Warn("Failed to remove current active topic", "topicId", topicId, "block", currentBlock, "error", err)
 		return errors.Wrap(err, "failed to remove current active topic from block")
 	}
 

--- a/x/emissions/migrations/v3/migrate.go
+++ b/x/emissions/migrations/v3/migrate.go
@@ -2,7 +2,6 @@ package v3
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"cosmossdk.io/collections"
 	errorsmod "cosmossdk.io/errors"
@@ -192,7 +191,7 @@ func MigrateTopics(
 		}
 		topicWeightData[oldMsg.Id] = weight
 		blockHeight := oldMsg.EpochLastEnded + oldMsg.EpochLength
-		ctx.Logger().Warn(fmt.Sprintf("update blockHeight %d", blockHeight))
+		ctx.Logger().Warn("update blockHeight", "blockHeight", blockHeight)
 		// If the weight is less than minimum weight then skip this topic
 		if weight.Lt(params.MinTopicWeight) {
 			topicsToChange[string(iterator.Key())] = getNewTopic(oldMsg)

--- a/x/emissions/migrations/v5/migrate.go
+++ b/x/emissions/migrations/v5/migrate.go
@@ -2,7 +2,6 @@ package v5
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"cosmossdk.io/collections"
 	errorsmod "cosmossdk.io/errors"
@@ -147,7 +146,7 @@ func MigrateTopics(
 	for id := uint64(1); id < nextTopicId; id++ {
 		idByte := make([]byte, 8)
 		binary.BigEndian.PutUint64(idByte, id)
-		ctx.Logger().Info(fmt.Sprintf("MIGRATION V5: Updating topic:%d", id))
+		ctx.Logger().Info("MIGRATION V5: Updating topic", "topicId", id)
 		topic, err := emissionsKeeper.GetTopic(ctx, id)
 		if err != nil {
 			return errorsmod.Wrapf(err, "failed to get topic")
@@ -174,7 +173,7 @@ func MigrateTopics(
 				return errorsmod.Wrapf(err, "failed to add topic weight")
 			}
 		} else {
-			ctx.Logger().Debug("MIGRATION V5: Topic is not active, skipping weight - topic", topic.Id)
+			ctx.Logger().Debug("MIGRATION V5: Topic is not active, skipping weight - topicId", "topicId", topic.Id)
 		}
 	}
 	ctx.Logger().Debug("MIGRATION V5: Setting modified topics")
@@ -221,7 +220,7 @@ func ResetMapsWithNonNumericValues(ctx sdk.Context, store storetypes.KVStore, cd
 	}
 
 	for _, prefix := range prefixes {
-		ctx.Logger().Info(fmt.Sprintf("MIGRATION V5: RESETTING %v MAP", prefix.name))
+		ctx.Logger().Info("MIGRATION V5: RESETTING MAP", "name", prefix.name)
 		err := migutils.SafelyClearWholeMap(ctx, store, prefix.prefix, maxPageSize)
 		if err != nil {
 			return err

--- a/x/emissions/migrations/v6/migrate.go
+++ b/x/emissions/migrations/v6/migrate.go
@@ -2,7 +2,6 @@ package v6
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
@@ -133,7 +132,7 @@ func FlipOnTopicWhitelists(
 	for id := uint64(1); id < nextTopicId; id++ {
 		idByte := make([]byte, 8)
 		binary.BigEndian.PutUint64(idByte, id)
-		ctx.Logger().Info(fmt.Sprintf("MIGRATION V6: Updating topic:%d", id))
+		ctx.Logger().Info("MIGRATION V6: Updating topic", "topicId", id)
 
 		err = emissionsKeeper.EnableTopicWorkerWhitelist(ctx, id)
 		if err != nil {

--- a/x/emissions/migrations/v7/migrate.go
+++ b/x/emissions/migrations/v7/migrate.go
@@ -1,8 +1,6 @@
 package v7
 
 import (
-	"fmt"
-
 	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
@@ -117,7 +115,7 @@ func MigrateParams(ctx sdk.Context, store storetypes.KVStore, cdc codec.BinaryCo
 		MaxWhitelistInputArrayLength:       defaultParams.MaxWhitelistInputArrayLength,
 	}
 
-	ctx.Logger().Info(fmt.Sprintf("MIGRATED PARAMS: %+v", newParams))
+	ctx.Logger().Info("MIGRATED PARAMS", "params", newParams)
 	store.Delete(emissionstypes.ParamsKey)
 	store.Set(emissionstypes.ParamsKey, cdc.MustMarshal(&newParams))
 	return nil

--- a/x/emissions/migrations/v8/migrate.go
+++ b/x/emissions/migrations/v8/migrate.go
@@ -1,8 +1,6 @@
 package v8
 
 import (
-	"fmt"
-
 	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
@@ -113,7 +111,7 @@ func MigrateParams(ctx sdk.Context, store storetypes.KVStore, cdc codec.BinaryCo
 		MinWeightThresholdForStdnorm: defaultParams.MinWeightThresholdForStdnorm,
 	}
 
-	ctx.Logger().Info(fmt.Sprintf("MIGRATED PARAMS: %+v", newParams))
+	ctx.Logger().Info("MIGRATED PARAMS", "params", newParams)
 	store.Delete(emissionstypes.ParamsKey)
 	store.Set(emissionstypes.ParamsKey, cdc.MustMarshal(&newParams))
 	return nil

--- a/x/emissions/migrations/v9/migrate.go
+++ b/x/emissions/migrations/v9/migrate.go
@@ -1,8 +1,6 @@
 package v9
 
 import (
-	"fmt"
-
 	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
@@ -111,7 +109,7 @@ func MigrateParams(ctx sdk.Context, store storetypes.KVStore, cdc codec.BinaryCo
 		// NEW PARAMS
 	}
 
-	ctx.Logger().Info(fmt.Sprintf("MIGRATED PARAMS: %+v", newParams))
+	ctx.Logger().Info("MIGRATED PARAMS", "params", newParams)
 	store.Delete(emissionstypes.ParamsKey)
 	store.Set(emissionstypes.ParamsKey, cdc.MustMarshal(&newParams))
 	return nil

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -74,7 +74,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 			// Check if there is an unfulfilled nonce
 			nonces, err := am.keeper.GetUnfulfilledWorkerNonces(sdkCtx, topicId)
 			if err != nil {
-				sdkCtx.Logger().Warn("Error getting unfulfilled worker nonces", "error", err.Error())
+				sdkCtx.Logger().Warn("Error getting unfulfilled worker nonces", "error", err)
 				continue
 			} else if len(nonces.Nonces) == 0 {
 				// No nonces to fulfill
@@ -82,7 +82,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 			} else {
 				topic, err := am.keeper.GetTopic(sdkCtx, topicId)
 				if err != nil {
-					sdkCtx.Logger().Warn("Error getting topic", "error", err.Error())
+					sdkCtx.Logger().Warn("Error getting topic", "error", err)
 					continue
 				}
 				for _, nonce := range nonces.Nonces {
@@ -90,11 +90,11 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 					sdkCtx.Logger().Debug("ABCI EndBlocker", "blockHeight", blockHeight, "closing worker window for topic", "topicId", topicId, "nonce", nonce)
 					err = allorautils.CloseWorkerNonce(&am.keeper, sdkCtx, topic, *nonce)
 					if err != nil {
-						sdkCtx.Logger().Info("Error closing worker nonce, proactively fulfilling", "error", err.Error())
+						sdkCtx.Logger().Info("Error closing worker nonce, proactively fulfilling", "error", err)
 						// Proactively close the nonce
 						fulfilledNonce, err := am.keeper.FulfillWorkerNonce(sdkCtx, topicId, nonce)
 						if err != nil {
-							sdkCtx.Logger().Warn("Error fulfilling worker nonce", "error", err.Error())
+							sdkCtx.Logger().Warn("Error fulfilling worker nonce", "error", err)
 						} else {
 							sdkCtx.Logger().Debug("Fulfilled", "fulfilledNonce", fulfilledNonce, "nonce", nonce)
 						}
@@ -104,7 +104,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		}
 		err = am.keeper.DeleteWorkerWindowBlockHeight(sdkCtx, blockHeight)
 		if err != nil {
-			sdkCtx.Logger().Warn("Error deleting worker window blockheight", "error", err.Error())
+			sdkCtx.Logger().Warn("Error deleting worker window blockheight", "error", err)
 		}
 	}
 	return nil

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -2,7 +2,6 @@ package module
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"cosmossdk.io/errors"
@@ -18,9 +17,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	blockHeight := sdkCtx.BlockHeight()
-	sdkCtx.Logger().Debug(
-		fmt.Sprintf("\n ---------------- Emissions EndBlock %d ------------------- \n",
-			blockHeight))
+	sdkCtx.Logger().Debug("---------------- Emissions EndBlock -------------------", "blockHeight", blockHeight)
 	moduleParams, err := am.keeper.GetParams(sdkCtx)
 	if err != nil {
 		sdkCtx.Logger().Error("Error Getting module params", err)
@@ -42,7 +39,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		return errors.Wrapf(err, "Weights error")
 	}
 
-	sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker %d: Total Revenue: %v, Sum Weight: %v", blockHeight, totalRevenue, sumWeight))
+	sdkCtx.Logger().Debug("ABCI EndBlocker", "blockHeight", blockHeight, "totalRevenue", totalRevenue, "sumWeight", sumWeight)
 
 	err = rewards.UpdateNoncesOfActiveTopics(
 		sdkCtx,
@@ -73,11 +70,11 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 	workerWindowsToClose := am.keeper.GetWorkerWindowTopicIds(sdkCtx, blockHeight)
 	if len(workerWindowsToClose.TopicIds) > 0 {
 		for _, topicId := range workerWindowsToClose.TopicIds {
-			sdkCtx.Logger().Info(fmt.Sprintf("ABCI EndBlocker: Worker close cadence met for topic: %d", topicId))
+			sdkCtx.Logger().Info("ABCI EndBlocker: Worker close cadence met for topic", "topicId", topicId)
 			// Check if there is an unfulfilled nonce
 			nonces, err := am.keeper.GetUnfulfilledWorkerNonces(sdkCtx, topicId)
 			if err != nil {
-				sdkCtx.Logger().Warn(fmt.Sprintf("Error getting unfulfilled worker nonces: %s", err.Error()))
+				sdkCtx.Logger().Warn("Error getting unfulfilled worker nonces", "error", err.Error())
 				continue
 			} else if len(nonces.Nonces) == 0 {
 				// No nonces to fulfill
@@ -85,21 +82,21 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 			} else {
 				topic, err := am.keeper.GetTopic(sdkCtx, topicId)
 				if err != nil {
-					sdkCtx.Logger().Warn(fmt.Sprintf("Error getting topic: %s", err.Error()))
+					sdkCtx.Logger().Warn("Error getting topic", "error", err.Error())
 					continue
 				}
 				for _, nonce := range nonces.Nonces {
 					// No need to validate blockHeight boundaries - we accept submissions until this block.
-					sdkCtx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker %d: Closing Worker window for topic: %d, nonce: %v", blockHeight, topicId, nonce))
+					sdkCtx.Logger().Debug("ABCI EndBlocker", "blockHeight", blockHeight, "closing worker window for topic", "topicId", topicId, "nonce", nonce)
 					err = allorautils.CloseWorkerNonce(&am.keeper, sdkCtx, topic, *nonce)
 					if err != nil {
-						sdkCtx.Logger().Info(fmt.Sprintf("Error closing worker nonce, proactively fulfilling: %s", err.Error()))
+						sdkCtx.Logger().Info("Error closing worker nonce, proactively fulfilling", "error", err.Error())
 						// Proactively close the nonce
 						fulfilledNonce, err := am.keeper.FulfillWorkerNonce(sdkCtx, topicId, nonce)
 						if err != nil {
-							sdkCtx.Logger().Warn(fmt.Sprintf("Error fulfilling worker nonce: %s", err.Error()))
+							sdkCtx.Logger().Warn("Error fulfilling worker nonce", "error", err.Error())
 						} else {
-							sdkCtx.Logger().Debug(fmt.Sprintf("Fulfilled: %t, worker nonce: %v", fulfilledNonce, nonce))
+							sdkCtx.Logger().Debug("Fulfilled", "fulfilledNonce", fulfilledNonce, "nonce", nonce)
 						}
 					}
 				}
@@ -107,7 +104,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		}
 		err = am.keeper.DeleteWorkerWindowBlockHeight(sdkCtx, blockHeight)
 		if err != nil {
-			sdkCtx.Logger().Warn(fmt.Sprintf("Error deleting worker window blockheight: %s", err.Error()))
+			sdkCtx.Logger().Warn("Error deleting worker window blockheight", "error", err.Error())
 		}
 	}
 	return nil

--- a/x/emissions/module/rewards/nonce_management.go
+++ b/x/emissions/module/rewards/nonce_management.go
@@ -11,7 +11,7 @@ import (
 func UpdateReputerNonce(ctx sdk.Context, k keeper.Keeper, topic types.Topic, block BlockHeight) error {
 	nonces, err := k.GetUnfulfilledReputerNonces(ctx, topic.Id)
 	if err != nil {
-		ctx.Logger().Warn("Error getting unfulfilled worker nonces", "error", err.Error())
+		ctx.Logger().Warn("Error getting unfulfilled worker nonces", "error", err)
 		return err
 	}
 	for _, nonce := range nonces.Nonces {
@@ -22,11 +22,11 @@ func UpdateReputerNonce(ctx sdk.Context, k keeper.Keeper, topic types.Topic, blo
 			ctx.Logger().Debug("ABCI EndBlocker: Closing reputer nonce", "topic", topic.Id, "nonce", nonce, "min", closingReputerNonceMinBlockHeight)
 			err = allorautils.CloseReputerNonce(&k, ctx, topic, *nonce.ReputerNonce)
 			if err != nil {
-				ctx.Logger().Warn("Error closing reputer nonce", "error", err.Error())
+				ctx.Logger().Warn("Error closing reputer nonce", "error", err)
 				// Proactively close the nonce to avoid
 				_, err = k.FulfillReputerNonce(ctx, topic.Id, nonce.ReputerNonce)
 				if err != nil {
-					ctx.Logger().Warn("Error fulfilling reputer nonce", "error", err.Error())
+					ctx.Logger().Warn("Error fulfilling reputer nonce", "error", err)
 				}
 			}
 		}
@@ -39,7 +39,7 @@ func PruneReputerAndWorkerNonces(ctx sdk.Context, k keeper.Keeper, topic types.T
 	var maxUnfulfilledReputerRequests uint64
 	moduleParams, err := k.GetParams(ctx)
 	if err != nil {
-		ctx.Logger().Warn("Error getting max retries to fulfil nonces for worker requests (using default)", "error", err.Error())
+		ctx.Logger().Warn("Error getting max retries to fulfil nonces for worker requests (using default)", "error", err)
 		return err
 	} else {
 		maxUnfulfilledReputerRequests = moduleParams.MaxUnfulfilledReputerRequests
@@ -50,7 +50,7 @@ func PruneReputerAndWorkerNonces(ctx sdk.Context, k keeper.Keeper, topic types.T
 		ctx.Logger().Debug("Pruning reputer nonces before block", "reputerPruningBlock", reputerPruningBlock, "topicId", topic.Id, "block", block)
 		err = k.PruneReputerNonces(ctx, topic.Id, reputerPruningBlock)
 		if err != nil {
-			ctx.Logger().Warn("Error pruning reputer nonces", "error", err.Error())
+			ctx.Logger().Warn("Error pruning reputer nonces", "error", err)
 		}
 
 		// Reputer nonces need to check worker nonces from one epoch before
@@ -60,7 +60,7 @@ func PruneReputerAndWorkerNonces(ctx sdk.Context, k keeper.Keeper, topic types.T
 			// Prune old worker nonces previous to current block to avoid inserting inferences after its time has passed
 			err = k.PruneWorkerNonces(ctx, topic.Id, workerPruningBlock)
 			if err != nil {
-				ctx.Logger().Warn("Error pruning worker nonces", "error", err.Error())
+				ctx.Logger().Warn("Error pruning worker nonces", "error", err)
 			}
 		}
 	}

--- a/x/emissions/module/rewards/nonce_management.go
+++ b/x/emissions/module/rewards/nonce_management.go
@@ -1,8 +1,6 @@
 package rewards
 
 import (
-	"fmt"
-
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	allorautils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
 	"github.com/allora-network/allora-chain/x/emissions/types"
@@ -13,7 +11,7 @@ import (
 func UpdateReputerNonce(ctx sdk.Context, k keeper.Keeper, topic types.Topic, block BlockHeight) error {
 	nonces, err := k.GetUnfulfilledReputerNonces(ctx, topic.Id)
 	if err != nil {
-		ctx.Logger().Warn(fmt.Sprintf("Error getting unfulfilled worker nonces: %s", err.Error()))
+		ctx.Logger().Warn("Error getting unfulfilled worker nonces", "error", err.Error())
 		return err
 	}
 	for _, nonce := range nonces.Nonces {
@@ -21,15 +19,14 @@ func UpdateReputerNonce(ctx sdk.Context, k keeper.Keeper, topic types.Topic, blo
 		// This means one epochLength is allowed for reputation responses to be sent since ground truth is revealed.
 		closingReputerNonceMinBlockHeight := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag + topic.EpochLength
 		if block >= closingReputerNonceMinBlockHeight {
-			ctx.Logger().Debug(fmt.Sprintf("ABCI EndBlocker: Closing reputer nonce for topic: %v nonce: %v, min: %d. \n",
-				topic.Id, nonce, closingReputerNonceMinBlockHeight))
+			ctx.Logger().Debug("ABCI EndBlocker: Closing reputer nonce", "topic", topic.Id, "nonce", nonce, "min", closingReputerNonceMinBlockHeight)
 			err = allorautils.CloseReputerNonce(&k, ctx, topic, *nonce.ReputerNonce)
 			if err != nil {
-				ctx.Logger().Warn(fmt.Sprintf("Error closing reputer nonce: %s", err.Error()))
+				ctx.Logger().Warn("Error closing reputer nonce", "error", err.Error())
 				// Proactively close the nonce to avoid
 				_, err = k.FulfillReputerNonce(ctx, topic.Id, nonce.ReputerNonce)
 				if err != nil {
-					ctx.Logger().Warn(fmt.Sprintf("Error fulfilling reputer nonce: %s", err.Error()))
+					ctx.Logger().Warn("Error fulfilling reputer nonce", "error", err.Error())
 				}
 			}
 		}
@@ -42,7 +39,7 @@ func PruneReputerAndWorkerNonces(ctx sdk.Context, k keeper.Keeper, topic types.T
 	var maxUnfulfilledReputerRequests uint64
 	moduleParams, err := k.GetParams(ctx)
 	if err != nil {
-		ctx.Logger().Warn(fmt.Sprintf("Error getting max retries to fulfil nonces for worker requests (using default), err: %s", err.Error()))
+		ctx.Logger().Warn("Error getting max retries to fulfil nonces for worker requests (using default)", "error", err.Error())
 		return err
 	} else {
 		maxUnfulfilledReputerRequests = moduleParams.MaxUnfulfilledReputerRequests
@@ -50,20 +47,20 @@ func PruneReputerAndWorkerNonces(ctx sdk.Context, k keeper.Keeper, topic types.T
 	// Adding one to cover for one extra epochLength
 	reputerPruningBlock := block - (int64(maxUnfulfilledReputerRequests+1)*topic.EpochLength + topic.GroundTruthLag) //nolint:gosec // G115: integer overflow conversion uint64 -> int64 (gosec)
 	if reputerPruningBlock > 0 {
-		ctx.Logger().Debug(fmt.Sprintf("Pruning reputer nonces before block: %v for topic: %d on block: %v", reputerPruningBlock, topic.Id, block))
+		ctx.Logger().Debug("Pruning reputer nonces before block", "reputerPruningBlock", reputerPruningBlock, "topicId", topic.Id, "block", block)
 		err = k.PruneReputerNonces(ctx, topic.Id, reputerPruningBlock)
 		if err != nil {
-			ctx.Logger().Warn(fmt.Sprintf("Error pruning reputer nonces: %s", err.Error()))
+			ctx.Logger().Warn("Error pruning reputer nonces", "error", err.Error())
 		}
 
 		// Reputer nonces need to check worker nonces from one epoch before
 		workerPruningBlock := reputerPruningBlock - topic.EpochLength
 		if workerPruningBlock > 0 {
-			ctx.Logger().Debug(fmt.Sprintf("Pruning worker nonces before block: %d  for topic: %d", workerPruningBlock, topic.Id))
+			ctx.Logger().Debug("Pruning worker nonces before block", "workerPruningBlock", workerPruningBlock, "topicId", topic.Id)
 			// Prune old worker nonces previous to current block to avoid inserting inferences after its time has passed
 			err = k.PruneWorkerNonces(ctx, topic.Id, workerPruningBlock)
 			if err != nil {
-				ctx.Logger().Warn(fmt.Sprintf("Error pruning worker nonces: %s", err.Error()))
+				ctx.Logger().Warn("Error pruning worker nonces", "error", err.Error())
 			}
 		}
 	}

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -339,7 +339,7 @@ func GenerateRewardsDistributionByTopicParticipant(
 	if args.TopicReward == nil {
 		return nil, alloraMath.Dec{}, types.ErrInvalidReward
 	}
-	args.Ctx.Logger().Debug("Generating rewards distribution for topic", "topicId", args.TopicId, "block", args.BlockHeight, "topicReward", args.TopicReward.String())
+	args.Ctx.Logger().Debug("Generating rewards distribution for topic", "topicId", args.TopicId, "block", args.BlockHeight, "topicReward", args.TopicReward)
 	bundles, err := args.K.GetReputerLossBundlesAtBlock(args.Ctx, args.TopicId, args.BlockHeight)
 	if err != nil {
 		return []types.TaskReward{}, alloraMath.Dec{}, errors.Wrapf(err, "failed to get reputer loss bundle at block %d", args.BlockHeight)

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -205,7 +205,7 @@ func getDistributionAndPayoutRewardsToTopicActors(args GetDistributionAndPayoutR
 	payoutErrors := payoutRewards(args.Ctx, args.K, totalRewardsDistribution, args.TopicRewardNonce)
 	if len(payoutErrors) > 0 {
 		for _, payoutErr := range payoutErrors {
-			Logger(args.Ctx).Warn("Failed to pay out rewards", "topicId", args.TopicId, "error", payoutErr.Error())
+			Logger(args.Ctx).Warn("Failed to pay out rewards", "topicId", args.TopicId, "error", payoutErr)
 		}
 		return alloraMath.ZeroDec(), nil // continue to next topic
 	}

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -134,7 +134,7 @@ func EmitRewards(args EmitRewardsArgs) error {
 		// Defer pruning records after rewards payout
 		defer func(topicId uint64, topicRewardNonce int64) {
 			if err := pruneRecordsAfterRewards(args.Ctx, args.K, args.ModuleParams.MinEpochLengthRecordLimit, topicId, topicRewardNonce); err != nil {
-				Logger(args.Ctx).Error("Failed to prune records after rewards", "topicId", topicId, "topicRewardNonce", topicRewardNonce, "error", err.Error())
+				Logger(args.Ctx).Error("Failed to prune records after rewards", "topicId", topicId, "topicRewardNonce", topicRewardNonce, "error", err)
 			}
 		}(topicId, topicRewardNonce)
 
@@ -148,7 +148,7 @@ func EmitRewards(args EmitRewardsArgs) error {
 			ModuleParams:     args.ModuleParams,
 		})
 		if err != nil {
-			Logger(args.Ctx).Error("Failed to process rewards", "topicId", topicId, "error", err.Error())
+			Logger(args.Ctx).Error("Failed to process rewards", "topicId", topicId, "error", err)
 			continue
 		}
 

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -1,8 +1,6 @@
 package rewards
 
 import (
-	"fmt"
-
 	"cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
@@ -54,7 +52,7 @@ type EmitRewardsArgs struct {
 func EmitRewards(args EmitRewardsArgs) error {
 	// Get current total treasury, to confirm it covers the rewards to give
 	totalRewardTreasury, err := args.K.GetTotalRewardToDistribute(args.Ctx)
-	Logger(args.Ctx).Debug(fmt.Sprintf("Max rewards to distribute this epoch: %s", totalRewardTreasury.String()))
+	Logger(args.Ctx).Debug("Max rewards to distribute this epoch", "totalRewardTreasury", totalRewardTreasury.String())
 	if err != nil {
 		return errors.Wrapf(err, "failed to get max rewards to distribute")
 	}
@@ -65,7 +63,7 @@ func EmitRewards(args EmitRewardsArgs) error {
 
 	// Sorted, active topics by weight descending. Still need skim top N to truly be the rewardable topics
 	sortedRewardableTopics := alloraMath.GetSortedElementsByDecWeightDesc(args.Weights)
-	Logger(args.Ctx).Debug(fmt.Sprintf("Rewardable topics: %v", sortedRewardableTopics))
+	Logger(args.Ctx).Debug("Rewardable topics", "sortedRewardableTopics", sortedRewardableTopics)
 
 	if len(sortedRewardableTopics) == 0 {
 		Logger(args.Ctx).Warn("No rewardable topics found")
@@ -100,7 +98,7 @@ func EmitRewards(args EmitRewardsArgs) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get current block emission")
 	}
-	Logger(args.Ctx).Debug(fmt.Sprintf("Current block emission: %s", currentBlockEmission.String()))
+	Logger(args.Ctx).Debug("Current block emission", "currentBlockEmission", currentBlockEmission.String())
 
 	currentBlockEmissionDec, err := alloraMath.NewDecFromSdkInt(currentBlockEmission)
 	if err != nil {
@@ -121,7 +119,7 @@ func EmitRewards(args EmitRewardsArgs) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to calculate topic rewards")
 	}
-	Logger(args.Ctx).Debug(fmt.Sprintf("Topic rewards: %v", topicRewards))
+	Logger(args.Ctx).Debug("Topic rewards", "topicRewards", topicRewards)
 
 	// Initialize totalRewardToStakedReputers
 	totalRewardToStakedReputers := alloraMath.ZeroDec()
@@ -130,13 +128,13 @@ func EmitRewards(args EmitRewardsArgs) error {
 	for _, topicId := range sortedRewardableTopics {
 		topicRewardNonce, err := args.K.GetTopicRewardNonce(args.Ctx, topicId)
 		if err != nil || topicRewardNonce == 0 {
-			Logger(args.Ctx).Info(fmt.Sprintf("Topic %d has no valid reward nonce, skipping", topicId))
+			Logger(args.Ctx).Info("Topic has no valid reward nonce, skipping", "topicId", topicId)
 			continue
 		}
 		// Defer pruning records after rewards payout
 		defer func(topicId uint64, topicRewardNonce int64) {
 			if err := pruneRecordsAfterRewards(args.Ctx, args.K, args.ModuleParams.MinEpochLengthRecordLimit, topicId, topicRewardNonce); err != nil {
-				Logger(args.Ctx).Error(fmt.Sprintf("Failed to prune records after rewards for Topic %d, nonce: %d, err: %s", topicId, topicRewardNonce, err.Error()))
+				Logger(args.Ctx).Error("Failed to prune records after rewards", "topicId", topicId, "topicRewardNonce", topicRewardNonce, "error", err.Error())
 			}
 		}(topicId, topicRewardNonce)
 
@@ -150,7 +148,7 @@ func EmitRewards(args EmitRewardsArgs) error {
 			ModuleParams:     args.ModuleParams,
 		})
 		if err != nil {
-			Logger(args.Ctx).Error(fmt.Sprintf("Failed to process rewards for topic %d: %s", topicId, err.Error()))
+			Logger(args.Ctx).Error("Failed to process rewards", "topicId", topicId, "error", err.Error())
 			continue
 		}
 
@@ -167,10 +165,7 @@ func EmitRewards(args EmitRewardsArgs) error {
 	}
 
 	// Log and handle the final totalRewardToStakedReputers
-	Logger(args.Ctx).Debug(
-		fmt.Sprintf("Paid out %s to staked reputers over %d topics",
-			totalRewardToStakedReputers.String(),
-			len(topicRewards)))
+	Logger(args.Ctx).Debug("Paid out to staked reputers", "totalRewardToStakedReputers", totalRewardToStakedReputers.String(), "topics", len(topicRewards))
 
 	if !totalRewardTreasury.IsZero() && uint64(args.BlockHeight)%args.ModuleParams.BlocksPerMonth == 0 {
 		percentageToStakedReputers, err := totalRewardToStakedReputers.Quo(totalRewardTreasury)
@@ -191,7 +186,7 @@ func EmitRewards(args EmitRewardsArgs) error {
 // This function distributes and pays out rewards to topic actors based on their participation.
 // It returns the total reward distributed to reputers
 func getDistributionAndPayoutRewardsToTopicActors(args GetDistributionAndPayoutRewardsToTopicActorsArgs) (alloraMath.Dec, error) {
-	Logger(args.Ctx).Debug(fmt.Sprintf("Generating rewards distribution for topic: %d, topicRewardNonce: %d, topicReward: %s", args.TopicId, args.TopicRewardNonce, args.TopicReward))
+	Logger(args.Ctx).Debug("Generating rewards distribution for topic", "topicId", args.TopicId, "topicRewardNonce", args.TopicRewardNonce, "topicReward", args.TopicReward)
 
 	// Get the distribution of rewards across actor types and participants in this topic
 	totalRewardsDistribution, rewardInTopicToActors, err := GenerateRewardsDistributionByTopicParticipant(GenerateRewardsDistributionByTopicParticipantArgs{
@@ -210,7 +205,7 @@ func getDistributionAndPayoutRewardsToTopicActors(args GetDistributionAndPayoutR
 	payoutErrors := payoutRewards(args.Ctx, args.K, totalRewardsDistribution, args.TopicRewardNonce)
 	if len(payoutErrors) > 0 {
 		for _, payoutErr := range payoutErrors {
-			Logger(args.Ctx).Warn(fmt.Sprintf("Failed to pay out rewards to participant in Topic %d: %s", args.TopicId, payoutErr.Error()))
+			Logger(args.Ctx).Warn("Failed to pay out rewards", "topicId", args.TopicId, "error", payoutErr.Error())
 		}
 		return alloraMath.ZeroDec(), nil // continue to next topic
 	}
@@ -267,7 +262,7 @@ func calculateRewardsForCurrentTopics(args CalcTopicRewardsArgs) (topicRewards m
 			return nil, alloraMath.Dec{}, errors.Wrapf(err, "topic reward fraction error")
 		}
 		if alloraMath.ZeroDec().Equal(topicRewardFraction) {
-			args.Ctx.Logger().Warn(fmt.Sprintf("Skipping rewards for topic: %d, zero weights", topicId))
+			args.Ctx.Logger().Warn("Skipping rewards for topic - zero weights", "topicId", topicId)
 			continue
 		}
 		topicRewardPerBlock, err := GetTopicReward(topicRewardFraction, args.CurrentRewardsEmissionPerBlock)
@@ -344,7 +339,7 @@ func GenerateRewardsDistributionByTopicParticipant(
 	if args.TopicReward == nil {
 		return nil, alloraMath.Dec{}, types.ErrInvalidReward
 	}
-	args.Ctx.Logger().Debug(fmt.Sprintf("Generating rewards distribution for topic: %d, block: %d, topicReward: %s", args.TopicId, args.BlockHeight, args.TopicReward.String()))
+	args.Ctx.Logger().Debug("Generating rewards distribution for topic", "topicId", args.TopicId, "block", args.BlockHeight, "topicReward", args.TopicReward.String())
 	bundles, err := args.K.GetReputerLossBundlesAtBlock(args.Ctx, args.TopicId, args.BlockHeight)
 	if err != nil {
 		return []types.TaskReward{}, alloraMath.Dec{}, errors.Wrapf(err, "failed to get reputer loss bundle at block %d", args.BlockHeight)

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -82,7 +82,7 @@ func UpdateNoncesOfActiveTopics(
 		// Update the last inference ran
 		err = k.UpdateTopicEpochLastEnded(ctx, topic.Id, block)
 		if err != nil {
-			ctx.Logger().Warn("Error updating last inference ran", "error", err.Error())
+			ctx.Logger().Warn("Error updating last inference ran", "error", err)
 			continue
 		}
 
@@ -90,14 +90,14 @@ func UpdateNoncesOfActiveTopics(
 		nextNonce := types.Nonce{BlockHeight: block}
 		err = k.AddWorkerNonce(ctx, topic.Id, &nextNonce)
 		if err != nil {
-			ctx.Logger().Warn("Error adding worker nonce", "error", err.Error())
+			ctx.Logger().Warn("Error adding worker nonce", "error", err)
 			continue
 		}
 		ctx.Logger().Debug("Added worker nonce for topic", "topicId", topic.Id, "nonce", nextNonce.BlockHeight)
 
 		err = k.AddWorkerWindowTopicId(ctx, block+topic.WorkerSubmissionWindow, topic.Id)
 		if err != nil {
-			ctx.Logger().Warn("Error adding worker window topic id", "error", err.Error())
+			ctx.Logger().Warn("Error adding worker window topic id", "error", err)
 			continue
 		}
 

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -1,8 +1,6 @@
 package rewards
 
 import (
-	"fmt"
-
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -84,7 +82,7 @@ func UpdateNoncesOfActiveTopics(
 		// Update the last inference ran
 		err = k.UpdateTopicEpochLastEnded(ctx, topic.Id, block)
 		if err != nil {
-			ctx.Logger().Warn(fmt.Sprintf("Error updating last inference ran: %s", err.Error()))
+			ctx.Logger().Warn("Error updating last inference ran", "error", err.Error())
 			continue
 		}
 
@@ -92,26 +90,26 @@ func UpdateNoncesOfActiveTopics(
 		nextNonce := types.Nonce{BlockHeight: block}
 		err = k.AddWorkerNonce(ctx, topic.Id, &nextNonce)
 		if err != nil {
-			ctx.Logger().Warn(fmt.Sprintf("Error adding worker nonce: %s", err.Error()))
+			ctx.Logger().Warn("Error adding worker nonce", "error", err.Error())
 			continue
 		}
-		ctx.Logger().Debug(fmt.Sprintf("Added worker nonce for topic %d: %v \n", topic.Id, nextNonce.BlockHeight))
+		ctx.Logger().Debug("Added worker nonce for topic", "topicId", topic.Id, "nonce", nextNonce.BlockHeight)
 
 		err = k.AddWorkerWindowTopicId(ctx, block+topic.WorkerSubmissionWindow, topic.Id)
 		if err != nil {
-			ctx.Logger().Warn(fmt.Sprintf("Error adding worker window topic id: %s", err.Error()))
+			ctx.Logger().Warn("Error adding worker window topic id", "error", err.Error())
 			continue
 		}
 
 		err = PruneReputerAndWorkerNonces(ctx, k, topic, block)
 		if err != nil {
-			Logger(ctx).Warn("Error pruning reputer and worker nonces: ", err)
+			Logger(ctx).Warn("Error pruning reputer and worker nonces", "error", err)
 			continue
 		}
 
 		err = UpdateReputerNonce(ctx, k, topic, block)
 		if err != nil {
-			Logger(ctx).Warn("Error updating reputer nonce: ", err)
+			Logger(ctx).Warn("Error updating reputer nonce", "error", err)
 		}
 	}
 	return nil
@@ -164,7 +162,7 @@ func GetAndUpdateActiveTopicWeights(
 		if err != nil {
 			return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get current topic weight")
 		}
-		Logger(ctx).Debug(fmt.Sprintf("Setting previous topic weight for topic %d: %s", topic.Id, weight.String()))
+		Logger(ctx).Debug("Setting previous topic weight for topic", "topicId", topic.Id, "weight", weight.String())
 		err = k.SetPreviousTopicWeight(ctx, topic.Id, weight)
 		if err != nil {
 			return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to set previous topic weight")
@@ -184,7 +182,7 @@ func GetAndUpdateActiveTopicWeights(
 			if err != nil {
 				return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to inactivate topic")
 			}
-			ctx.Logger().Debug(fmt.Sprintf("Topic %d inactivated at block %d", topic.Id, block))
+			ctx.Logger().Debug("Topic inactivated at block", "topicId", topic.Id, "block", block)
 			continue
 		}
 
@@ -196,7 +194,7 @@ func GetAndUpdateActiveTopicWeights(
 			if err != nil {
 				return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to inactivate topic")
 			}
-			ctx.Logger().Debug(fmt.Sprintf("Topic %d inactivated at block %d", topic.Id, block))
+			ctx.Logger().Debug("Topic inactivated at block", "topicId", topic.Id, "block", block)
 			continue
 		}
 		totalRevenue = totalRevenue.Add(topicFeeRevenue)

--- a/x/emissions/module/rewards/topic_skimming.go
+++ b/x/emissions/module/rewards/topic_skimming.go
@@ -1,7 +1,6 @@
 package rewards
 
 import (
-	"fmt"
 	"sort"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
@@ -35,9 +34,7 @@ func SkimTopTopicsByWeightDesc(ctx sdk.Context, weights map[TopicId]*alloraMath.
 		listOfTopN[i] = topicIds[i]
 	}
 
-	Logger(ctx).Debug(
-		fmt.Sprintf("SkimTopTopicsByWeightDesc took top %d topics out of %d",
-			numberToAdd, len(topicIds)))
+	Logger(ctx).Debug("SkimTopTopicsByWeightDesc took top", "number", numberToAdd, "from topics", len(topicIds))
 
 	return weightsOfTopN, listOfTopN, nil
 }

--- a/x/emissions/module/stake_removals.go
+++ b/x/emissions/module/stake_removals.go
@@ -2,7 +2,6 @@ package module
 
 import (
 	"context"
-	"fmt"
 
 	"cosmossdk.io/errors"
 	cosmosMath "cosmossdk.io/math"
@@ -77,11 +76,7 @@ func RemoveStakes(
 			stakeRemoval.Amount,
 		)
 		if err != nil {
-			sdkCtx.Logger().Error(fmt.Sprintf(
-				"Error removing stake data structures: %v | %v",
-				stakeRemoval,
-				err,
-			))
+			sdkCtx.Logger().Error("Error removing stake data structures", "stakeRemoval", stakeRemoval, "error", err)
 			continue
 		}
 
@@ -100,11 +95,7 @@ func RemoveStakes(
 			coins,
 		)
 		if err != nil {
-			sdkCtx.Logger().Error(fmt.Sprintf(
-				"Error removing stake funds: %v | %v",
-				stakeRemoval,
-				err,
-			))
+			sdkCtx.Logger().Error("Error removing stake funds", "stakeRemoval", stakeRemoval, "error", err)
 			continue
 		}
 
@@ -148,11 +139,7 @@ func RemoveDelegateStakes(
 			stakeRemoval.Amount,
 		)
 		if err != nil {
-			sdkCtx.Logger().Error(fmt.Sprintf(
-				"Error removing delegate stake state: %v | %v",
-				stakeRemoval,
-				err,
-			))
+			sdkCtx.Logger().Error("Error removing delegate stake state", "stakeRemoval", stakeRemoval, "error", err)
 			continue
 		}
 
@@ -169,11 +156,7 @@ func RemoveDelegateStakes(
 			emissionstypes.AlloraStakingAccountName,
 			stakeRemoval.Delegator, coins)
 		if err != nil {
-			sdkCtx.Logger().Error(fmt.Sprintf(
-				"Error removing delegate stake send funds: %v | %v",
-				stakeRemoval,
-				err,
-			))
+			sdkCtx.Logger().Error("Error removing delegate stake send funds", "stakeRemoval", stakeRemoval, "error", err)
 			continue
 		}
 

--- a/x/emissions/types/events_emitters.go
+++ b/x/emissions/types/events_emitters.go
@@ -15,7 +15,7 @@ func EmitNewInfererScoresSetEvent(ctx sdk.Context, scores []Score) {
 	metrics.IncrProducerEventCount(metrics.INFERER_SCORE_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewScoresSetEventBase(ActorType_ACTOR_TYPE_INFERER_UNSPECIFIED, scores))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewInfererScoresSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewInfererScoresSetEvent", "error", err)
 	}
 }
 
@@ -26,7 +26,7 @@ func EmitNewForecasterScoresSetEvent(ctx sdk.Context, scores []Score) {
 	metrics.IncrProducerEventCount(metrics.FORECASTER_SCORE_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewScoresSetEventBase(ActorType_ACTOR_TYPE_FORECASTER, scores))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewForecasterScoresSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewForecasterScoresSetEvent", "error", err)
 	}
 }
 
@@ -37,7 +37,7 @@ func EmitNewReputerScoresSetEvent(ctx sdk.Context, scores []Score) {
 	metrics.IncrProducerEventCount(metrics.REPUTER_SOCRE_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewScoresSetEventBase(ActorType_ACTOR_TYPE_REPUTER, scores))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewReputerScoresSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewReputerScoresSetEvent", "error", err)
 	}
 }
 
@@ -45,7 +45,7 @@ func EmitNewNetworkLossSetEvent(ctx sdk.Context, topicId TopicId, blockHeight Bl
 	metrics.IncrProducerEventCount(metrics.NETWORK_LOSS_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewNetworkLossSetEventBase(topicId, blockHeight, lossBundle))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewNetworkLossSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewNetworkLossSetEvent", "error", err)
 	}
 }
 
@@ -53,7 +53,7 @@ func EmitNewForecastTaskUtilityScoreSetEvent(ctx sdk.Context, topicId TopicId, s
 	metrics.IncrProducerEventCount(metrics.FORECAST_TASK_SCORE_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewForecastTaskScoreSetEventBase(topicId, score))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting EmitNewReputerLastCommitSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewForecastTaskUtilityScoreSetEvent", "error", err)
 	}
 }
 
@@ -64,7 +64,7 @@ func EmitNewActorEMAScoresSetEvent(ctx sdk.Context, actorType ActorType, scores 
 	metrics.IncrProducerEventCount(metrics.WORKER_EMA_SCORE_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewEMAScoresSetEventBase(actorType, scores, activations))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting EmitNewActorEMAScoresSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewActorEMAScoresSetEvent", "error", err)
 	}
 }
 
@@ -77,7 +77,7 @@ func EmitNewInfererRewardsSettledEvent(ctx sdk.Context, blockHeight, blockHeight
 	metrics.IncrProducerEventCount(metrics.INFERER_REWARD_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewRewardsSetEventBase(ActorType_ACTOR_TYPE_INFERER_UNSPECIFIED, blockHeight, blockHeightTx, rewards))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewInfererRewardsSettledEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewInfererRewardsSettledEvent", "error", err)
 	}
 }
 
@@ -88,7 +88,7 @@ func EmitNewForecasterRewardsSettledEvent(ctx sdk.Context, blockHeight, blockHei
 	metrics.IncrProducerEventCount(metrics.FORECASTER_REWARD_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewRewardsSetEventBase(ActorType_ACTOR_TYPE_FORECASTER, blockHeight, blockHeightTx, rewards))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewForecasterRewardsSettledEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewForecasterRewardsSettledEvent", "error", err)
 	}
 }
 
@@ -99,7 +99,7 @@ func EmitNewReputerAndDelegatorRewardsSettledEvent(ctx sdk.Context, blockHeight,
 	metrics.IncrProducerEventCount(metrics.REPUTER_REWARD_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewRewardsSetEventBase(ActorType_ACTOR_TYPE_REPUTER, blockHeight, blockHeightTx, rewards))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewReputerAndDelegatorRewardsSettledEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewReputerAndDelegatorRewardsSettledEvent", "error", err)
 	}
 }
 
@@ -107,7 +107,7 @@ func EmitNewTopicRewardSetEvent(ctx sdk.Context, topicRewards map[uint64]*allora
 	metrics.IncrProducerEventCount(metrics.TOPIC_REWARD_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewTopicRewardSetEventBase(topicRewards))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting EmitNewTopicRewardSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewTopicRewardSetEvent", "error", err)
 	}
 }
 
@@ -117,7 +117,7 @@ func EmitNewWorkerLastCommitSetEvent(ctx sdk.Context, topicId TopicId, height Bl
 	metrics.IncrProducerEventCount(metrics.WORKER_LAST_COMMIT_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewWorkerLastCommitSetEventBase(topicId, height, nonce))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewWorkerLastCommitSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewWorkerLastCommitSetEvent", "error", err)
 	}
 }
 
@@ -125,7 +125,7 @@ func EmitNewReputerLastCommitSetEvent(ctx sdk.Context, topicId TopicId, height B
 	metrics.IncrProducerEventCount(metrics.REPUTER_LAST_COMMIT_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewReputerLastCommitSetEventBase(topicId, height, nonce))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting EmitNewReputerLastCommitSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewReputerLastCommitSetEvent", "error", err)
 	}
 }
 
@@ -138,7 +138,7 @@ func EmitNewListeningCoefficientsSetEvent(ctx sdk.Context, actorType ActorType, 
 	metrics.IncrProducerEventCount(metrics.LISTENING_COEFFICIENTS_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewListeningCoefficientsSetEventBase(topicId, blockHeight, addresses, actorType, coefficients))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewListeningCoefficientsSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewListeningCoefficientsSetEvent", "error", err)
 	}
 }
 
@@ -151,7 +151,7 @@ func EmitNewInfererNetworkRegretSetEvent(ctx sdk.Context, topicId uint64, blockH
 	metrics.IncrProducerEventCount(metrics.INFERER_NETWORK_REGRET_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewInfererNetworkRegretSetEventBase(topicId, blockHeight, addresses, regrets))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewInfererNetworkRegretSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewInfererNetworkRegretSetEvent", "error", err)
 	}
 }
 
@@ -162,7 +162,7 @@ func EmitNewForecasterNetworkRegretSetEvent(ctx sdk.Context, topicId uint64, blo
 	metrics.IncrProducerEventCount(metrics.FORECASTER_NETWORK_REGRET_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewForecasterNetworkRegretSetEventBase(topicId, blockHeight, addresses, regrets))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewForecasterNetworkRegretSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewForecasterNetworkRegretSetEvent", "error", err)
 	}
 }
 
@@ -173,7 +173,7 @@ func EmitNewNaiveInfererNetworkRegretSetEvent(ctx sdk.Context, topicId uint64, b
 	metrics.IncrProducerEventCount(metrics.NAIVE_INFERER_NETWORK_REGRET_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewNaiveInfererNetworkRegretSetEventBase(topicId, blockHeight, addresses, regrets))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewNaiveInfererNetworkRegretSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewNaiveInfererNetworkRegretSetEvent", "error", err)
 	}
 }
 
@@ -181,7 +181,7 @@ func EmitNewTopicInitialRegretSetEvent(ctx sdk.Context, topicId uint64, blockHei
 	metrics.IncrProducerEventCount(metrics.TOPIC_INITIAL_REGRET_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewTopicInitialRegretSetEventBase(topicId, blockHeight, regret))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewTopicInitialRegretSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewTopicInitialRegretSetEvent", "error", err)
 	}
 }
 
@@ -189,7 +189,7 @@ func EmitNewTopicInitialEmaScoreSetEvent(ctx sdk.Context, actorType ActorType, t
 	metrics.IncrProducerEventCount(metrics.TOPIC_INITIAL_EMA_SCORE_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewTopicInitialEmaScoreSetEventBase(actorType, topicId, blockHeight, score))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewTopicInitialEmaScoreSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewTopicInitialEmaScoreSetEvent", "error", err)
 	}
 }
 
@@ -198,7 +198,7 @@ func EmitNewRegretStdNormSetEvent(ctx sdk.Context, topicId uint64, blockHeight i
 	metrics.IncrProducerEventCount(metrics.REGRET_STDNORM_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewRegretStdNormSetEventBase(topicId, blockHeight, stdNorm))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewRegretStdNormSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewRegretStdNormSetEvent", "error", err)
 	}
 }
 
@@ -206,7 +206,7 @@ func EmitNewInfererWeightSetEvent(ctx sdk.Context, topicId uint64, blockHeight i
 	metrics.IncrProducerEventCount(metrics.INFERER_WEIGHTS_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewInfererWeightSetEventBase(topicId, blockHeight, address, weight))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewInfererWeightSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewInfererWeightSetEvent", "error", err)
 	}
 }
 
@@ -214,6 +214,6 @@ func EmitNewForecasterWeightSetEvent(ctx sdk.Context, topicId uint64, blockHeigh
 	metrics.IncrProducerEventCount(metrics.FORECASTER_WEIGHTS_EVENT)
 	err := ctx.EventManager().EmitTypedEvent(NewForecasterWeightSetEventBase(topicId, blockHeight, address, weight))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting NewForecasterWeightSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting NewForecasterWeightSetEvent", "error", err)
 	}
 }

--- a/x/mint/module/module.go
+++ b/x/mint/module/module.go
@@ -115,28 +115,28 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	// we don't have any data to migrate, so the migration itself is a no-op,
 	// but it's good to print that we're doing a migration
 	err := cfg.RegisterMigration(types.ModuleName, 1, func(ctx sdk.Context) error {
-		ctx.Logger().Info(fmt.Sprintf("MIGRATING %s MODULE FROM VERSION 1 TO VERSION 2", types.ModuleName))
+		ctx.Logger().Info("MIGRATING %s MODULE FROM VERSION 1 TO VERSION 2", "module", types.ModuleName)
 		return nil
 	})
 	if err != nil {
 		panic(fmt.Sprintf("failed to migrate x/%s from version 1 to 2: %v", types.ModuleName, err))
 	}
 	err = cfg.RegisterMigration(types.ModuleName, 2, func(ctx sdk.Context) error {
-		ctx.Logger().Info(fmt.Sprintf("MIGRATING %s MODULE FROM VERSION 2 TO VERSION 3", types.ModuleName))
+		ctx.Logger().Info("MIGRATING %s MODULE FROM VERSION 2 TO VERSION 3", "module", types.ModuleName)
 		return nil
 	})
 	if err != nil {
 		panic(fmt.Sprintf("failed to migrate x/%s from version 2 to 3: %v", types.ModuleName, err))
 	}
 	err = cfg.RegisterMigration(types.ModuleName, 3, func(ctx sdk.Context) error {
-		ctx.Logger().Info(fmt.Sprintf("MIGRATING %s MODULE FROM VERSION 3 TO VERSION 4", types.ModuleName))
+		ctx.Logger().Info("MIGRATING %s MODULE FROM VERSION 3 TO VERSION 4", "module", types.ModuleName)
 		return nil
 	})
 	if err != nil {
 		panic(fmt.Sprintf("failed to migrate x/%s from version 3 to 4: %v", types.ModuleName, err))
 	}
 	err = cfg.RegisterMigration(types.ModuleName, 4, func(ctx sdk.Context) error {
-		ctx.Logger().Info(fmt.Sprintf("MIGRATING %s MODULE FROM VERSION 4 TO VERSION 5", types.ModuleName))
+		ctx.Logger().Info("MIGRATING %s MODULE FROM VERSION 4 TO VERSION 5", "module", types.ModuleName)
 		return migrationsV5.MigrateStore(ctx, am.keeper)
 	})
 	if err != nil {

--- a/x/mint/types/events.go
+++ b/x/mint/types/events.go
@@ -9,7 +9,7 @@ import (
 func EmitNewTokenomicsSetEvent(ctx sdk.Context, stakedTokenAmount, circulatingAmount, emissionsAmount math.Int) {
 	err := ctx.EventManager().EmitTypedEvent(NewTokenomicsSetEventBase(stakedTokenAmount, circulatingAmount, emissionsAmount))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting EmitNewTokenomicsSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting EmitNewTokenomicsSetEvent", "error", err)
 	}
 }
 
@@ -24,7 +24,7 @@ func NewTokenomicsSetEventBase(stakedTokenAmount, circulatingAmount, emissionsAm
 func EmitNewEcosystemTokenMintSetEvent(ctx sdk.Context, blockHeight uint64, amount math.Int) {
 	err := ctx.EventManager().EmitTypedEvent(EcosystemTokenMintSetEventBase(blockHeight, amount))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting EmitNewEcosystemTokenMintSetEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting EmitNewEcosystemTokenMintSetEvent", "error", err)
 	}
 }
 
@@ -38,7 +38,7 @@ func EcosystemTokenMintSetEventBase(blockHeight uint64, tokenAmount math.Int) pr
 func EmitNewRewardCurrentBlockEmissionEvent(ctx sdk.Context, blockHeight uint64, amount math.Int) {
 	err := ctx.EventManager().EmitTypedEvent(RewardCurrentBlockEmissionEventBase(blockHeight, amount))
 	if err != nil {
-		ctx.Logger().Warn("Error emitting EmitNewRewardCurrentBlockEmissionEvent: ", err.Error())
+		ctx.Logger().Warn("Error emitting EmitNewRewardCurrentBlockEmissionEvent", "error", err)
 	}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Created linter to spot occurrences of logging using `fmt.Sprintf` which forces string interpolation even if not in use. 
* Removed occurrences of ^ 
* Added linter to custom linters on CI 
* Precalculation of fixed values on bounded_dec. 


## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- tested using existing unit tests. Changes should not affect functionality.
- [x] If documented, please describe where. If not, describe why docs are not needed. -- no need - no change of functionality.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?


