### PR TITLE
Optim: do not recalc networkInfs if no outliers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#760](https://github.com/allora-network/allora-chain/pull/760) Fix topic low-weight inactive topic weight vulnerability
 * [#771](https://github.com/allora-network/allora-chain/pull/771) Fix reputer/worker window boundaries
 * [#782](https://github.com/allora-network/allora-chain/pull/782) More efficient logging, added check-log-sprintf linter
+* [#784](https://github.com/allora-network/allora-chain/pull/784) Optimize: do not recalc outlier-resistant network inferences if no outliers
 
 ### Security
 

--- a/x/emissions/keeper/actor_utils/worker.go
+++ b/x/emissions/keeper/actor_utils/worker.go
@@ -3,6 +3,7 @@ package actorutils
 import (
 	"sort"
 
+	errorsmod "cosmossdk.io/errors"
 	keeper "github.com/allora-network/allora-chain/x/emissions/keeper"
 	synth "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/types"
@@ -103,39 +104,8 @@ func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonc
 		return err
 	}
 
-	// Calculate and store network inferences for this block.
-	networkInferencesResult, err := synth.GetNetworkInferences(
-		sdk.UnwrapSDKContext(ctx),
-		*k,
-		topic.Id,
-		&nonce.BlockHeight,
-		activeInferences,
-		activeForecasts,
-		false,
-	)
-	if err != nil {
-		return err
-	}
-
-	err = k.InsertNetworkInference(ctx, topic.Id, nonce.BlockHeight, *networkInferencesResult.NetworkInferences)
-	if err != nil {
-		return err
-	}
-
-	// Calculate and store outlier resistant network inferences for this block.
-	outlierResistantNetworkInferencesResult, err := synth.GetNetworkInferences(
-		sdk.UnwrapSDKContext(ctx),
-		*k,
-		topic.Id,
-		&nonce.BlockHeight,
-		activeInferences,
-		activeForecasts,
-		true,
-	)
-	if err != nil {
-		return err
-	}
-	err = k.InsertOutlierResistantNetworkInference(ctx, topic.Id, nonce.BlockHeight, *outlierResistantNetworkInferencesResult.NetworkInferences)
+	// Computes and stores both regular and outlier-resistant network inferences
+	err = ProcessAndStoreNetworkInferences(k, ctx, topic.Id, nonce.BlockHeight, activeInferences, activeForecasts)
 	if err != nil {
 		return err
 	}
@@ -143,6 +113,68 @@ func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonc
 	types.EmitNewWorkerLastCommitSetEvent(ctx, topic.Id, blockHeight, &nonce)
 	ctx.Logger().Info("Closed worker nonce", "topicId", topic.Id, "nonce", nonce)
 	// Return an empty response as the operation was successful
+	return nil
+}
+
+// ProcessAndStoreNetworkInferences calculates and stores both regular and outlier-resistant network inferences
+// for a given topic and block height.
+func ProcessAndStoreNetworkInferences(
+	k *keeper.Keeper,
+	ctx sdk.Context,
+	topicId uint64,
+	blockHeight int64,
+	activeInferences *types.Inferences,
+	activeForecasts *types.Forecasts,
+) error {
+	// Calculate regular network inferences
+	networkInferencesResult, err := synth.GetNetworkInferences(
+		sdk.UnwrapSDKContext(ctx),
+		*k,
+		topicId,
+		&blockHeight,
+		activeInferences,
+		activeForecasts,
+		false,
+	)
+	if err != nil {
+		return errorsmod.Wrap(err, "failed to calculate network inferences")
+	}
+
+	// Store regular network inferences
+	if err := k.InsertNetworkInferences(ctx, topicId, blockHeight, *networkInferencesResult.NetworkInferences); err != nil {
+		return errorsmod.Wrap(err, "failed to insert network inference")
+	}
+
+	// Get outlier resistant inferences
+	outlierResistantFilteredInferences, err := k.FilterOutlierResistantInferences(ctx, topicId, *activeInferences)
+	if err != nil {
+		return errorsmod.Wrap(err, "failed to filter outlier resistant inferences")
+	}
+
+	// Initialize outlier resistant result with regular result
+	outlierResistantNetworkInferencesResult := networkInferencesResult
+
+	// Recalculate only if outlier filtering changed the inference set
+	if len(outlierResistantFilteredInferences.Inferences) != len(activeInferences.Inferences) {
+		outlierResistantNetworkInferencesResult, err = synth.GetNetworkInferences(
+			sdk.UnwrapSDKContext(ctx),
+			*k,
+			topicId,
+			&blockHeight,
+			&outlierResistantFilteredInferences,
+			activeForecasts,
+			true,
+		)
+		if err != nil {
+			return errorsmod.Wrap(err, "failed to calculate outlier resistant network inferences")
+		}
+	}
+
+	// Store outlier resistant network inferences
+	if err := k.InsertOutlierResistantNetworkInferences(ctx, topicId, blockHeight, *outlierResistantNetworkInferencesResult.NetworkInferences); err != nil {
+		return errorsmod.Wrap(err, "failed to insert outlier resistant network inference")
+	}
+
 	return nil
 }
 

--- a/x/emissions/keeper/actor_utils/worker_test.go
+++ b/x/emissions/keeper/actor_utils/worker_test.go
@@ -271,12 +271,12 @@ func (s *WorkerTestSuite) TestCloseWorkerNonce() {
 	s.Require().False(isUnfulfilled, "Nonce should no longer be unfulfilled")
 
 	// Verify network inferences were created
-	networkInferences, err := s.emissionsKeeper.GetNetworkInference(s.ctx, topicId, blockHeight)
+	networkInferences, err := s.emissionsKeeper.GetNetworkInferences(s.ctx, topicId, blockHeight)
 	s.Require().NoError(err)
 	s.Require().NotNil(networkInferences, "Network inferences should exist")
 
 	// Verify outlier resistant network inferences were created
-	outlierResistantInferences, err := s.emissionsKeeper.GetOutlierResistantNetworkInference(s.ctx, topicId, blockHeight)
+	outlierResistantInferences, err := s.emissionsKeeper.GetOutlierResistantNetworkInferences(s.ctx, topicId, blockHeight)
 	s.Require().NoError(err)
 	s.Require().NotNil(outlierResistantInferences, "Outlier resistant network inferences should exist")
 }
@@ -365,4 +365,303 @@ func (s *WorkerTestSuite) TestCloseWorkerNonceFailures() {
 	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, nonce)
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, types.ErrUnfulfilledNonceNotFound)
+}
+
+func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesCatchesOutliers() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+	require := s.Require()
+
+	// Create topic using MsgServer
+	newTopicMsg := &types.CreateNewTopicRequest{
+		Creator:                  s.addrsStr[0],
+		Metadata:                 "test",
+		LossMethod:               "mse",
+		AllowNegative:            false,
+		EpochLength:              100,
+		GroundTruthLag:           100,
+		WorkerSubmissionWindow:   10,
+		AlphaRegret:              alloraMath.NewDecFromInt64(1),
+		PNorm:                    alloraMath.NewDecFromInt64(3),
+		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
+		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
+		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
+		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		EnableWorkerWhitelist:    true,
+		EnableReputerWhitelist:   true,
+	}
+	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
+	s.Require().NoError(err)
+	topicId := res.TopicId
+	blockHeight := int64(100)
+
+	// Set up workers/forecasters using existing suite addresses
+	worker0 := s.addrsStr[0]
+	worker1 := s.addrsStr[1]
+	worker2 := s.addrsStr[2]
+	worker3 := s.addrsStr[3]
+	forecaster0 := s.addrsStr[4]
+	forecaster1 := s.addrsStr[5]
+
+	// Create inferences where worker3 is an obvious outlier
+	inferences := &types.Inferences{
+		Inferences: []*types.Inference{
+			{
+				Inferer:     worker0,
+				Value:       alloraMath.MustNewDecFromString("1.0"),
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+			{
+				Inferer:     worker1,
+				Value:       alloraMath.MustNewDecFromString("1.1"),
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+			{
+				Inferer:     worker2,
+				Value:       alloraMath.MustNewDecFromString("0.9"),
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+			{
+				Inferer:     worker3,
+				Value:       alloraMath.MustNewDecFromString("100.0"), // Clear outlier
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+		},
+	}
+
+	// Set up forecasts
+	forecasts := &types.Forecasts{
+		Forecasts: []*types.Forecast{
+			{
+				Forecaster: forecaster0,
+				ForecastElements: []*types.ForecastElement{
+					{Inferer: worker0, Value: alloraMath.MustNewDecFromString("1.05")},
+					{Inferer: worker1, Value: alloraMath.MustNewDecFromString("1.15")},
+					{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.95")},
+					{Inferer: worker3, Value: alloraMath.MustNewDecFromString("9.5")},
+				},
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+			{
+				Forecaster: forecaster1,
+				ForecastElements: []*types.ForecastElement{
+					{Inferer: worker0, Value: alloraMath.MustNewDecFromString("0.95")},
+					{Inferer: worker1, Value: alloraMath.MustNewDecFromString("1.05")},
+					{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.85")},
+					{Inferer: worker3, Value: alloraMath.MustNewDecFromString("10.5")},
+				},
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+		},
+	}
+
+	// Set up the last median and MAD for outlier detection
+	lastMedian := alloraMath.MustNewDecFromString("1.0")
+	mad := alloraMath.MustNewDecFromString("0.2")
+	err = keeper.SetLastMedianInferences(ctx, topicId, lastMedian)
+	require.NoError(err)
+	err = keeper.SetMadInferences(ctx, topicId, mad)
+	require.NoError(err)
+
+	// Set the outlier threshold in params
+	params, err := keeper.GetParams(ctx)
+	require.NoError(err)
+	params.InferenceOutlierDetectionThreshold = alloraMath.MustNewDecFromString("3.0") // 3 * MAD threshold
+	err = keeper.SetParams(ctx, params)
+	require.NoError(err)
+
+	// Call the function we're testing
+	err = actorutils.ProcessAndStoreNetworkInferences(&keeper, ctx, topicId, blockHeight, inferences, forecasts)
+	require.NoError(err)
+
+	// Retrieve both regular and outlier-resistant network inferences
+	regularInferences, err := keeper.GetNetworkInferences(ctx, topicId, blockHeight)
+	require.NoError(err)
+	outlierResistantInferences, err := keeper.GetOutlierResistantNetworkInferences(ctx, topicId, blockHeight)
+	require.NoError(err)
+
+	// Regular network inferences should include all values
+	require.Equal(4, len(regularInferences.InfererValues))
+
+	// Outlier resistant network inferences should exclude worker3
+	require.Equal(3, len(outlierResistantInferences.InfererValues))
+
+	// Verify worker3 is not in outlier resistant results
+	for _, infValue := range outlierResistantInferences.InfererValues {
+		require.NotEqual(worker3, infValue.Worker, "Outlier should not be present in outlier-resistant results")
+	}
+
+	// Verify the values are different between regular and outlier-resistant
+	require.NotEqual(
+		regularInferences.CombinedValue,
+		outlierResistantInferences.CombinedValue,
+		"Regular and outlier-resistant combined values should differ",
+	)
+
+	// Verify the outlier-resistant combined value is closer to the median
+	regularDiff, err := regularInferences.CombinedValue.Sub(lastMedian)
+	require.NoError(err)
+	regularDiffAbs, err := regularDiff.Abs()
+	require.NoError(err)
+
+	outlierDiff, err := outlierResistantInferences.CombinedValue.Sub(lastMedian)
+	require.NoError(err)
+	outlierDiffAbs, err := outlierDiff.Abs()
+	require.NoError(err)
+
+	require.True(
+		outlierDiffAbs.Lt(regularDiffAbs),
+		"Outlier-resistant value should be closer to the median",
+	)
+}
+
+func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesNoOutliers() {
+	ctx := s.ctx
+	keeper := s.emissionsKeeper
+	require := s.Require()
+
+	// Create topic using MsgServer
+	newTopicMsg := &types.CreateNewTopicRequest{
+		Creator:                  s.addrsStr[0],
+		Metadata:                 "test",
+		LossMethod:               "mse",
+		AllowNegative:            false,
+		EpochLength:              100,
+		GroundTruthLag:           100,
+		WorkerSubmissionWindow:   10,
+		AlphaRegret:              alloraMath.NewDecFromInt64(1),
+		PNorm:                    alloraMath.NewDecFromInt64(3),
+		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
+		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
+		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
+		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		EnableWorkerWhitelist:    true,
+		EnableReputerWhitelist:   true,
+	}
+	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
+	s.Require().NoError(err)
+	topicId := res.TopicId
+	blockHeight := int64(100)
+
+	// Set up workers/forecasters using existing suite addresses
+	worker0 := s.addrsStr[0]
+	worker1 := s.addrsStr[1]
+	worker2 := s.addrsStr[2]
+	worker3 := s.addrsStr[3]
+	forecaster0 := s.addrsStr[4]
+	forecaster1 := s.addrsStr[5]
+
+	// Create inferences where all values are within normal bounds
+	inferences := &types.Inferences{
+		Inferences: []*types.Inference{
+			{
+				Inferer:     worker0,
+				Value:       alloraMath.MustNewDecFromString("1.0"),
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+			{
+				Inferer:     worker1,
+				Value:       alloraMath.MustNewDecFromString("1.1"),
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+			{
+				Inferer:     worker2,
+				Value:       alloraMath.MustNewDecFromString("0.9"),
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+			{
+				Inferer:     worker3,
+				Value:       alloraMath.MustNewDecFromString("1.2"), // Normal value, not an outlier
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+		},
+	}
+
+	// Set up forecasts with similarly normal values
+	forecasts := &types.Forecasts{
+		Forecasts: []*types.Forecast{
+			{
+				Forecaster: forecaster0,
+				ForecastElements: []*types.ForecastElement{
+					{Inferer: worker0, Value: alloraMath.MustNewDecFromString("1.05")},
+					{Inferer: worker1, Value: alloraMath.MustNewDecFromString("1.15")},
+					{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.95")},
+					{Inferer: worker3, Value: alloraMath.MustNewDecFromString("1.25")},
+				},
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+			{
+				Forecaster: forecaster1,
+				ForecastElements: []*types.ForecastElement{
+					{Inferer: worker0, Value: alloraMath.MustNewDecFromString("0.95")},
+					{Inferer: worker1, Value: alloraMath.MustNewDecFromString("1.05")},
+					{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.85")},
+					{Inferer: worker3, Value: alloraMath.MustNewDecFromString("1.15")},
+				},
+				TopicId:     topicId,
+				BlockHeight: blockHeight,
+			},
+		},
+	}
+
+	// Set up the last median and MAD for outlier detection
+	lastMedian := alloraMath.MustNewDecFromString("1.0")
+	mad := alloraMath.MustNewDecFromString("0.2")
+	err = keeper.SetLastMedianInferences(ctx, topicId, lastMedian)
+	require.NoError(err)
+	err = keeper.SetMadInferences(ctx, topicId, mad)
+	require.NoError(err)
+
+	// Set the outlier threshold in params (same as other test)
+	params, err := keeper.GetParams(ctx)
+	require.NoError(err)
+	params.InferenceOutlierDetectionThreshold = alloraMath.MustNewDecFromString("3.0") // 3 * MAD threshold
+	err = keeper.SetParams(ctx, params)
+	require.NoError(err)
+
+	// Call the function we're testing
+	err = actorutils.ProcessAndStoreNetworkInferences(&keeper, ctx, topicId, blockHeight, inferences, forecasts)
+	require.NoError(err)
+
+	// Retrieve both regular and outlier-resistant network inferences
+	regularInferences, err := keeper.GetNetworkInferences(ctx, topicId, blockHeight)
+	require.NoError(err)
+	outlierResistantInferences, err := keeper.GetOutlierResistantNetworkInferences(ctx, topicId, blockHeight)
+	require.NoError(err)
+
+	// Both should include all values
+	require.Equal(4, len(regularInferences.InfererValues))
+	require.Equal(4, len(outlierResistantInferences.InfererValues))
+
+	// Verify all workers are present in both results
+	regularWorkers := make(map[string]bool)
+	outlierWorkers := make(map[string]bool)
+
+	for _, infValue := range regularInferences.InfererValues {
+		regularWorkers[infValue.Worker] = true
+	}
+	for _, infValue := range outlierResistantInferences.InfererValues {
+		outlierWorkers[infValue.Worker] = true
+	}
+
+	require.Equal(regularWorkers, outlierWorkers, "Both results should contain the same workers")
+
+	// Verify the combined values are equal (within decimal precision)
+	require.True(
+		regularInferences.CombinedValue.Equal(outlierResistantInferences.CombinedValue),
+		"Regular and outlier-resistant combined values should be equal when there are no outliers",
+	)
 }

--- a/x/emissions/keeper/actor_utils/worker_test.go
+++ b/x/emissions/keeper/actor_utils/worker_test.go
@@ -488,10 +488,10 @@ func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesCatchesOutliers() 
 	require.NoError(err)
 
 	// Regular network inferences should include all values
-	require.Equal(4, len(regularInferences.InfererValues))
+	require.Len(regularInferences.InfererValues, 4)
 
 	// Outlier resistant network inferences should exclude worker3
-	require.Equal(3, len(outlierResistantInferences.InfererValues))
+	require.Len(outlierResistantInferences.InfererValues, 3)
 
 	// Verify worker3 is not in outlier resistant results
 	for _, infValue := range outlierResistantInferences.InfererValues {
@@ -643,8 +643,8 @@ func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesNoOutliers() {
 	require.NoError(err)
 
 	// Both should include all values
-	require.Equal(4, len(regularInferences.InfererValues))
-	require.Equal(4, len(outlierResistantInferences.InfererValues))
+	require.Len(regularInferences.InfererValues, 4)
+	require.Len(outlierResistantInferences.InfererValues, 4)
 
 	// Verify all workers are present in both results
 	regularWorkers := make(map[string]bool)

--- a/x/emissions/keeper/genesis.go
+++ b/x/emissions/keeper/genesis.go
@@ -993,7 +993,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 	// NetworkInferences
 	for _, networkInference := range data.NetworkInferences {
 		if networkInference != nil {
-			if err := k.InsertNetworkInference(ctx, networkInference.TopicId, networkInference.BlockHeight, *networkInference.ValueBundle); err != nil {
+			if err := k.InsertNetworkInferences(ctx, networkInference.TopicId, networkInference.BlockHeight, *networkInference.ValueBundle); err != nil {
 				return errors.Wrap(err, "error setting network inference")
 			}
 		}
@@ -1002,7 +1002,7 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) erro
 	// OutlierResistantNetworkInferences
 	for _, outlierResistantNetworkInference := range data.OutlierResistantNetworkInferences {
 		if outlierResistantNetworkInference != nil {
-			if err := k.InsertOutlierResistantNetworkInference(ctx, outlierResistantNetworkInference.TopicId, outlierResistantNetworkInference.BlockHeight, *outlierResistantNetworkInference.ValueBundle); err != nil {
+			if err := k.InsertOutlierResistantNetworkInferences(ctx, outlierResistantNetworkInference.TopicId, outlierResistantNetworkInference.BlockHeight, *outlierResistantNetworkInference.ValueBundle); err != nil {
 				return errors.Wrap(err, "error setting outlier resistant network inference")
 			}
 		}

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -45,13 +45,6 @@ func GetNetworkInferences(
 		ctx.Logger().Debug("Gradient cache cleared after network inference calculation")
 	}()
 
-	// Retrieve the requested inferences (either latest or specified, depending on inferencesNonce)
-	// If outlierResistant is true, outliers will be filtered out before calculating the network inference
-	// inferences, inferenceBlockHeight, err := getRequestedInferences(ctx, k, topicId, inferencesNonce, outlierResistant)
-	// if err != nil {
-	// 	return nil, errorsmod.Wrap(err, "while getting inferences")
-	// }
-
 	if len(inferences.Inferences) > 1 {
 		// If we have multiple inferences:
 		// 1. Try to get latest network loss

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -405,7 +405,7 @@ func (k *Keeper) GetBinaryCodec() codec.BinaryCodec {
 }
 
 // Insert a network inference for a topic at a block
-func (k *Keeper) InsertNetworkInference(ctx context.Context, topicId TopicId, blockHeight BlockHeight, bundle types.ValueBundle) error {
+func (k *Keeper) InsertNetworkInferences(ctx context.Context, topicId TopicId, blockHeight BlockHeight, bundle types.ValueBundle) error {
 	if err := types.ValidateTopicId(topicId); err != nil {
 		return errorsmod.Wrap(err, "topic id validation failed")
 	}
@@ -419,7 +419,7 @@ func (k *Keeper) InsertNetworkInference(ctx context.Context, topicId TopicId, bl
 }
 
 // Get Network Inferences
-func (k *Keeper) GetNetworkInference(ctx context.Context, topicId TopicId, blockHeight BlockHeight) (*types.ValueBundle, error) {
+func (k *Keeper) GetNetworkInferences(ctx context.Context, topicId TopicId, blockHeight BlockHeight) (*types.ValueBundle, error) {
 	key := collections.Join(topicId, blockHeight)
 	networkInferences, err := k.networkInferences.Get(ctx, key)
 	if errors.Is(err, collections.ErrNotFound) {
@@ -447,7 +447,7 @@ func (k *Keeper) GetNetworkInference(ctx context.Context, topicId TopicId, block
 	return &networkInferences, nil
 }
 
-func (k *Keeper) InsertOutlierResistantNetworkInference(ctx context.Context, topicId TopicId, blockHeight BlockHeight, bundle types.ValueBundle) error {
+func (k *Keeper) InsertOutlierResistantNetworkInferences(ctx context.Context, topicId TopicId, blockHeight BlockHeight, bundle types.ValueBundle) error {
 	if err := types.ValidateTopicId(topicId); err != nil {
 		return errorsmod.Wrap(err, "topic id validation failed")
 	}
@@ -461,7 +461,7 @@ func (k *Keeper) InsertOutlierResistantNetworkInference(ctx context.Context, top
 }
 
 // Get Outlier Resistant Network Inferences
-func (k *Keeper) GetOutlierResistantNetworkInference(ctx context.Context, topicId TopicId, blockHeight BlockHeight) (*types.ValueBundle, error) {
+func (k *Keeper) GetOutlierResistantNetworkInferences(ctx context.Context, topicId TopicId, blockHeight BlockHeight) (*types.ValueBundle, error) {
 	key := collections.Join(topicId, blockHeight)
 	networkInferences, err := k.outlierResistantNetworkInferences.Get(ctx, key)
 	if errors.Is(err, collections.ErrNotFound) {

--- a/x/emissions/keeper/queryserver/query_server_inferences.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences.go
@@ -82,7 +82,7 @@ func (qs queryServer) GetNetworkInferencesAtBlock(ctx context.Context, req *emis
 		return nil, status.Errorf(codes.NotFound, "network inference not available for topic %v", req.TopicId)
 	}
 
-	networkInferences, err := qs.k.GetNetworkInference(ctx, req.TopicId, req.BlockHeightLastInference)
+	networkInferences, err := qs.k.GetNetworkInferences(ctx, req.TopicId, req.BlockHeightLastInference)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (qs queryServer) GetNetworkInferencesAtBlockOutlierResistant(
 		return nil, status.Errorf(codes.NotFound, "network inference not available for topic %v", req.TopicId)
 	}
 
-	outlierResistantNetworkInferences, err := qs.k.GetOutlierResistantNetworkInference(ctx, req.TopicId, req.BlockHeightLastInference)
+	outlierResistantNetworkInferences, err := qs.k.GetOutlierResistantNetworkInferences(ctx, req.TopicId, req.BlockHeightLastInference)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/keeper/queryserver/query_server_inferences_test.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences_test.go
@@ -475,7 +475,7 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferences() {
 		false,
 	)
 	require.NoError(err)
-	err = keeper.InsertNetworkInference(s.ctx, topicId, inferenceNonce.BlockHeight, *networkInferences.NetworkInferences)
+	err = keeper.InsertNetworkInferences(s.ctx, topicId, inferenceNonce.BlockHeight, *networkInferences.NetworkInferences)
 	require.NoError(err)
 
 	// Test querying the server


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Do not recalculate outlier-resistant version of network inferences if no outliers.
* Refactor network inference code into function, added two unit tests w and w/o outliers
* Refactor function names to align
* Other cleaning


## Link(s) to Ticket(s) or Issue(s) resolved by this PR
ENGN-3588

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- current unit tests and added new ones
- [x] If documented, please describe where. If not, describe why docs are not needed. -- no need, optim + refactor
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

