### PR TITLE
fix windows build target in build-all-platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#760](https://github.com/allora-network/allora-chain/pull/760) Fix topic low-weight inactive topic weight vulnerability
 * [#771](https://github.com/allora-network/allora-chain/pull/771) Fix reputer/worker window boundaries
 * [#782](https://github.com/allora-network/allora-chain/pull/782) More efficient logging, added check-log-sprintf linter
+* [#785](https://github.com/allora-network/allora-chain/pull/785) Fix Windows build target in build-all-platforms to generate distinct output files for Windows AMD64 and ARM64
 
 ### Security
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ build-all-platforms:
 	GOOS=darwin GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_darwin_amd64 github.com/allora-network/allora-chain/cmd/allorad
 	GOOS=darwin GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_darwin_arm64 github.com/allora-network/allora-chain/cmd/allorad
 	GOOS=windows GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_windows_amd64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=windows GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_windows_amd64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=windows GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_windows_arm64 github.com/allora-network/allora-chain/cmd/allorad
 
 lint:
 	@echo "--> Running linter"


### PR DESCRIPTION
## Purpose of Changes and their Description

This PR fixes a problem with the Makefile's `build-all-platforms` target. The ARM64 binary overwrote the AMD64 binary because the Windows ARM64 build was being output to the same file as the Windows AMD64 build (`$(BUILDDIR)/allorad_windows_amd64`). 

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

None

## Are these changes tested and documented?

- [x] **Tested:**  
  Locally confirmed by executing `make build-all-platforms` and verifying that both `allorad_windows_arm64` (for Windows ARM64) and `allorad_windows_amd64` (for Windows AMD64) are present in the build directory.

- [x] **Documented:**  
  Enough context is given by the commit message and Makefile comments. No other paperwork is needed.

- [x] **CHANGELOG.md:**  
  
  
## Still Left Todo

None
