### PR TITLE
Fix: ln calculation determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#771](https://github.com/allora-network/allora-chain/pull/771) Fix reputer/worker window boundaries
 * [#782](https://github.com/allora-network/allora-chain/pull/782) More efficient logging, added check-log-sprintf linter
 * [#784](https://github.com/allora-network/allora-chain/pull/784) Optimize: do not recalc outlier-resistant network inferences if no outliers
+* [#789](https://github.com/allora-network/allora-chain/pull/789) Fix natural logarithm undeterministic calculation 
 
 ### Security
 

--- a/math/dec.go
+++ b/math/dec.go
@@ -66,7 +66,7 @@ func init() {
 		panic(err)
 	}
 	b.Coeff.Mul(&b.Coeff, apd.NewBigInt(10).Exp(apd.NewBigInt(10), apd.NewBigInt(int64(dec128Context.Precision+1)), nil))
-	b.Exponent -= int32(dec128Context.Precision + 1)
+	b.Exponent -= int32(dec128Context.Precision + 1) //nolint:gosec // we must panic if this overflows anyway
 	log2B = *b
 }
 
@@ -445,7 +445,7 @@ func Log2(x Dec) (Dec, error) {
 	if precDelta > 0 && int64(xCopy.Exponent)-precDelta >= goMath.MinInt32 {
 		ten := apd.NewBigInt(10)
 		xCopy.Coeff.Mul(&xCopy.Coeff, ten.Exp(ten, apd.NewBigInt(precDelta), nil))
-		xCopy.Exponent -= int32(precDelta)
+		xCopy.Exponent -= int32(precDelta) //nolint:gosec // potential overflow already checked above
 	}
 
 	yBig := apd.NewBigInt(0)
@@ -455,11 +455,9 @@ func Log2(x Dec) (Dec, error) {
 		yBig.Sub(yBig, oneBigInt)
 	}
 
-	if xCopy.Cmp(twoDec) >= 0 {
-		for xCopy.Cmp(twoDec) >= 0 {
-			xCopy.Coeff.Rsh(&xCopy.Coeff, 1)
-			yBig.Add(yBig, oneBigInt)
-		}
+	for xCopy.Cmp(twoDec) >= 0 {
+		xCopy.Coeff.Rsh(&xCopy.Coeff, 1)
+		yBig.Add(yBig, oneBigInt)
 	}
 
 	var b apd.Decimal
@@ -483,7 +481,7 @@ func Log2(x Dec) (Dec, error) {
 		b.Coeff.Rsh(&b.Coeff, 1)
 	}
 
-	return Dec{dec: *y}, nil
+	return Dec{dec: *y, isNaN: false}, nil
 }
 
 // Exp returns a new Dec with the value of e^x, without mutating x.

--- a/math/dec.go
+++ b/math/dec.go
@@ -65,8 +65,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	b.Coeff.Mul(&b.Coeff, apd.NewBigInt(10).Exp(apd.NewBigInt(10), apd.NewBigInt(int64(dec128Context.Precision+1)), nil))
-	b.Exponent -= int32(dec128Context.Precision + 1) //nolint:gosec // we must panic if this overflows anyway
+	enforceDecimalPrecision(b, dec128Context.Precision+1)
 	log2B = *b
 }
 
@@ -437,16 +436,12 @@ func Log2(x Dec) (Dec, error) {
 	var xCopy apd.Decimal
 	xCopy.Set(&x.dec)
 
-	// As we'll make divisions by 2 through bit right shift, we need to make sure we have enough digit precision in the coeff.
+	// As we'll make divisions by 2 through bit right shift, we need to make sure we have enough decimal digit precision
+	// in the coeff.
 	// For example:
 	// Taking a 2.12 dec represented by {coeff: 212, exp: -2}
 	// It is here transformed to {coeff: 212000000000000000000000000000000000, exp: -35}
-	precDelta := int64(decCtx.Precision) + min(int64(xCopy.Exponent), 0)
-	if precDelta > 0 && int64(xCopy.Exponent)-precDelta >= goMath.MinInt32 {
-		ten := apd.NewBigInt(10)
-		xCopy.Coeff.Mul(&xCopy.Coeff, ten.Exp(ten, apd.NewBigInt(precDelta), nil))
-		xCopy.Exponent -= int32(precDelta) //nolint:gosec // potential overflow already checked above
-	}
+	enforceDecimalPrecision(&xCopy, decCtx.Precision)
 
 	yBig := apd.NewBigInt(0)
 
@@ -912,11 +907,7 @@ func (x Dec) IsFinite() bool {
 
 // NumDecimalPlaces returns the number of decimal places in x.
 func (x Dec) NumDecimalPlaces() uint32 {
-	exp := x.dec.Exponent
-	if exp >= 0 {
-		return 0
-	}
-	return uint32(-exp)
+	return decimalPlaces(&x.dec)
 }
 
 // Reduce returns a copy of x with all trailing zeros removed and the number
@@ -925,4 +916,18 @@ func (x Dec) Reduce() (Dec, int) {
 	y := ZeroDec()
 	_, n := y.dec.Reduce(&x.dec)
 	return y, n
+}
+
+// enforceDecimalPrecision mutably enforce a decimal digit precision.
+func enforceDecimalPrecision(d *apd.Decimal, precision uint32) {
+	precDelta := int64(precision - decimalPlaces(d))
+	if precDelta > 0 && int64(d.Exponent)-precDelta >= goMath.MinInt32 {
+		ten := apd.NewBigInt(10)
+		d.Coeff.Mul(&d.Coeff, ten.Exp(ten, apd.NewBigInt(precDelta), nil))
+		d.Exponent -= int32(precDelta) //nolint:gosec // potential overflow already checked above
+	}
+}
+
+func decimalPlaces(d *apd.Decimal) uint32 {
+	return uint32(-min(d.Exponent, 0))
 }

--- a/math/dec.go
+++ b/math/dec.go
@@ -50,14 +50,38 @@ var (
 	ErrOutOfRange         = errorsmod.Register(mathCodespace, 8, "value is out of range")
 )
 
+var (
+	logOfEbase2 = MustNewDecFromString("1.442695040888963407359924681001892137")
+	// 0.5 with sufficient precision digit to allow right shifting keeping dec128 precision
+	log2B     apd.Decimal
+	oneBigInt = apd.NewBigInt(1)
+	zeroDec   = apd.New(0, 0)
+	oneDec    = apd.New(1, 0)
+	twoDec    = apd.New(2, 0)
+)
+
+func init() {
+	b, _, err := apd.NewFromString("0.5")
+	if err != nil {
+		panic(err)
+	}
+	b.Coeff.Mul(&b.Coeff, apd.NewBigInt(10).Exp(apd.NewBigInt(10), apd.NewBigInt(int64(dec128Context.Precision+1)), nil))
+	b.Exponent -= int32(dec128Context.Precision + 1)
+	log2B = *b
+}
+
 // The number 0 encoded as Dec
 func ZeroDec() Dec {
-	return NewDecFromInt64(0)
+	var d apd.Decimal
+	d.Set(zeroDec)
+	return Dec{dec: d, isNaN: false}
 }
 
 // The number 1 encoded as Dec
 func OneDec() Dec {
-	return NewDecFromInt64(1)
+	var d apd.Decimal
+	d.Set(oneDec)
+	return Dec{dec: d, isNaN: false}
 }
 
 // In cosmos-sdk#7773, decimal128 (with 34 digits of precision) was suggested for performing
@@ -388,18 +412,78 @@ func Log10(x Dec) (Dec, error) {
 
 // Ln returns a new Dec with the value of the natural logarithm of x, without mutating x.
 func Ln(x Dec) (Dec, error) {
-	if x.IsNaN() {
-		return Dec{}, errorsmod.Wrapf(ErrNaN, "cannot Ln a NaN %s", x.String())
-	}
-	var z Dec
-	_, err := dec128Context.Ln(&z.dec, &x.dec)
-	if z.IsNaN() {
-		return z, errorsmod.Wrapf(ErrNaN, "Ln result is NaN %s", x.String())
-	}
+	log2x, err := Log2(x)
 	if err != nil {
-		return z, errorsmod.Wrapf(err, "decimal natural logarithm error %s", x.String())
+		return Dec{}, errorsmod.Wrap(ErrNaN, "decimal natural logarithm error")
 	}
-	return z, nil
+
+	return log2x.Quo(logOfEbase2)
+}
+
+// Log2 returns a new Dec with the value of the base 2 logarithm of x, without mutating x.
+// It implements the algorithm described in http://www.claysturner.com/dsp/binarylogarithm.pdf
+// And inspired from Osmosis implementation: https://github.com/osmosis-labs/osmosis/blob/927d940cf569e25e5a21911a77d5c81a0c5a0dc6/osmomath/decimal.go#L1070
+func Log2(x Dec) (Dec, error) {
+	if x.IsNaN() {
+		return Dec{}, errorsmod.Wrapf(ErrNaN, "cannot Log2 a NaN %s", x.String())
+	}
+	if x.dec.Sign() < 0 {
+		return Dec{}, errorsmod.Wrap(ErrNaN, "cannot Log2 a negative value")
+	}
+
+	// Increase precision for result accuracy.
+	decCtx := dec128Context.WithPrecision(dec128Context.Precision + 1)
+
+	var xCopy apd.Decimal
+	xCopy.Set(&x.dec)
+
+	// As we'll make divisions by 2 through bit right shift, we need to make sure we have enough digit precision in the coeff.
+	// For example:
+	// Taking a 2.12 dec represented by {coeff: 212, exp: -2}
+	// It is here transformed to {coeff: 212000000000000000000000000000000000, exp: -35}
+	precDelta := int64(decCtx.Precision) + min(int64(xCopy.Exponent), 0)
+	if precDelta > 0 && int64(xCopy.Exponent)-precDelta >= goMath.MinInt32 {
+		ten := apd.NewBigInt(10)
+		xCopy.Coeff.Mul(&xCopy.Coeff, ten.Exp(ten, apd.NewBigInt(precDelta), nil))
+		xCopy.Exponent -= int32(precDelta)
+	}
+
+	yBig := apd.NewBigInt(0)
+
+	for xCopy.Cmp(oneDec) == -1 {
+		xCopy.Coeff.Lsh(&xCopy.Coeff, 1)
+		yBig.Sub(yBig, oneBigInt)
+	}
+
+	if xCopy.Cmp(twoDec) >= 0 {
+		for xCopy.Cmp(twoDec) >= 0 {
+			xCopy.Coeff.Rsh(&xCopy.Coeff, 1)
+			yBig.Add(yBig, oneBigInt)
+		}
+	}
+
+	var b apd.Decimal
+	b.Set(&log2B)
+	y := apd.NewWithBigInt(yBig, 0)
+
+	// The more iterations, the more accurate the result.
+	// 200 iterations seems enough for 34 precision when not too close from log limits.
+	for i := 0; i < 200; i++ {
+		_, err := decCtx.Mul(&xCopy, &xCopy, &xCopy)
+		if err != nil {
+			return Dec{}, errorsmod.Wrap(ErrNaN, "decimal binary logarithm error")
+		}
+		if xCopy.Cmp(twoDec) >= 0 {
+			xCopy.Coeff.Rsh(&xCopy.Coeff, 1)
+			_, err = apd.BaseContext.Add(y, y, &b)
+			if err != nil {
+				return Dec{}, errorsmod.Wrap(ErrNaN, "decimal binary logarithm error")
+			}
+		}
+		b.Coeff.Rsh(&b.Coeff, 1)
+	}
+
+	return Dec{dec: *y}, nil
 }
 
 // Exp returns a new Dec with the value of e^x, without mutating x.

--- a/math/dec.go
+++ b/math/dec.go
@@ -55,6 +55,7 @@ var (
 	// 0.5 with sufficient precision digit to allow right shifting keeping dec128 precision
 	log2B     apd.Decimal
 	oneBigInt = apd.NewBigInt(1)
+	tenBigInt = apd.NewBigInt(10)
 	zeroDec   = apd.New(0, 0)
 	oneDec    = apd.New(1, 0)
 	twoDec    = apd.New(2, 0)
@@ -922,8 +923,8 @@ func (x Dec) Reduce() (Dec, int) {
 func enforceDecimalPrecision(d *apd.Decimal, precision uint32) {
 	precDelta := int64(precision - decimalPlaces(d))
 	if precDelta > 0 && int64(d.Exponent)-precDelta >= goMath.MinInt32 {
-		ten := apd.NewBigInt(10)
-		d.Coeff.Mul(&d.Coeff, ten.Exp(ten, apd.NewBigInt(precDelta), nil))
+		var exp apd.BigInt
+		d.Coeff.Mul(&d.Coeff, exp.Exp(tenBigInt, apd.NewBigInt(precDelta), nil))
 		d.Exponent -= int32(precDelta) //nolint:gosec // potential overflow already checked above
 	}
 }

--- a/math/dec.go
+++ b/math/dec.go
@@ -66,7 +66,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	enforceDecimalPrecision(b, dec128Context.Precision+1)
+	enforceDecimalPrecision(b, dec128Context.Precision+2)
 	log2B = *b
 }
 
@@ -427,12 +427,12 @@ func Log2(x Dec) (Dec, error) {
 	if x.IsNaN() {
 		return Dec{}, errorsmod.Wrapf(ErrNaN, "cannot Log2 a NaN %s", x.String())
 	}
-	if x.dec.Sign() < 0 {
-		return Dec{}, errorsmod.Wrap(ErrNaN, "cannot Log2 a negative value")
+	if x.dec.Sign() <= 0 {
+		return Dec{}, errorsmod.Wrap(ErrNaN, "cannot Log2 a non positive value")
 	}
 
 	// Increase precision for result accuracy.
-	decCtx := dec128Context.WithPrecision(dec128Context.Precision + 1)
+	decCtx := dec128Context.WithPrecision(dec128Context.Precision + 2)
 
 	var xCopy apd.Decimal
 	xCopy.Set(&x.dec)

--- a/math/dec_bench_test.go
+++ b/math/dec_bench_test.go
@@ -20,7 +20,10 @@ func BenchmarkLn(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 		for _, test := range tests {
-			alloramath.Ln(test)
+			_, err := alloramath.Ln(test)
+			if err != nil {
+				b.Fatal(err)
+			}
 		}
 		b.StopTimer()
 	}

--- a/math/dec_bench_test.go
+++ b/math/dec_bench_test.go
@@ -1,0 +1,27 @@
+package math_test
+
+import (
+	"testing"
+
+	alloramath "github.com/allora-network/allora-chain/math"
+)
+
+func BenchmarkLn(b *testing.B) {
+	tests := []alloramath.Dec{
+		alloramath.MustNewDecFromString("1.2"),
+		alloramath.MustNewDecFromString("1.234"),
+		alloramath.MustNewDecFromString("1024"),
+		alloramath.NewDecFromInt64(2048 * 2048 * 2048 * 2048 * 2048),
+		alloramath.MustNewDecFromString("999999999999999999999999999999999999999999999999999999.9122181273612911"),
+		alloramath.MustNewDecFromString("0.5632892391219024912482190471290471"),
+		alloramath.MustNewDecFromString("0.0000000391219024912482190471290471"),
+	}
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for _, test := range tests {
+			alloramath.Ln(test)
+		}
+		b.StopTimer()
+	}
+}

--- a/math/dec_internal_test.go
+++ b/math/dec_internal_test.go
@@ -1,0 +1,72 @@
+package math
+
+import (
+	goMath "math"
+	"testing"
+
+	"github.com/cockroachdb/apd/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnforceDecimalPrecision(t *testing.T) {
+	testCases := []struct {
+		name      string
+		precision uint32
+		before    *apd.Decimal
+		after     *apd.Decimal
+	}{
+		{
+			name:      "no precision",
+			precision: 0,
+			before:    apd.New(1, 0), // 1
+			after:     apd.New(1, 0),
+		},
+		{
+			name:      "no decimals",
+			precision: 5,
+			before:    apd.New(1, 0), // 1
+			after:     apd.New(100000, -5),
+		},
+		{
+			name:      "no decimals but not 1",
+			precision: 5,
+			before:    apd.New(12345, 0), // 12345
+			after:     apd.New(1234500000, -5),
+		},
+		{
+			name:      "with decimals",
+			precision: 5,
+			before:    apd.New(1, -3), // 0.001
+			after:     apd.New(100, -5),
+		},
+		{
+			name:      "already at precision",
+			precision: 5,
+			before:    apd.New(1, -5), // 0.00001
+			after:     apd.New(1, -5),
+		},
+		{
+			name:      "overprecise, don't reduce precision",
+			precision: 5,
+			before:    apd.New(1, -10), // 0.0000000001
+			after:     apd.New(1, -10),
+		},
+		{
+			name:      "would overflow, don't touch",
+			precision: goMath.MaxUint32,
+			before:    apd.New(1, -5),
+			after:     apd.New(1, -5),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.before
+			enforceDecimalPrecision(r, tc.precision)
+			require.Equal(t, tc.after.Coeff, r.Coeff)
+			require.Equal(t, tc.after.Exponent, r.Exponent)
+			require.Equal(t, tc.after.Form, r.Form)
+			require.Equal(t, tc.after.Negative, r.Negative)
+		})
+	}
+}

--- a/math/dec_test.go
+++ b/math/dec_test.go
@@ -177,9 +177,15 @@ func TestDec(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, zero.Equal(logEOne))
 
+	// See https://github.com/allora-network/allora-chain/pull/789
 	logDeterminism, err := alloraMath.Ln(alloraMath.MustNewDecFromString("1.6285091944505809264504560045920167"))
 	require.NoError(t, err)
 	require.True(t, alloraMath.MustNewDecFromString("0.4876649916811116824516548471782886").Equal(logDeterminism))
+
+	_, err = alloraMath.Ln(alloraMath.MustNewDecFromString("-1"))
+	require.Error(t, err)
+	_, err = alloraMath.Ln(alloraMath.MustNewDecFromString("0"))
+	require.Error(t, err)
 
 	eight := alloraMath.NewDecFromInt64(8)
 	twoCubed, err := alloraMath.Pow(two, three)

--- a/math/dec_test.go
+++ b/math/dec_test.go
@@ -177,6 +177,10 @@ func TestDec(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, zero.Equal(logEOne))
 
+	logDeterminism, err := alloraMath.Ln(alloraMath.MustNewDecFromString("1.6285091944505809264504560045920167"))
+	require.NoError(t, err)
+	require.True(t, alloraMath.MustNewDecFromString("0.4876649916811116824516548471782886").Equal(logDeterminism))
+
 	eight := alloraMath.NewDecFromInt64(8)
 	twoCubed, err := alloraMath.Pow(two, three)
 	require.NoError(t, err)


### PR DESCRIPTION
## Purpose of Changes and their Description

This fixes the natural logarithmic calculation non-deterministic behaviour by switching from [apd](https://github.com/cockroachdb/apd)'s implementation to a custom one.

For instance with the following snippet using apd:

```go
var dec128Context = &apd.Context{
	Precision:   34,
	MaxExponent: apd.MaxExponent,
	MinExponent: apd.MinExponent,
	Traps:       apd.DefaultTraps,
	Rounding:    apd.RoundDown,
}
i, _, _ := apd.NewFromString("1.6285091944505809264504560045920167")
var r apd.Decimal
dec128Context.Ln(&r, i)
fmt.Println(r.String())
```

It outputs to `0.4876649916811116824516548471782886` on arm64 and `0.4876649916811116824516548471782887` on amd64, which can cause app hash mismatch.

The root cause is that apd in some cases uses a first approximation with the standard `math.Log()` which is platform dependent, I've raised an [issue](https://github.com/cockroachdb/apd/issues/141) on apd.

To solve the issue I've followed a similar strategy to [Osmosis](https://github.com/osmosis-labs/osmosis/blob/927d940cf569e25e5a21911a77d5c81a0c5a0dc6/osmomath/decimal.go#L1070) by implementing the binary logarithm algorithm described [here](http://www.claysturner.com/dsp/binarylogarithm.pdf), with some adaptations to make it work with `apd.Decimal`. The natural logarithm is then derived from it.

The precision seems to slightly differ from apd's implementation but in the order of `1ulp` on non close to limits values.

I've added some benchmark, and here's the benchmark results comparing with old `apd` implementation:

```
goos: darwin
goarch: arm64
pkg: github.com/allora-network/allora-chain/math
cpu: Apple M3 Pro
BenchmarkLnAPD
BenchmarkLnAPD-12    	    2455	    423923 ns/op	  369017 B/op	    7118 allocs/op
BenchmarkLn
BenchmarkLn-12       	    1916	    604703 ns/op	  593910 B/op	   11306 allocs/op
PASS
```

It is much slower with more allocations, this seems not to be used intensively in the codebase so I'd tend to consider it ok. There's some perf improvements that can be made using different approaches of ln calculation though.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?