### PR TITLE
Add integration test for topic distribution

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -41,6 +41,8 @@ func TestExternalTestSuite(t *testing.T) {
 	TopicFundingChecks(testConfig)
 	t.Log(">>> Test Making Inference <<<")
 	WorkerInferenceAndForecastChecks(testConfig)
+	t.Log(">>> Test Topic Weight Distribution <<<")
+	TopicWeightDistributionChecks(testConfig)
 	t.Log(">>> Test Reputer Un-Staking <<<")
 	UnstakingChecks(testConfig)
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -39,10 +39,10 @@ func TestExternalTestSuite(t *testing.T) {
 	StakingChecks(testConfig)
 	t.Log(">>> Test Topic Funding and Activation <<<")
 	TopicFundingChecks(testConfig)
-	t.Log(">>> Test Making Inference <<<")
-	WorkerInferenceAndForecastChecks(testConfig)
 	t.Log(">>> Test Topic Weight Distribution <<<")
 	TopicWeightDistributionChecks(testConfig)
+	t.Log(">>> Test Making Inference <<<")
+	WorkerInferenceAndForecastChecks(testConfig)
 	t.Log(">>> Test Reputer Un-Staking <<<")
 	UnstakingChecks(testConfig)
 }

--- a/test/integration/topic_distribution_test.go
+++ b/test/integration/topic_distribution_test.go
@@ -2,9 +2,6 @@ package integration_test
 
 import (
 	"context"
-	// "time"
-
-	// "fmt" // Removed unused import
 
 	cosmosMath "cosmossdk.io/math"
 	"github.com/allora-network/allora-chain/app/params"
@@ -106,8 +103,6 @@ func TopicWeightDistributionChecks(m testCommon.TestConfig) {
 		topic2Weights.Weight.String(),
 	)
 	m.T.Log("Topic previous weights are equal as expected.")
-
-	_ = ctx // Use ctx to avoid unused variable error for now
 }
 
 // Helper function to register an actor (worker or reputer) in a topic
@@ -118,7 +113,7 @@ func registerActor(m testCommon.TestConfig, account cosmosaccount.Account, topic
 
 	registerRequest := &types.RegisterRequest{
 		Sender:    addr,
-		Owner:     addr, // Assuming owner is the same as sender for simplicity
+		Owner:     addr,
 		TopicId:   topicId,
 		IsReputer: isReputer,
 	}
@@ -126,7 +121,7 @@ func registerActor(m testCommon.TestConfig, account cosmosaccount.Account, topic
 	require.NoError(m.T, err)
 	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	require.NoError(m.T, err)
-	registerResponse := &types.RegisterResponse{}
+	registerResponse := &types.RegisterResponse{} //nolint:exhaustruct // the fields are populated by decode
 	err = txResp.Decode(registerResponse)
 	require.NoError(m.T, err)
 	require.True(m.T, registerResponse.Success)
@@ -137,10 +132,6 @@ func addStake(m testCommon.TestConfig, account cosmosaccount.Account, topicId ui
 	ctx := context.Background()
 	addr, err := account.Address(params.HumanCoinUnit)
 	require.NoError(m.T, err)
-
-	// Ensure the reputer is whitelisted for the topic first
-	// Need to check if EnableReputerWhitelist is true for the topic first, but simplifying for now
-	// addTopicReputerWhitelist(m, addr, topicId)
 
 	addStakeRequest := &types.AddStakeRequest{
 		Sender:  addr,
@@ -196,7 +187,7 @@ func createTestTopic(m testCommon.TestConfig, creator string, metadata string, e
 	require.NoError(m.T, err)
 	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
 	require.NoError(m.T, err)
-	createTopicResponse := &types.CreateNewTopicResponse{}
+	createTopicResponse := &types.CreateNewTopicResponse{} //nolint:exhaustruct // the fields are populated by decode
 	err = txResp.Decode(createTopicResponse)
 	require.NoError(m.T, err)
 	return createTopicResponse.TopicId
@@ -205,15 +196,14 @@ func createTestTopic(m testCommon.TestConfig, creator string, metadata string, e
 // Helper function to fund a topic
 func fundTestTopic(m testCommon.TestConfig, funderAcc cosmosaccount.Account, topicId uint64, amount int64) {
 	ctx := context.Background()
-	// Get the sender address string from the account
 	funderAddr, err := funderAcc.Address(params.HumanCoinUnit)
 	require.NoError(m.T, err)
 
 	txResp, err := m.Client.BroadcastTx(
 		ctx,
-		funderAcc, // Use the provided account info
+		funderAcc,
 		&types.FundTopicRequest{
-			Sender:  funderAddr, // Use the derived address string
+			Sender:  funderAddr,
 			TopicId: topicId,
 			Amount:  cosmosMath.NewInt(amount),
 		},

--- a/test/integration/topic_distribution_test.go
+++ b/test/integration/topic_distribution_test.go
@@ -1,0 +1,227 @@
+package integration_test
+
+import (
+	"context"
+	// "time"
+
+	// "fmt" // Removed unused import
+
+	cosmosMath "cosmossdk.io/math"
+	"github.com/allora-network/allora-chain/app/params"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	testCommon "github.com/allora-network/allora-chain/test/common"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+	"github.com/ignite/cli/v28/ignite/pkg/cosmosaccount"
+	"github.com/stretchr/testify/require"
+)
+
+// TopicWeightDistributionChecks tests that topic weights are distributed correctly
+// even when topics have different epoch lengths.
+func TopicWeightDistributionChecks(m testCommon.TestConfig) {
+	ctx := context.Background()
+
+	m.T.Log("--- Creating Topics for Weight Distribution Test ---")
+	// Allow Alice to create topics
+	addTopicCreator(m, m.AliceAddr)
+
+	// Topic 1: Short Epoch Length
+	topic1Id := createTestTopic(m, m.AliceAddr, "Topic 1 - Short Epoch", 10) // Example Epoch Length: 10
+	m.T.Logf("Created Topic 1 with ID: %d and Epoch Length: 10", topic1Id)
+
+	// Topic 2: Long Epoch Length
+	topic2Id := createTestTopic(m, m.AliceAddr, "Topic 2 - Long Epoch", 20) // Example Epoch Length: 20
+	m.T.Logf("Created Topic 2 with ID: %d and Epoch Length: 20", topic2Id)
+
+	m.T.Log("--- Funding Topics for Weight Distribution Test ---")
+	// Fund Topic 1
+	fundTestTopic(m, m.BobAcc, topic1Id, 10000)
+	// Fund Topic 2
+	fundTestTopic(m, m.BobAcc, topic2Id, 10000)
+
+	m.T.Log("--- Registering Participants for Weight Distribution Test ---")
+	// Register Bob as Worker in Topic 1
+	registerActor(m, m.BobAcc, topic1Id, false)
+	m.T.Logf("Registered Bob as Worker in Topic %d", topic1Id)
+	// Register Bob as Worker in Topic 2
+	registerActor(m, m.BobAcc, topic2Id, false)
+	m.T.Logf("Registered Bob as Worker in Topic %d", topic2Id)
+
+	// Register Alice as Reputer in Topic 1
+	registerActor(m, m.AliceAcc, topic1Id, true)
+	m.T.Logf("Registered Alice as Reputer in Topic %d", topic1Id)
+	// Register Alice as Reputer in Topic 2
+	registerActor(m, m.AliceAcc, topic2Id, true)
+	m.T.Logf("Registered Alice as Reputer in Topic %d", topic2Id)
+
+	m.T.Log("--- Staking Participants for Weight Distribution Test ---")
+	const stakeAmount = 1000000
+	const delegateStakeAmount = 200000
+	// Alice stakes in Topic 1
+	addStake(m, m.AliceAcc, topic1Id, stakeAmount)
+	m.T.Logf("Alice staked %d in Topic %d", stakeAmount, topic1Id)
+	// Alice stakes in Topic 2
+	addStake(m, m.AliceAcc, topic2Id, stakeAmount)
+	m.T.Logf("Alice staked %d in Topic %d", stakeAmount, topic2Id)
+
+	// Bob delegates stake to Alice in Topic 1
+	addDelegateStake(m, m.BobAcc, m.AliceAddr, topic1Id, delegateStakeAmount)
+	m.T.Logf("Bob delegated %d to Alice in Topic %d", delegateStakeAmount, topic1Id)
+	// Bob delegates stake to Alice in Topic 2
+	addDelegateStake(m, m.BobAcc, m.AliceAddr, topic2Id, delegateStakeAmount)
+	m.T.Logf("Bob delegated %d to Alice in Topic %d", delegateStakeAmount, topic2Id)
+
+	m.T.Log("--- Waiting for Epoch End and Checking Weights for Weight Distribution Test ---")
+	// Wait for the next epoch end for Topic 1
+	m.T.Logf("Waiting for next churning block for Topic %d", topic1Id)
+	updatedTopic1, err := waitForNextChurningBlock(m, topic1Id)
+	require.NoError(m.T, err)
+	m.T.Logf("Epoch ended for Topic %d at block %d", topic1Id, updatedTopic1.EpochLastEnded)
+
+	// Query weights for Topic 1 (using previous weight after epoch end)
+	m.T.Logf("Querying previous weights for Topic %d", topic1Id)
+	topic1Weights, err := m.Client.QueryEmissions().GetPreviousTopicWeight(ctx, &types.GetPreviousTopicWeightRequest{TopicId: topic1Id})
+	require.NoError(m.T, err)
+	require.NotNil(m.T, topic1Weights, "Weights for topic 1 should not be nil")
+	m.T.Logf("Topic %d Previous Weight: %s", topic1Id, topic1Weights.Weight.String())
+
+	m.T.Logf("Waiting for next churning block for Topic %d", topic2Id)
+	updatedTopic2, err := waitForNextChurningBlock(m, topic2Id)
+	require.NoError(m.T, err)
+	m.T.Logf("Epoch ended for Topic %d at block %d", topic2Id, updatedTopic2.EpochLastEnded)
+
+	// Query weights for Topic 2 (using previous weight after epoch end)
+	m.T.Logf("Querying previous weights for Topic %d", topic2Id)
+	topic2Weights, err := m.Client.QueryEmissions().GetPreviousTopicWeight(ctx, &types.GetPreviousTopicWeightRequest{TopicId: topic2Id})
+	require.NoError(m.T, err)
+	require.NotNil(m.T, topic2Weights, "Weights for topic 2 should not be nil")
+	m.T.Logf("Topic %d Previous Weight: %s", topic2Id, topic2Weights.Weight.String())
+
+	// Assert weights are equal
+	m.T.Logf("Comparing previous weights for Topic %d and Topic %d", topic1Id, topic2Id)
+	require.True(
+		m.T,
+		topic1Weights.Weight.Equal(topic2Weights.Weight),
+		"Topic previous weights should be equal after one epoch of the shorter topic. Topic 1: %s, Topic 2: %s",
+		topic1Weights.Weight.String(),
+		topic2Weights.Weight.String(),
+	)
+	m.T.Log("Topic previous weights are equal as expected.")
+
+	_ = ctx // Use ctx to avoid unused variable error for now
+}
+
+// Helper function to register an actor (worker or reputer) in a topic
+func registerActor(m testCommon.TestConfig, account cosmosaccount.Account, topicId uint64, isReputer bool) {
+	ctx := context.Background()
+	addr, err := account.Address(params.HumanCoinUnit)
+	require.NoError(m.T, err)
+
+	registerRequest := &types.RegisterRequest{
+		Sender:    addr,
+		Owner:     addr, // Assuming owner is the same as sender for simplicity
+		TopicId:   topicId,
+		IsReputer: isReputer,
+	}
+	txResp, err := m.Client.BroadcastTx(ctx, account, registerRequest)
+	require.NoError(m.T, err)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
+	require.NoError(m.T, err)
+	registerResponse := &types.RegisterResponse{}
+	err = txResp.Decode(registerResponse)
+	require.NoError(m.T, err)
+	require.True(m.T, registerResponse.Success)
+}
+
+// Helper function to add stake for a reputer in a topic
+func addStake(m testCommon.TestConfig, account cosmosaccount.Account, topicId uint64, amount int64) {
+	ctx := context.Background()
+	addr, err := account.Address(params.HumanCoinUnit)
+	require.NoError(m.T, err)
+
+	// Ensure the reputer is whitelisted for the topic first
+	// Need to check if EnableReputerWhitelist is true for the topic first, but simplifying for now
+	// addTopicReputerWhitelist(m, addr, topicId)
+
+	addStakeRequest := &types.AddStakeRequest{
+		Sender:  addr,
+		TopicId: topicId,
+		Amount:  cosmosMath.NewInt(amount),
+	}
+	txResp, err := m.Client.BroadcastTx(ctx, account, addStakeRequest)
+	require.NoError(m.T, err)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
+	require.NoError(m.T, err)
+}
+
+// Helper function to add delegate stake for a delegator on a reputer in a topic
+func addDelegateStake(m testCommon.TestConfig, delegatorAccount cosmosaccount.Account, reputerAddr string, topicId uint64, amount int64) {
+	ctx := context.Background()
+	delegatorAddr, err := delegatorAccount.Address(params.HumanCoinUnit)
+	require.NoError(m.T, err)
+
+	addDelegateStakeRequest := &types.DelegateStakeRequest{
+		Sender:  delegatorAddr,
+		Reputer: reputerAddr,
+		TopicId: topicId,
+		Amount:  cosmosMath.NewInt(amount),
+	}
+	txResp, err := m.Client.BroadcastTx(ctx, delegatorAccount, addDelegateStakeRequest)
+	require.NoError(m.T, err)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
+	require.NoError(m.T, err)
+}
+
+// Helper function to create a topic with a specific epoch length
+func createTestTopic(m testCommon.TestConfig, creator string, metadata string, epochLength int64) uint64 {
+	ctx := context.Background()
+	createTopicRequest := &types.CreateNewTopicRequest{
+		Creator:                  creator,
+		Metadata:                 metadata,
+		LossMethod:               "mse",
+		EpochLength:              epochLength, // Use the provided epoch length
+		GroundTruthLag:           epochLength,
+		WorkerSubmissionWindow:   4,
+		PNorm:                    alloraMath.NewDecFromInt64(3),
+		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
+		AllowNegative:            true,
+		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
+		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
+		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
+		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		EnableWorkerWhitelist:    false, // Simplification for testing
+		EnableReputerWhitelist:   false, // Simplification for testing
+	}
+	txResp, err := m.Client.BroadcastTx(ctx, m.AliceAcc, createTopicRequest)
+	require.NoError(m.T, err)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
+	require.NoError(m.T, err)
+	createTopicResponse := &types.CreateNewTopicResponse{}
+	err = txResp.Decode(createTopicResponse)
+	require.NoError(m.T, err)
+	return createTopicResponse.TopicId
+}
+
+// Helper function to fund a topic
+func fundTestTopic(m testCommon.TestConfig, funderAcc cosmosaccount.Account, topicId uint64, amount int64) {
+	ctx := context.Background()
+	// Get the sender address string from the account
+	funderAddr, err := funderAcc.Address(params.HumanCoinUnit)
+	require.NoError(m.T, err)
+
+	txResp, err := m.Client.BroadcastTx(
+		ctx,
+		funderAcc, // Use the provided account info
+		&types.FundTopicRequest{
+			Sender:  funderAddr, // Use the derived address string
+			TopicId: topicId,
+			Amount:  cosmosMath.NewInt(amount),
+		},
+	)
+	require.NoError(m.T, err)
+	_, err = m.Client.WaitForTx(ctx, txResp.TxHash)
+	require.NoError(m.T, err)
+	resp := &types.FundTopicResponse{}
+	err = txResp.Decode(resp)
+	require.NoError(m.T, err)
+}

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -4690,6 +4690,85 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenue() {
 		"The topic fee revenue should match the expected value after dripping")
 }
 
+func (s *KeeperTestSuite) TestDripTopicFeeRevenueWithTwoTopicsDifferentEpochLengths() {
+	// Initialize the test environment
+	ctx := s.ctx
+	k := s.emissionsKeeper
+	require := s.Require()
+
+	// Define test data
+	topicId1 := uint64(1)
+	topicId2 := uint64(2)
+	block := int64(100)
+	initialRevenue := cosmosMath.NewInt(1000000) // 0.001 in Int representation (assuming 6 decimal places)
+
+	params := types.DefaultParams()
+	params.MinEpochLength = 1
+	err := k.SetParams(ctx, params)
+	require.NoError(err, "Setting a new topic should not fail")
+
+	// Create and activate topics
+	topic1 := s.mockTopic()
+	topic1.EpochLength = 5
+	topic1.WorkerSubmissionWindow = 5
+	err = k.SetTopic(ctx, topicId1, topic1)
+	require.NoError(err, "Setting a new topic should not fail")
+
+	topic2 := s.mockTopic()
+	topic2.EpochLength = 10
+	topic2.WorkerSubmissionWindow = 10
+	err = k.SetTopic(ctx, topicId2, topic2)
+	require.NoError(err, "Setting a new topic should not fail")
+
+	// Activate the topics
+	err = k.ActivateTopic(ctx, topicId1)
+	require.NoError(err, "Activating the topic should not fail")
+
+	err = k.ActivateTopic(ctx, topicId2)
+	require.NoError(err, "Activating the topic should not fail")
+
+	// Set up initial topic fee revenue
+	err = k.AddTopicFeeRevenue(ctx, topicId1, initialRevenue)
+	require.NoError(err, "Setting initial topic fee revenue should not fail")
+
+	err = k.AddTopicFeeRevenue(ctx, topicId2, initialRevenue)
+	require.NoError(err, "Setting initial topic fee revenue should not fail")
+
+	// Call the function under test
+	err = k.DripTopicFeeRevenue(ctx, topicId1, block)
+	require.NoError(err, "DripTopicFeeRevenue should not return an error")
+
+	err = k.DripTopicFeeRevenue(ctx, topicId2, block)
+	require.NoError(err, "DripTopicFeeRevenue should not return an error")
+
+	// Retrieve the updated topic fee revenue
+	updatedTopicFeeRevenue1, err := k.GetTopicFeeRevenue(ctx, topicId1)
+	require.NoError(err, "Getting topic fee revenue should not fail")
+
+	updatedTopicFeeRevenue2, err := k.GetTopicFeeRevenue(ctx, topicId2)
+	require.NoError(err, "Getting topic fee revenue should not fail")
+
+	// Assert the expected results
+	require.True(updatedTopicFeeRevenue1.LT(initialRevenue),
+		"The topic fee revenue should have decreased after dripping")
+	require.True(updatedTopicFeeRevenue2.LT(initialRevenue),
+		"The topic fee revenue should have decreased after dripping")
+
+	// Expected revenue should be the initial revenue minus the expected drip
+	// Topic 1 should have a smaller drip because it has a shorter epoch length
+	// Topic 2 should have a larger drip because it has a longer epoch length
+	// The initial expectation of the drip in this case is approximately 25.14 for topic 1 and 50.28 for topic 2 (since epoch length is 5 and 10 respectively)
+	// But because the revenue is truncated to the nearest integer, the actual drip is 26 for topic 1 and 51 for topic 2
+	expectedDripTopic1 := cosmosMath.NewInt(26)
+	expectedDripTopic2 := cosmosMath.NewInt(51)
+	expectedRevenue1 := initialRevenue.Sub(expectedDripTopic1)
+	expectedRevenue2 := initialRevenue.Sub(expectedDripTopic2)
+	require.Equal(expectedRevenue1.String(), updatedTopicFeeRevenue1.String(),
+		"The topic fee revenue for topic 1 should match the expected value after dripping")
+	require.Equal(expectedRevenue2.String(), updatedTopicFeeRevenue2.String(),
+		"The topic fee revenue for topic 2 should match the expected value after dripping")
+}
+
 func (s *KeeperTestSuite) TestActiveInfererFunctions() {
 	ctx := s.ctx
 	k := s.emissionsKeeper


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
This PR introduces a new integration test, `TopicWeightDistributionChecks`, located in `test/integration/topic_distribution_test.go`. The primary goal of this test is to verify that the Allora chain correctly calculates and distributes topic weights, particularly when topics have different epoch lengths.


## Link(s) to Ticket(s) or Issue(s) resolved by this PR
https://linear.app/alloralabs/issue/ENGN-3608/test-topic-weight-changes
