### PR TITLE
Optimize topic weights fetch and update flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#776](https://github.com/allora-network/allora-chain/pull/776) Target weight: rm div by topic epochLength
 * [#764](https://github.com/allora-network/allora-chain/pull/764) TopicRewardAlpha using weekly cadence
 * [#769](https://github.com/allora-network/allora-chain/pull/769) Stored NetworkInferences instead of query-time. Removal of `GetLatestAvailableNetworkInferences`
+* [#794](https://github.com/allora-network/allora-chain/pull/794) Optimize topic weights fetch and update flow
 
 ### Deprecated
 
 ### Removed
+* [#793](https://github.com/allora-network/allora-chain/pull/793) Remove stress tests
 
 ### Fixed
 

--- a/math/utils.go
+++ b/math/utils.go
@@ -8,6 +8,8 @@ import (
 	errorsmod "cosmossdk.io/errors"
 )
 
+var weeksPerMonth = MustNewDecFromString("4.345") //nolint:gochecknoglobals // constant
+
 // all exponential moving average functions take the form
 // x_average=α*x_current + (1-α)*x_previous
 //
@@ -708,4 +710,18 @@ func GetSmoothedAlpha(epochLength int64, baseIntervalDec Dec, baseAlpha Dec) (De
 	}
 
 	return smoothedAlpha, nil
+}
+
+// return the blocks per week
+// defined as the blocks per month divided by 4.345 (weeks per month)
+func CalculateBlocksPerWeek(blocksPerMonth uint64) (Dec, error) {
+	blocksPerMonthDec, err := NewDecFromUint64(blocksPerMonth)
+	if err != nil {
+		return Dec{}, errorsmod.Wrap(err, "error creating blocks per month")
+	}
+	blocksPerWeek, err := blocksPerMonthDec.Quo(weeksPerMonth)
+	if err != nil {
+		return Dec{}, errorsmod.Wrap(err, "error calculating blocks per week")
+	}
+	return blocksPerWeek, nil
 }

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -3312,7 +3312,7 @@ func (k *Keeper) AddTopicFeeRevenue(ctx context.Context, topicId TopicId, amount
 
 // return the blocks per week
 // defined as the blocks per month divided by 4.345
-var weeksPerMonth = alloraMath.MustNewDecFromString("4.345")
+var weeksPerMonth = alloraMath.MustNewDecFromString("4.345") //nolint:gochecknoglobals // constant
 func (k *Keeper) CalculateBlocksPerWeek(ctx context.Context, blocksPerMonth uint64) (alloraMath.Dec, error) {
 	blocksPerMonthDec, err := alloraMath.NewDecFromUint64(blocksPerMonth)
 	if err != nil {

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -3312,21 +3312,13 @@ func (k *Keeper) AddTopicFeeRevenue(ctx context.Context, topicId TopicId, amount
 
 // return the blocks per week
 // defined as the blocks per month divided by 4.345
-func (k *Keeper) calculateBlocksPerWeek(ctx context.Context) (alloraMath.Dec, error) {
-	moduleParams, err := k.GetParams(ctx)
-	if err != nil {
-		return alloraMath.Dec{}, errorsmod.Wrap(err, "error getting params")
-	}
-	blocksPerMonth, err := alloraMath.NewDecFromUint64(moduleParams.BlocksPerMonth)
+var weeksPerMonth = alloraMath.MustNewDecFromString("4.345")
+func (k *Keeper) CalculateBlocksPerWeek(ctx context.Context, blocksPerMonth uint64) (alloraMath.Dec, error) {
+	blocksPerMonthDec, err := alloraMath.NewDecFromUint64(blocksPerMonth)
 	if err != nil {
 		return alloraMath.Dec{}, errorsmod.Wrap(err, "error creating blocks per month")
 	}
-	// 4.345 weeks per month on average
-	weeksPerMonth, err := alloraMath.NewDecFromString("4.345")
-	if err != nil {
-		return alloraMath.Dec{}, errorsmod.Wrap(err, "error creating weeks per month")
-	}
-	blocksPerWeek, err := blocksPerMonth.Quo(weeksPerMonth)
+	blocksPerWeek, err := blocksPerMonthDec.Quo(weeksPerMonth)
 	if err != nil {
 		return alloraMath.Dec{}, errorsmod.Wrap(err, "error calculating blocks per week")
 	}
@@ -3361,14 +3353,14 @@ func (k *Keeper) SetLastDripBlock(ctx context.Context, topicId TopicId, block Bl
 // where C_{t,i} is the topic fee revenue
 // and N_{epochs,w} is the number of epochs per week
 // and this decay or drip happens each epoch
-func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topicId TopicId, block BlockHeight) error {
-	if err := types.ValidateTopicId(topicId); err != nil {
+func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topic types.Topic, blocksPerWeek alloraMath.Dec, block BlockHeight) error {
+	if err := types.ValidateTopicId(topic.Id); err != nil {
 		return errorsmod.Wrap(err, "topic id validation failed")
 	}
 	if err := types.ValidateBlockHeight(block); err != nil {
 		return errorsmod.Wrap(err, "block height validation failed")
 	}
-	topicFeeRevenue, err := k.GetTopicFeeRevenue(ctx, topicId)
+	topicFeeRevenue, err := k.GetTopicFeeRevenue(ctx, topic.Id)
 	if err != nil {
 		return errorsmod.Wrap(err, "error getting topic fee revenue")
 	}
@@ -3376,18 +3368,10 @@ func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topicId TopicId, block Blo
 	if err != nil {
 		return errorsmod.Wrap(err, "error creating decimal from sdk int")
 	}
-	topic, err := k.GetTopic(ctx, topicId)
-	if err != nil {
-		return errorsmod.Wrap(err, "error getting topic")
-	}
 	blocksPerEpoch := alloraMath.NewDecFromInt64(topic.EpochLength)
 	if blocksPerEpoch.IsZero() {
-		ctx.Logger().Warn("Blocks per epoch is zero for topic", "topicId", topicId)
+		ctx.Logger().Warn("Blocks per epoch is zero for topic", "topicId", topic.Id)
 		return nil
-	}
-	blocksPerWeek, err := k.calculateBlocksPerWeek(ctx)
-	if err != nil {
-		return errorsmod.Wrap(err, "error calculating blocks per week")
 	}
 	epochsPerWeek, err := blocksPerWeek.Quo(blocksPerEpoch)
 	if err != nil {
@@ -3395,7 +3379,7 @@ func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topicId TopicId, block Blo
 	}
 	if epochsPerWeek.IsZero() {
 		// Log a warning
-		ctx.Logger().Warn("Epochs per week is zero for topic", "topicId", topicId)
+		ctx.Logger().Warn("Epochs per week is zero for topic", "topicId", topic.Id)
 		return nil
 	}
 	// this delta is the drip per epoch
@@ -3403,7 +3387,7 @@ func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topicId TopicId, block Blo
 	if err != nil {
 		return errorsmod.Wrap(err, "error calculating drip per epoch")
 	}
-	lastDripBlock, err := k.GetLastDripBlock(ctx, topicId)
+	lastDripBlock, err := k.GetLastDripBlock(ctx, topic.Id)
 	if err != nil {
 		return errorsmod.Wrap(err, "error getting last drip block")
 	}
@@ -3423,18 +3407,18 @@ func (k *Keeper) DripTopicFeeRevenue(ctx sdk.Context, topicId TopicId, block Blo
 			return errorsmod.Wrap(err, "error converting decimal to sdk int")
 		}
 
-		if err = k.SetLastDripBlock(ctx, topicId, topic.EpochLastEnded); err != nil {
+		if err = k.SetLastDripBlock(ctx, topic.Id, topic.EpochLastEnded); err != nil {
 			return errorsmod.Wrap(err, "error setting last drip block")
 		}
 		ctx.Logger().Debug("Dripping topic fee revenue",
 			"block", ctx.BlockHeight(),
-			"topicId", topicId,
+			"topicId", topic.Id,
 			"oldRevenue", topicFeeRevenue,
 			"newRevenue", newTopicFeeRevenue)
 		if err = types.ValidateSdkIntRepresentingMonetaryValue(newTopicFeeRevenue); err != nil {
 			return errorsmod.Wrap(err, "error validating new topic fee revenue")
 		}
-		return k.topicFeeRevenue.Set(ctx, topicId, newTopicFeeRevenue)
+		return k.topicFeeRevenue.Set(ctx, topic.Id, newTopicFeeRevenue)
 	}
 	return nil
 }

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -3310,21 +3310,6 @@ func (k *Keeper) AddTopicFeeRevenue(ctx context.Context, topicId TopicId, amount
 	return k.topicFeeRevenue.Set(ctx, topicId, topicFeeRevenue)
 }
 
-// return the blocks per week
-// defined as the blocks per month divided by 4.345
-var weeksPerMonth = alloraMath.MustNewDecFromString("4.345") //nolint:gochecknoglobals // constant
-func (k *Keeper) CalculateBlocksPerWeek(ctx context.Context, blocksPerMonth uint64) (alloraMath.Dec, error) {
-	blocksPerMonthDec, err := alloraMath.NewDecFromUint64(blocksPerMonth)
-	if err != nil {
-		return alloraMath.Dec{}, errorsmod.Wrap(err, "error creating blocks per month")
-	}
-	blocksPerWeek, err := blocksPerMonthDec.Quo(weeksPerMonth)
-	if err != nil {
-		return alloraMath.Dec{}, errorsmod.Wrap(err, "error calculating blocks per week")
-	}
-	return blocksPerWeek, nil
-}
-
 // return the last time we dripped the fee revenue for a topic
 func (k *Keeper) GetLastDripBlock(ctx context.Context, topicId TopicId) (BlockHeight, error) {
 	bh, err := k.lastDripBlock.Get(ctx, topicId)

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -2608,7 +2608,7 @@ func (s *KeeperTestSuite) TestAddTopicFeeRevenue() {
 
 	params := types.DefaultParams()
 
-	blocksPerWeek, err := keeper.CalculateBlocksPerWeek(ctx, params.BlocksPerMonth)
+	blocksPerWeek, err := alloraMath.CalculateBlocksPerWeek(params.BlocksPerMonth)
 	s.Require().NoError(err, "error calculating blocks per week")
 
 	err = keeper.DripTopicFeeRevenue(ctx, newTopic, blocksPerWeek, block)
@@ -4678,7 +4678,7 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenue() {
 	require.NoError(err, "Setting initial topic fee revenue should not fail")
 
 	// Calculate the blocks per week
-	blocksPerWeek, err := k.CalculateBlocksPerWeek(ctx, params.BlocksPerMonth)
+	blocksPerWeek, err := alloraMath.CalculateBlocksPerWeek(params.BlocksPerMonth)
 	require.NoError(err, "error calculating blocks per week")
 
 	// Call the function under test

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -4743,11 +4743,15 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenueWithTwoTopicsDifferentEpochLeng
 	err = k.AddTopicFeeRevenue(ctx, topicId2, initialRevenue)
 	require.NoError(err, "Setting initial topic fee revenue should not fail")
 
+	// Calculate the blocks per week
+	blocksPerWeek, err := alloraMath.CalculateBlocksPerWeek(params.BlocksPerMonth)
+	require.NoError(err, "error calculating blocks per week")
+
 	// Call the function under test
-	err = k.DripTopicFeeRevenue(ctx, topicId1, block)
+	err = k.DripTopicFeeRevenue(ctx, topic1, blocksPerWeek, block)
 	require.NoError(err, "DripTopicFeeRevenue should not return an error")
 
-	err = k.DripTopicFeeRevenue(ctx, topicId2, block)
+	err = k.DripTopicFeeRevenue(ctx, topic2, blocksPerWeek, block)
 	require.NoError(err, "DripTopicFeeRevenue should not return an error")
 
 	// Retrieve the updated topic fee revenue

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -4718,29 +4718,31 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenueWithTwoTopicsDifferentEpochLeng
 
 	// Create and activate topics
 	topic1 := s.mockTopic()
+	topic1.Id = topicId1
 	topic1.EpochLength = 5
 	topic1.WorkerSubmissionWindow = 5
 	err = k.SetTopic(ctx, topicId1, topic1)
 	require.NoError(err, "Setting a new topic should not fail")
 
 	topic2 := s.mockTopic()
+	topic2.Id = topicId2
 	topic2.EpochLength = 10
 	topic2.WorkerSubmissionWindow = 10
 	err = k.SetTopic(ctx, topicId2, topic2)
 	require.NoError(err, "Setting a new topic should not fail")
 
 	// Activate the topics
-	err = k.ActivateTopic(ctx, topicId1)
+	err = k.ActivateTopic(ctx, topic1.Id)
 	require.NoError(err, "Activating the topic should not fail")
 
-	err = k.ActivateTopic(ctx, topicId2)
+	err = k.ActivateTopic(ctx, topic2.Id)
 	require.NoError(err, "Activating the topic should not fail")
 
 	// Set up initial topic fee revenue
-	err = k.AddTopicFeeRevenue(ctx, topicId1, initialRevenue)
+	err = k.AddTopicFeeRevenue(ctx, topic1.Id, initialRevenue)
 	require.NoError(err, "Setting initial topic fee revenue should not fail")
 
-	err = k.AddTopicFeeRevenue(ctx, topicId2, initialRevenue)
+	err = k.AddTopicFeeRevenue(ctx, topic2.Id, initialRevenue)
 	require.NoError(err, "Setting initial topic fee revenue should not fail")
 
 	// Calculate the blocks per week
@@ -4755,10 +4757,10 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenueWithTwoTopicsDifferentEpochLeng
 	require.NoError(err, "DripTopicFeeRevenue should not return an error")
 
 	// Retrieve the updated topic fee revenue
-	updatedTopicFeeRevenue1, err := k.GetTopicFeeRevenue(ctx, topicId1)
+	updatedTopicFeeRevenue1, err := k.GetTopicFeeRevenue(ctx, topic1.Id)
 	require.NoError(err, "Getting topic fee revenue should not fail")
 
-	updatedTopicFeeRevenue2, err := k.GetTopicFeeRevenue(ctx, topicId2)
+	updatedTopicFeeRevenue2, err := k.GetTopicFeeRevenue(ctx, topic2.Id)
 	require.NoError(err, "Getting topic fee revenue should not fail")
 
 	// Assert the expected results

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -2605,7 +2605,13 @@ func (s *KeeperTestSuite) TestAddTopicFeeRevenue() {
 	}
 	err := keeper.SetTopic(ctx, topicId, newTopic)
 	s.Require().NoError(err, "Setting a new topic should not fail")
-	err = keeper.DripTopicFeeRevenue(ctx, topicId, block)
+
+	params := types.DefaultParams()
+
+	blocksPerWeek, err := keeper.CalculateBlocksPerWeek(ctx, params.BlocksPerMonth)
+	s.Require().NoError(err, "error calculating blocks per week")
+
+	err = keeper.DripTopicFeeRevenue(ctx, newTopic, blocksPerWeek, block)
 	s.Require().NoError(err, "Resetting topic fee revenue should not fail")
 
 	// Add initial revenue
@@ -4672,8 +4678,12 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenue() {
 	err = k.AddTopicFeeRevenue(ctx, topicId, initialRevenue)
 	require.NoError(err, "Setting initial topic fee revenue should not fail")
 
+	// Calculate the blocks per week
+	blocksPerWeek, err := k.CalculateBlocksPerWeek(ctx, params.BlocksPerMonth)
+	require.NoError(err, "error calculating blocks per week")
+
 	// Call the function under test
-	err = k.DripTopicFeeRevenue(ctx, topicId, block)
+	err = k.DripTopicFeeRevenue(ctx, topic, blocksPerWeek, block)
 	require.NoError(err, "DripTopicFeeRevenue should not return an error")
 
 	// Retrieve the updated topic fee revenue

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -4653,7 +4653,6 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenue() {
 	require := s.Require()
 
 	// Define test data
-	topicId := uint64(1)
 	block := int64(100)
 	// Calculated expected drip with these values: 26
 	expectedDrip := cosmosMath.NewInt(26)
@@ -4668,14 +4667,14 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenue() {
 	topic := s.mockTopic()
 	topic.EpochLength = 5
 	topic.WorkerSubmissionWindow = 5
-	err = k.SetTopic(ctx, topicId, topic)
+	err = k.SetTopic(ctx, topic.Id, topic)
 	require.NoError(err, "Setting a new topic should not fail")
 
-	err = k.ActivateTopic(ctx, topicId)
+	err = k.ActivateTopic(ctx, topic.Id)
 	require.NoError(err, "Activating the topic should not fail")
 
 	// Set up initial topic fee revenue
-	err = k.AddTopicFeeRevenue(ctx, topicId, initialRevenue)
+	err = k.AddTopicFeeRevenue(ctx, topic.Id, initialRevenue)
 	require.NoError(err, "Setting initial topic fee revenue should not fail")
 
 	// Calculate the blocks per week
@@ -4687,7 +4686,7 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenue() {
 	require.NoError(err, "DripTopicFeeRevenue should not return an error")
 
 	// Retrieve the updated topic fee revenue
-	updatedTopicFeeRevenue, err := k.GetTopicFeeRevenue(ctx, topicId)
+	updatedTopicFeeRevenue, err := k.GetTopicFeeRevenue(ctx, topic.Id)
 	require.NoError(err, "Getting topic fee revenue should not fail")
 
 	// Assert the expected results

--- a/x/emissions/keeper/msgserver/msg_server_demand_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand_test.go
@@ -37,6 +37,7 @@ func (s *MsgServerTestSuite) TestFundTopicSimple() {
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
 	response, err := s.msgServer.FundTopic(s.ctx, &r)
@@ -55,6 +56,7 @@ func (s *MsgServerTestSuite) TestFundTopicSimple() {
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
 	s.Require().True(feeRevAfter.GT(feeRevBefore), "Topic fee revenue should be greater after funding the topic")
@@ -116,6 +118,7 @@ func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
 
@@ -126,6 +129,7 @@ func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
 
@@ -205,6 +209,7 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
 
@@ -215,6 +220,7 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
 	// Topics should have equal weights at this point because their previous topic weight is still zero
@@ -234,6 +240,7 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
 
@@ -244,6 +251,7 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
 	// Topics should have equal weights because the target weight is not affected by the epoch length

--- a/x/emissions/keeper/msgserver/msg_server_util_payment.go
+++ b/x/emissions/keeper/msgserver/msg_server_util_payment.go
@@ -40,6 +40,7 @@ func activateTopicIfWeightAtLeastGlobalMin(
 			params.TopicRewardAlpha,
 			params.TopicRewardStakeImportance,
 			params.TopicRewardFeeRevenueImportance,
+			params.BlocksPerMonth,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "error getting current topic weight")

--- a/x/emissions/keeper/queryserver/query_server_topics.go
+++ b/x/emissions/keeper/queryserver/query_server_topics.go
@@ -42,6 +42,7 @@ func (qs queryServer) GetTopic(ctx context.Context, req *types.GetTopicRequest) 
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting current topic weight")

--- a/x/emissions/keeper/topic_weight.go
+++ b/x/emissions/keeper/topic_weight.go
@@ -41,12 +41,8 @@ func (k *Keeper) GetCurrentTopicWeight(
 	topicRewardAlpha alloraMath.Dec,
 	stakeImportance alloraMath.Dec,
 	feeImportance alloraMath.Dec,
+	blocksPerMonth uint64,
 ) (weight alloraMath.Dec, topicRevenue cosmosMath.Int, err error) {
-	blocksPerWeek, err := k.calculateBlocksPerWeek(ctx)
-	if err != nil {
-		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to calculate blocks per week")
-	}
-
 	topicStake, err := k.GetTopicStake(ctx, topicId)
 	if err != nil {
 		return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get topic stake")
@@ -86,6 +82,11 @@ func (k *Keeper) GetCurrentTopicWeight(
 			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get previous topic weight")
 		}
 
+		blocksPerWeek, err := k.CalculateBlocksPerWeek(ctx, blocksPerMonth)
+		if err != nil {
+			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to calculate blocks per week")
+		}
+
 		// Calculate alpha
 		topicSmoothedAlpha, err := alloraMath.GetSmoothedAlpha(topicEpochLength, blocksPerWeek, topicRewardAlpha)
 		if err != nil {
@@ -118,6 +119,7 @@ func (k *Keeper) GetTopicWeightFromTopicId(ctx context.Context, topicId types.To
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
+		params.BlocksPerMonth,
 	)
 
 	if err != nil {

--- a/x/emissions/keeper/topic_weight.go
+++ b/x/emissions/keeper/topic_weight.go
@@ -82,7 +82,7 @@ func (k *Keeper) GetCurrentTopicWeight(
 			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get previous topic weight")
 		}
 
-		blocksPerWeek, err := k.CalculateBlocksPerWeek(ctx, blocksPerMonth)
+		blocksPerWeek, err := alloraMath.CalculateBlocksPerWeek(blocksPerMonth)
 		if err != nil {
 			return alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to calculate blocks per week")
 		}

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -132,6 +132,10 @@ func GetAndUpdateActiveTopicWeights(
 	if err != nil {
 		return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get alpha")
 	}
+	blocksPerWeek, err := k.CalculateBlocksPerWeek(ctx, moduleParams.BlocksPerMonth)
+	if err != nil {
+		return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "error calculating blocks per week")
+	}
 
 	// Retrieve and sort all active topics with epoch ending at this block
 	// default page limit for the max because default is 100 and max is 1000
@@ -158,6 +162,7 @@ func GetAndUpdateActiveTopicWeights(
 			moduleParams.TopicRewardAlpha,
 			moduleParams.TopicRewardStakeImportance,
 			moduleParams.TopicRewardFeeRevenueImportance,
+			moduleParams.BlocksPerMonth,
 		)
 		if err != nil {
 			return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get current topic weight")
@@ -171,7 +176,7 @@ func GetAndUpdateActiveTopicWeights(
 		// This revenue will be paid to top active topics of this block (the churnable topics).
 		// This happens regardless of this topic's fate (inactivation or not)
 		// => the influence of this topic's revenue needs to be appropriately diminished.
-		err = k.DripTopicFeeRevenue(ctx, topic.Id, block)
+		err = k.DripTopicFeeRevenue(ctx, topic, blocksPerWeek, block)
 		if err != nil {
 			return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to reset topic fee revenue")
 		}

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -132,7 +132,7 @@ func GetAndUpdateActiveTopicWeights(
 	if err != nil {
 		return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get alpha")
 	}
-	blocksPerWeek, err := k.CalculateBlocksPerWeek(ctx, moduleParams.BlocksPerMonth)
+	blocksPerWeek, err := alloraMath.CalculateBlocksPerWeek(moduleParams.BlocksPerMonth)
 	if err != nil {
 		return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "error calculating blocks per week")
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
- Remove repeated and unnecessary fetches for the module params and topic structure during the topic `GetCurrentTopicWeight` and `DripTopicFeeRevenue`

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
No ticket was created for this. This optimization opportunity was found during the execution of this ticket: 
https://linear.app/alloralabs/issue/ENGN-3608/test-topic-weight-changes

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
