### PR TITLE
Fix: rework nondet math operations

### DIFF
--- a/math/dec_bench_test.go
+++ b/math/dec_bench_test.go
@@ -1,30 +1,103 @@
 package math_test
 
 import (
+	"fmt"
 	"testing"
 
 	alloramath "github.com/allora-network/allora-chain/math"
 )
 
-func BenchmarkLn(b *testing.B) {
-	tests := []alloramath.Dec{
-		alloramath.MustNewDecFromString("1.2"),
-		alloramath.MustNewDecFromString("1.234"),
-		alloramath.MustNewDecFromString("1024"),
-		alloramath.NewDecFromInt64(2048 * 2048 * 2048 * 2048 * 2048),
-		alloramath.MustNewDecFromString("999999999999999999999999999999999999999999999999999999.9122181273612911"),
-		alloramath.MustNewDecFromString("0.5632892391219024912482190471290471"),
-		alloramath.MustNewDecFromString("0.0000000391219024912482190471290471"),
-	}
+// Carries testing dec for logarithms benchmarks
+var benchLogData = []alloramath.Dec{
+	alloramath.MustNewDecFromString("1.2"),
+	alloramath.MustNewDecFromString("1024"),
+	alloramath.NewDecFromInt64(2048 * 2048 * 2048 * 2048 * 2048),
+	alloramath.MustNewDecFromString("999999999999999999999999999999999999999999999999999999.9122181273612911"),
+	alloramath.MustNewDecFromString("0.5632892391219024912482190471290471"),
+	alloramath.MustNewDecFromString("0.0000000000000024912482190471290471"),
+}
 
-	for i := 0; i < b.N; i++ {
-		b.StartTimer()
-		for _, test := range tests {
-			_, err := alloramath.Ln(test)
-			if err != nil {
-				b.Fatal(err)
+// Carries testing dec for exponential benchmarks
+var benchExpData = []alloramath.Dec{
+	alloramath.MustNewDecFromString("1.2"),
+	alloramath.MustNewDecFromString("1024"),
+	alloramath.MustNewDecFromString("0.5632892391219024912482190471290471"),
+	alloramath.MustNewDecFromString("0.0000000000000024912482190471290471"),
+}
+
+func BenchmarkLn(b *testing.B) {
+	for _, test := range benchLogData {
+		b.Run(fmt.Sprintf("input_%v", test), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				_, err := alloramath.Ln(test)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.StopTimer()
 			}
+		})
+	}
+}
+
+func BenchmarkLog10(b *testing.B) {
+	for _, test := range benchLogData {
+		b.Run(fmt.Sprintf("input_%v", test), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				_, err := alloramath.Log10(test)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.StopTimer()
+			}
+		})
+	}
+}
+
+func BenchmarkExp(b *testing.B) {
+	for _, test := range benchExpData {
+		b.Run(fmt.Sprintf("input_%v", test), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				_, err := alloramath.Exp(test)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.StopTimer()
+			}
+		})
+	}
+}
+
+func BenchmarkExp10(b *testing.B) {
+	for _, test := range benchExpData {
+		b.Run(fmt.Sprintf("input_%v", test), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				_, err := alloramath.Exp10(test)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.StopTimer()
+			}
+		})
+	}
+}
+
+func BenchmarkPow(b *testing.B) {
+	for _, d := range benchExpData {
+		for _, e := range benchExpData {
+			b.Run(fmt.Sprintf("input_%v_%v", d, e), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StartTimer()
+					_, err := alloramath.Pow(d, e)
+					if err != nil {
+						b.Fatal(err)
+					}
+					b.StopTimer()
+				}
+			})
 		}
-		b.StopTimer()
 	}
 }


### PR DESCRIPTION
## Purpose of Changes and their Description

Benchmarks before re-implementation:
```
BenchmarkLn
BenchmarkLn/input_1.2
BenchmarkLn/input_1.2-12                                                                                	   12574	     95334 ns/op
BenchmarkLn/input_1024
BenchmarkLn/input_1024-12                                                                               	   16348	    108261 ns/op
BenchmarkLn/input_36028797018963968
BenchmarkLn/input_36028797018963968-12                                                                  	   15177	     75549 ns/op
BenchmarkLn/input_999999999999999999999999999999999999999999999999999999.9122181273612911
BenchmarkLn/input_999999999999999999999999999999999999999999999999999999.9122181273612911-12            	   10000	    111765 ns/op
BenchmarkLn/input_0.5632892391219024912482190471290471
BenchmarkLn/input_0.5632892391219024912482190471290471-12                                               	   10000	    104735 ns/op
BenchmarkLn/input_0.0000000000000024912482190471290471
BenchmarkLn/input_0.0000000000000024912482190471290471-12                                               	   12079	     96838 ns/op
BenchmarkLog10
BenchmarkLog10/input_1.2
BenchmarkLog10/input_1.2-12                                                                             	   17979	     66241 ns/op
BenchmarkLog10/input_1024
BenchmarkLog10/input_1024-12                                                                            	   18159	     68151 ns/op
BenchmarkLog10/input_36028797018963968
BenchmarkLog10/input_36028797018963968-12                                                               	   17491	     65390 ns/op
BenchmarkLog10/input_999999999999999999999999999999999999999999999999999999.9122181273612911
BenchmarkLog10/input_999999999999999999999999999999999999999999999999999999.9122181273612911-12         	  164803	      7181 ns/op
BenchmarkLog10/input_0.5632892391219024912482190471290471
BenchmarkLog10/input_0.5632892391219024912482190471290471-12                                            	   17254	     69098 ns/op
BenchmarkLog10/input_0.0000000000000024912482190471290471
BenchmarkLog10/input_0.0000000000000024912482190471290471-12                                            	   18475	     64864 ns/op
BenchmarkExp
BenchmarkExp/input_1.2
BenchmarkExp/input_1.2-12                                                                               	   44658	     26917 ns/op
BenchmarkExp/input_1024
BenchmarkExp/input_1024-12                                                                              	   28041	     42834 ns/op
BenchmarkExp/input_0.5632892391219024912482190471290471
BenchmarkExp/input_0.5632892391219024912482190471290471-12                                              	   38924	     31125 ns/op
BenchmarkExp/input_0.0000000000000024912482190471290471
BenchmarkExp/input_0.0000000000000024912482190471290471-12                                              	  208060	      5973 ns/op
BenchmarkExp10
BenchmarkExp10/input_1.2
BenchmarkExp10/input_1.2-12                                                                             	    9841	    122567 ns/op
BenchmarkExp10/input_1024
BenchmarkExp10/input_1024-12                                                                            	  331681	      3487 ns/op
BenchmarkExp10/input_0.5632892391219024912482190471290471
BenchmarkExp10/input_0.5632892391219024912482190471290471-12                                            	   10000	    114478 ns/op
BenchmarkExp10/input_0.0000000000000024912482190471290471
BenchmarkExp10/input_0.0000000000000024912482190471290471-12                                            	   13747	     86255 ns/op
BenchmarkPow
BenchmarkPow/input_1.2_1.2
BenchmarkPow/input_1.2_1.2-12                                                                           	   10000	    103102 ns/op
BenchmarkPow/input_1.2_1024
BenchmarkPow/input_1.2_1024-12                                                                          	  271375	      4306 ns/op
BenchmarkPow/input_1.2_0.5632892391219024912482190471290471
BenchmarkPow/input_1.2_0.5632892391219024912482190471290471-12                                          	   10000	    108747 ns/op
BenchmarkPow/input_1.2_0.0000000000000024912482190471290471
BenchmarkPow/input_1.2_0.0000000000000024912482190471290471-12                                          	   14313	     84533 ns/op
BenchmarkPow/input_1024_1.2
BenchmarkPow/input_1024_1.2-12                                                                          	   10000	    115053 ns/op
BenchmarkPow/input_1024_1024
BenchmarkPow/input_1024_1024-12                                                                         	  205261	      5301 ns/op
BenchmarkPow/input_1024_0.5632892391219024912482190471290471
BenchmarkPow/input_1024_0.5632892391219024912482190471290471-12                                         	    9950	    117483 ns/op
BenchmarkPow/input_1024_0.0000000000000024912482190471290471
BenchmarkPow/input_1024_0.0000000000000024912482190471290471-12                                         	   13574	     84458 ns/op
BenchmarkPow/input_0.5632892391219024912482190471290471_1.2
BenchmarkPow/input_0.5632892391219024912482190471290471_1.2-12                                          	   10000	    114668 ns/op
BenchmarkPow/input_0.5632892391219024912482190471290471_1024
BenchmarkPow/input_0.5632892391219024912482190471290471_1024-12                                         	  175396	      6831 ns/op
BenchmarkPow/input_0.5632892391219024912482190471290471_0.5632892391219024912482190471290471
BenchmarkPow/input_0.5632892391219024912482190471290471_0.5632892391219024912482190471290471-12         	    9762	    120427 ns/op
BenchmarkPow/input_0.5632892391219024912482190471290471_0.0000000000000024912482190471290471
BenchmarkPow/input_0.5632892391219024912482190471290471_0.0000000000000024912482190471290471-12         	   13046	     93029 ns/op
BenchmarkPow/input_0.0000000000000024912482190471290471_1.2
BenchmarkPow/input_0.0000000000000024912482190471290471_1.2-12                                          	    9841	    118837 ns/op
BenchmarkPow/input_0.0000000000000024912482190471290471_1024
BenchmarkPow/input_0.0000000000000024912482190471290471_1024-12                                         	  181774	      6511 ns/op
BenchmarkPow/input_0.0000000000000024912482190471290471_0.5632892391219024912482190471290471
BenchmarkPow/input_0.0000000000000024912482190471290471_0.5632892391219024912482190471290471-12         	   10000	    112465 ns/op
BenchmarkPow/input_0.0000000000000024912482190471290471_0.0000000000000024912482190471290471
BenchmarkPow/input_0.0000000000000024912482190471290471_0.0000000000000024912482190471290471-12         	   14572	     82107 ns/op
```

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?