### PR TITLE
cmd: remove duplicate call to SetCmdClientContextHandler

### DIFF
--- a/cmd/allorad/cmd/root.go
+++ b/cmd/allorad/cmd/root.go
@@ -94,10 +94,6 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			if err := client.SetCmdClientContextHandler(clientCtx, cmd); err != nil {
-				return err
-			}
-
 			// overwrite the minimum gas price from the app configuration
 			srvCfg := serverconfig.DefaultConfig()
 			srvCfg.MinGasPrices = "0uallo"


### PR DESCRIPTION
## Purpose of Changes and their Description

In the `PersistentPreRunE` function of `NewRootCmd`, a duplicate call to the function ```go client.SetCmdClientContextHandler(clientCtx, cmd)``` is eliminated by this PR. 

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

This PR is not associated with any particular ticket or issue.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
We've verified it works all the same.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
No additional documentation is required.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?
This change is minor.


