### PR TITLE
Add reset/cleanup functions to defer in close nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-## v0.10.1
+# v0.11.0
 
 ### Added
 
@@ -74,7 +74,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-* [805](https://github.com/allora-network/allora-chain/pull/805) An invalid bundle gets ignored on networkLoss calc
+
+* [#803](https://github.com/allora-network/allora-chain/pull/803) Add reset/cleanup functions to defer in CloseReputerNonce 
+* [#804](https://github.com/allora-network/allora-chain/pull/804) Additional validations + use inferenceBlockheight in NetworkInferences
+* [#805](https://github.com/allora-network/allora-chain/pull/805) An invalid bundle gets ignored on networkLoss calc
 
 ### Security
 
@@ -86,7 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-# [v0.10.0]
+# v0.10.0
 
 ### Added
 

--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -23,8 +23,11 @@ func CloseReputerNonce(
 	k *keeper.Keeper,
 	ctx sdk.Context,
 	topic types.Topic,
-	nonce types.Nonce) error {
-	/// All filters should be done in order of increasing computational complexity
+	nonce types.Nonce,
+) (err error) {
+	blockHeight := ctx.BlockHeight()
+
+	// All filters should be done in order of increasing computational complexity
 	// Check if the worker nonce is unfulfilled
 	workerNonceUnfulfilled, err := k.IsWorkerNonceUnfulfilled(ctx, topic.Id, &nonce)
 	if err != nil {
@@ -53,10 +56,50 @@ func CloseReputerNonce(
 		)
 	}
 	// Check if the window time has passed
-	blockHeight := ctx.BlockHeight()
 	if blockHeight < nonce.BlockHeight+topic.GroundTruthLag {
 		return types.ErrReputerNonceWindowNotAvailable
 	}
+
+	defer func() {
+		if err != nil {
+			ctx.Logger().Error(
+				"Error occurred before finalization in CloseReputerNonce, attempting cleanup anyway",
+				"topicId", topic.Id,
+				"nonce", nonce,
+				"error", err,
+			)
+		}
+
+		_, fulfillErr := k.FulfillReputerNonce(ctx, topic.Id, &nonce)
+		if fulfillErr != nil {
+			ctx.Logger().Error(
+				"Error fulfilling reputer nonce during deferred cleanup",
+				"topicId", topic.Id,
+				"nonce", nonce,
+				"error", fulfillErr,
+			)
+		}
+
+		resetActiveErr := k.ResetActiveReputersForTopic(ctx, topic.Id)
+		if resetActiveErr != nil {
+			ctx.Logger().Error(
+				"Error resetting active reputers during deferred cleanup",
+				"topicId", topic.Id,
+				"error", resetActiveErr,
+			)
+		}
+
+		resetSubmissionsErr := k.ResetReputersIndividualSubmissionsForTopic(ctx, topic.Id)
+		if resetSubmissionsErr != nil {
+			ctx.Logger().Error(
+				"Error resetting reputer individual submissions during deferred cleanup",
+				"topicId", topic.Id,
+				"error", resetSubmissionsErr,
+			)
+		}
+
+		ctx.Logger().Info("Closed reputer nonce", "topicId", topic.Id, "nonce", nonce)
+	}()
 
 	params, err := k.GetParams(ctx)
 	if err != nil {
@@ -74,16 +117,19 @@ func CloseReputerNonce(
 	for _, address := range activeReputerAddresses {
 		bundle, err := k.GetReputerLatestLossByTopicId(ctx, topic.Id, address)
 		if err != nil {
-			return types.ErrNoValidBundles
+			ctx.Logger().Warn("Could not get latest loss bundle for reputer, skipping", "reputer", address, "topicId", topic.Id, "error", err)
+			continue // Skip this reputer
 		}
 
 		// Check that the reputer enough stake in the topic
 		stake, err := k.GetStakeReputerAuthority(ctx, topic.Id, bundle.ValueBundle.Reputer)
 		if err != nil {
-			continue
+			ctx.Logger().Warn("Could not get stake for reputer, skipping", "reputer", bundle.ValueBundle.Reputer, "topicId", topic.Id, "error", err)
+			continue // Skip this reputer
 		}
 		if stake.LT(params.RequiredMinimumStake) {
-			continue
+			ctx.Logger().Debug("Reputer stake below minimum, skipping", "reputer", bundle.ValueBundle.Reputer, "topicId", topic.Id, "stake", stake)
+			continue // Skip this reputer
 		}
 
 		// Examine forecast elements to verify that they're for registered inferers in the current set.
@@ -92,7 +138,8 @@ func CloseReputerNonce(
 		// if they're left with no valid losses.
 		filteredBundle, err := FilterUnacceptedWorkersFromReputerValueBundle(k, ctx, topic.Id, *bundle.ValueBundle.ReputerRequestNonce, &bundle)
 		if err != nil {
-			continue
+			ctx.Logger().Warn("Could not filter bundle for reputer, skipping", "reputer", bundle.ValueBundle.Reputer, "topicId", topic.Id, "error", err)
+			continue // Skip this reputer
 		}
 
 		/// Filtering done now, now write what we must for inclusion
@@ -220,34 +267,31 @@ func CloseReputerNonce(
 	}
 	// -- end of regrets_stdnorm and weights multistep process
 
-	_, err = k.FulfillReputerNonce(ctx, topic.Id, &nonce)
-	if err != nil {
-		return err
-	}
-
 	err = k.SetTopicRewardNonce(ctx, topic.Id, nonce.BlockHeight)
 	if err != nil {
+		ctx.Logger().Error(
+			"Error setting topic reward nonce during deferred cleanup",
+			"topicId", topic.Id,
+			"nonceBlockHeight", nonce.BlockHeight,
+			"error", err,
+		)
 		return err
 	}
 
 	err = k.SetReputerTopicLastCommit(ctx, topic.Id, blockHeight, &nonce)
 	if err != nil {
+		ctx.Logger().Error(
+			"Error setting reputer topic last commit during deferred cleanup",
+			"topicId", topic.Id,
+			"blockHeight", blockHeight,
+			"nonce", nonce,
+			"error", err,
+		)
 		return err
 	}
-
-	err = k.ResetActiveReputersForTopic(ctx, topic.Id)
-	if err != nil {
-		return err
-	}
-
-	err = k.ResetReputersIndividualSubmissionsForTopic(ctx, topic.Id)
-	if err != nil {
-		return err
-	}
-
 	types.EmitNewReputerLastCommitSetEvent(ctx, topic.Id, blockHeight, &nonce)
-	ctx.Logger().Info("Closed reputer nonce", "topicId", topic.Id, "nonce", nonce)
-	return nil
+
+	return err
 }
 
 // Filter out values of unaccepted workers.
@@ -262,9 +306,8 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 ) (*types.ReputerValueBundle, error) {
 	// Get the accepted inferers of the associated worker response payload
 	inferences, err := k.GetInferencesAtBlock(ctx, topicId, reputerRequestNonce.ReputerNonce.BlockHeight, false)
-
 	if errors.Is(err, collections.ErrNotFound) {
-		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "no inferences found at block height")
+		return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "no inferences found at block height %d for topic %d", reputerRequestNonce.ReputerNonce.BlockHeight, topicId)
 	} else if err != nil {
 		return nil, err
 	}
@@ -277,6 +320,9 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 	// Get the accepted forecasters of the associated worker response payload
 	forecasts, err := k.GetForecastsAtBlock(ctx, topicId, reputerRequestNonce.ReputerNonce.BlockHeight)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "no forecasts found at block height %d for topic %d", reputerRequestNonce.ReputerNonce.BlockHeight, topicId)
+		}
 		return nil, err
 	}
 	acceptedForecastersOfBatch := make(map[string]bool)
@@ -367,23 +413,33 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 		}
 	}
 
+	// Construct the filtered bundle
+	filteredValueBundle := &types.ValueBundle{
+		TopicId:                       reputerValueBundle.ValueBundle.TopicId,
+		ReputerRequestNonce:           reputerValueBundle.ValueBundle.ReputerRequestNonce,
+		Reputer:                       reputerValueBundle.ValueBundle.Reputer,
+		ExtraData:                     reputerValueBundle.ValueBundle.ExtraData,
+		InfererValues:                 acceptedInfererValues,
+		ForecasterValues:              acceptedForecasterValues,
+		OneOutInfererValues:           acceptedOneOutInfererValues,
+		OneOutForecasterValues:        acceptedOneOutForecasterValues,
+		OneInForecasterValues:         acceptedOneInForecasterValues,
+		OneOutInfererForecasterValues: acceptedOneOutInfererForecasterValues,
+		NaiveValue:                    reputerValueBundle.ValueBundle.NaiveValue,
+		CombinedValue:                 reputerValueBundle.ValueBundle.CombinedValue,
+	}
+
+	// Check if the filtering resulted in an effectively empty bundle that might be invalid downstream
+	// e.g., if CalcNetworkLosses requires at least one value. Add checks if necessary.
+
+	if len(acceptedInfererValues) == 0 {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "no valid values found after filtering")
+	}
+
 	acceptedReputerValueBundle := &types.ReputerValueBundle{
-		Pubkey: reputerValueBundle.Pubkey,
-		ValueBundle: &types.ValueBundle{
-			TopicId:                       reputerValueBundle.ValueBundle.TopicId,
-			ReputerRequestNonce:           reputerValueBundle.ValueBundle.ReputerRequestNonce,
-			Reputer:                       reputerValueBundle.ValueBundle.Reputer,
-			ExtraData:                     reputerValueBundle.ValueBundle.ExtraData,
-			InfererValues:                 acceptedInfererValues,
-			ForecasterValues:              acceptedForecasterValues,
-			OneOutInfererValues:           acceptedOneOutInfererValues,
-			OneOutForecasterValues:        acceptedOneOutForecasterValues,
-			OneInForecasterValues:         acceptedOneInForecasterValues,
-			OneOutInfererForecasterValues: acceptedOneOutInfererForecasterValues,
-			NaiveValue:                    reputerValueBundle.ValueBundle.NaiveValue,
-			CombinedValue:                 reputerValueBundle.ValueBundle.CombinedValue,
-		},
-		Signature: reputerValueBundle.Signature,
+		Pubkey:      reputerValueBundle.Pubkey,
+		ValueBundle: filteredValueBundle,
+		Signature:   reputerValueBundle.Signature,
 	}
 
 	return acceptedReputerValueBundle, nil

--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -320,9 +320,6 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 	// Get the accepted forecasters of the associated worker response payload
 	forecasts, err := k.GetForecastsAtBlock(ctx, topicId, reputerRequestNonce.ReputerNonce.BlockHeight)
 	if err != nil {
-		if errors.Is(err, collections.ErrNotFound) {
-			return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "no forecasts found at block height %d for topic %d", reputerRequestNonce.ReputerNonce.BlockHeight, topicId)
-		}
 		return nil, err
 	}
 	acceptedForecastersOfBatch := make(map[string]bool)

--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -147,6 +147,10 @@ func CloseReputerNonce(
 		stakesByReputer[bundle.ValueBundle.Reputer] = stake
 	}
 
+	if len(lossBundlesByReputer) == 0 {
+		return errorsmod.Wrapf(sdkerrors.ErrNotFound, "no valid losses found for reputers")
+	}
+
 	// sort by reputer score descending
 	sort.Slice(lossBundlesByReputer, func(i, j int) bool {
 		return lossBundlesByReputer[i].ValueBundle.Reputer < lossBundlesByReputer[j].ValueBundle.Reputer

--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -317,9 +317,6 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 	// Get the accepted forecasters of the associated worker response payload
 	forecasts, err := k.GetForecastsAtBlock(ctx, topicId, reputerRequestNonce.ReputerNonce.BlockHeight)
 	if err != nil {
-		if errors.Is(err, collections.ErrNotFound) {
-			return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "no forecasts found at block height %d for topic %d", reputerRequestNonce.ReputerNonce.BlockHeight, topicId)
-		}
 		return nil, err
 	}
 	acceptedForecastersOfBatch := make(map[string]bool)

--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -23,8 +23,11 @@ func CloseReputerNonce(
 	k *keeper.Keeper,
 	ctx sdk.Context,
 	topic types.Topic,
-	nonce types.Nonce) error {
-	/// All filters should be done in order of increasing computational complexity
+	nonce types.Nonce,
+) (err error) {
+	blockHeight := ctx.BlockHeight()
+
+	// All filters should be done in order of increasing computational complexity
 	// Check if the worker nonce is unfulfilled
 	workerNonceUnfulfilled, err := k.IsWorkerNonceUnfulfilled(ctx, topic.Id, &nonce)
 	if err != nil {
@@ -53,10 +56,50 @@ func CloseReputerNonce(
 		)
 	}
 	// Check if the window time has passed
-	blockHeight := ctx.BlockHeight()
 	if blockHeight < nonce.BlockHeight+topic.GroundTruthLag {
 		return types.ErrReputerNonceWindowNotAvailable
 	}
+
+	defer func() {
+		if err != nil {
+			ctx.Logger().Error(
+				"Error occurred before finalization in CloseReputerNonce, attempting cleanup anyway",
+				"topicId", topic.Id,
+				"nonce", nonce,
+				"error", err,
+			)
+		}
+
+		_, fulfillErr := k.FulfillReputerNonce(ctx, topic.Id, &nonce)
+		if fulfillErr != nil {
+			ctx.Logger().Error(
+				"Error fulfilling reputer nonce during deferred cleanup",
+				"topicId", topic.Id,
+				"nonce", nonce,
+				"error", fulfillErr,
+			)
+		}
+
+		resetActiveErr := k.ResetActiveReputersForTopic(ctx, topic.Id)
+		if resetActiveErr != nil {
+			ctx.Logger().Error(
+				"Error resetting active reputers during deferred cleanup",
+				"topicId", topic.Id,
+				"error", resetActiveErr,
+			)
+		}
+
+		resetSubmissionsErr := k.ResetReputersIndividualSubmissionsForTopic(ctx, topic.Id)
+		if resetSubmissionsErr != nil {
+			ctx.Logger().Error(
+				"Error resetting reputer individual submissions during deferred cleanup",
+				"topicId", topic.Id,
+				"error", resetSubmissionsErr,
+			)
+		}
+
+		ctx.Logger().Info("Closed reputer nonce", "topicId", topic.Id, "nonce", nonce)
+	}()
 
 	params, err := k.GetParams(ctx)
 	if err != nil {
@@ -74,16 +117,19 @@ func CloseReputerNonce(
 	for _, address := range activeReputerAddresses {
 		bundle, err := k.GetReputerLatestLossByTopicId(ctx, topic.Id, address)
 		if err != nil {
-			return types.ErrNoValidBundles
+			ctx.Logger().Warn("Could not get latest loss bundle for reputer, skipping", "reputer", address, "topicId", topic.Id, "error", err)
+			continue // Skip this reputer
 		}
 
 		// Check that the reputer enough stake in the topic
 		stake, err := k.GetStakeReputerAuthority(ctx, topic.Id, bundle.ValueBundle.Reputer)
 		if err != nil {
-			continue
+			ctx.Logger().Warn("Could not get stake for reputer, skipping", "reputer", bundle.ValueBundle.Reputer, "topicId", topic.Id, "error", err)
+			continue // Skip this reputer
 		}
 		if stake.LT(params.RequiredMinimumStake) {
-			continue
+			ctx.Logger().Debug("Reputer stake below minimum, skipping", "reputer", bundle.ValueBundle.Reputer, "topicId", topic.Id, "stake", stake)
+			continue // Skip this reputer
 		}
 
 		// Examine forecast elements to verify that they're for registered inferers in the current set.
@@ -92,7 +138,8 @@ func CloseReputerNonce(
 		// if they're left with no valid losses.
 		filteredBundle, err := FilterUnacceptedWorkersFromReputerValueBundle(k, ctx, topic.Id, *bundle.ValueBundle.ReputerRequestNonce, &bundle)
 		if err != nil {
-			continue
+			ctx.Logger().Warn("Could not filter bundle for reputer, skipping", "reputer", bundle.ValueBundle.Reputer, "topicId", topic.Id, "error", err)
+			continue // Skip this reputer
 		}
 
 		/// Filtering done now, now write what we must for inclusion
@@ -217,34 +264,31 @@ func CloseReputerNonce(
 	}
 	// -- end of regrets_stdnorm and weights multistep process
 
-	_, err = k.FulfillReputerNonce(ctx, topic.Id, &nonce)
-	if err != nil {
-		return err
-	}
-
 	err = k.SetTopicRewardNonce(ctx, topic.Id, nonce.BlockHeight)
 	if err != nil {
+		ctx.Logger().Error(
+			"Error setting topic reward nonce during deferred cleanup",
+			"topicId", topic.Id,
+			"nonceBlockHeight", nonce.BlockHeight,
+			"error", err,
+		)
 		return err
 	}
 
 	err = k.SetReputerTopicLastCommit(ctx, topic.Id, blockHeight, &nonce)
 	if err != nil {
+		ctx.Logger().Error(
+			"Error setting reputer topic last commit during deferred cleanup",
+			"topicId", topic.Id,
+			"blockHeight", blockHeight,
+			"nonce", nonce,
+			"error", err,
+		)
 		return err
 	}
-
-	err = k.ResetActiveReputersForTopic(ctx, topic.Id)
-	if err != nil {
-		return err
-	}
-
-	err = k.ResetReputersIndividualSubmissionsForTopic(ctx, topic.Id)
-	if err != nil {
-		return err
-	}
-
 	types.EmitNewReputerLastCommitSetEvent(ctx, topic.Id, blockHeight, &nonce)
-	ctx.Logger().Info("Closed reputer nonce", "topicId", topic.Id, "nonce", nonce)
-	return nil
+
+	return err
 }
 
 // Filter out values of unaccepted workers.
@@ -259,9 +303,8 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 ) (*types.ReputerValueBundle, error) {
 	// Get the accepted inferers of the associated worker response payload
 	inferences, err := k.GetInferencesAtBlock(ctx, topicId, reputerRequestNonce.ReputerNonce.BlockHeight, false)
-
 	if errors.Is(err, collections.ErrNotFound) {
-		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "no inferences found at block height")
+		return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "no inferences found at block height %d for topic %d", reputerRequestNonce.ReputerNonce.BlockHeight, topicId)
 	} else if err != nil {
 		return nil, err
 	}
@@ -274,6 +317,9 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 	// Get the accepted forecasters of the associated worker response payload
 	forecasts, err := k.GetForecastsAtBlock(ctx, topicId, reputerRequestNonce.ReputerNonce.BlockHeight)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "no forecasts found at block height %d for topic %d", reputerRequestNonce.ReputerNonce.BlockHeight, topicId)
+		}
 		return nil, err
 	}
 	acceptedForecastersOfBatch := make(map[string]bool)
@@ -364,23 +410,33 @@ func FilterUnacceptedWorkersFromReputerValueBundle(
 		}
 	}
 
+	// Construct the filtered bundle
+	filteredValueBundle := &types.ValueBundle{
+		TopicId:                       reputerValueBundle.ValueBundle.TopicId,
+		ReputerRequestNonce:           reputerValueBundle.ValueBundle.ReputerRequestNonce,
+		Reputer:                       reputerValueBundle.ValueBundle.Reputer,
+		ExtraData:                     reputerValueBundle.ValueBundle.ExtraData,
+		InfererValues:                 acceptedInfererValues,
+		ForecasterValues:              acceptedForecasterValues,
+		OneOutInfererValues:           acceptedOneOutInfererValues,
+		OneOutForecasterValues:        acceptedOneOutForecasterValues,
+		OneInForecasterValues:         acceptedOneInForecasterValues,
+		OneOutInfererForecasterValues: acceptedOneOutInfererForecasterValues,
+		NaiveValue:                    reputerValueBundle.ValueBundle.NaiveValue,
+		CombinedValue:                 reputerValueBundle.ValueBundle.CombinedValue,
+	}
+
+	// Check if the filtering resulted in an effectively empty bundle that might be invalid downstream
+	// e.g., if CalcNetworkLosses requires at least one value. Add checks if necessary.
+
+	if len(acceptedInfererValues) == 0 {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "no valid values found after filtering")
+	}
+
 	acceptedReputerValueBundle := &types.ReputerValueBundle{
-		Pubkey: reputerValueBundle.Pubkey,
-		ValueBundle: &types.ValueBundle{
-			TopicId:                       reputerValueBundle.ValueBundle.TopicId,
-			ReputerRequestNonce:           reputerValueBundle.ValueBundle.ReputerRequestNonce,
-			Reputer:                       reputerValueBundle.ValueBundle.Reputer,
-			ExtraData:                     reputerValueBundle.ValueBundle.ExtraData,
-			InfererValues:                 acceptedInfererValues,
-			ForecasterValues:              acceptedForecasterValues,
-			OneOutInfererValues:           acceptedOneOutInfererValues,
-			OneOutForecasterValues:        acceptedOneOutForecasterValues,
-			OneInForecasterValues:         acceptedOneInForecasterValues,
-			OneOutInfererForecasterValues: acceptedOneOutInfererForecasterValues,
-			NaiveValue:                    reputerValueBundle.ValueBundle.NaiveValue,
-			CombinedValue:                 reputerValueBundle.ValueBundle.CombinedValue,
-		},
-		Signature: reputerValueBundle.Signature,
+		Pubkey:      reputerValueBundle.Pubkey,
+		ValueBundle: filteredValueBundle,
+		Signature:   reputerValueBundle.Signature,
 	}
 
 	return acceptedReputerValueBundle, nil

--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -292,7 +292,7 @@ func CloseReputerNonce(
 	}
 	types.EmitNewReputerLastCommitSetEvent(ctx, topic.Id, blockHeight, &nonce)
 
-	return err
+	return nil
 }
 
 // Filter out values of unaccepted workers.

--- a/x/emissions/keeper/actor_utils/worker.go
+++ b/x/emissions/keeper/actor_utils/worker.go
@@ -13,7 +13,9 @@ import (
 // WORKER NONCES CLOSING
 
 // Closes an open worker nonce.
-func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonce types.Nonce) error {
+func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonce types.Nonce) (err error) {
+	blockHeight := ctx.BlockHeight()
+
 	// Check if the nonce is unfulfilled
 	nonceUnfulfilled, err := k.IsWorkerNonceUnfulfilled(ctx, topic.Id, &nonce)
 	if err != nil {
@@ -25,11 +27,51 @@ func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonc
 	}
 
 	// Check if the window time has passed: if blockHeight > nonce.BlockHeight + topic.WorkerSubmissionWindow
-	blockHeight := ctx.BlockHeight()
 	if blockHeight <= nonce.BlockHeight ||
 		blockHeight > nonce.BlockHeight+topic.WorkerSubmissionWindow {
 		return types.ErrWorkerNonceWindowNotAvailable
 	}
+
+	defer func() {
+		if err != nil {
+			ctx.Logger().Error(
+				"Error occurred before finalization in CloseWorkerNonce, attempting cleanup anyway",
+				"topicId", topic.Id,
+				"nonce", nonce,
+				"error", err,
+			)
+		}
+
+		_, fulfillErr := k.FulfillWorkerNonce(ctx, topic.Id, &nonce)
+		if fulfillErr != nil {
+			ctx.Logger().Error(
+				"Error fulfilling worker nonce during deferred cleanup",
+				"topicId", topic.Id,
+				"nonce", nonce,
+				"error", fulfillErr,
+			)
+		}
+
+		resetActiveErr := k.ResetActiveWorkersForTopic(ctx, topic.Id)
+		if resetActiveErr != nil {
+			ctx.Logger().Error(
+				"Error resetting active workers during deferred cleanup",
+				"topicId", topic.Id,
+				"error", resetActiveErr,
+			)
+		}
+
+		resetSubmissionsErr := k.ResetWorkersIndividualSubmissionsForTopic(ctx, topic.Id)
+		if resetSubmissionsErr != nil {
+			ctx.Logger().Error(
+				"Error resetting worker individual submissions during deferred cleanup",
+				"topicId", topic.Id,
+				"error", resetSubmissionsErr,
+			)
+		}
+
+		ctx.Logger().Info("Closed worker nonce", "topicId", topic.Id, "nonce", nonce)
+	}()
 
 	// Get all active inferers for this topic
 	activeInfererAddresses, err := k.GetActiveInferersForTopic(ctx, topic.Id)
@@ -72,11 +114,6 @@ func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonc
 	if err != nil {
 		return err
 	}
-	// Update the unfulfilled worker nonce
-	_, err = k.FulfillWorkerNonce(ctx, topic.Id, &nonce)
-	if err != nil {
-		return err
-	}
 
 	err = k.AddReputerNonce(ctx, topic.Id, &nonce)
 	if err != nil {
@@ -84,16 +121,6 @@ func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonc
 	}
 
 	err = k.SetWorkerTopicLastCommit(ctx, topic.Id, blockHeight, &nonce)
-	if err != nil {
-		return err
-	}
-
-	err = k.ResetActiveWorkersForTopic(ctx, topic.Id)
-	if err != nil {
-		return err
-	}
-
-	err = k.ResetWorkersIndividualSubmissionsForTopic(ctx, topic.Id)
 	if err != nil {
 		return err
 	}
@@ -111,8 +138,6 @@ func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonc
 	}
 
 	types.EmitNewWorkerLastCommitSetEvent(ctx, topic.Id, blockHeight, &nonce)
-	ctx.Logger().Info("Closed worker nonce", "topicId", topic.Id, "nonce", nonce)
-	// Return an empty response as the operation was successful
 	return nil
 }
 

--- a/x/emissions/keeper/actor_utils/worker_test.go
+++ b/x/emissions/keeper/actor_utils/worker_test.go
@@ -328,43 +328,6 @@ func (s *WorkerTestSuite) TestCloseWorkerNonceFailures() {
 	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, nonce)
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, types.ErrNoQualifiedInferers)
-
-	// Test 3: Closing an already fulfilled nonce
-	// First register and activate a worker
-	worker := s.addrsStr[0]
-	workerRegMsg := &types.RegisterRequest{
-		Sender:    worker,
-		TopicId:   topicId,
-		IsReputer: false,
-		Owner:     s.addrsStr[4],
-	}
-	_, err = s.msgServer.Register(s.ctx, workerRegMsg)
-	s.Require().NoError(err)
-
-	// Add worker as active inferer
-	err = s.emissionsKeeper.AddActiveInferer(s.ctx, topicId, worker)
-	s.Require().NoError(err)
-
-	// Insert an inference
-	inference := types.Inference{
-		Inferer:     worker,
-		Value:       alloraMath.MustNewDecFromString("-0.035995138925040600"),
-		TopicId:     topicId,
-		BlockHeight: blockHeight,
-		ExtraData:   nil,
-		Proof:       "",
-	}
-	err = s.emissionsKeeper.InsertInference(s.ctx, topicId, inference)
-	s.Require().NoError(err)
-
-	// Close the nonce first time (should succeed)
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, nonce)
-	s.Require().NoError(err)
-
-	// Try to close the same nonce again (should fail)
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, nonce)
-	s.Require().Error(err)
-	s.Require().ErrorIs(err, types.ErrUnfulfilledNonceNotFound)
 }
 
 func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesCatchesOutliers() {

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -90,14 +90,7 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 					sdkCtx.Logger().Debug("ABCI EndBlocker", "blockHeight", blockHeight, "closing worker window for topic", "topicId", topicId, "nonce", nonce)
 					err = allorautils.CloseWorkerNonce(&am.keeper, sdkCtx, topic, *nonce)
 					if err != nil {
-						sdkCtx.Logger().Info("Error closing worker nonce, proactively fulfilling", "error", err)
-						// Proactively close the nonce
-						fulfilledNonce, err := am.keeper.FulfillWorkerNonce(sdkCtx, topicId, nonce)
-						if err != nil {
-							sdkCtx.Logger().Warn("Error fulfilling worker nonce", "error", err)
-						} else {
-							sdkCtx.Logger().Debug("Fulfilled", "fulfilledNonce", fulfilledNonce, "nonce", nonce)
-						}
+						sdkCtx.Logger().Info("Error closing worker nonce", "error", err)
 					}
 				}
 			}

--- a/x/emissions/module/rewards/nonce_management.go
+++ b/x/emissions/module/rewards/nonce_management.go
@@ -22,12 +22,7 @@ func UpdateReputerNonce(ctx sdk.Context, k keeper.Keeper, topic types.Topic, blo
 			ctx.Logger().Debug("ABCI EndBlocker: Closing reputer nonce", "topic", topic.Id, "nonce", nonce, "min", closingReputerNonceMinBlockHeight)
 			err = allorautils.CloseReputerNonce(&k, ctx, topic, *nonce.ReputerNonce)
 			if err != nil {
-				ctx.Logger().Warn("Error closing reputer nonce", "error", err)
-				// Proactively close the nonce to avoid
-				_, err = k.FulfillReputerNonce(ctx, topic.Id, nonce.ReputerNonce)
-				if err != nil {
-					ctx.Logger().Warn("Error fulfilling reputer nonce", "error", err)
-				}
+				ctx.Logger().Error("Error closing reputer nonce", "error", err)
 			}
 		}
 	}

--- a/x/emissions/module/rewards/nonce_management_test.go
+++ b/x/emissions/module/rewards/nonce_management_test.go
@@ -81,12 +81,14 @@ func (s *RewardsTestSuite) TestCloseReputerNonceTest_DeferExec() {
 	}
 
 	// Insert unfullfiled nonces
-	s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
+	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
 		BlockHeight: currentBlockHeight,
 	})
-	s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
+	s.Require().NoError(err)
+	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
 		BlockHeight: currentBlockHeight,
 	})
+	s.Require().NoError(err)
 
 	workerValues := make([]TestWorkerValue, len(workerIndexes))
 	for i, index := range workerIndexes {

--- a/x/emissions/module/rewards/nonce_management_test.go
+++ b/x/emissions/module/rewards/nonce_management_test.go
@@ -1,0 +1,188 @@
+package rewards_test
+
+import (
+	"cosmossdk.io/collections"
+	cosmosMath "cosmossdk.io/math"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Test defer execution of CloseReputerNonce
+func (s *RewardsTestSuite) TestCloseReputerNonceTest_DeferExec() {
+	currentBlockHeight := int64(10)
+	s.ctx = s.ctx.WithBlockHeight(currentBlockHeight)
+
+	// Create topic
+	createTopicReq := &types.CreateNewTopicRequest{
+		Creator:                  s.addrsStr[0],
+		Metadata:                 "test-topic-close-nonce",
+		LossMethod:               "mse",
+		EpochLength:              10800,
+		AllowNegative:            false,
+		GroundTruthLag:           10800,
+		WorkerSubmissionWindow:   10,
+		AlphaRegret:              alloraMath.NewDecFromInt64(1),
+		PNorm:                    alloraMath.NewDecFromInt64(3),
+		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
+		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
+		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
+		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		EnableWorkerWhitelist:    true,
+		EnableReputerWhitelist:   true,
+	}
+	res, err := s.msgServer.CreateNewTopic(s.ctx, createTopicReq)
+	s.Require().NoError(err)
+	topicId := res.TopicId
+
+	// Reputer Addresses
+	reputerIndexes := s.returnIndexes(0, 5)
+
+	workerIndexes := s.returnIndexes(5, 5)
+
+	// Register and add stakes for reputers
+	for _, index := range reputerIndexes {
+		registerReq := &types.RegisterRequest{
+			Sender:    s.addrsStr[index],
+			TopicId:   topicId,
+			IsReputer: true,
+			Owner:     s.addrsStr[index],
+		}
+		_, err = s.msgServer.Register(s.ctx, registerReq)
+		s.Require().NoError(err)
+	}
+
+	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
+	stakeAmount := cosmosMath.NewInt(100).Mul(cosmosOneE18)
+
+	for _, index := range reputerIndexes {
+		s.MintTokensToAddress(s.addrs[index], stakeAmount)
+		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
+			Sender:  s.addrsStr[index],
+			Amount:  stakeAmount,
+			TopicId: topicId,
+		})
+		s.Require().NoError(err)
+	}
+
+	// Register workers
+	for _, index := range workerIndexes {
+		registerReq := &types.RegisterRequest{
+			Sender:    s.addrsStr[index],
+			TopicId:   topicId,
+			IsReputer: false,
+			Owner:     s.addrsStr[index],
+		}
+		_, err = s.msgServer.Register(s.ctx, registerReq)
+		s.Require().NoError(err)
+	}
+
+	// Insert unfullfiled nonces
+	s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
+		BlockHeight: currentBlockHeight,
+	})
+	s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
+		BlockHeight: currentBlockHeight,
+	})
+
+	workerValues := make([]TestWorkerValue, len(workerIndexes))
+	for i, index := range workerIndexes {
+		workerValues[i] = TestWorkerValue{
+			Index: index,
+			Value: "100",
+		}
+	}
+
+	getIndexesFromValues := func(values []TestWorkerValue) []int {
+		indexes := make([]int, 0)
+		for _, value := range values {
+			indexes = append(indexes, value.Index)
+		}
+		return indexes
+	}
+
+	workerIndexesFromValues := getIndexesFromValues(workerValues)
+
+	// Insert inference from workers
+	inferenceBundles := generateSimpleWorkerDataBundles(s, topicId, currentBlockHeight, currentBlockHeight, workerValues, workerIndexesFromValues)
+	for _, payload := range inferenceBundles {
+		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
+			Sender:           payload.Worker,
+			WorkerDataBundle: payload,
+		})
+		s.Require().NoError(err)
+	}
+
+	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
+	s.Require().NoError(err)
+
+	// Move to end of worker submission window
+	s.ctx = s.ctx.WithBlockHeight(currentBlockHeight + topic.WorkerSubmissionWindow)
+	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
+	s.Require().NoError(err)
+
+	newBlockheight := currentBlockHeight + topic.GroundTruthLag
+	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
+	// Trigger end block - rewards distribution
+	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
+	s.Require().NoError(err)
+	err = s.emissionsAppModule.EndBlock(s.ctx)
+	s.Require().NoError(err)
+
+	// Insert loss bundle from reputer
+	// Use different indexes to enforce different workers are used
+	// This will trigger an error and test if the defer execution of CloseReputerNonce works properly
+	workerIndexes = s.returnIndexes(10, 5)
+	lossBundles := generateLossBundles(s, currentBlockHeight, topicId, reputerIndexes, workerIndexes)
+	for _, payload := range lossBundles.ReputerValueBundles {
+		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
+		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
+		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
+			Sender:             payload.ValueBundle.Reputer,
+			ReputerValueBundle: payload,
+		})
+		s.Require().NoError(err)
+	}
+
+	// before closing the nonce, the nonce should be unfulfilled
+	unfulfilled, err := s.emissionsKeeper.IsReputerNonceUnfulfilled(s.ctx, topicId, lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce)
+	s.Require().NoError(err)
+	s.Require().True(unfulfilled)
+
+	// before closing the nonce, the active reputers for topic should not be
+	activeReputers, err := s.emissionsKeeper.GetActiveReputersForTopic(s.ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(len(reputerIndexes), len(activeReputers))
+
+	// before closing the nonce, the submissions for the topic should not be empty
+	for _, bundle := range lossBundles.ReputerValueBundles {
+		submissions, err := s.emissionsKeeper.GetReputerLatestLossByTopicId(s.ctx, topicId, bundle.ValueBundle.Reputer)
+		s.Require().NoError(err)
+		s.Require().NotNil(submissions)
+	}
+
+	err = actorutils.CloseReputerNonce(
+		&s.emissionsKeeper, s.ctx, topic,
+		*lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce,
+	)
+	s.Require().Error(err)
+
+	// Check if reputer nonce is fulfilled
+	unfulfilled, err = s.emissionsKeeper.IsReputerNonceUnfulfilled(s.ctx, topicId, lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce)
+	s.Require().NoError(err)
+	s.Require().False(unfulfilled)
+
+	// Check if the active reputers for topic have been reset
+	activeReputers, err = s.emissionsKeeper.GetActiveReputersForTopic(s.ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(0, len(activeReputers))
+
+	// Check if the submissions for the topic have been reset
+	for _, bundle := range lossBundles.ReputerValueBundles {
+		_, err := s.emissionsKeeper.GetReputerLatestLossByTopicId(s.ctx, topicId, bundle.ValueBundle.Reputer)
+		s.Require().ErrorIs(err, collections.ErrNotFound)
+	}
+}

--- a/x/emissions/module/rewards/nonce_management_test.go
+++ b/x/emissions/module/rewards/nonce_management_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Test defer execution of CloseReputerNonce
-func (s *RewardsTestSuite) TestCloseReputerNonceTest_DeferExec() {
+func (s *RewardsTestSuite) TestCloseReputerNonceTest_DeferExecWhenError() {
 	currentBlockHeight := int64(10)
 	s.ctx = s.ctx.WithBlockHeight(currentBlockHeight)
 
@@ -185,6 +185,127 @@ func (s *RewardsTestSuite) TestCloseReputerNonceTest_DeferExec() {
 	// Check if the submissions for the topic have been reset
 	for _, bundle := range lossBundles.ReputerValueBundles {
 		_, err := s.emissionsKeeper.GetReputerLatestLossByTopicId(s.ctx, topicId, bundle.ValueBundle.Reputer)
+		s.Require().ErrorIs(err, collections.ErrNotFound)
+	}
+}
+
+// Test defer execution of CloseWorkerNonce
+func (s *RewardsTestSuite) TestCloseWorkerNonce_DeferExecWhenError() {
+	currentBlockHeight := int64(20)
+	s.ctx = s.ctx.WithBlockHeight(currentBlockHeight)
+
+	// Create topic
+	createTopicReq := &types.CreateNewTopicRequest{
+		Creator:                  s.addrsStr[0],
+		Metadata:                 "test-topic-close-worker-nonce",
+		LossMethod:               "mse",
+		EpochLength:              10800,
+		AllowNegative:            false,
+		GroundTruthLag:           10800,
+		WorkerSubmissionWindow:   10,
+		AlphaRegret:              alloraMath.NewDecFromInt64(1),
+		PNorm:                    alloraMath.NewDecFromInt64(3),
+		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
+		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
+		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
+		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		EnableWorkerWhitelist:    true,
+		EnableReputerWhitelist:   true,
+	}
+	res, err := s.msgServer.CreateNewTopic(s.ctx, createTopicReq)
+	s.Require().NoError(err)
+	topicId := res.TopicId
+
+	workerIndexes := s.returnIndexes(0, 5)
+
+	// Register workers
+	for _, index := range workerIndexes {
+		registerReq := &types.RegisterRequest{
+			Sender:    s.addrsStr[index],
+			TopicId:   topicId,
+			IsReputer: false,
+			Owner:     s.addrsStr[index],
+		}
+		_, err = s.msgServer.Register(s.ctx, registerReq)
+		s.Require().NoError(err)
+	}
+
+	// Insert unfulfilled worker nonce
+	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
+		BlockHeight: currentBlockHeight,
+	})
+	s.Require().NoError(err)
+
+	workerValues := make([]TestWorkerValue, len(workerIndexes))
+	for i, index := range workerIndexes {
+		workerValues[i] = TestWorkerValue{
+			Index: index,
+			Value: "100",
+		}
+	}
+
+	getIndexesFromValues := func(values []TestWorkerValue) []int {
+		indexes := make([]int, 0)
+		for _, value := range values {
+			indexes = append(indexes, value.Index)
+		}
+		return indexes
+	}
+
+	workerIndexesFromValues := getIndexesFromValues(workerValues)
+
+	// Insert inference from workers
+	inferenceBundles := generateSimpleWorkerDataBundles(s, topicId, currentBlockHeight, currentBlockHeight, workerValues, workerIndexesFromValues)
+	for _, payload := range inferenceBundles {
+		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
+			Sender:           payload.Worker,
+			WorkerDataBundle: payload,
+		})
+		s.Require().NoError(err)
+	}
+
+	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
+	s.Require().NoError(err)
+
+	// Move to end of worker submission window
+	s.ctx = s.ctx.WithBlockHeight(currentBlockHeight + topic.WorkerSubmissionWindow)
+
+	// Before closing, check nonce is unfulfilled, active workers exist, and submissions exist
+	unfulfilled, err := s.emissionsKeeper.IsWorkerNonceUnfulfilled(s.ctx, topicId, inferenceBundles[0].Nonce)
+	s.Require().NoError(err)
+	s.Require().True(unfulfilled)
+
+	activeInferers, err := s.emissionsKeeper.GetActiveInferersForTopic(s.ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(len(workerIndexes), len(activeInferers))
+
+	for _, bundle := range inferenceBundles {
+		submissions, err := s.emissionsKeeper.GetWorkerLatestInferenceByTopicId(s.ctx, topicId, bundle.Worker)
+		s.Require().NoError(err)
+		s.Require().NotNil(submissions)
+	}
+
+	// Enforcing that the active inferer to create an error
+	enforcedInferer := s.addrsStr[10]
+	err = s.emissionsKeeper.AddActiveInferer(s.ctx, topicId, enforcedInferer)
+	s.Require().NoError(err)
+
+	// Call CloseWorkerNonce, expecting an error
+	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
+	s.Require().Error(err)
+
+	// After closing, check nonce is fulfilled, active workers are reset, and submissions are cleared
+	unfulfilled, err = s.emissionsKeeper.IsWorkerNonceUnfulfilled(s.ctx, topicId, inferenceBundles[0].Nonce)
+	s.Require().NoError(err)
+	s.Require().False(unfulfilled)
+
+	activeInferers, err = s.emissionsKeeper.GetActiveInferersForTopic(s.ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(0, len(activeInferers))
+
+	for _, bundle := range inferenceBundles {
+		_, err := s.emissionsKeeper.GetWorkerLatestInferenceByTopicId(s.ctx, topicId, bundle.Worker)
 		s.Require().ErrorIs(err, collections.ErrNotFound)
 	}
 }

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -343,7 +343,7 @@ func (s *RewardsTestSuite) TestStandardRewardEmission() {
 	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
 
 	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes)
+	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
 	for _, payload := range lossBundles.ReputerValueBundles {
 		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
 		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
@@ -494,7 +494,7 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionShouldRewardTopicsWithFulfi
 	err = s.emissionsAppModule.EndBlock(s.ctx)
 	s.Require().NoError(err)
 	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes)
+	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
 	for _, payload := range lossBundles.ReputerValueBundles {
 		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
 		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
@@ -1387,7 +1387,7 @@ func (s *RewardsTestSuite) TestGenerateTasksRewardsShouldIncreaseRewardShareIfMo
 	s.Require().NoError(err)
 
 	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes)
+	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
 	for _, payload := range lossBundles.ReputerValueBundles {
 		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
 		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
@@ -1556,7 +1556,7 @@ func (s *RewardsTestSuite) TestGenerateTasksRewardsShouldIncreaseRewardShareIfMo
 	s.Require().NoError(err)
 
 	// Insert loss bundle from reputers
-	lossBundles = generateLossBundles(s, block, topicId, reputerIndexes)
+	lossBundles = generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
 	for _, payload := range lossBundles.ReputerValueBundles {
 		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
 		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
@@ -1865,7 +1865,7 @@ func (s *RewardsTestSuite) TestRewardsIncreasesBalance() {
 	s.Require().NoError(err)
 
 	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes)
+	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
 	for _, payload := range lossBundles.ReputerValueBundles {
 		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
 			Sender:             payload.ValueBundle.Reputer,
@@ -2086,7 +2086,7 @@ func (s *RewardsTestSuite) TestRewardsHandleStandardDeviationOfZero() {
 	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
 
 	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId1, reputerIndexes)
+	lossBundles := generateLossBundles(s, block, topicId1, reputerIndexes, workerIndexes)
 	for i, payload := range lossBundles.ReputerValueBundles {
 		s.RegisterAllReputersOfPayload(topicId1, payload)
 		if i <= 2 {
@@ -2106,7 +2106,7 @@ func (s *RewardsTestSuite) TestRewardsHandleStandardDeviationOfZero() {
 	newBlockheight = block + topic2.GroundTruthLag
 	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
 
-	lossBundles2 := generateLossBundles(s, block, topicId2, reputerIndexes)
+	lossBundles2 := generateLossBundles(s, block, topicId2, reputerIndexes, workerIndexes)
 	for i, payload := range lossBundles2.ReputerValueBundles {
 		s.RegisterAllReputersOfPayload(topicId2, payload)
 		if i > 2 {

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -784,13 +784,17 @@ func prepareMockLosses(reputersCount int, workersCount int) (
 		reputersForecasterOneOutLosses,
 		reputersOneInNaiveLosses
 }
-func generateLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64, reputerIndexes []int) types.InputReputerValueBundles {
+
+func generateLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64, reputerIndexes []int, workerIndexes []int) types.InputReputerValueBundles {
+	if len(workerIndexes) != 5 {
+		panic("workerIndexes length must be 5")
+	}
 	workers := []sdk.AccAddress{
-		s.addrs[5],
-		s.addrs[6],
-		s.addrs[7],
-		s.addrs[8],
-		s.addrs[9],
+		s.addrs[workerIndexes[0]],
+		s.addrs[workerIndexes[1]],
+		s.addrs[workerIndexes[2]],
+		s.addrs[workerIndexes[3]],
+		s.addrs[workerIndexes[4]],
 	}
 	reputersLosses := []alloraMath.BoundedExp40Dec{
 		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01127")),

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -236,6 +236,50 @@ func (s *RewardsTestSuite) TestGetInferenceScores() {
 	}
 }
 
+func (s *RewardsTestSuite) TestGenerateInferenceScores_AllNilOneOutAndOneIn() {
+	newTopicMsg := &types.CreateNewTopicRequest{
+		Creator:                  s.addrs[0].String(),
+		Metadata:                 "test",
+		LossMethod:               "mse",
+		EpochLength:              10800,
+		GroundTruthLag:           10800,
+		WorkerSubmissionWindow:   10,
+		PNorm:                    alloraMath.NewDecFromInt64(3),
+		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
+		AllowNegative:            true,
+		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
+		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
+		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
+		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		EnableWorkerWhitelist:    true,
+		EnableReputerWhitelist:   true,
+	}
+	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
+	s.Require().NoError(err)
+	topicId := res.TopicId
+	block := int64(2001)
+
+	// Generate normal network losses, then set all one-out/one-in fields to nil
+	reportedLosses, err := mockNetworkLosses(s, topicId, block)
+	s.Require().NoError(err)
+
+	reportedLosses.OneOutInfererValues = nil
+	reportedLosses.OneOutForecasterValues = nil
+	reportedLosses.OneInForecasterValues = nil
+
+	scores, err := rewards.GenerateInferenceScores(
+		s.ctx,
+		s.emissionsKeeper,
+		topicId,
+		block,
+		reportedLosses,
+	)
+	// Should not panic, should return empty slice and no error
+	s.Require().NoError(err)
+	s.Require().Len(scores, 0, "Expected no scores when all one-out/one-in values are nil")
+}
+
 func (s *RewardsTestSuite) TestGetInferenceScoresFromCsv() {
 	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
 	epoch3Get := epochGet[300]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
This PR enhances the robustness of the CloseReputerNonce function by implementing a defer block to ensure critical cleanup operations (fulfilling the nonce, resetting active reputers, resetting submissions) are always executed, even if errors occur during the processing of reputer bundles.

The primary goal is to prevent the system from getting stuck in an inconsistent state if CloseReputerNonce fails mid-execution. By guaranteeing cleanup actions via defer, we ensure the nonce is properly fulfilled and associated state (active reputers, submissions) is reset, improving the reliability of the nonce management and reward distribution process.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
https://linear.app/alloralabs/issue/ENGN-3672/required-functions-not-being-called-not-deferd

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo
- PR Review 
- Check if more tests need to be done
