### PR TITLE
Additional validations + use inferenceBlockheight in NetworkInferences

### DIFF
--- a/x/emissions/keeper/inference_synthesis/network_inference_builder.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder.go
@@ -856,6 +856,7 @@ type CalcNetworkInferencesArgs struct {
 	PNorm                                alloraMath.Dec
 	CNorm                                alloraMath.Dec
 	StdDevPlusEpsilon                    alloraMath.Dec
+	InferenceBlockHeight                 BlockHeight
 }
 
 // Calculates all network inferences in the set I_i given historical state (e.g. regrets)
@@ -1048,7 +1049,7 @@ func CalcNetworkInferences(
 	return &emissions.ValueBundle{
 		TopicId: args.TopicId,
 		ReputerRequestNonce: &emissions.ReputerRequestNonce{
-			ReputerNonce: &emissions.Nonce{BlockHeight: args.Ctx.BlockHeight()},
+			ReputerNonce: &emissions.Nonce{BlockHeight: args.InferenceBlockHeight},
 		},
 		Reputer:                       "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
 		ExtraData:                     nil,

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
@@ -188,8 +188,23 @@ func (s *InferenceSynthesisTestSuite) mockTopic() emissionstypes.Topic {
 	}
 }
 
+// ConvertInferencesToWorkerAttributedValues converts an Inferences type to a slice of WorkerAttributedValue
+func (s *InferenceSynthesisTestSuite) ConvertInferencesToWorkerAttributedValues(inferences emissionstypes.Inferences) []*emissionstypes.WorkerAttributedValue {
+	result := make([]*emissionstypes.WorkerAttributedValue, 0, len(inferences.Inferences))
+
+	for _, inference := range inferences.Inferences {
+		result = append(result, &emissionstypes.WorkerAttributedValue{
+			Worker: inference.Inferer,
+			Value:  inference.Value,
+		})
+	}
+
+	return result
+}
+
 func (s *InferenceSynthesisTestSuite) mockEmptyValueBundle(
 	combinedAndNaiveValue alloraMath.Dec,
+	infererValues []*emissionstypes.WorkerAttributedValue,
 ) emissionstypes.ValueBundle {
 	return emissionstypes.ValueBundle{
 		TopicId: uint64(1),
@@ -199,7 +214,7 @@ func (s *InferenceSynthesisTestSuite) mockEmptyValueBundle(
 		Reputer:                       s.addrsStr[9],
 		ExtraData:                     nil,
 		CombinedValue:                 combinedAndNaiveValue,
-		InfererValues:                 nil,
+		InfererValues:                 infererValues,
 		ForecasterValues:              nil,
 		NaiveValue:                    combinedAndNaiveValue,
 		OneOutInfererValues:           nil,
@@ -548,6 +563,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 		topic,
 		valueBundle,
 		moduleParams,
+		blockHeight,
 	)
 	s.Require().NoError(err)
 	return ctx, k, ctx.Logger(), topicId, calcArgs.AllInferersAreNew,
@@ -599,6 +615,7 @@ func (s *InferenceSynthesisTestSuite) getNetworkCalcArgs(
 		topic,
 		networkLosses,
 		moduleParams,
+		blockHeight,
 	)
 	s.Require().NoError(err)
 	return calcArgs.Inferers, calcArgs.InfererToInference, calcArgs.InfererToRegret, calcArgs.AllInferersAreNew,
@@ -949,6 +966,7 @@ func (s *InferenceSynthesisTestSuite) TestBuildNetworkInferencesIncompleteData()
 		PNorm:                                pNorm,
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
+		InferenceBlockHeight:                 blockHeightInferences,
 	}
 
 	valueBundle, _, err := inferencesynthesis.CalcNetworkInferences(calcArgs)
@@ -1062,6 +1080,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesTwoWorkerTwoForec
 		PNorm:                                pNorm,
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
+		InferenceBlockHeight:                 blockHeight,
 	}
 	valueBundle, _, err := inferencesynthesis.CalcNetworkInferences(calcArgs)
 	s.Require().NoError(err)
@@ -1205,6 +1224,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesThreeWorkerThreeF
 		PNorm:                                pNorm,
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
+		InferenceBlockHeight:                 blockHeight,
 	}
 
 	valueBundle, _, err := inferencesynthesis.CalcNetworkInferences(
@@ -1352,6 +1372,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesThreeWorkerTwoFor
 		PNorm:                                pNorm,
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
+		InferenceBlockHeight:                 blockHeight,
 	}
 
 	valueBundle, weights, err := inferencesynthesis.CalcNetworkInferences(
@@ -1460,6 +1481,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneInInferencesTwoForecastersOldTw
 		PNorm:                                pNorm,
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
+		InferenceBlockHeight:                 blockHeight,
 	}
 
 	valueBundle, _, err := inferencesynthesis.CalcNetworkInferences(calcArgs)

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -51,7 +51,7 @@ func GetNetworkInferences(
 		networkLosses, err := k.GetLatestNetworkLossBundle(ctx, topicId)
 		if errors.Is(err, emissions.ErrNotFound) {
 			// 2a. If we have no network losses, fallback to using the median of the inferences.
-			return calcNetworkInferencesMultipleByMedian(ctx, topicId, inferences, *inferencesNonce)
+			return calcNetworkInferencesMultipleByMedian(topicId, inferences, *inferencesNonce)
 		} else if err != nil {
 			return nil, errorsmod.Wrap(err, "while getting latest network loss bundle")
 		}
@@ -67,7 +67,6 @@ func GetNetworkInferences(
 }
 
 func calcNetworkInferencesMultipleByMedian(
-	ctx sdk.Context,
 	topicId TopicId,
 	inferences *emissions.Inferences,
 	inferenceBlockHeight BlockHeight,
@@ -83,7 +82,7 @@ func calcNetworkInferencesMultipleByMedian(
 		TopicId:   topicId,
 		ExtraData: nil,
 		ReputerRequestNonce: &emissions.ReputerRequestNonce{
-			ReputerNonce: &emissions.Nonce{BlockHeight: ctx.BlockHeight()},
+			ReputerNonce: &emissions.Nonce{BlockHeight: inferenceBlockHeight},
 		},
 		Reputer:       "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
 		CombinedValue: medianValue,
@@ -144,6 +143,7 @@ func calcNetworkInferencesMultiple(
 		topic,
 		*networkLosses,
 		moduleParams,
+		inferenceBlockHeight,
 	)
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "while getting network inference args")
@@ -215,6 +215,7 @@ func GetCalcNetworkInferenceArgs(
 	topic emissions.Topic,
 	networkLosses emissions.ValueBundle,
 	moduleParams emissions.Params,
+	inferenceBlockHeight BlockHeight,
 ) (
 	calcArgs CalcNetworkInferencesArgs,
 	err error,
@@ -296,6 +297,7 @@ func GetCalcNetworkInferenceArgs(
 		PNorm:                                topic.PNorm,
 		CNorm:                                moduleParams.CNorm,
 		StdDevPlusEpsilon:                    stdDevPlusEpsilon,
+		InferenceBlockHeight:                 inferenceBlockHeight,
 	}
 
 	// If there are forecast-implied inferences, add forecasters info

--- a/x/emissions/keeper/inference_synthesis/network_inferences_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences_test.go
@@ -136,13 +136,14 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 	forecaster2 := s.addrsStr[7]
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
-	// Set Previous Loss
-	valueBundlePrevious := s.mockEmptyValueBundle(epoch2Get("network_loss"))
-	err = keeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, blockHeightPreviousLosses, valueBundlePrevious)
-	require.NoError(err)
-
 	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch3Get)
 	s.Require().NoError(err)
+	infererValues := s.ConvertInferencesToWorkerAttributedValues(inferences)
+
+	// Set Previous Loss
+	valueBundlePrevious := s.mockEmptyValueBundle(epoch2Get("network_loss"), infererValues)
+	err = keeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, blockHeightPreviousLosses, valueBundlePrevious)
+	require.NoError(err)
 
 	err = keeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
 	s.Require().NoError(err)
@@ -376,13 +377,13 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOneOldI
 	inferer4 := s.addrsStr[4]
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
+	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch2Get)
+	s.Require().NoError(err)
+	infererValues := s.ConvertInferencesToWorkerAttributedValues(inferences)
 	// Set Previous Loss
-	valueBundlePrevious := s.mockEmptyValueBundle(epoch1Get("network_loss"))
+	valueBundlePrevious := s.mockEmptyValueBundle(epoch1Get("network_loss"), infererValues)
 	err = s.emissionsKeeper.InsertNetworkLossBundleAtBlock(
 		s.ctx, topicId, blockHeightPreviousLosses, valueBundlePrevious)
-	s.Require().NoError(err)
-
-	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch2Get)
 	s.Require().NoError(err)
 
 	err = s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
@@ -455,12 +456,13 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOldInfe
 	forecaster2 := s.addrsStr[7]
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
-	// Set Previous Loss
-	emptyValueBundle := s.mockEmptyValueBundle(epoch1Get("network_loss"))
-	err = s.emissionsKeeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, blockHeightPreviousLosses, emptyValueBundle)
-	s.Require().NoError(err)
-
 	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch2Get)
+	s.Require().NoError(err)
+	infererValues := s.ConvertInferencesToWorkerAttributedValues(inferences)
+
+	// Set Previous Loss
+	emptyValueBundle := s.mockEmptyValueBundle(epoch1Get("network_loss"), infererValues)
+	err = s.emissionsKeeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, blockHeightPreviousLosses, emptyValueBundle)
 	s.Require().NoError(err)
 
 	err = s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
@@ -601,15 +603,16 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOldInfe
 	forecaster2 := s.addrsStr[7]
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
+	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch2Get)
+	s.Require().NoError(err)
+	infererValues := s.ConvertInferencesToWorkerAttributedValues(inferences)
+
 	// Set Previous Loss
-	emptyValueBundle := s.mockEmptyValueBundle(epoch1Get("network_loss"))
+	emptyValueBundle := s.mockEmptyValueBundle(epoch1Get("network_loss"), infererValues)
 	err = s.emissionsKeeper.InsertNetworkLossBundleAtBlock(
 		s.ctx, topicId, blockHeightPreviousLosses,
 		emptyValueBundle,
 	)
-	s.Require().NoError(err)
-
-	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch2Get)
 	s.Require().NoError(err)
 
 	err = s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
@@ -693,7 +696,6 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOldInfe
 		case forecaster1:
 			testutil.InEpsilon5(s.T(), oneOutForecasterValue.Value, "0.13368285139309616")
 		case forecaster2:
-
 			testutil.InEpsilon5(s.T(), oneOutForecasterValue.Value, "0.1339967078008638")
 		default:
 			s.Require().Fail("Unexpected worker %v", oneOutForecasterValue.Worker)
@@ -745,12 +747,12 @@ func (s *InferenceSynthesisTestSuite) TestGetLatestNetworkInferenceFromCsv() {
 	forecaster2 := s.addrsStr[7]
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
-	// Set Previous Loss
-	valueBundlePrevious := s.mockEmptyValueBundle(epoch2Get("network_loss"))
-	err = keeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, blockHeightPreviousLosses, valueBundlePrevious)
-	require.NoError(err)
-
 	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeightInferences, infererAddresses, epoch3Get)
+	require.NoError(err)
+	infererValues := s.ConvertInferencesToWorkerAttributedValues(inferences)
+	// Set Previous Loss
+	valueBundlePrevious := s.mockEmptyValueBundle(epoch2Get("network_loss"), infererValues)
+	err = keeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, blockHeightPreviousLosses, valueBundlePrevious)
 	require.NoError(err)
 
 	err = keeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -541,7 +541,7 @@ func (k *Keeper) GetLatestNetworkInferences(ctx context.Context, topicId TopicId
 
 /// NONCES
 
-// GetTopicIds returns the TopicIds for a given BlockHeight.
+// GetWorkerWindowTopicIds returns the TopicIds for a given BlockHeight.
 // If no TopicIds are found for the BlockHeight, it returns an empty slice.
 func (k *Keeper) GetWorkerWindowTopicIds(ctx sdk.Context, height BlockHeight) types.TopicIds {
 	topicIds, err := k.openWorkerWindows.Get(ctx, height)
@@ -551,7 +551,7 @@ func (k *Keeper) GetWorkerWindowTopicIds(ctx sdk.Context, height BlockHeight) ty
 	return topicIds
 }
 
-// SetTopicId appends a new TopicId to the list of TopicIds for a given BlockHeight.
+// AddWorkerWindowTopicId appends a new TopicId to the list of TopicIds for a given BlockHeight.
 // If no entry exists for the BlockHeight, it creates a new entry with the TopicId.
 func (k *Keeper) AddWorkerWindowTopicId(ctx sdk.Context, height BlockHeight, topicId TopicId) error {
 	if err := types.ValidateTopicId(topicId); err != nil {

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -1337,7 +1337,7 @@ func (s *KeeperTestSuite) TestInsertActiveReputerLosses() {
 		Reputer:                       s.addrsStr[0],
 		ExtraData:                     []byte("data"),
 		CombinedValue:                 alloraMath.MustNewDecFromString("123"),
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
 		OneOutInfererValues:           nil,
@@ -1392,7 +1392,7 @@ func (s *KeeperTestSuite) TestInsertNetworkLossBundleAtBlock() {
 		Reputer:                       "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
 		ExtraData:                     []byte("data"),
 		CombinedValue:                 alloraMath.MustNewDecFromString("123"),
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
 		OneOutInfererValues:           nil,
@@ -1445,7 +1445,7 @@ func (s *KeeperTestSuite) TestGetLatestNetworkLossBundle() {
 		Reputer:                       "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
 		ExtraData:                     []byte("data"),
 		CombinedValue:                 alloraMath.MustNewDecFromString("123"),
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
 		OneOutInfererValues:           nil,
@@ -1466,7 +1466,7 @@ func (s *KeeperTestSuite) TestGetLatestNetworkLossBundle() {
 		Reputer:                       "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
 		ExtraData:                     []byte("data"),
 		CombinedValue:                 alloraMath.MustNewDecFromString("456"),
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
 		OneOutInfererValues:           nil,
@@ -3285,7 +3285,7 @@ func (s *KeeperTestSuite) TestPruneRecordsAfterRewards() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4345,7 +4345,7 @@ func (s *KeeperTestSuite) TestAppendReputerLoss() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4365,7 +4365,7 @@ func (s *KeeperTestSuite) TestAppendReputerLoss() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4385,7 +4385,7 @@ func (s *KeeperTestSuite) TestAppendReputerLoss() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4421,7 +4421,7 @@ func (s *KeeperTestSuite) TestAppendReputerLoss() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4448,7 +4448,7 @@ func (s *KeeperTestSuite) TestAppendReputerLoss() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4512,7 +4512,7 @@ func (s *KeeperTestSuite) TestAppendReputerLossWithResetActiveReputers() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4532,7 +4532,7 @@ func (s *KeeperTestSuite) TestAppendReputerLossWithResetActiveReputers() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4552,7 +4552,7 @@ func (s *KeeperTestSuite) TestAppendReputerLossWithResetActiveReputers() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4572,7 +4572,7 @@ func (s *KeeperTestSuite) TestAppendReputerLossWithResetActiveReputers() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4592,7 +4592,7 @@ func (s *KeeperTestSuite) TestAppendReputerLossWithResetActiveReputers() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topicId,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -4960,7 +4960,7 @@ func (s *KeeperTestSuite) TestRemoveReputerLoss() {
 		Reputer:                       reputer,
 		ExtraData:                     []byte("data"),
 		CombinedValue:                 alloraMath.MustNewDecFromString("123"),
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
 		OneOutInfererValues:           nil,
@@ -5442,7 +5442,7 @@ func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendReputer() {
 		Reputer:                       reputer,
 		ExtraData:                     nil,
 		CombinedValue:                 alloraMath.MustNewDecFromString("0.52"),
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.52"),
 		OneOutInfererValues:           nil,
@@ -5672,7 +5672,7 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendReputerLoss() {
 		ReputerRequestNonce:           reputerRequestNonce,
 		TopicId:                       topic.Id,
 		ExtraData:                     nil,
-		InfererValues:                 nil,
+		InfererValues:                 s.createDefaultInfererValues(),
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
 		OneOutInfererValues:           nil,
@@ -5791,4 +5791,21 @@ func (s *KeeperTestSuite) TestLatestRegretStdNormFunctions() {
 	// Test setting zero value (should fail)
 	err = k.SetLatestRegretStdNorm(ctx, topicId, alloraMath.ZeroDec())
 	s.Require().Error(err, "Setting zero regret stdNorm should fail")
+}
+
+// createDefaultInfererValues generates a set of inferer values including all test addresses
+// This can be used to ensure ValueBundle validation passes when InfererValues cannot be nil
+func (s *KeeperTestSuite) createDefaultInfererValues() []*types.WorkerAttributedValue {
+	// Create an array to hold all worker attributed values
+	infererValues := make([]*types.WorkerAttributedValue, len(s.addrsStr))
+
+	// Add a WorkerAttributedValue for each address in the test suite
+	for i, addr := range s.addrsStr {
+		infererValues[i] = &types.WorkerAttributedValue{
+			Worker: addr,
+			Value:  alloraMath.NewDecFromInt64(int64(i + 1)), // Using different values based on index
+		}
+	}
+
+	return infererValues
 }

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -1504,12 +1504,17 @@ func (s *MsgServerTestSuite) TestRewardDelegateStake() {
 	reputerValueBundle := &types.ReputerValueBundle{
 		Pubkey: s.pubKeyHexStr[1],
 		ValueBundle: &types.ValueBundle{
-			TopicId:                       topicId,
-			ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
-			Reputer:                       reputer,
-			ExtraData:                     nil,
-			CombinedValue:                 alloraMath.MustNewDecFromString("1500.0"),
-			InfererValues:                 nil,
+			TopicId:             topicId,
+			ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
+			Reputer:             reputer,
+			ExtraData:           nil,
+			CombinedValue:       alloraMath.MustNewDecFromString("1500.0"),
+			InfererValues: []*types.WorkerAttributedValue{
+				{
+					Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+					Value:  alloraMath.MustNewDecFromString("1"),
+				},
+			},
 			ForecasterValues:              nil,
 			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
 			OneOutInfererValues:           nil,
@@ -1570,12 +1575,17 @@ func (s *MsgServerTestSuite) TestRewardDelegateStake() {
 
 	newReputerValueBundle := &types.ReputerValueBundle{
 		ValueBundle: &types.ValueBundle{
-			TopicId:                       topicId,
-			ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: newBlock}},
-			Reputer:                       reputer,
-			ExtraData:                     nil,
-			CombinedValue:                 alloraMath.MustNewDecFromString("1500.0"),
-			InfererValues:                 nil,
+			TopicId:             topicId,
+			ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: newBlock}},
+			Reputer:             reputer,
+			ExtraData:           nil,
+			CombinedValue:       alloraMath.MustNewDecFromString("1500.0"),
+			InfererValues: []*types.WorkerAttributedValue{
+				{
+					Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+					Value:  alloraMath.MustNewDecFromString("1"),
+				},
+			},
 			ForecasterValues:              nil,
 			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
 			OneOutInfererValues:           nil,
@@ -1656,12 +1666,17 @@ func (s *MsgServerTestSuite) insertValueBundlesAndGetRewards(
 	err := keeper.InsertReputerScore(s.ctx, topicId, block, scoreToAdd)
 	s.Require().NoError(err)
 	valueBundle := &types.ValueBundle{
-		TopicId:                       topicId,
-		ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
-		Reputer:                       reputer,
-		ExtraData:                     nil,
-		CombinedValue:                 alloraMath.MustNewDecFromString("1500.0"),
-		InfererValues:                 nil,
+		TopicId:             topicId,
+		ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
+		Reputer:             reputer,
+		ExtraData:           nil,
+		CombinedValue:       alloraMath.MustNewDecFromString("1500.0"),
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
 		OneOutInfererValues:           nil,

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
@@ -271,7 +271,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithMismatchedTopicI
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 
 	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
-	require.ErrorIs(err, types.ErrInvalidTopicId)
+	require.ErrorIs(err, sdkerrors.ErrInvalidRequest)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithUnregisteredInferer() {
@@ -462,7 +462,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithMismatchedForeca
 
 	ctx = ctx.WithBlockHeight(blockHeight)
 	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
-	require.ErrorIs(err, types.ErrInvalidTopicId)
+	require.ErrorIs(err, sdkerrors.ErrInvalidRequest)
 
 	forecastsCount1 := s.getCountForecastsAtBlock(originalTopicId, blockHeight)
 	require.Equal(forecastsCount1, 0)

--- a/x/emissions/keeper/queryserver/query_server_inferences_test.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences_test.go
@@ -129,12 +129,17 @@ func (s *QueryServerTestSuite) TestGetNetworkInferencesAtBlock() {
 	// Set Loss bundles
 
 	valueBundle1 := types.ValueBundle{
-		TopicId:                       topicId,
-		Reputer:                       reputer0,
-		ExtraData:                     nil,
-		ReputerRequestNonce:           reputerRequestNonce,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000117005278862668"),
-		InfererValues:                 nil,
+		TopicId:             topicId,
+		Reputer:             reputer0,
+		ExtraData:           nil,
+		ReputerRequestNonce: reputerRequestNonce,
+		CombinedValue:       alloraMath.MustNewDecFromString(".0000117005278862668"),
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString(".0000117005278862668"),
 		OneOutInfererValues:           nil,
@@ -145,12 +150,17 @@ func (s *QueryServerTestSuite) TestGetNetworkInferencesAtBlock() {
 	signature1 := s.signValueBundle(&valueBundle1, s.privKeys[5])
 
 	valueBundle2 := types.ValueBundle{
-		TopicId:                       topicId,
-		Reputer:                       reputer1,
-		ExtraData:                     nil,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".00000962701954026944"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		InfererValues:                 nil,
+		TopicId:             topicId,
+		Reputer:             reputer1,
+		ExtraData:           nil,
+		CombinedValue:       alloraMath.MustNewDecFromString(".00000962701954026944"),
+		ReputerRequestNonce: reputerRequestNonce,
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString(".00000962701954026944"),
 		OneOutInfererValues:           nil,
@@ -160,12 +170,17 @@ func (s *QueryServerTestSuite) TestGetNetworkInferencesAtBlock() {
 	}
 	signature2 := s.signValueBundle(&valueBundle2, s.privKeys[6])
 	valueBundle3 := types.ValueBundle{
-		Reputer:                       reputer2,
-		ExtraData:                     nil,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		InfererValues:                 nil,
+		Reputer:             reputer2,
+		ExtraData:           nil,
+		CombinedValue:       alloraMath.MustNewDecFromString(".0000256948644008351"),
+		ReputerRequestNonce: reputerRequestNonce,
+		TopicId:             topicId,
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString(".0000256948644008351"),
 		OneOutInfererValues:           nil,
@@ -175,12 +190,17 @@ func (s *QueryServerTestSuite) TestGetNetworkInferencesAtBlock() {
 	}
 	signature3 := s.signValueBundle(&valueBundle3, s.privKeys[7])
 	valueBundle4 := types.ValueBundle{
-		Reputer:                       reputer3,
-		ExtraData:                     nil,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000123986052417188"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		InfererValues:                 nil,
+		Reputer:             reputer3,
+		ExtraData:           nil,
+		CombinedValue:       alloraMath.MustNewDecFromString(".0000123986052417188"),
+		ReputerRequestNonce: reputerRequestNonce,
+		TopicId:             topicId,
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString(".0000123986052417188"),
 		OneOutInfererValues:           nil,
@@ -190,12 +210,17 @@ func (s *QueryServerTestSuite) TestGetNetworkInferencesAtBlock() {
 	}
 	signature4 := s.signValueBundle(&valueBundle4, s.privKeys[8])
 	valueBundle5 := types.ValueBundle{
-		Reputer:                       reputer4,
-		ExtraData:                     nil,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000115363240547692"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		InfererValues:                 nil,
+		Reputer:             reputer4,
+		ExtraData:           nil,
+		CombinedValue:       alloraMath.MustNewDecFromString(".0000115363240547692"),
+		ReputerRequestNonce: reputerRequestNonce,
+		TopicId:             topicId,
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString(".0000115363240547692"),
 		OneOutInfererValues:           nil,
@@ -306,7 +331,7 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferences() {
 	require.NoError(err)
 
 	epochLength := topic.EpochLength
-	epochLastEnded := topic.EpochLastEnded
+	epochLastEnded := int64(1) // topic.EpochLastEnded , but 0 is not a valid nonce
 
 	lossBlockHeight := epochLastEnded
 	inferenceBlockHeight := epochLastEnded + epochLength
@@ -320,12 +345,17 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferences() {
 
 	// Set Loss bundles
 	err = keeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, lossBlockHeight, types.ValueBundle{
-		TopicId:                       topicId,
-		ReputerRequestNonce:           reputerLossRequestNonce,
-		ExtraData:                     nil,
-		Reputer:                       s.addrsStr[8],
-		CombinedValue:                 alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
-		InfererValues:                 nil,
+		TopicId:             topicId,
+		ReputerRequestNonce: reputerLossRequestNonce,
+		ExtraData:           nil,
+		Reputer:             s.addrsStr[8],
+		CombinedValue:       alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
 		OneOutInfererValues:           nil,
@@ -708,7 +738,7 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferencesWithMissingInferenc
 	require.NoError(err)
 
 	epochLength := topic.EpochLength
-	epochLastEnded := topic.EpochLastEnded
+	epochLastEnded := int64(1) // topic.EpochLastEnded , but 0 is not a valid nonce
 
 	lossBlockHeight := epochLastEnded
 	inferenceBlockHeight := epochLastEnded + epochLength
@@ -724,13 +754,18 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferencesWithMissingInferenc
 
 	// Set Loss bundles
 	lossBundle := types.ValueBundle{
-		CombinedValue:                 alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
-		ReputerRequestNonce:           reputerLossRequestNonce,
-		TopicId:                       topicId,
-		Reputer:                       s.addrsStr[0],
-		ExtraData:                     nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
-		InfererValues:                 nil,
+		CombinedValue:       alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
+		ReputerRequestNonce: reputerLossRequestNonce,
+		TopicId:             topicId,
+		Reputer:             s.addrsStr[0],
+		ExtraData:           nil,
+		NaiveValue:          alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		ForecasterValues:              nil,
 		OneOutInfererValues:           nil,
 		OneOutForecasterValues:        nil,

--- a/x/emissions/keeper/queryserver/query_server_losses_test.go
+++ b/x/emissions/keeper/queryserver/query_server_losses_test.go
@@ -23,8 +23,14 @@ func (s *QueryServerTestSuite) TestGetNetworkLossBundleAtBlock() {
 				BlockHeight: blockHeight,
 			},
 		},
-		ExtraData:                     []byte("sample_extra_data"),
-		InfererValues:                 nil,
+		ExtraData: []byte("sample_extra_data"),
+		// Initialize InfererValues with at least one element to meet the new validation requirement
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		CombinedValue:                 alloraMath.ZeroDec(),
 		NaiveValue:                    alloraMath.ZeroDec(),
 		ForecasterValues:              nil,
@@ -113,13 +119,19 @@ func (s *QueryServerTestSuite) TestGetReputerLossBundlesAtBlock() {
 	topicId := uint64(1)
 	block := types.BlockHeight(100)
 	valueBundle := types.ValueBundle{
-		TopicId:                       topicId,
-		Reputer:                       s.addrsStr[0],
-		ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
-		ExtraData:                     []byte("sample_extra_data"),
-		CombinedValue:                 alloraMath.NewDecFromInt64(100),
-		NaiveValue:                    alloraMath.NewDecFromInt64(100),
-		InfererValues:                 nil,
+		TopicId:             topicId,
+		Reputer:             s.addrsStr[0],
+		ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
+		ExtraData:           []byte("sample_extra_data"),
+		CombinedValue:       alloraMath.NewDecFromInt64(100),
+		NaiveValue:          alloraMath.NewDecFromInt64(100),
+		// Initialize InfererValues with at least one element to meet the new validation requirement
+		InfererValues: []*types.WorkerAttributedValue{
+			{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			},
+		},
 		ForecasterValues:              nil,
 		OneOutInfererValues:           nil,
 		OneOutForecasterValues:        nil,

--- a/x/emissions/module/rewards/reputer_rewards_test.go
+++ b/x/emissions/module/rewards/reputer_rewards_test.go
@@ -621,10 +621,13 @@ func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64, reputerI
 			TopicId: topicId,
 			ReputerRequestNonce: &types.ReputerRequestNonce{
 				ReputerNonce: &types.Nonce{BlockHeight: block}},
-			Reputer:                       s.addrsStr[reputerIndex],
-			ExtraData:                     nil,
-			CombinedValue:                 alloraMath.MustNewDecFromString("1500.0"),
-			InfererValues:                 nil,
+			Reputer:       s.addrsStr[reputerIndex],
+			ExtraData:     nil,
+			CombinedValue: alloraMath.MustNewDecFromString("1500.0"),
+			InfererValues: []*types.WorkerAttributedValue{{
+				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				Value:  alloraMath.MustNewDecFromString("1"),
+			}},
 			ForecasterValues:              nil,
 			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
 			OneOutInfererValues:           nil,

--- a/x/emissions/module/rewards/worker_rewards_test.go
+++ b/x/emissions/module/rewards/worker_rewards_test.go
@@ -571,6 +571,29 @@ func (s *RewardsTestSuite) TestForecastRewardsFromCsv() {
 }
 
 func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.ValueBundle, error) {
+	infererValues := []*types.WorkerAttributedValue{
+		{
+			Worker: s.addrs[0].String(),
+			Value:  alloraMath.MustNewDecFromString("0.01327"),
+		},
+		{
+			Worker: s.addrs[1].String(),
+			Value:  alloraMath.MustNewDecFromString("0.01302"),
+		},
+		{
+			Worker: s.addrs[2].String(),
+			Value:  alloraMath.MustNewDecFromString("0.0136"),
+		},
+		{
+			Worker: s.addrs[3].String(),
+			Value:  alloraMath.MustNewDecFromString("0.01491"),
+		},
+		{
+			Worker: s.addrs[4].String(),
+			Value:  alloraMath.MustNewDecFromString("0.01686"),
+		},
+	}
+
 	oneOutInfererLosses := []*types.WithheldWorkerAttributedValue{
 		{
 			Worker: s.addrs[0].String(),
@@ -646,7 +669,7 @@ func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.
 		Reputer:                       s.addrsStr[9],
 		ExtraData:                     nil,
 		CombinedValue:                 alloraMath.MustNewDecFromString("0.013481256018186383"),
-		InfererValues:                 nil,
+		InfererValues:                 infererValues,
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.01344474872292"),
 		OneOutInfererValues:           oneOutInfererLosses,
@@ -670,6 +693,21 @@ func mockSimpleNetworkLosses(
 	block int64,
 	worker0Value string,
 ) (types.ValueBundle, error) {
+	infererValues := []*types.WorkerAttributedValue{
+		{
+			Worker: s.addrs[0].String(),
+			Value:  alloraMath.MustNewDecFromString(worker0Value),
+		},
+		{
+			Worker: s.addrs[1].String(),
+			Value:  alloraMath.MustNewDecFromString("0.3"),
+		},
+		{
+			Worker: s.addrs[2].String(),
+			Value:  alloraMath.MustNewDecFromString("0.4"),
+		},
+	}
+
 	genericLossesWithheld := []*types.WithheldWorkerAttributedValue{
 		{
 			Worker: s.addrs[0].String(),
@@ -706,7 +744,7 @@ func mockSimpleNetworkLosses(
 		Reputer:                       s.addrsStr[9],
 		ExtraData:                     nil,
 		CombinedValue:                 alloraMath.MustNewDecFromString("0.05"),
-		InfererValues:                 nil,
+		InfererValues:                 infererValues,
 		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.MustNewDecFromString("0.05"),
 		OneOutInfererValues:           genericLossesWithheld,

--- a/x/emissions/types/validations.go
+++ b/x/emissions/types/validations.go
@@ -282,6 +282,13 @@ func (bundle *InputWorkerDataBundle) Validate() error {
 	if bundle.Nonce == nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "worker data bundle nonce cannot be nil")
 	}
+	if err := bundle.Nonce.Validate(); err != nil {
+		return errors.Wrap(err, "worker data bundle nonce is invalid")
+	}
+	// Additional validation on zero height for bundles
+	if bundle.Nonce.BlockHeight <= 0 {
+		return errors.Wrap(sdkerrors.ErrInvalidType, "worker data bundle nonce block height must be greater than 0")
+	}
 	if len(bundle.Worker) == 0 {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "worker cannot be empty")
 	}
@@ -310,6 +317,7 @@ func (bundle *InputWorkerDataBundle) Validate() error {
 		if err := bundle.InferenceForecastsBundle.Inference.Validate(); err != nil {
 			return err
 		}
+		// Validate against the current bundle
 		if bundle.InferenceForecastsBundle.Inference.Inferer != pubKeyConvertedToAddress {
 			return errors.Wrapf(sdkerrors.ErrUnauthorized,
 				"Inference.Inferer %s does not match pubkey %s",
@@ -320,11 +328,18 @@ func (bundle *InputWorkerDataBundle) Validate() error {
 				"Inference.Inferer %s does not match worker address %s",
 				bundle.InferenceForecastsBundle.Inference.Inferer, bundle.Worker)
 		}
+		if bundle.TopicId != bundle.InferenceForecastsBundle.Inference.TopicId {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "inference topic id %d does not match bundle topic id %d", bundle.InferenceForecastsBundle.Inference.TopicId, bundle.TopicId)
+		}
+		if bundle.Nonce.BlockHeight != bundle.InferenceForecastsBundle.Inference.BlockHeight {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "inference block height %d does not match bundle block height %d", bundle.InferenceForecastsBundle.Inference.BlockHeight, bundle.Nonce.BlockHeight)
+		}
 	}
 	if bundle.InferenceForecastsBundle.Forecast != nil {
 		if err := bundle.InferenceForecastsBundle.Forecast.Validate(); err != nil {
 			return err
 		}
+		// Validate against the current bundle
 		if bundle.InferenceForecastsBundle.Forecast.Forecaster != pubKeyConvertedToAddress {
 			return errors.Wrapf(sdkerrors.ErrUnauthorized,
 				"Forecast.Forecaster %s does not match pubkey %s",
@@ -334,6 +349,12 @@ func (bundle *InputWorkerDataBundle) Validate() error {
 			return errors.Wrapf(sdkerrors.ErrUnauthorized,
 				"Forecast.Forecaster %s does not match worker address %s",
 				bundle.InferenceForecastsBundle.Forecast.Forecaster, bundle.Worker)
+		}
+		if bundle.TopicId != bundle.InferenceForecastsBundle.Forecast.TopicId {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "forecast topic id %d does not match bundle topic id %d", bundle.InferenceForecastsBundle.Forecast.TopicId, bundle.TopicId)
+		}
+		if bundle.Nonce.BlockHeight != bundle.InferenceForecastsBundle.Forecast.BlockHeight {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "forecast block height %d does not match bundle block height %d", bundle.InferenceForecastsBundle.Forecast.BlockHeight, bundle.Nonce.BlockHeight)
 		}
 	}
 
@@ -391,6 +412,7 @@ func (bundle *WorkerDataBundle) Validate() error {
 		if err := bundle.InferenceForecastsBundle.Inference.Validate(); err != nil {
 			return err
 		}
+		// Validate against the current bundle
 		if bundle.InferenceForecastsBundle.Inference.Inferer != pubKeyConvertedToAddress {
 			return errors.Wrapf(sdkerrors.ErrUnauthorized,
 				"Inference.Inferer %s does not match pubkey %s",
@@ -401,11 +423,18 @@ func (bundle *WorkerDataBundle) Validate() error {
 				"Inference.Inferer %s does not match worker address %s",
 				bundle.InferenceForecastsBundle.Inference.Inferer, bundle.Worker)
 		}
+		if bundle.TopicId != bundle.InferenceForecastsBundle.Inference.TopicId {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "inference topic id %d does not match bundle topic id %d", bundle.InferenceForecastsBundle.Inference.TopicId, bundle.TopicId)
+		}
+		if bundle.Nonce.BlockHeight != bundle.InferenceForecastsBundle.Inference.BlockHeight {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "inference block height %d does not match bundle block height %d", bundle.InferenceForecastsBundle.Inference.BlockHeight, bundle.Nonce.BlockHeight)
+		}
 	}
 	if bundle.InferenceForecastsBundle.Forecast != nil {
 		if err := bundle.InferenceForecastsBundle.Forecast.Validate(); err != nil {
 			return err
 		}
+		// Validate against the current bundle
 		if bundle.InferenceForecastsBundle.Forecast.Forecaster != pubKeyConvertedToAddress {
 			return errors.Wrapf(sdkerrors.ErrUnauthorized,
 				"Forecast.Forecaster %s does not match pubkey %s",
@@ -415,6 +444,12 @@ func (bundle *WorkerDataBundle) Validate() error {
 			return errors.Wrapf(sdkerrors.ErrUnauthorized,
 				"Forecast.Forecaster %s does not match worker address %s",
 				bundle.InferenceForecastsBundle.Forecast.Forecaster, bundle.Worker)
+		}
+		if bundle.TopicId != bundle.InferenceForecastsBundle.Forecast.TopicId {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "forecast topic id %d does not match bundle topic id %d", bundle.InferenceForecastsBundle.Forecast.TopicId, bundle.TopicId)
+		}
+		if bundle.Nonce.BlockHeight != bundle.InferenceForecastsBundle.Forecast.BlockHeight {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "forecast block height %d does not match bundle block height %d", bundle.InferenceForecastsBundle.Forecast.BlockHeight, bundle.Nonce.BlockHeight)
 		}
 	}
 
@@ -448,10 +483,21 @@ func (bundle *InputValueBundle) Validate() error {
 	if bundle.ReputerRequestNonce == nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "value bundle reputer request nonce cannot be nil")
 	}
+	if err := bundle.ReputerRequestNonce.Validate(); err != nil {
+		return errors.Wrap(err, "value bundle reputer request nonce is invalid")
+	}
+	// Additional validation on zero height for bundles
+	if bundle.ReputerRequestNonce.ReputerNonce.BlockHeight <= 0 {
+		return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle reputer request nonce block height must be greater than 0")
+	}
 	if err := ValidateBech32(bundle.Reputer); err != nil {
 		return errors.Wrap(err, "value bundle reputer address is invalid")
 	}
 	// extraData is not checked as it is not used by the chain
+
+	if len(bundle.InfererValues) == 0 {
+		return errors.Wrap(sdkerrors.ErrInvalidRequest, "value bundle inferer values cannot be nil")
+	}
 
 	// nil values for bundle.InfererValues are interpreted to mean that there
 	// are no inferer values for this bundle, and are allowed
@@ -514,6 +560,13 @@ func (bundle *ValueBundle) Validate() error {
 	if bundle.ReputerRequestNonce == nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "value bundle reputer request nonce cannot be nil")
 	}
+	if err := bundle.ReputerRequestNonce.Validate(); err != nil {
+		return errors.Wrap(err, "value bundle reputer request nonce is invalid")
+	}
+	// Additional validation on zero height for bundles
+	if bundle.ReputerRequestNonce.ReputerNonce.BlockHeight <= 0 {
+		return errors.Wrap(sdkerrors.ErrInvalidType, "value bundle reputer request nonce block height must be greater than or equal to 0")
+	}
 	if err := ValidateBech32(bundle.Reputer); err != nil {
 		return errors.Wrap(err, "value bundle reputer address is invalid")
 	}
@@ -521,6 +574,10 @@ func (bundle *ValueBundle) Validate() error {
 
 	if err := ValidateDec(bundle.CombinedValue); err != nil {
 		return errors.Wrap(err, "value bundle combined value is invalid")
+	}
+
+	if len(bundle.InfererValues) == 0 {
+		return errors.Wrap(sdkerrors.ErrInvalidRequest, "value bundle inferer values cannot be nil")
 	}
 
 	// nil values for bundle.InfererValues are interpreted to mean that there

--- a/x/emissions/types/validations_test.go
+++ b/x/emissions/types/validations_test.go
@@ -199,6 +199,60 @@ func TestInputValueBundle_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "zero block height in reputer request nonce",
+			input: &InputValueBundle{
+				TopicId:                       1,
+				ReputerRequestNonce:           &ReputerRequestNonce{ReputerNonce: &Nonce{BlockHeight: 0}},
+				Reputer:                       "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
+				NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
+				InfererValues:                 []*InputWorkerAttributedValue{validInfererValue},
+				ForecasterValues:              nil,
+				OneOutInfererValues:           nil,
+				OneOutForecasterValues:        nil,
+				OneInForecasterValues:         nil,
+				OneOutInfererForecasterValues: nil,
+				ExtraData:                     nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil inferer values",
+			input: &InputValueBundle{
+				TopicId:                       1,
+				ReputerRequestNonce:           &ReputerRequestNonce{ReputerNonce: &Nonce{BlockHeight: 100}},
+				Reputer:                       "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
+				NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
+				InfererValues:                 nil,
+				ForecasterValues:              nil,
+				OneOutInfererValues:           nil,
+				OneOutForecasterValues:        nil,
+				OneInForecasterValues:         nil,
+				OneOutInfererForecasterValues: nil,
+				ExtraData:                     nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty inferer values",
+			input: &InputValueBundle{
+				TopicId:                       1,
+				ReputerRequestNonce:           &ReputerRequestNonce{ReputerNonce: &Nonce{BlockHeight: 100}},
+				Reputer:                       "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+				CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
+				NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
+				InfererValues:                 []*InputWorkerAttributedValue{},
+				ForecasterValues:              nil,
+				OneOutInfererValues:           nil,
+				OneOutForecasterValues:        nil,
+				OneInForecasterValues:         nil,
+				OneOutInfererForecasterValues: nil,
+				ExtraData:                     nil,
+			},
+			wantErr: true,
+		},
+		{
 			name: "negative combined value valid",
 			input: &InputValueBundle{
 				TopicId:                       1,
@@ -206,7 +260,7 @@ func TestInputValueBundle_Validate(t *testing.T) {
 				Reputer:                       "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
 				CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("-1")),
 				NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
-				InfererValues:                 nil,
+				InfererValues:                 []*InputWorkerAttributedValue{validInfererValue},
 				ForecasterValues:              nil,
 				OneOutInfererValues:           nil,
 				OneOutForecasterValues:        nil,
@@ -224,7 +278,7 @@ func TestInputValueBundle_Validate(t *testing.T) {
 				Reputer:                       "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
 				CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("")),
 				NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
-				InfererValues:                 nil,
+				InfererValues:                 []*InputWorkerAttributedValue{validInfererValue},
 				ForecasterValues:              nil,
 				OneOutInfererValues:           nil,
 				OneOutForecasterValues:        nil,
@@ -242,7 +296,7 @@ func TestInputValueBundle_Validate(t *testing.T) {
 				Reputer:                       "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
 				CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
 				NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("-1")),
-				InfererValues:                 nil,
+				InfererValues:                 []*InputWorkerAttributedValue{validInfererValue},
 				ForecasterValues:              nil,
 				OneOutInfererValues:           nil,
 				OneOutForecasterValues:        nil,
@@ -260,7 +314,7 @@ func TestInputValueBundle_Validate(t *testing.T) {
 				Reputer:                       "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
 				CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("1")),
 				NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("")),
-				InfererValues:                 nil,
+				InfererValues:                 []*InputWorkerAttributedValue{validInfererValue},
 				ForecasterValues:              nil,
 				OneOutInfererValues:           nil,
 				OneOutForecasterValues:        nil,
@@ -282,7 +336,6 @@ func TestInputValueBundle_Validate(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestInputWorkerAttributedValue_Validate(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Additional validations on `validations.go`
  * nonempty `infererValues` is required
  *  input data `blockheight` is required to be non-nil and non-zero
  * inference and forecasts `blockheight` need to be aligned with bundle `blockheight`

* fix usage of current block `ctx.Blockheight()` in `inferenceBlockheight` in `NetworkInferences` responses.  

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- unit tests fixed + cases added.
- [x] If documented, please describe where. If not, describe why docs are not needed. -- no need to document, not relevant functional changes.
- [x] Added to `Unreleased` section of `CHANGELOG.md`? 


