### PR TITLE
Fix: Align Dockerfile.cosmovisor with actual released binary filenames

### DIFF
--- a/Dockerfile.cosmovisor
+++ b/Dockerfile.cosmovisor
@@ -38,15 +38,15 @@ ADD https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor/${COSMOVIS
 RUN tar -xvf /tmp/cosmovisor.tar.gz -C /usr/local/bin/ && \
     chmod +x /usr/local/bin/cosmovisor
 
-ARG ALLORAD_CURRENT_VERSION="v0.5.0"
-ARG ALLORAD_UPGRADE_VERSION="v0.6.0"
+ARG ALLORAD_CURRENT_VERSION="0.10.0"
+ARG ALLORAD_UPGRADE_VERSION="0.11.0"
 
 RUN mkdir -p ${INITIAL_COSMOVISOR_DIR}/genesis/bin && \
-    curl -Lo ${INITIAL_COSMOVISOR_DIR}/genesis/bin/allorad https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_CURRENT_VERSION}/allorad_linux_amd64 && \
+    curl -Lo ${INITIAL_COSMOVISOR_DIR}/genesis/bin/allorad https://github.com/allora-network/allora-chain/releases/download/v${ALLORAD_CURRENT_VERSION}/allora-chain_${ALLORAD_CURRENT_VERSION}_linux_amd64 && \
     chmod +x ${INITIAL_COSMOVISOR_DIR}/genesis/bin/allorad
 
-RUN mkdir -p ${INITIAL_COSMOVISOR_DIR}/upgrades/${ALLORAD_UPGRADE_VERSION}/bin && \
-    curl -Lo ${INITIAL_COSMOVISOR_DIR}/upgrades/${ALLORAD_UPGRADE_VERSION}/bin/allorad https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_UPGRADE_VERSION}/allorad_linux_amd64
+RUN mkdir -p ${INITIAL_COSMOVISOR_DIR}/upgrades/v${ALLORAD_UPGRADE_VERSION}/bin && \
+    curl -Lo ${INITIAL_COSMOVISOR_DIR}/upgrades/v${ALLORAD_UPGRADE_VERSION}/bin/allorad https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_UPGRADE_VERSION}/allora-chain_${ALLORAD_UPGRADE_VERSION}_linux_amd64
 
 VOLUME ${APP_PATH}
 WORKDIR ${APP_PATH}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

- This brings the `allorad` binary filenames referenced within `Dockerfile.cosmovisor` into alignment with the actual released binary filename patterns present in [release versions after v0.6.0](https://github.com/allora-network/allora-chain/releases/tag/v0.11.0).
- This fixes the Docker-upgrade upgrade path, which is currently resulting in a broken `*-docker-upgrade` image due to referencing a non-existent `allorad` download.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
