### PR TITLE
fix: validate reputer bundle contents against network inference

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
@@ -2,14 +2,17 @@ package msgserver
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	errorsmod "cosmossdk.io/errors"
+
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/metrics"
 
-	"github.com/allora-network/allora-chain/x/emissions/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 // A tx function that accepts a individual loss and possibly returns an error
@@ -81,6 +84,10 @@ func (ms msgServer) InsertReputerPayload(ctx context.Context, msg *types.InsertR
 		return nil, errorsmod.Wrapf(types.ErrAddressNotRegistered, "reputer is not registered in this topic")
 	}
 
+	if err := ms.validateInfererAddresses(ctx, msg.ReputerValueBundle.ValueBundle.InfererValues, topicId, nonce.ReputerNonce.BlockHeight); err != nil {
+		return nil, err
+	}
+
 	// Check that the reputer enough stake in the topic
 	stake, err := ms.k.GetStakeReputerAuthority(ctx, topicId, rvb.ValueBundle.Reputer)
 	if err != nil {
@@ -102,4 +109,39 @@ func (ms msgServer) InsertReputerPayload(ctx context.Context, msg *types.InsertR
 	}
 
 	return &types.InsertReputerPayloadResponse{}, err
+}
+
+func (ms msgServer) validateInfererAddresses(ctx context.Context, infererValues []*types.InputWorkerAttributedValue, topicId uint64, blockHeight int64) error {
+	networkInferences, err := ms.k.GetInferencesAtBlock(ctx, topicId, blockHeight, false)
+	if err != nil {
+		return errorsmod.Wrapf(err, "error getting inferences")
+	}
+
+	if len(networkInferences.Inferences) != len(infererValues) {
+		return fmt.Errorf("worker sets don't match - different unique workers")
+	}
+
+	networkWorkerCount := make(map[string]int)
+	infererValueWorkerCount := make(map[string]int)
+
+	for _, inference := range networkInferences.Inferences {
+		networkWorkerCount[inference.Inferer]++
+	}
+
+	for _, infererVal := range infererValues {
+		infererValueWorkerCount[infererVal.Worker]++
+	}
+
+	for worker, count := range networkWorkerCount {
+		if infererValueWorkerCount[worker] != count {
+			return fmt.Errorf("worker frequency mismatch for worker %s", worker)
+		}
+	}
+
+	for worker, count := range infererValueWorkerCount {
+		if networkWorkerCount[worker] != count {
+			return fmt.Errorf("inferer frequency mismatch for worker %s", worker)
+		}
+	}
+	return nil
 }

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
@@ -1,21 +1,20 @@
 package msgserver_test
 
 import (
-	alloraMath "github.com/allora-network/allora-chain/math"
-	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
-	"github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 const block = types.BlockHeight(1)
 
 func (s *MsgServerTestSuite) setUpMsgReputerPayload(
-	reputer string,
 	reputerAddr sdk.AccAddress,
-	worker string,
-	workerAddr sdk.AccAddress,
+	workerAddr ...sdk.AccAddress,
 ) (
 	reputerValueBundle types.InputValueBundle,
 	expectedInferences types.Inferences,
@@ -31,7 +30,7 @@ func (s *MsgServerTestSuite) setUpMsgReputerPayload(
 
 	minStakeScaled := params.RequiredMinimumStake.Mul(inferencesynthesis.CosmosIntOneE18())
 
-	topicId = s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, minStakeScaled)
+	topicId = s.commonStakingSetup(ctx, reputerAddr, minStakeScaled, workerAddr...)
 	s.MintTokensToAddress(reputerAddr, params.RequiredMinimumStake)
 
 	addStakeMsg := &types.AddStakeRequest{
@@ -54,66 +53,77 @@ func (s *MsgServerTestSuite) setUpMsgReputerPayload(
 	err = keeper.AddReputerNonce(ctx, topicId, &workerNonce)
 	require.NoError(err)
 
-	// add in inference and forecast data
+	inferences := make([]*types.Inference, 0, len(workerAddr))
+	forecasts := make([]*types.Forecast, 0, len(workerAddr))
+	infererValues := make([]*types.InputWorkerAttributedValue, 0, len(workerAddr))
+	forecasterValues := make([]*types.InputWorkerAttributedValue, 0, len(workerAddr))
+	oneOutForecasterValues := make([]*types.InputWithheldWorkerAttributedValue, 0, len(workerAddr))
+	oneInForecasterValues := make([]*types.InputWorkerAttributedValue, 0, len(workerAddr))
+
+	for _, worker := range workerAddr {
+		inferences = append(inferences, &types.Inference{
+			TopicId:     topicId,
+			BlockHeight: block,
+			Value:       alloraMath.NewDecFromInt64(1),
+			Inferer:     worker.String(),
+		})
+
+		forecastElements := make([]*types.ForecastElement, 0, len(workerAddr))
+		for _, inferWorker := range workerAddr {
+			forecastElements = append(forecastElements, &types.ForecastElement{
+				Inferer: inferWorker.String(),
+				Value:   alloraMath.NewDecFromInt64(1),
+			})
+		}
+
+		forecasts = append(forecasts, &types.Forecast{
+			TopicId:          topicId,
+			BlockHeight:      block,
+			Forecaster:       worker.String(),
+			ForecastElements: forecastElements,
+		})
+
+		infererValues = append(infererValues, &types.InputWorkerAttributedValue{
+			Worker: worker.String(),
+			Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
+		})
+
+		forecasterValues = append(forecasterValues, &types.InputWorkerAttributedValue{
+			Worker: worker.String(),
+			Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
+		})
+
+		oneOutForecasterValues = append(oneOutForecasterValues, &types.InputWithheldWorkerAttributedValue{
+			Worker: worker.String(),
+			Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
+		})
+
+		oneInForecasterValues = append(oneInForecasterValues, &types.InputWorkerAttributedValue{
+			Worker: worker.String(),
+			Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
+		})
+	}
+
 	expectedInferences = types.Inferences{
-		Inferences: []*types.Inference{
-			{
-				TopicId:     topicId,
-				BlockHeight: block,
-				Value:       alloraMath.NewDecFromInt64(1), // Assuming NewDecFromInt64 exists and is appropriate
-				Inferer:     workerAddr.String(),
-			},
-		},
+		Inferences: inferences,
 	}
 
 	expectedForecasts = types.Forecasts{
-		Forecasts: []*types.Forecast{
-			{
-				TopicId:     topicId,
-				BlockHeight: block,
-				Forecaster:  workerAddr.String(),
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: workerAddr.String(),
-						Value:   alloraMath.NewDecFromInt64(1),
-					},
-				},
-			},
-		},
+		Forecasts: forecasts,
 	}
 
 	reputerValueBundle = types.InputValueBundle{
-		TopicId:             topicId,
-		ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &workerNonce},
-		Reputer:             reputerAddr.String(),
-		ExtraData:           nil,
-		CombinedValue:       alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-		InfererValues: []*types.InputWorkerAttributedValue{
-			{
-				Worker: workerAddr.String(),
-				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-			},
-		},
-		ForecasterValues: []*types.InputWorkerAttributedValue{
-			{
-				Worker: workerAddr.String(),
-				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-			},
-		},
-		NaiveValue:          alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-		OneOutInfererValues: []*types.InputWithheldWorkerAttributedValue{},
-		OneOutForecasterValues: []*types.InputWithheldWorkerAttributedValue{
-			{
-				Worker: workerAddr.String(),
-				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-			},
-		},
-		OneInForecasterValues: []*types.InputWorkerAttributedValue{
-			{
-				Worker: workerAddr.String(),
-				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-			},
-		},
+		TopicId:                       topicId,
+		ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &workerNonce},
+		Reputer:                       reputerAddr.String(),
+		ExtraData:                     nil,
+		CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
+		InfererValues:                 infererValues,
+		ForecasterValues:              forecasterValues,
+		NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
+		OneOutInfererValues:           []*types.InputWithheldWorkerAttributedValue{},
+		OneOutForecasterValues:        oneOutForecasterValues,
+		OneInForecasterValues:         oneInForecasterValues,
 		OneOutInfererForecasterValues: nil,
 	}
 
@@ -170,12 +180,10 @@ func (s *MsgServerTestSuite) TestMsgInsertReputerPayloadFailsEarlyWindowAndWhite
 	reputerPrivateKey := s.privKeys[0]
 	reputerPublicKeyHex := s.pubKeyHexStr[0]
 	reputerAddr := s.addrs[0]
-	reputer := s.addrsStr[0]
 
 	workerAddr := s.addrs[1]
-	worker := s.addrsStr[1]
 
-	reputerValueBundle, expectedInferences, expectedForecasts, topicId := s.setUpMsgReputerPayload(reputer, reputerAddr, worker, workerAddr)
+	reputerValueBundle, expectedInferences, expectedForecasts, topicId := s.setUpMsgReputerPayload(reputerAddr, workerAddr)
 
 	err := keeper.InsertActiveForecasts(ctx, topicId, block, expectedForecasts)
 	require.NoError(err)
@@ -226,12 +234,10 @@ func (s *MsgServerTestSuite) TestMsgInsertReputerPayloadReputerNotMatchSignature
 
 	reputerPrivateKey := s.privKeys[0]
 	reputerAddr := s.addrs[0]
-	reputer := s.addrsStr[0]
 	reputerPublicKeyHex := s.pubKeyHexStr[0]
 	workerAddr := s.addrs[1]
-	worker := s.addrsStr[1]
 
-	reputerValueBundle, expectedInferences, expectedForecasts, topicId := s.setUpMsgReputerPayload(reputer, reputerAddr, worker, workerAddr)
+	reputerValueBundle, expectedInferences, expectedForecasts, topicId := s.setUpMsgReputerPayload(reputerAddr, workerAddr)
 
 	err := keeper.InsertActiveForecasts(ctx, topicId, block, expectedForecasts)
 	require.NoError(err)

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
@@ -268,3 +268,114 @@ func (s *MsgServerTestSuite) TestMsgInsertReputerPayloadReputerNotMatchSignature
 	_, err = s.msgServer.InsertReputerPayload(ctx, lossesMsg)
 	require.ErrorIs(err, sdkerrors.ErrUnauthorized)
 }
+
+func (s *MsgServerTestSuite) TestMsgInsertReputerPayloadWorkerAddressValidation() {
+	testCases := []struct {
+		name            string
+		setupBundle     func(bundle types.InputValueBundle) types.InputValueBundle
+		setupInferences func(inferences types.Inferences) types.Inferences
+		expectedError   string
+	}{
+		{
+			name: "Different worker sets - missing worker",
+			setupBundle: func(bundle types.InputValueBundle) types.InputValueBundle {
+				bundle.InfererValues = bundle.InfererValues[1:]
+				return bundle
+			},
+			setupInferences: func(inferences types.Inferences) types.Inferences {
+				return inferences
+			},
+			expectedError: "worker sets don't match",
+		},
+		{
+			name: "Different worker sets - different unique worker",
+			setupBundle: func(bundle types.InputValueBundle) types.InputValueBundle {
+				modifiedBundle := bundle
+				for i, infVal := range bundle.InfererValues {
+					modifiedBundle.InfererValues[i] = &types.InputWorkerAttributedValue{
+						Worker: infVal.Worker,
+						Value:  infVal.Value,
+					}
+				}
+				modifiedBundle.InfererValues[0].Worker = s.addrsStr[4]
+				return modifiedBundle
+			},
+			setupInferences: func(inferences types.Inferences) types.Inferences {
+				return inferences
+			},
+			expectedError: "worker frequency mismatch",
+		},
+		{
+			name: "Same workers but different frequencies",
+			setupBundle: func(bundle types.InputValueBundle) types.InputValueBundle {
+				return bundle
+			},
+			setupInferences: func(inferences types.Inferences) types.Inferences {
+				duplicateInferences := inferences
+				duplicateInferences.Inferences[1] = duplicateInferences.Inferences[0]
+				return duplicateInferences
+			},
+			expectedError: "worker frequency mismatch",
+		},
+		{
+			name: "Valid worker sets match",
+			setupBundle: func(bundle types.InputValueBundle) types.InputValueBundle {
+				return bundle
+			},
+			setupInferences: func(inferences types.Inferences) types.Inferences {
+				return inferences
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			require := s.Require()
+			keeper := s.emissionsKeeper
+
+			reputerPrivateKey := s.privKeys[0]
+			reputerAddr := s.addrs[0]
+			reputerPublicKeyHex := s.pubKeyHexStr[0]
+			workerAddr1 := s.addrs[1]
+			workerAddr2 := s.addrs[2]
+			workerAddr3 := s.addrs[3]
+
+			reputerValueBundle, expectedInferences, expectedForecasts, topicId := s.setUpMsgReputerPayload(reputerAddr, workerAddr1, workerAddr2, workerAddr3)
+
+			err := keeper.InsertActiveForecasts(s.ctx, topicId, block, expectedForecasts)
+			require.NoError(err)
+
+			modifiedInferences := tc.setupInferences(expectedInferences)
+			err = keeper.InsertActiveInferences(s.ctx, topicId, block, modifiedInferences)
+			require.NoError(err)
+
+			topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
+			require.NoError(err)
+
+			newBlockheight := block + topic.GroundTruthLag
+			s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
+
+			modifiedBundle := tc.setupBundle(reputerValueBundle)
+			valueBundleSignature := s.signInputValueBundle(&modifiedBundle, reputerPrivateKey)
+
+			lossesMsg := &types.InsertReputerPayloadRequest{
+				Sender: reputerAddr.String(),
+				ReputerValueBundle: &types.InputReputerValueBundle{
+					ValueBundle: &modifiedBundle,
+					Signature:   valueBundleSignature,
+					Pubkey:      reputerPublicKeyHex,
+				},
+			}
+
+			_, err = s.msgServer.InsertReputerPayload(s.ctx, lossesMsg)
+
+			if tc.expectedError != "" {
+				require.Error(err)
+				require.Contains(err.Error(), tc.expectedError)
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
+}

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -8,28 +8,31 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	cosmosMath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (s *MsgServerTestSuite) commonStakingSetup(
 	ctx sdk.Context,
-	reputer string,
 	reputerAddr sdk.AccAddress,
-	worker string,
-	workerAddr sdk.AccAddress,
 	reputerInitialBalanceUint cosmosMath.Int,
+	workerAddr ...sdk.AccAddress,
 ) uint64 {
+	if len(workerAddr) == 0 {
+		panic("worker address must not be empty")
+	}
+
 	msgServer := s.msgServer
 	require := s.Require()
 
 	// Create Topic
 	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  reputer,
+		Creator:                  reputerAddr.String(),
 		Metadata:                 "Some metadata for the new topic",
 		LossMethod:               "mse",
 		EpochLength:              10800,
@@ -51,7 +54,7 @@ func (s *MsgServerTestSuite) commonStakingSetup(
 
 	reputerInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, reputerInitialBalance))
 
-	err := s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, reputer)
+	err := s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, reputerAddr.String())
 	require.NoError(err)
 
 	err = s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, reputerInitialBalanceCoins)
@@ -65,8 +68,8 @@ func (s *MsgServerTestSuite) commonStakingSetup(
 
 	// Register Reputer
 	reputerRegMsg := &types.RegisterRequest{
-		Sender:    reputer,
-		Owner:     reputer,
+		Sender:    reputerAddr.String(),
+		Owner:     reputerAddr.String(),
 		TopicId:   topicId,
 		IsReputer: true,
 	}
@@ -75,23 +78,25 @@ func (s *MsgServerTestSuite) commonStakingSetup(
 
 	workerInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(11000)))
 
-	err = s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, workerInitialBalanceCoins)
+	err = s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, workerInitialBalanceCoins.MulInt(cosmosMath.NewInt(int64(len(workerAddr)))))
 	require.NoError(err, "Minting coins should not return an error")
-	err = s.bankKeeper.MintCoins(ctx, types.AlloraRewardsAccountName, workerInitialBalanceCoins)
+	err = s.bankKeeper.MintCoins(ctx, types.AlloraRewardsAccountName, workerInitialBalanceCoins.MulInt(cosmosMath.NewInt(int64(len(workerAddr)))))
 	require.NoError(err, "Minting coins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, workerAddr, workerInitialBalanceCoins)
-	require.NoError(err, "Sending coins should not return an error")
 
-	// Register Worker
-	workerRegMsg := &types.RegisterRequest{
-		Sender:    worker,
-		Owner:     worker,
-		TopicId:   topicId,
-		IsReputer: false,
+	for _, worker := range workerAddr {
+		err = s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, worker, workerInitialBalanceCoins)
+		require.NoError(err, "Sending coins should not return an error")
+		// Register Worker
+		workerRegMsg := &types.RegisterRequest{
+			Sender:    worker.String(),
+			Owner:     worker.String(),
+			TopicId:   topicId,
+			IsReputer: false,
+		}
+		_, err = msgServer.Register(ctx, workerRegMsg)
+		require.NoError(err, "Registering worker should not return an error")
+
 	}
-	_, err = msgServer.Register(ctx, workerRegMsg)
-	require.NoError(err, "Registering worker should not return an error")
-
 	return topicId
 }
 
@@ -101,14 +106,13 @@ func (s *MsgServerTestSuite) TestMsgAddStakeWithWhitelistCheck() {
 
 	reputer := s.addrsStr[0]
 	reputerAddr := s.addrs[0]
-	worker := s.addrsStr[1]
 	workerAddr := s.addrs[1]
 	stakeAmount := cosmosMath.NewInt(10)
 	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
 	require.NoError(err)
 	registrationInitialBalance := moduleParams.RegistrationFee.Add(stakeAmount)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.commonStakingSetup(ctx, reputerAddr, registrationInitialBalance, workerAddr)
 
 	addStakeMsg := &types.AddStakeRequest{
 		Sender:  reputer,
@@ -159,14 +163,13 @@ func (s *MsgServerTestSuite) TestMsgAddStakeNil() {
 
 	reputer := s.addrsStr[0]
 	reputerAddr := s.addrs[0]
-	worker := s.addrsStr[1]
 	workerAddr := s.addrs[1]
 	stakeAmount := cosmosMath.NewInt(10)
 	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
 	require.NoError(err)
 	registrationInitialBalance := moduleParams.RegistrationFee.Add(stakeAmount)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.commonStakingSetup(ctx, reputerAddr, registrationInitialBalance, workerAddr)
 
 	addStakeMsg := &types.AddStakeRequest{
 		Sender:  reputer,
@@ -1435,7 +1438,6 @@ func (s *MsgServerTestSuite) TestRewardDelegateStake() {
 	delegatorAddr := s.addrs[0]
 	reputer := s.addrsStr[1]
 	reputerAddr := s.addrs[1]
-	worker := s.addrsStr[2]
 	workerAddr := s.addrs[2]
 	delegator2 := s.addrsStr[3]
 	delegator2Addr := s.addrs[3]
@@ -1445,7 +1447,7 @@ func (s *MsgServerTestSuite) TestRewardDelegateStake() {
 	delegatorStakeAmount2 := cosmosMath.NewInt(500)
 	delegator2StakeAmount := cosmosMath.NewInt(5000)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.commonStakingSetup(ctx, reputerAddr, registrationInitialBalance, workerAddr)
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegator2Addr, cosmosMath.NewInt(1000000))
@@ -1778,13 +1780,12 @@ func (s *MsgServerTestSuite) TestEqualStakeRewardsToDelegatorAndReputer() {
 	reputerAddr := s.addrs[1]
 	reputerPubKeyHex := s.pubKeyHexStr[1]
 	reputerPrivKey := s.privKeys[1]
-	worker := s.addrsStr[2]
 	workerAddr := s.addrs[2]
 
 	registrationInitialBalance := cosmosMath.NewInt(1000)
 	stakeAmount := cosmosMath.NewInt(500000)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.commonStakingSetup(ctx, reputerAddr, registrationInitialBalance, workerAddr)
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
 
@@ -1873,14 +1874,13 @@ func (s *MsgServerTestSuite) Test1000xDelegatorStakeVsReputerStake() {
 	reputerPrivKey := s.privKeys[1]
 	reputer := s.addrsStr[1]
 	workerAddr := s.addrs[2]
-	worker := s.addrsStr[2]
 
 	registrationInitialBalance := cosmosMath.NewInt(10000)
 	reputerStakeAmount := cosmosMath.NewInt(1e2)
 	delegatorRatio := cosmosMath.NewInt(1e3)
 	delegatorStakeAmount := reputerStakeAmount.Mul(delegatorRatio)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.commonStakingSetup(ctx, reputerAddr, registrationInitialBalance, workerAddr)
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
 	err := s.bankKeeper.MintCoins(ctx, types.AlloraRewardsAccountName,
@@ -1948,14 +1948,13 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 	largeDelegatorAddr := s.addrs[2]
 	largeDelegator := s.addrsStr[2]
 	workerAddr := s.addrs[3]
-	worker := s.addrsStr[3]
 
 	registrationInitialBalance := cosmosMath.NewInt(10000)
 	reputerStakeAmount := cosmosMath.NewInt(1e2)
 	largeDelegatorRatio := cosmosMath.NewInt(1e3)
 	largeDelegatorStakeAmount := reputerStakeAmount.Mul(largeDelegatorRatio)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.commonStakingSetup(ctx, reputerAddr, registrationInitialBalance, workerAddr)
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(largeDelegatorAddr, cosmosMath.NewInt(1000000))
@@ -2142,12 +2141,11 @@ func (s *MsgServerTestSuite) TestCancelRemoveDelegateStake() {
 	delegator := s.addrsStr[0]
 	reputer := s.addrsStr[1]
 	reputerAddr := s.addrs[1]
-	worker := s.addrsStr[2]
 	workerAddr := s.addrs[2]
 	registrationInitialBalance := cosmosMath.NewInt(10000)
 	amount := cosmosMath.NewInt(50)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.commonStakingSetup(ctx, reputerAddr, registrationInitialBalance, workerAddr)
 
 	// Add a delegate stake removal
 	stakeToRemove := types.DelegateStakeRemovalInfo{
@@ -2185,11 +2183,10 @@ func (s *MsgServerTestSuite) TestCancelRemoveDelegateStakeNotExist() {
 	delegator := s.addrsStr[0]
 	reputer := s.addrsStr[1]
 	reputerAddr := s.addrs[1]
-	worker := s.addrsStr[2]
 	workerAddr := s.addrs[2]
 	registrationInitialBalance := cosmosMath.NewInt(10000)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.commonStakingSetup(ctx, reputerAddr, registrationInitialBalance, workerAddr)
 
 	// Call CancelRemoveDelegateStake
 	msg := &types.CancelRemoveDelegateStakeRequest{

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
@@ -3,11 +3,12 @@ package msgserver_test
 import (
 	"encoding/hex"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 func getNewAddress() (sdk.AccAddress, string) {
@@ -30,7 +31,7 @@ func (s *MsgServerTestSuite) setUpMsgInsertWorkerPayloadWithBlockHeight(
 	topic := s.CreateOneTopic()
 
 	// Mock setup for addresses
-	reputerAddr, reputer := getNewAddress()
+	reputerAddr, _ := getNewAddress()
 	workerAddr := sdk.AccAddress(workerPrivateKey.PubKey().Address())
 	worker := workerAddr.String()
 	_, Inferer2 := getNewAddress()
@@ -47,7 +48,7 @@ func (s *MsgServerTestSuite) setUpMsgInsertWorkerPayloadWithBlockHeight(
 	s.Require().NoError(err)
 
 	// Create topic 0 and register reputer in it
-	s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, moduleParams.RegistrationFee)
+	s.commonStakingSetup(ctx, reputerAddr, moduleParams.RegistrationFee, workerAddr)
 	err = keeper.AddWorkerNonce(ctx, topic.Id, &nonce)
 	s.Require().NoError(err)
 	err = keeper.InsertWorker(ctx, topic.Id, worker, workerInfo)
@@ -560,7 +561,6 @@ func (s *MsgServerTestSuite) TestInsertingHugeBundleWorkerPayloadFails() {
 	nonce := types.Nonce{BlockHeight: 1}
 
 	// Mock setup for addresses
-	reputer := s.addrsStr[0]
 	reputerAddr := s.addrs[0]
 	worker := s.addrsStr[1]
 	workerPrivateKey := s.privKeys[1]
@@ -579,7 +579,7 @@ func (s *MsgServerTestSuite) TestInsertingHugeBundleWorkerPayloadFails() {
 	require.NoError(err)
 
 	// Create topic 0 and register reputer in it
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, moduleParams.RegistrationFee)
+	topicId := s.commonStakingSetup(ctx, reputerAddr, moduleParams.RegistrationFee, workerAddr)
 	err = keeper.AddWorkerNonce(ctx, topicId, &nonce)
 	require.NoError(err)
 	err = keeper.InsertWorker(ctx, topicId, InfererAddr, workerInfo)
@@ -645,7 +645,6 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadVerifyFailed() {
 	nonce := types.Nonce{BlockHeight: 1}
 
 	// Mock setup for addresses
-	reputer := s.addrsStr[0]
 	reputerAddr := s.addrs[0]
 	worker := s.addrsStr[1]
 	workerAddr := s.addrs[1]
@@ -663,7 +662,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadVerifyFailed() {
 	require.NoError(err)
 
 	// Create topic 0 and register reputer in it
-	s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, moduleParams.RegistrationFee)
+	s.commonStakingSetup(ctx, reputerAddr, moduleParams.RegistrationFee, workerAddr)
 	err = keeper.AddWorkerNonce(ctx, topicId, &nonce)
 	require.NoError(err)
 	err = keeper.InsertWorker(ctx, topicId, Inferer, workerInfo)
@@ -903,7 +902,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadForecastIncludesSelf() {
 	_ = keeper.AddWhitelistAdmin(s.ctx, adminAddr.String())
 
 	// Set up params similar to other tests
-	newParams := &types.OptionalParams{ //nolint: exhaustruct
+	newParams := &types.OptionalParams{ // nolint: exhaustruct
 		MaxElementsPerForecast: []uint64{3},
 		// not updated params remain nil
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
Adding inferer address validation to insert reputer payload handler

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
https://linear.app/alloralabs/issue/ENGN-3677/validate-reputer-bundle-contents-against-network-inference

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
