### PR TITLE
chore(ci): bump robherley/go-test-action to v0.6.0

### DIFF
--- a/.github/workflows/format_and_test.yml
+++ b/.github/workflows/format_and_test.yml
@@ -25,7 +25,7 @@ jobs:
         go-version: 1.22.x
 
     - name: Test
-      uses: robherley/go-test-action@v0.4.1
+      uses: robherley/go-test-action@v0.6.0
 
   integration-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Description: 
  * upgrade `robherley/go-test-action` from **v0.4.1** → **v0.6.0**
  * no workflow-input changes required (drop-in replacement)
  [Reference](https://github.com/robherley/go-test-action/releases/tag/v0.6.0) 