### PR TITLE
Refund ecosystem account when invalid topic to reward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* [#815](https://github.com/allora-network/allora-chain/pull/815) Refund ecosystem account when invalid topic to reward 
 
 ### Deprecated
 

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -16,9 +16,9 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/address"
-
 	coreStore "cosmossdk.io/core/store"
 	"github.com/allora-network/allora-chain/x/emissions/types"
+	minttypes "github.com/allora-network/allora-chain/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -3958,6 +3958,23 @@ func (k *Keeper) SendCoinsFromModuleToModule(ctx context.Context, senderModule, 
 // wrapper around bank keeper GetBalance
 func (k *Keeper) GetBankBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin {
 	return k.bankKeeper.GetBalance(ctx, addr, denom)
+}
+
+// MoveCoinsFromAlloraRewardsToEcosystem moves funds from the allora rewards account to the ecosystem account
+func (k *Keeper) MoveCoinsFromAlloraRewardsToEcosystem(ctx context.Context, amount alloraMath.Dec) error {
+	if amount.IsZero() {
+		return nil
+	}
+	amountInt, err := amount.SdkIntTrim()
+	if err != nil {
+		return errorsmod.Wrap(err, "failed to sdk int trim amount")
+	}
+	return k.bankKeeper.SendCoinsFromModuleToModule(
+		ctx,
+		types.AlloraRewardsAccountName,
+		minttypes.EcosystemModuleName,
+		sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amountInt)),
+	)
 }
 
 // Gets the total rewards available to be distributed from the Allora Rewards Module Account

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -127,6 +127,14 @@ func EmitRewards(args EmitRewardsArgs) error {
 	for _, topicId := range sortedRewardableTopics {
 		topicRewardNonce, err := args.K.GetTopicRewardNonce(args.Ctx, topicId)
 		if err != nil || topicRewardNonce == 0 {
+			// return reward to ecosystem account
+			err = args.K.MoveCoinsFromAlloraRewardsToEcosystem(args.Ctx, *topicRewards[topicId])
+			if err != nil {
+				Logger(args.Ctx).Error("Failed to move coins from allora rewards to ecosystem", "topicId", topicId, "error", err)
+				panic(err)
+			}
+			*topicRewards[topicId] = alloraMath.ZeroDec()
+
 			Logger(args.Ctx).Info("Topic has no valid reward nonce, skipping", "topicId", topicId)
 			continue
 		}
@@ -147,6 +155,14 @@ func EmitRewards(args EmitRewardsArgs) error {
 			ModuleParams:     args.ModuleParams,
 		})
 		if err != nil {
+			// return reward to ecosystem account
+			err = args.K.MoveCoinsFromAlloraRewardsToEcosystem(args.Ctx, *topicRewards[topicId])
+			if err != nil {
+				Logger(args.Ctx).Error("Failed to move coins from allora rewards to ecosystem", "topicId", topicId, "error", err)
+				panic(err)
+			}
+			*topicRewards[topicId] = alloraMath.ZeroDec()
+			
 			Logger(args.Ctx).Error("Failed to process rewards", "topicId", topicId, "error", err)
 			continue
 		}

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -162,7 +162,7 @@ func EmitRewards(args EmitRewardsArgs) error {
 				panic(err)
 			}
 			*topicRewards[topicId] = alloraMath.ZeroDec()
-			
+
 			Logger(args.Ctx).Error("Failed to process rewards", "topicId", topicId, "error", err)
 			continue
 		}

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -4220,3 +4220,108 @@ func (s *RewardsTestSuite) TestMonthlyPercentageRewardCalculation_ZeroTopicRewar
 	s.Require().NoError(err)
 	s.Require().True(topicRewardsAfter.IsZero(), "Monthly topic rewards not reset by EndBlocker")
 }
+
+func (s *RewardsTestSuite) TestNoActiveParticipantsNoRewardsForTopic() {
+	require := s.Require()
+
+	block := int64(1)
+	s.ctx = s.ctx.WithBlockHeight(block)
+
+	s.SetParamsForTest()
+
+	creatorIndex := 40
+	reputerIndex := 41
+
+	// Create topic
+	newTopicMsg := &types.CreateNewTopicRequest{
+		Creator:                  s.addrsStr[creatorIndex],
+		Metadata:                 "test",
+		LossMethod:               "mse",
+		EpochLength:              100,
+		AllowNegative:            false,
+		GroundTruthLag:           100,
+		WorkerSubmissionWindow:   10,
+		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
+		PNorm:                    alloraMath.NewDecFromInt64(3),
+		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
+		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
+		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
+		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		EnableWorkerWhitelist:    true,
+		EnableReputerWhitelist:   true,
+	}
+	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
+	require.NoError(err)
+	topicId := res.TopicId
+
+	// Register the single reputer
+	// But it will not be actively participating in the topic
+	reputerRegMsg := &types.RegisterRequest{
+		Sender:    s.addrsStr[reputerIndex],
+		TopicId:   topicId,
+		IsReputer: true,
+		Owner:     s.addrsStr[reputerIndex],
+	}
+	_, err = s.msgServer.Register(s.ctx, reputerRegMsg)
+	require.NoError(err)
+
+	// Add stake for the reputer
+	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
+	s.MintTokensToAddress(s.addrs[reputerIndex], stake)
+	_, err = s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
+		Sender:  s.addrsStr[reputerIndex],
+		Amount:  stake,
+		TopicId: topicId,
+	})
+	require.NoError(err)
+
+	// Fund the topic
+	s.MintTokensToAddress(s.addrs[creatorIndex], stake)
+	fundTopicMessage := types.FundTopicRequest{
+		Sender:  s.addrsStr[creatorIndex],
+		TopicId: topicId,
+		Amount:  stake,
+	}
+	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
+	require.NoError(err)
+
+	// Record initial balance of the rewards module account
+	rewardsModuleAddr := s.accountKeeper.GetModuleAddress(types.AlloraRewardsAccountName)
+	initialRewardsBalance := s.bankKeeper.GetBalance(s.ctx, rewardsModuleAddr, params.DefaultBondDenom)
+
+	// Record initial balance of the ecosystem account
+	ecosystemAddr := s.accountKeeper.GetModuleAddress(minttypes.EcosystemModuleName)
+	initialEcosystemBalance := s.bankKeeper.GetBalance(s.ctx, ecosystemAddr, params.DefaultBondDenom)
+
+	// Simulate moving to the end of the first epoch
+	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
+	require.NoError(err)
+	nextBlock := block + topic.EpochLength
+	s.ctx = s.ctx.WithBlockHeight(nextBlock)
+
+	// Set some block emission (even though it shouldn't be used for this topic)
+	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(1000))
+	require.NoError(err)
+
+	// Trigger EndBlocker to process potential rewards
+	err = s.emissionsAppModule.EndBlock(s.ctx)
+	require.NoError(err)
+
+	// Check topic weight after funding and epoch end
+	topicWeight, _, err := s.emissionsKeeper.GetPreviousTopicWeight(s.ctx, topicId)
+	require.NoError(err)
+	require.True(topicWeight.Gt(alloraMath.ZeroDec()), "Topic weight should be greater than zero after funding")
+
+	// Verify no rewards were distributed for this topic (moved to ecosystem account)
+	finalRewardsBalance := s.bankKeeper.GetBalance(s.ctx, rewardsModuleAddr, params.DefaultBondDenom)
+	require.True(initialRewardsBalance.Amount.GT(finalRewardsBalance.Amount),
+		"Rewards module - topic %d: Initial: %s, Final: %s",
+		topicId, initialRewardsBalance.String(), finalRewardsBalance.String())
+
+	// Verify if rewards were moved to the ecosystem account
+	ecosystemBalance := s.bankKeeper.GetBalance(s.ctx, ecosystemAddr, params.DefaultBondDenom)
+	require.True(ecosystemBalance.Amount.GT(initialEcosystemBalance.Amount),
+		"Ecosystem account - topic %d: Initial: %s, Final: %s",
+		topicId, initialEcosystemBalance.String(), ecosystemBalance.String())
+}

--- a/x/mint/module/module_test.go
+++ b/x/mint/module/module_test.go
@@ -87,7 +87,7 @@ func (s *MintModuleTestSuite) SetupTest() {
 		thirdParty:                              {"minter"},
 		"ecosystem":                             {"burner", "minter", "staking"},
 		"mint":                                  {"minter"},
-		emissionstypes.AlloraRewardsAccountName: nil,
+		emissionstypes.AlloraRewardsAccountName: {"minter"},
 		emissionstypes.AlloraPendingRewardForDelegatorAccountName: nil,
 		emissionstypes.AlloraStakingAccountName:                   {"burner", "minter", "staking"},
 		"bonded_tokens_pool":                                      {"burner", "staking"},
@@ -673,6 +673,105 @@ func (s *MintModuleTestSuite) TestInflationRateAsMorePeopleStakeGoesUp() {
 		ecosystemTokensMintedDelta2.String(),
 		ecosystemTokensMintedDelta1.String(),
 	)
+}
+
+func (s *MintModuleTestSuite) TestEcosystemRefundReducesMintingInSubsequentBlock() {
+	s.ctx = s.ctx.WithBlockHeight(1)
+	topicId := uint64(1)
+	ecosystemAddress := s.accountKeeper.GetModuleAddress(types.EcosystemModuleName)
+	refundSenderAddr := s.addrs[2] // Use one of the pre-generated addresses
+
+	// 1. Initial setup: stake, initial supply (mint to a regular account)
+	stake, ok := cosmosMath.NewIntFromString("40000000000000000000") // Sufficient stake
+	s.Require().True(ok)
+	err := s.emissionsKeeper.AddReputerStake(s.ctx, topicId, s.addrsStr[0], stake)
+	s.Require().NoError(err)
+
+	initialSupply, ok := cosmosMath.NewIntFromString("500000000000000000000000000")
+	s.Require().True(ok)
+	err = s.bankKeeper.MintCoins(s.ctx, "mint", sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, initialSupply)))
+	s.Require().NoError(err)
+	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, "mint", refundSenderAddr, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, initialSupply)))
+	s.Require().NoError(err)
+
+	// Ensure ecosystem starts empty
+	ecosystemBalStart := s.bankKeeper.GetBalance(s.ctx, ecosystemAddress, sdk.DefaultBondDenom)
+	s.Require().True(ecosystemBalStart.Amount.IsZero(), "Ecosystem account should start empty")
+	ecosystemTokensMintedStart, err := s.mintKeeper.EcosystemTokensMinted.Get(s.ctx)
+	s.Require().NoError(err)
+	s.Require().True(ecosystemTokensMintedStart.IsZero(), "Ecosystem tokens minted should start at zero")
+	tokenSupplyStart := s.bankKeeper.GetSupply(s.ctx, sdk.DefaultBondDenom)
+
+	// 2. Run BeginBlocker at block 1 - should mint tokens
+	err = mint.BeginBlocker(s.ctx, s.mintKeeper)
+	s.Require().NoError(err)
+
+	tokenSupplyAfterBlock1 := s.bankKeeper.GetSupply(s.ctx, sdk.DefaultBondDenom)
+	ecosystemTokensMintedAfterBlock1, err := s.mintKeeper.EcosystemTokensMinted.Get(s.ctx)
+	s.Require().NoError(err)
+	emissionBlock1, err := s.mintKeeper.PreviousBlockEmission.Get(s.ctx)
+	s.Require().NoError(err)
+	s.Require().True(emissionBlock1.GT(cosmosMath.ZeroInt()), "Emission for block 1 should be positive")
+
+	mintedInBlock1 := tokenSupplyAfterBlock1.Amount.Sub(tokenSupplyStart.Amount)
+	s.Require().True(mintedInBlock1.GT(cosmosMath.ZeroInt()), "Tokens should have been minted in block 1")
+	s.Require().True(mintedInBlock1.Equal(ecosystemTokensMintedAfterBlock1.Sub(ecosystemTokensMintedStart)), "Minted tokens should match increase in EcosystemTokensMinted")
+	s.Require().True(mintedInBlock1.Equal(emissionBlock1), "Minted tokens in block 1 should equal the calculated emission when ecosystem is empty")
+
+	// 3. Simulate refund to ecosystem account (less than the emission amount)
+	// This simulates funds arriving in the ecosystem account before BeginBlocker runs.
+	// In a real scenario, this represents collected fees or undistributed rewards
+	// being returned from another module (like emissions returning funds from AlloraRewardsAccountName).
+	// The latter is the case in this test.
+	// For this test's purpose, sending from a regular account isolates the mint module's
+	// reaction to a pre-existing balance.
+	refundAmount := emissionBlock1.QuoRaw(2) // Refund half the emission amount
+	s.Require().True(refundAmount.GT(cosmosMath.ZeroInt()), "Refund amount must be positive")
+	refundCoins := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, refundAmount))
+	// Send coins from the user account to the ecosystem module account using bankKeeper
+	err = s.bankKeeper.SendCoinsFromAccountToModule(s.ctx, refundSenderAddr, types.EcosystemModuleName, refundCoins)
+	s.Require().NoError(err)
+	ecosystemBalAfterRefund := s.bankKeeper.GetBalance(s.ctx, ecosystemAddress, sdk.DefaultBondDenom)
+	s.Require().True(ecosystemBalAfterRefund.Amount.Equal(refundAmount), "Ecosystem balance should equal refund amount")
+
+	// 4. Run BeginBlocker at block 2
+	s.ctx = s.ctx.WithBlockHeight(2) // Advance block height, avoid recalculation
+	err = mint.BeginBlocker(s.ctx, s.mintKeeper)
+	s.Require().NoError(err)
+
+	// 5. Check results after block 2
+	tokenSupplyAfterBlock2 := s.bankKeeper.GetSupply(s.ctx, sdk.DefaultBondDenom)
+	ecosystemTokensMintedAfterBlock2, err := s.mintKeeper.EcosystemTokensMinted.Get(s.ctx)
+	s.Require().NoError(err)
+	emissionBlock2, err := s.mintKeeper.PreviousBlockEmission.Get(s.ctx) // Should be same as block 1
+	s.Require().NoError(err)
+	s.Require().True(emissionBlock2.Equal(emissionBlock1), "Emission should not change between block 1 and 2")
+
+	// Calculate changes in block 2
+	mintedInBlock2 := tokenSupplyAfterBlock2.Amount.Sub(tokenSupplyAfterBlock1.Amount)
+	ecosystemMintedInBlock2 := ecosystemTokensMintedAfterBlock2.Sub(ecosystemTokensMintedAfterBlock1)
+
+	// 6. Verify less minting occurred due to refund (Now these should be equal!)
+	s.Require().True(mintedInBlock2.Equal(ecosystemMintedInBlock2), "Minted supply change should equal EcosystemTokensMinted change in block 2")
+	expectedMintAmountBlock2 := emissionBlock2.Sub(refundAmount)
+	s.Require().True(expectedMintAmountBlock2.GT(cosmosMath.ZeroInt()), "Expected mint amount should still be positive")
+	s.Require().True(
+		mintedInBlock2.Equal(expectedMintAmountBlock2),
+		"Actual minted tokens in block 2 (%s) should equal emission (%s) minus refund (%s)",
+		mintedInBlock2.String(),
+		emissionBlock2.String(),
+		refundAmount.String(),
+	)
+	s.Require().True(
+		mintedInBlock2.LT(emissionBlock2),
+		"Minted tokens in block 2 (%s) should be less than the total emission (%s) because of the refund",
+		mintedInBlock2.String(),
+		emissionBlock2.String(),
+	)
+
+	// Check final ecosystem balance is zero (refund + minted tokens were paid out)
+	ecosystemBalFinal := s.bankKeeper.GetBalance(s.ctx, ecosystemAddress, sdk.DefaultBondDenom)
+	s.Require().True(ecosystemBalFinal.Amount.IsZero(), "Ecosystem account should be empty after paying emissions")
 }
 
 func (s *MintModuleTestSuite) TestEmissionDisabled() {

--- a/x/mint/testutil/expected_keepers_mocks.go
+++ b/x/mint/testutil/expected_keepers_mocks.go
@@ -209,6 +209,20 @@ func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToModule(ctx, senderMod
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromModuleToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToModule), ctx, senderModule, recipientModule, amt)
 }
 
+// SendCoinsFromAccountToModule mocks base method.
+func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, senderAddr types.AccAddress, recipientModule string, amt types.Coins) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendCoinsFromAccountToModule", ctx, senderAddr, recipientModule, amt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendCoinsFromAccountToModule indicates an expected call of SendCoinsFromAccountToModule.
+func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(ctx, senderAddr, recipientModule, amt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromAccountToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromAccountToModule), ctx, senderAddr, recipientModule, amt)
+}
+
 // GetSupply mocks base method.
 func (m *MockBankKeeper) GetSupply(ctx context.Context, denom string) types.Coin {
 	m.ctrl.T.Helper()

--- a/x/mint/types/expected_keepers.go
+++ b/x/mint/types/expected_keepers.go
@@ -34,6 +34,7 @@ type BankKeeper interface {
 	MintCoins(ctx context.Context, name string, amt sdk.Coins) error
 	GetSupply(ctx context.Context, denom string) sdk.Coin
 	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 }
 
 type EmissionsKeeper interface {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
This PR modifies the rewards distribution logic to handle cases where a topic is eligible for rewards based on its weight but cannot distribute them due to lack of active participation (e.g., no reward nonce submitted or errors during reward processing).

Previously, these rewards might have remained undistributed in the rewards module. Now, any rewards allocated to a topic that cannot be processed are transferred to the `EcosystemModuleName` account.

**Changes:**

-   Added `keeper.MoveCoinsFromAlloraRewardsToEcosystem` function to facilitate the transfer.
-   Updated `rewards.EmitRewards` to call the new keeper function when a topic's rewards cannot be processed.
-   Added the test case `TestNoActiveParticipantsNoRewardsForTopic` to verify that rewards for topics without active participation are correctly moved to the ecosystem module account.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
https://linear.app/alloralabs/issue/ENGN-3525/189-185-apy-over-12percent

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
