### PR TITLE
Hotfix feature 0.12.1: ensure statically linked release binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,10 @@ builds:
       - darwin
       - windows
 
+    # Environment variables
+    env:
+      - CGO_ENABLED=0
+
     # GOARCH to build for.
     # For more info refer to: https://go.dev/doc/install/source#environment
     goarch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+# v0.12.1
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+* [#821](https://github.com/allora-network/allora-chain/pull/821) Disable CGO in goreleaser to produce static binaries
+
+### Security
+
+### API Breaking Changes
+
+#### Removed
+
+#### Added
+
+#### Changed
+
+# [Released]
+
 # v0.12.0
 
 ### Added
@@ -95,8 +121,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added 
 
 #### Changed
-
-# [Released]
 
 # v0.11.0
 


### PR DESCRIPTION
## Purpose of Changes and their Description

Disable CGO when building release binaries with goreleaser in order to produce statically linked binaries, so that these do not depend on any system's lib at runtime.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?