### PR TITLE
fix Update nurse.go

### DIFF
--- a/health/nurse.go
+++ b/health/nurse.go
@@ -257,7 +257,7 @@ func (n *Nurse) appendLog(now time.Time, reason string, meta Meta, wg *sync.Wait
 	lines := make([]string, 2+len(meta))
 	lines[0] = fmt.Sprintf("==== %v", now)
 	lines[1] = fmt.Sprintf("reason: %v", reason)
-	i := 0
+	i := 2
 	for k, v := range meta {
 		lines[i] = fmt.Sprintf("- %v: %v", k, v)
 		i++


### PR DESCRIPTION
Fix off-by-two bug in `appendLog` entry construction

## Description

This pull request fixes a critical bug in the `appendLog` method of the `Nurse` module that caused log entries to overwrite the first two lines or potentially panic due to an out-of-bounds write.

### What was the issue?

In the loop that constructs log lines based on metadata, the index variable `i` was initialized to `0`, leading to overwriting the first two lines of the `lines` slice:
```go
lines[0] = fmt.Sprintf("==== %v", now)
lines[1] = fmt.Sprintf("reason: %v", reason)
i := 0
for k, v := range meta {
	lines[i] = ...
	i++
}
This caused:

Overwriting of headers (lines[0] and lines[1])

Panic at runtime when len(meta) > 2 due to exceeding allocated slice size
The index i is now correctly initialized to 2 to preserve header lines and avoid overflow:
i := 2
for k, v := range meta {
	lines[i] = ...
	i++
}
This fix prevents unpredictable logging behavior and potential panics, especially during high-stress conditions when nurse is triggered to gather vitals.
