### PR TITLE
docs: Fix typo in ReadFromClientConfig comment

### DIFF
--- a/cmd/allorad/cmd/root.go
+++ b/cmd/allorad/cmd/root.go
@@ -79,7 +79,7 @@ func NewRootCmd() *cobra.Command {
 
 			// sign mode textual is only available in online mode
 			if !clientCtx.Offline {
-				// This needs to go after ReadFromClientConfig, as that function ets the RPC client needed for SIGN_MODE_TEXTUAL.
+				// This needs to go after ReadFromClientConfig, as that function sets the RPC client needed for SIGN_MODE_TEXTUAL.
 				txConfigOpts.EnabledSignModes = append(txConfigOpts.EnabledSignModes, signing.SignMode_SIGN_MODE_TEXTUAL)
 				txConfigOpts.TextualCoinMetadataQueryFn = txmodule.NewGRPCCoinMetadataQueryFn(clientCtx)
 				txConfigWithTextual, err := tx.NewTxConfigWithOptions(codec.NewProtoCodec(clientCtx.InterfaceRegistry), txConfigOpts)


### PR DESCRIPTION
Fixed a typo in the comment preceding ReadFromClientConfig in cmd/allorad/cmd/root.go, changing "ets" to "sets" for better clarity.

Before:
// This needs to go after ReadFromClientConfig, as that function ets the RPC client...

After:
// This needs to go after ReadFromClientConfig, as that function sets the RPC client...