### PR TITLE
build: update golangci-lint-action to v8

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: 1.23.6
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v1.60.3
           args: --timeout=10m


### PR DESCRIPTION
Updated golangci-lint-action to v8 for better compatibility with the latest runner environments. Workflows only updated—no functional changes. Release notes: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?
