### PR TITLE
fix: refactor all x/emissions unit tests

### DIFF
--- a/test/testutil/expected_keepers_mocks.go
+++ b/test/testutil/expected_keepers_mocks.go
@@ -1,16 +1,17 @@
 package testutil
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
-	address "cosmossdk.io/core/address"
+	"cosmossdk.io/core/address"
 	cosmosMath "cosmossdk.io/math"
+	types0 "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/golang/mock/gomock"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	keeperTypes "github.com/allora-network/allora-chain/x/emissions/types"
-	types0 "github.com/cosmos/cosmos-sdk/types"
-	types "github.com/cosmos/cosmos-sdk/x/auth/types"
-	gomock "github.com/golang/mock/gomock"
 )
 
 type MockBankKeeper struct {

--- a/test/testutil/stake_removals_mocks.go
+++ b/test/testutil/stake_removals_mocks.go
@@ -5,14 +5,15 @@
 package testutil
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
-	math "cosmossdk.io/math"
-	keeper "github.com/allora-network/allora-chain/x/emissions/keeper"
-	types "github.com/allora-network/allora-chain/x/emissions/types"
+	"cosmossdk.io/math"
 	types0 "github.com/cosmos/cosmos-sdk/types"
-	gomock "github.com/golang/mock/gomock"
+	"github.com/golang/mock/gomock"
+
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 // MockEmissionsKeeper is a mock of EmissionsKeeper interface.

--- a/test/testutil/test_utils.go
+++ b/test/testutil/test_utils.go
@@ -68,6 +68,7 @@ type TestSuite struct {
 }
 
 func NewTestSuite(moduleName string) TestSuite {
+	//nolint:exhaustruct
 	return TestSuite{
 		ModuleName: moduleName,
 	}
@@ -753,6 +754,7 @@ type builderValueO interface {
 	SetValue(alloraMath.Dec)
 }
 
+//nolint:forcetypeassert
 func createValue[O builderValueO](worker string, value alloraMath.Dec) (out O) {
 	out = reflect.New(reflect.TypeOf(out).Elem()).Interface().(O)
 	out.SetWorker(worker)
@@ -834,7 +836,6 @@ func (s *TestSuite) CreateTopic(opts ...Option) uint64 {
 		s.Require().NoError(err)
 		maxGTL := prms.MaxUnfulfilledReputerRequests * uint64(newTopicMsg.EpochLength)
 		if uint64(newTopicMsg.GroundTruthLag) > maxGTL {
-			// TODO: on FullTopicPass they have to be the same. why?
 			newTopicMsg.GroundTruthLag = newTopicMsg.EpochLength
 		}
 	}
@@ -1031,6 +1032,18 @@ func (s *TestSuite) FullTopicSetup(workerIndexes, reputerIndexes []int, options 
 	return topic
 }
 
+// FullTopicPass runs a full pass for a topic. It:
+// 	- takes the option and sets up the topic
+// 	- in case topicID is provided, it assumes that topic exists so it skips creating it,
+// 	- finds the next churning block for the topic and uses it as the nonce,
+// 	- submits inferences for the unfulfilled worker nonce,
+// 	- forwards the chain to the end of the epoch,
+// 	- submits reputer loss bundles for the unfulfilled reputer nonce,
+// 	- forwards the chain to the rewards end blocker,
+// 	- runs the end blocker for closing the reputer nonce and calculating and distributing rewards (when appropriate),
+// 	- when running on a newly created topic, there will be no losses, so no rewards will be distributed.
+// Limitations:
+// 	- with the current design, `ground_truth_lag` needs to be the same as `epoch_length`.
 func (s *TestSuite) FullTopicPass(workerIndexes, reputerIndexes []int, options ...Option) (uint64, int64) {
 	p := new(customParams)
 	for _, opt := range options {

--- a/test/testutil/test_utils.go
+++ b/test/testutil/test_utils.go
@@ -1,0 +1,1094 @@
+package testutil
+
+import (
+	"errors"
+	"math/rand"
+	"reflect"
+	"slices"
+	"strconv"
+	"time"
+
+	"cosmossdk.io/core/header"
+	"cosmossdk.io/core/store"
+	"cosmossdk.io/log"
+	cosmosMath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cometbft/cometbft/crypto/secp256k1"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/allora-network/allora-chain/app/params"
+	alloralog "github.com/allora-network/allora-chain/log"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/utils/fn"
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
+	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
+	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
+	"github.com/allora-network/allora-chain/x/emissions/keeper/queryserver"
+	"github.com/allora-network/allora-chain/x/emissions/module"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+	mintkeeper "github.com/allora-network/allora-chain/x/mint/keeper"
+	minttypes "github.com/allora-network/allora-chain/x/mint/types"
+)
+
+type TestSuite struct {
+	suite.Suite
+	ModuleName string
+
+	ctx                   sdk.Context
+	codec                 codec.Codec
+	storeServiceBank      store.KVStoreService
+	storeServiceEmissions store.KVStoreService
+	accountKeeper         authkeeper.AccountKeeper
+	bankKeeper            bankkeeper.BaseKeeper
+	emissionsKeeper       *keeper.Keeper
+	mintKeeper            minttypes.MintKeeper
+	stakingKeeper         minttypes.StakingKeeper
+	emissionsAppModule    module.AppModule
+	emissionsQueryServer  types.QueryServiceServer
+	emissionsMsgServer    types.MsgServiceServer
+	privKeys              []secp256k1.PrivKey
+	addrs                 []sdk.AccAddress
+	addrsStr              []string
+	pubKeyHexStr          []string
+}
+
+func NewTestSuite(moduleName string) TestSuite {
+	return TestSuite{
+		ModuleName: moduleName,
+	}
+}
+
+func (s *TestSuite) Ctx() sdk.Context {
+	return s.ctx
+}
+
+func (s *TestSuite) Addrs(idx int) sdk.AccAddress {
+	return s.addrs[idx]
+}
+
+func (s *TestSuite) AddrsStr(idx int) string {
+	return s.addrsStr[idx]
+}
+
+func (s *TestSuite) PubKeyHexStr(idx int) string {
+	return s.pubKeyHexStr[idx]
+}
+
+func (s *TestSuite) PrivKeys(idx int) secp256k1.PrivKey {
+	return s.privKeys[idx]
+}
+
+func (s *TestSuite) LenAccounts() int {
+	return len(s.addrs)
+}
+
+func (s *TestSuite) EmissionsKeeper() *keeper.Keeper {
+	return s.emissionsKeeper
+}
+
+func (s *TestSuite) AccountKeeper() authkeeper.AccountKeeper {
+	return s.accountKeeper
+}
+
+func (s *TestSuite) BankKeeper() keeper.BankKeeper {
+	return s.bankKeeper
+}
+
+func (s *TestSuite) MintKeeper() minttypes.MintKeeper {
+	return s.mintKeeper
+}
+
+func (s *TestSuite) StakingKeeper() minttypes.StakingKeeper {
+	return s.stakingKeeper
+}
+
+func (s *TestSuite) EmissionsAppModule() module.AppModule {
+	return s.emissionsAppModule
+}
+
+func (s *TestSuite) EmissionsMsgServer() types.MsgServiceServer {
+	return s.emissionsMsgServer
+}
+
+func (s *TestSuite) EmissionsQueryServer() types.QueryServiceServer {
+	return s.emissionsQueryServer
+}
+
+func (s *TestSuite) StoreServiceEmissions() store.KVStoreService {
+	return s.storeServiceEmissions
+}
+
+func (s *TestSuite) StoreServiceBank() store.KVStoreService {
+	return s.storeServiceBank
+}
+
+func (s *TestSuite) WithBlockHeight(height int64) {
+	s.ctx = s.ctx.WithBlockHeight(height)
+}
+
+const (
+	multiPerm  = "multiple permissions account"
+	randomPerm = "random permission"
+)
+
+type (
+	Option       func(s *customParams)
+	customParams struct {
+		block             int64
+		topicID           uint64
+		initialTopicStake cosmosMath.Int
+		alphaRegret       alloraMath.Dec
+		epochLength,
+		groundTruthLag,
+		workerSubmissionWindow,
+		epochLastEnded int64
+		lossMethod,
+		initialRegret string
+		workerValues          []TestWorkerValue
+		reputerValues         []TestReputerValue
+		skipNetworkInferences bool
+		reputerStake          *cosmosMath.Int
+	}
+)
+
+func WithBlock(block int64) Option {
+	return func(s *customParams) {
+		s.block = block
+	}
+}
+
+func WithTopicID(topicID uint64) Option {
+	return func(s *customParams) {
+		s.topicID = topicID
+	}
+}
+
+func WithInitialTopicStake(stake cosmosMath.Int) Option {
+	return func(s *customParams) {
+		s.initialTopicStake = stake
+	}
+}
+
+func WithAlphaRegret(alphaRegret alloraMath.Dec) Option {
+	return func(s *customParams) {
+		s.alphaRegret = alphaRegret
+	}
+}
+
+func WithEpochLength(epochLength int64) Option {
+	return func(s *customParams) {
+		s.epochLength = epochLength
+	}
+}
+
+func WithGroundTruthLag(lag int64) Option {
+	return func(s *customParams) {
+		s.groundTruthLag = lag
+	}
+}
+
+func WithWorkerSubmissionWindow(window int64) Option {
+	return func(s *customParams) {
+		s.workerSubmissionWindow = window
+	}
+}
+
+func WithWorkerValues(workerValues []TestWorkerValue) Option {
+	return func(s *customParams) {
+		s.workerValues = workerValues
+	}
+}
+
+func WithReputerValues(reputerValues []TestReputerValue) Option {
+	return func(s *customParams) {
+		s.reputerValues = reputerValues
+	}
+}
+
+func WithReputerStake(reputerStake *cosmosMath.Int) Option {
+	return func(s *customParams) {
+		s.reputerStake = reputerStake
+	}
+}
+
+func WithEpochLastEnded(epochLastEnded int64) Option {
+	return func(s *customParams) {
+		s.epochLastEnded = epochLastEnded
+	}
+}
+
+func WithLossMethod(lossMethod string) Option {
+	return func(s *customParams) {
+		s.lossMethod = lossMethod
+	}
+}
+
+func WithInitialRegret(initialRegret string) Option {
+	return func(s *customParams) {
+		s.initialRegret = initialRegret
+	}
+}
+
+func WithSkipNetworkInferences() Option {
+	return func(p *customParams) {
+		p.skipNetworkInferences = true
+	}
+}
+
+func (s *TestSuite) SetupTest() {
+	var (
+		keyEmissions        = storetypes.NewKVStoreKey("emissions")
+		keyAccount          = storetypes.NewKVStoreKey("account")
+		keyBank             = storetypes.NewKVStoreKey("bank")
+		keyStaking          = storetypes.NewKVStoreKey("staking")
+		keyMint             = storetypes.NewKVStoreKey("mint")
+		storeServiceAccount = runtime.NewKVStoreService(keyAccount)
+		storeServiceStaking = runtime.NewKVStoreService(keyStaking)
+		storeServiceMint    = runtime.NewKVStoreService(keyMint)
+	)
+	s.storeServiceEmissions = runtime.NewKVStoreService(keyEmissions)
+	s.storeServiceBank = runtime.NewKVStoreService(keyBank)
+	testCtx := testutil.DefaultContextWithKeys(map[string]*storetypes.KVStoreKey{
+		"emissions": keyEmissions,
+		"account":   keyAccount,
+		"bank":      keyBank,
+		"staking":   keyStaking,
+		"mint":      keyMint,
+	}, map[string]*storetypes.TransientStoreKey{
+		"transient_test": storetypes.NewTransientStoreKey("transient_test"),
+	}, nil).WithHeaderInfo(header.Info{Time: time.Now()}) //nolint:exhaustruct
+
+	// Set logger to show logs from the module too
+	logger := alloralog.NewTestLogger(s.T()).With("module", s.ModuleName)
+	ctx := testCtx.WithHeaderInfo(header.Info{
+		Height:  1,
+		Hash:    []byte("1"),
+		AppHash: []byte("1"),
+		ChainID: "localnet",
+		Time:    time.Now(),
+	}).WithLogger(logger)
+	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
+	s.codec = encCfg.Codec
+
+	maccPerms := map[string][]string{
+		"fee_collector":                {"minter"},
+		"mint":                         {"minter"},
+		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
+		types.AlloraRewardsAccountName: {"minter"},
+		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
+		"ecosystem":              {"minter"},
+		"bonded_tokens_pool":     {"burner", "staking"},
+		"not_bonded_tokens_pool": {"burner", "staking"},
+		multiPerm:                {"burner", "minter", "staking"},
+		randomPerm:               {"random"},
+	}
+
+	accountKeeper := authkeeper.NewAccountKeeper(
+		encCfg.Codec,
+		storeServiceAccount,
+		authtypes.ProtoBaseAccount,
+		maccPerms,
+		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
+		params.Bech32PrefixAccAddr,
+		authtypes.NewModuleAddress("gov").String(),
+	)
+	bankKeeper := bankkeeper.NewBaseKeeper(
+		encCfg.Codec,
+		s.storeServiceBank,
+		accountKeeper,
+		map[string]bool{},
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		log.NewNopLogger(),
+	)
+	emissionsKeeper := keeper.NewKeeper(
+		encCfg.Codec,
+		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
+		s.storeServiceEmissions,
+		accountKeeper,
+		bankKeeper,
+		authtypes.FeeCollectorName)
+	stakingKeeper := stakingkeeper.NewKeeper(
+		encCfg.Codec,
+		storeServiceStaking,
+		accountKeeper,
+		bankKeeper,
+		authtypes.NewModuleAddress("gov").String(),
+		codecAddress.NewBech32Codec(sdk.Bech32PrefixValAddr),
+		codecAddress.NewBech32Codec(sdk.Bech32PrefixConsAddr),
+	)
+	mintKeeper := mintkeeper.NewKeeper(
+		encCfg.Codec,
+		storeServiceMint,
+		stakingKeeper,
+		accountKeeper,
+		bankKeeper,
+		emissionsKeeper,
+		authtypes.FeeCollectorName,
+	)
+
+	s.ctx = ctx
+	s.accountKeeper = accountKeeper
+	s.bankKeeper = bankKeeper
+	s.emissionsKeeper = &emissionsKeeper
+	s.mintKeeper = mintKeeper
+	s.stakingKeeper = stakingKeeper
+	emissionsAppModule := module.NewAppModule(encCfg.Codec, emissionsKeeper)
+	defaultEmissionsGenesis := emissionsAppModule.DefaultGenesis(encCfg.Codec)
+	emissionsAppModule.InitGenesis(ctx, encCfg.Codec, defaultEmissionsGenesis)
+	s.emissionsMsgServer = msgserver.NewMsgServerImpl(emissionsKeeper)
+	s.emissionsQueryServer = queryserver.NewQueryServerImpl(*s.emissionsKeeper)
+	s.emissionsAppModule = emissionsAppModule
+
+	// Fund the rewards account generously
+	s.FundAccount(10000000000, s.accountKeeper.GetModuleAddress(types.AlloraRewardsAccountName))
+
+	s.privKeys, s.pubKeyHexStr, s.addrs, s.addrsStr = GenerateTestAccounts(50)
+	for _, addr := range s.addrs {
+		s.FundAccount(10000000000, addr)
+	}
+
+	// Add all tests addresses in whitelists
+	for _, addr := range s.addrsStr {
+		err := s.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
+		s.Require().NoError(err)
+
+		err = s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, addr)
+		s.Require().NoError(err)
+
+		err = s.emissionsKeeper.AddToGlobalWhitelist(ctx, addr)
+		s.Require().NoError(err)
+	}
+
+	// create first topic
+	s.CreateTopic(WithEpochLength(100), WithGroundTruthLag(100), WithWorkerSubmissionWindow(100))
+}
+
+func (s *TestSuite) SetParamsForTest() {
+	// Setup a sender address
+	adminPrivateKey := secp256k1.GenPrivKey()
+	adminAddr := sdk.AccAddress(adminPrivateKey.PubKey().Address())
+	err := s.emissionsKeeper.AddWhitelistAdmin(s.Ctx(), adminAddr.String())
+	s.Require().NoError(err)
+
+	//nolint:exhaustruct
+	newParams := &types.OptionalParams{
+		MaxTopInferersToReward:  []uint64{24},
+		MinEpochLength:          []int64{1},
+		RegistrationFee:         []cosmosMath.Int{cosmosMath.NewInt(6)},
+		MaxActiveTopicsPerBlock: []uint64{2},
+		BlocksPerMonth:          []uint64{864000},
+		// Exaggerated TopicRewardAlpha to compensate the effect of latest topic reward alpha vs
+		// the dripping effect and separate epochs running multiple topics.
+		TopicRewardAlpha: []alloraMath.Dec{alloraMath.MustNewDecFromString("0.999375")},
+	}
+
+	updateMsg := &types.UpdateParamsRequest{
+		Sender: adminAddr.String(),
+		Params: newParams,
+	}
+
+	response, err := s.emissionsMsgServer.UpdateParams(s.Ctx(), updateMsg)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+}
+
+func (s *TestSuite) FundAccount(amount int64, accAddress sdk.AccAddress) {
+	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(amount)))
+	err := s.bankKeeper.MintCoins(s.Ctx(), types.AlloraStakingAccountName, initialStakeCoins)
+	s.Require().NoError(err)
+	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, accAddress, initialStakeCoins)
+	s.Require().NoError(err)
+}
+
+func (s *TestSuite) FundTopic(topicId uint64, funderAddr sdk.AccAddress, amount cosmosMath.Int) {
+	s.MintTokensToAddress(funderAddr, amount)
+	fundTopicMessage := types.FundTopicRequest{
+		Sender:  funderAddr.String(),
+		TopicId: topicId,
+		Amount:  amount,
+	}
+	response, err := s.emissionsMsgServer.FundTopic(s.Ctx(), &fundTopicMessage)
+	s.Require().NoError(err, "RequestInference should not return an error")
+	s.Require().NotNil(response, "Response should not be nil")
+}
+
+func (s *TestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
+	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
+
+	err := s.bankKeeper.MintCoins(s.Ctx(), types.AlloraStakingAccountName, creatorInitialBalanceCoins)
+	s.Require().NoError(err)
+	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
+	s.Require().NoError(err)
+}
+
+func (s *TestSuite) MintTokensToModule(moduleName string, amount cosmosMath.Int) {
+	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
+	err := s.bankKeeper.MintCoins(s.Ctx(), moduleName, creatorInitialBalanceCoins)
+	s.Require().NoError(err)
+}
+
+func DecPtr(s string) *alloraMath.Dec {
+	d := alloraMath.MustNewDecFromString(s)
+	return &d
+}
+
+func GetWorkerValuesFromIndexes(indexes []int, value ...string) []TestWorkerValue {
+	values := make([]TestWorkerValue, 0)
+	for i, index := range indexes {
+		values = append(values, TestWorkerValue{Index: index, Value: value[i%len(value)]})
+	}
+	return values
+}
+
+func (s *TestSuite) GetReputerValuesFromIndexes(reputerIndexes, workerIndexes []int, value ...string) []TestReputerValue {
+	if len(value) == 0 {
+		panic("value is empty")
+	}
+	addrs := make([]string, len(workerIndexes))
+	for i, index := range workerIndexes {
+		addrs[i] = s.addrsStr[index]
+	}
+	slices.Sort(addrs)
+	values := make([]TestReputerValue, len(reputerIndexes))
+	for i, repIdx := range reputerIndexes {
+		for j, wrkIdx := range workerIndexes {
+			if values[i].WorkerValues == nil {
+				values[i].WorkerValues = make(map[string]string)
+			}
+			values[i].WorkerValues[addrs[wrkIdx%len(addrs)]] = value[j%len(value)]
+			values[i].CombinedValue = value[repIdx%len(value)]
+		}
+	}
+	return values
+}
+
+type TestWorkerValue struct {
+	Index int
+	Value string
+}
+
+func generateWorkerDataBundles(s *TestSuite, nonce int64, topicId uint64, workerIndexes []int, workerValues []TestWorkerValue) []*types.InputWorkerDataBundle {
+	lwv := len(workerValues)
+	hasWorkerValues := lwv > 0
+	if hasWorkerValues && len(workerIndexes) != lwv {
+		panic("invalid worker values length")
+	}
+	var bundles []*types.InputWorkerDataBundle
+	totalAddresses := len(s.addrsStr)
+
+	for i, workerIdx := range workerIndexes {
+		// Generate random inference value between 0.1 and 0.25
+		// nolint:gosec
+		inferenceValueStr := strconv.FormatFloat(0.1+rand.Float64()*0.15, 'f', 5, 64)
+		if hasWorkerValues {
+			inferenceValueStr = workerValues[i].Value
+		}
+
+		// Select forecast targets (next two workers in sequence, wrapping if needed)
+		forecastTargets := []int{
+			(workerIdx + 0) % totalAddresses,
+			(workerIdx + 1) % totalAddresses,
+			(workerIdx + 2) % totalAddresses,
+		}
+
+		// Create forecast elements
+		forecastElements := []*types.InputForecastElement{
+			{
+				Inferer: s.addrs[forecastTargets[0]].String(),
+				Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(inferenceValueStr)),
+			},
+			{
+				Inferer: s.addrs[forecastTargets[1]].String(),
+				Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(inferenceValueStr)),
+			},
+			{
+				Inferer: s.addrs[forecastTargets[2]].String(),
+				Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(inferenceValueStr)),
+			},
+		}
+
+		// Create inference-forecast bundle
+		inferenceForecastBundle := &types.InputInferenceForecastBundle{
+			Inference: &types.InputInference{
+				TopicId:     topicId,
+				BlockHeight: nonce,
+				Inferer:     s.addrsStr[workerIdx],
+				Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(inferenceValueStr)),
+				ExtraData:   nil,
+				Proof:       "",
+			},
+			Forecast: &types.InputForecast{
+				TopicId:          topicId,
+				BlockHeight:      nonce,
+				Forecaster:       s.addrsStr[workerIdx],
+				ForecastElements: forecastElements,
+				ExtraData:        nil,
+			},
+		}
+
+		// Sign the bundle
+		inputBundle, err := types.NewInferenceForecastBundleFromInput(inferenceForecastBundle)
+		s.Require().NoError(err)
+		signature, err := signInferenceForecastBundle(inputBundle, s.privKeys[workerIdx])
+		s.Require().NoError(err)
+
+		// Create the complete worker data bundle
+		bundle := &types.InputWorkerDataBundle{
+			Worker:                             s.addrsStr[workerIdx],
+			Nonce:                              &types.Nonce{BlockHeight: nonce},
+			TopicId:                            topicId,
+			InferenceForecastsBundle:           inferenceForecastBundle,
+			InferencesForecastsBundleSignature: signature,
+			Pubkey:                             s.pubKeyHexStr[workerIdx],
+		}
+
+		bundles = append(bundles, bundle)
+	}
+
+	return bundles
+}
+
+func (s *TestSuite) SignInputValueBundle(InputValueBundle *types.InputValueBundle, privateKey secp256k1.PrivKey) []byte {
+	valueBundle, err := types.NewValueBundleFromInput(InputValueBundle)
+	s.Require().NoError(err)
+	return s.SignValueBundle(valueBundle, privateKey)
+}
+
+func signInferenceForecastBundle(
+	inferenceForecastBundle *types.InferenceForecastBundle,
+	privateKey secp256k1.PrivKey,
+) ([]byte, error) {
+	src := make([]byte, 0)
+	src, err := inferenceForecastBundle.XXX_Marshal(src, true)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := privateKey.Sign(src)
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
+}
+
+type TestReputerValue struct {
+	CombinedValue    string
+	WorkerValues     map[string]string
+	ForecasterValues map[string]string
+	OneOutInfValues  map[string]string
+}
+
+// GenerateLossBundles generates the reputer loss bundles for a given topic and nonce.
+//
+// Usage scenarios:
+// - If network inferences exist:
+//   - Will base output on existing network inferences
+//   - Uses provided reputerValues to set specific worker inference values per worker
+//   - If no reputerValues provided, applies arbitrary delta value to network inference entries
+//
+// - If no network inferences exist:
+//   - Uses Worker/Forecaster/OneOutInf values directly from reputerValues
+func (s *TestSuite) GenerateLossBundles(
+	nonce int64,
+	topicId uint64,
+	reputerIndexes []int,
+	opts ...Option,
+) (reputerValueBundles types.InputReputerValueBundles) {
+	p := new(customParams)
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	rv := len(p.reputerValues)
+	hasReputerValues := rv > 0
+	if hasReputerValues && len(reputerIndexes) != rv {
+		panic("invalid reputer values length")
+	}
+
+	// Get network inferences (may be empty)
+	networkInferences := new(types.ValueBundle)
+	if !p.skipNetworkInferences {
+		var err error
+		networkInferences, err = s.emissionsKeeper.GetLatestNetworkInferences(s.Ctx(), topicId, false)
+		s.Require().NoError(err)
+	}
+
+	for i, reputerIndex := range reputerIndexes {
+		var reputerValue TestReputerValue
+		if hasReputerValues {
+			reputerValue = p.reputerValues[i]
+		}
+
+		valueBundle := buildInputValueBundle(topicId, nonce, s.addrsStr[reputerIndex], reputerValue, networkInferences, p.skipNetworkInferences)
+		sig := s.SignInputValueBundle(valueBundle, s.privKeys[reputerIndex])
+
+		bundle := &types.InputReputerValueBundle{
+			Pubkey:      s.pubKeyHexStr[reputerIndex],
+			Signature:   sig,
+			ValueBundle: valueBundle,
+		}
+		reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, bundle)
+	}
+
+	return reputerValueBundles
+}
+
+// buildInputValueBundle creates an InputValueBundle based on network inferences and/or test reputer values.
+//
+// Decision logic:
+// - If network inferences exist and are non-empty, uses them as the base structure
+// - If both network inferences AND reputer values exist, applies reputer values to override network values (useTestValues=true)
+// - If only network inferences exist, applies deltaVal modification to network values
+// - If only reputer values exist (no network inferences), builds structure entirely from reputer values
+// - Special handling for OneOutInfererForecasterValues when no network inferences exist
+func buildInputValueBundle(
+	topicId uint64,
+	nonce int64,
+	reputerAddr string,
+	reputerValue TestReputerValue,
+	networkInferences *types.ValueBundle,
+	skipNetworkInferences bool,
+) *types.InputValueBundle {
+	combinedValStr := "0.1"
+	if reputerValue.CombinedValue != "" {
+		combinedValStr = reputerValue.CombinedValue
+	}
+	combinedVal := alloraMath.MustNewBoundedExp40DecFromString(combinedValStr)
+
+	useTestValues := len(reputerValue.WorkerValues) > 0 &&
+		len(networkInferences.InfererValues) > 0 &&
+		len(networkInferences.ForecasterValues) > 0 || // meaning there was a network loss
+		skipNetworkInferences
+
+	buildWorkerBundleValues := buildLossBundleValues[*types.WorkerAttributedValue, *types.InputWorkerAttributedValue]
+	buildWithheldBundleValues := buildLossBundleValues[*types.WithheldWorkerAttributedValue, *types.InputWithheldWorkerAttributedValue]
+
+	//nolint:exhaustruct
+	return &types.InputValueBundle{
+		TopicId:                topicId,
+		ReputerRequestNonce:    &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: nonce}},
+		Reputer:                reputerAddr,
+		CombinedValue:          combinedVal,
+		NaiveValue:             combinedVal,
+		InfererValues:          buildWorkerBundleValues(networkInferences.InfererValues, reputerValue, "worker", useTestValues),
+		ForecasterValues:       buildWorkerBundleValues(networkInferences.ForecasterValues, reputerValue, "forecaster", useTestValues),
+		OneOutInfererValues:    buildWithheldBundleValues(networkInferences.OneOutInfererValues, reputerValue, "oneOutWorker", useTestValues),
+		OneOutForecasterValues: buildWithheldBundleValues(networkInferences.OneOutForecasterValues, reputerValue, "forecaster", useTestValues),
+		OneInForecasterValues:  buildWorkerBundleValues(networkInferences.OneInForecasterValues, reputerValue, "forecaster", useTestValues),
+		OneOutInfererForecasterValues: fn.Map(networkInferences.OneOutInfererForecasterValues, func(inf *types.OneOutInfererForecasterValues) *types.InputOneOutInfererForecasterValues {
+			return &types.InputOneOutInfererForecasterValues{
+				Forecaster:          inf.Forecaster,
+				OneOutInfererValues: buildWithheldBundleValues(inf.OneOutInfererValues, reputerValue, "oneOutWorker", useTestValues)}
+		}),
+	}
+}
+
+func buildLossBundleValues[I builderValueI, O builderValueO](baseValues []I, reputerValue TestReputerValue, valueType string, useTestValues bool) (values []O) {
+	if len(baseValues) == 0 && useTestValues {
+		for worker, valueStr := range getValueMap(reputerValue, valueType) {
+			value := getWorkerValue(worker, alloraMath.MustNewDecFromString(valueStr), reputerValue, valueType)
+			values = append(values, createValue[O](worker, value))
+		}
+		return
+	}
+	return fn.Map(baseValues, func(inf I) O {
+		val := getWorkerValue(inf.GetWorker(), inf.GetValue(), reputerValue, valueType)
+		return createValue[O](inf.GetWorker(), val)
+	})
+}
+
+func getWorkerValue(worker string, baseValue alloraMath.Dec, reputerValue TestReputerValue, valueType string) (val alloraMath.Dec) {
+	// Use base value minus delta as fallback
+	deltaVal := alloraMath.MustNewDecFromString("0.01988")
+	val, _ = baseValue.Sub(deltaVal)
+	if valueMap := getValueMap(reputerValue, valueType); valueMap != nil {
+		if v, ok := valueMap[worker]; ok {
+			val = alloraMath.MustNewDecFromString(v)
+		}
+	}
+	return
+}
+
+func getValueMap(reputerValue TestReputerValue, valueType string) map[string]string {
+	switch valueType {
+	case "worker":
+		// InfererValues use WorkerValues
+		return reputerValue.WorkerValues
+	case "forecaster":
+		// ForecasterValues, OneOutForecasterValues, OneInForecasterValues use ForecasterValues
+		return reputerValue.ForecasterValues
+	case "oneOutWorker":
+		// OneOutInfererValues and OneOutInfererForecasterValues use OneOutInfValues first, then WorkerValues
+		if len(reputerValue.OneOutInfValues) != 0 {
+			return reputerValue.OneOutInfValues
+		}
+		return reputerValue.WorkerValues
+	}
+	return nil
+}
+
+type builderValueI interface {
+	GetWorker() string
+	GetValue() alloraMath.Dec
+}
+
+type builderValueO interface {
+	SetWorker(string)
+	SetValue(alloraMath.Dec)
+}
+
+func createValue[O builderValueO](worker string, value alloraMath.Dec) (out O) {
+	out = reflect.New(reflect.TypeOf(out).Elem()).Interface().(O)
+	out.SetWorker(worker)
+	out.SetValue(value)
+	return out
+}
+
+func (s *TestSuite) SignValueBundle(valueBundle *types.ValueBundle, privateKey secp256k1.PrivKey) []byte {
+	src := make([]byte, 0)
+	src, err := valueBundle.XXX_Marshal(src, true)
+	if err != nil {
+		return nil
+	}
+
+	valueBundleSignature, err := privateKey.Sign(src)
+	s.Require().NoError(err)
+
+	return valueBundleSignature
+}
+
+func (s *TestSuite) SetupTopic(creator sdk.AccAddress, opts ...Option) uint64 {
+	// create topic
+	p := new(customParams)
+	for _, opt := range opts {
+		opt(p)
+	}
+	topicId := s.CreateTopic(opts...)
+
+	// fund topic
+	initialStake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
+
+	if !p.initialTopicStake.IsNil() {
+		initialStake = p.initialTopicStake
+	}
+
+	s.FundTopic(topicId, creator, initialStake)
+	s.Require().True(
+		s.bankKeeper.HasBalance(
+			s.Ctx(),
+			s.accountKeeper.GetModuleAddress(minttypes.EcosystemModuleName),
+			sdk.NewCoin(params.DefaultBondDenom, initialStake),
+		),
+		"ecosystem account should have something in it after funding",
+	)
+
+	return topicId
+}
+
+func (s *TestSuite) CreateTopic(opts ...Option) uint64 {
+	newTopicMsg := s.MockTopicMsg()
+	newTopicMsg.Creator = s.AddrsStr(0)
+
+	p := new(customParams)
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	if !p.alphaRegret.IsZero() {
+		newTopicMsg.AlphaRegret = p.alphaRegret
+	}
+	if p.epochLength > 0 {
+		newTopicMsg.EpochLength = p.epochLength
+	}
+	if p.groundTruthLag > 0 {
+		newTopicMsg.GroundTruthLag = p.groundTruthLag
+	}
+	if p.workerSubmissionWindow > 0 {
+		newTopicMsg.WorkerSubmissionWindow = p.workerSubmissionWindow
+	}
+	if p.lossMethod != "" {
+		newTopicMsg.LossMethod = p.lossMethod
+	}
+
+	if newTopicMsg.EpochLength < newTopicMsg.WorkerSubmissionWindow {
+		newTopicMsg.WorkerSubmissionWindow = newTopicMsg.EpochLength - 1
+	}
+	if newTopicMsg.EpochLength < newTopicMsg.GroundTruthLag {
+		prms, err := s.EmissionsKeeper().GetParams(s.Ctx())
+		s.Require().NoError(err)
+		maxGTL := prms.MaxUnfulfilledReputerRequests * uint64(newTopicMsg.EpochLength)
+		if uint64(newTopicMsg.GroundTruthLag) > maxGTL {
+			// TODO: on FullTopicPass they have to be the same. why?
+			newTopicMsg.GroundTruthLag = newTopicMsg.EpochLength
+		}
+	}
+
+	res, err := s.emissionsMsgServer.CreateNewTopic(s.Ctx(), newTopicMsg)
+	s.Require().NoError(err)
+
+	if p.epochLastEnded > 0 || p.initialRegret != "" {
+		topic, err := s.emissionsKeeper.GetTopic(s.Ctx(), res.TopicId)
+		s.Require().NoError(err)
+		topic.EpochLastEnded = p.epochLastEnded
+		topic.InitialRegret = alloraMath.MustNewDecFromString(p.initialRegret)
+		err = s.emissionsKeeper.SetTopic(s.Ctx(), topic.Id, topic)
+		s.Require().NoError(err)
+	}
+
+	return res.TopicId
+}
+
+func (s *TestSuite) MockTopic() types.Topic {
+	return types.Topic{
+		Id:                       1,
+		Creator:                  s.addrs[0].String(),
+		Metadata:                 "metadata",
+		LossMethod:               "mse",
+		EpochLength:              10800,
+		EpochLastEnded:           0,
+		GroundTruthLag:           10800,
+		WorkerSubmissionWindow:   10,
+		PNorm:                    alloraMath.NewDecFromInt64(3),
+		InitialRegret:            alloraMath.MustNewDecFromString("0.0001"),
+		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
+		AllowNegative:            false,
+		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
+		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
+		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
+		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
+	}
+}
+
+func (s *TestSuite) MockTopicMsg() *types.CreateNewTopicRequest {
+	topic := s.MockTopic()
+	return &types.CreateNewTopicRequest{
+		Creator:                  topic.Creator,
+		Metadata:                 topic.Metadata,
+		LossMethod:               topic.LossMethod,
+		EpochLength:              topic.EpochLength,
+		GroundTruthLag:           topic.GroundTruthLag,
+		PNorm:                    topic.PNorm,
+		AlphaRegret:              topic.AlphaRegret,
+		AllowNegative:            topic.AllowNegative,
+		Epsilon:                  topic.Epsilon,
+		WorkerSubmissionWindow:   topic.WorkerSubmissionWindow,
+		MeritSortitionAlpha:      topic.MeritSortitionAlpha,
+		ActiveInfererQuantile:    topic.ActiveInfererQuantile,
+		ActiveForecasterQuantile: topic.ActiveForecasterQuantile,
+		ActiveReputerQuantile:    topic.ActiveReputerQuantile,
+		EnableWorkerWhitelist:    true,
+		EnableReputerWhitelist:   true,
+	}
+}
+
+// ReturnIndexes generates slice of consecutive numbers
+func ReturnIndexes(start, count int) []int {
+	res := make([]int, count)
+	for ind := start; ind < start+count; ind++ {
+		res[ind-start] = ind
+	}
+	return res
+}
+
+func (s *TestSuite) SetupParticipants(topicID uint64, indexes []int, isReputer bool, options ...Option) {
+	p := new(customParams)
+	for _, opt := range options {
+		opt(p)
+	}
+	var addresses []sdk.AccAddress
+
+	for _, index := range indexes {
+		addresses = append(addresses, s.addrs[index])
+		workerRegMsg := &types.RegisterRequest{
+			Sender:    s.addrs[index].String(),
+			TopicId:   topicID,
+			IsReputer: isReputer,
+			Owner:     s.addrs[index].String(),
+		}
+		_, err := s.emissionsMsgServer.Register(s.Ctx(), workerRegMsg)
+		if !errors.Is(err, types.ErrAddressAlreadyRegisteredInATopic) {
+			s.Require().NoError(err)
+		} else {
+			return
+		}
+	}
+
+	if !isReputer {
+		return
+	}
+
+	// Add Stake for reputers
+	stakes := GenerateTestStakes(len(addresses))
+	for i, addr := range addresses {
+		stake := stakes[i]
+		if p.reputerStake != nil {
+			stake = *p.reputerStake
+		}
+		if stake.IsZero() {
+			continue
+		}
+		s.MintTokensToAddress(addr, stake)
+		_, err := s.emissionsMsgServer.AddStake(s.Ctx(), &types.AddStakeRequest{
+			Sender:  addr.String(),
+			Amount:  stake,
+			TopicId: topicID,
+		})
+		s.Require().NoError(err)
+	}
+}
+
+func (s *TestSuite) SetupInferences(topicID uint64, nonce int64, workerIndexes []int, workerValues ...TestWorkerValue) types.Nonce {
+	if len(workerIndexes) == 0 {
+		return types.Nonce{} //nolint:exhaustruct
+	}
+	inferenceBundles := generateWorkerDataBundles(s, nonce, topicID, workerIndexes, workerValues)
+	for _, payload := range inferenceBundles {
+		_, err := s.emissionsMsgServer.InsertWorkerPayload(s.Ctx(), &types.InsertWorkerPayloadRequest{
+			Sender:           payload.Worker,
+			WorkerDataBundle: payload,
+		})
+		s.Require().NoError(err)
+	}
+	return *inferenceBundles[0].Nonce
+}
+
+func (s *TestSuite) CloseWorkerNonce(topic types.Topic, workerNonce types.Nonce) {
+	err := actorutils.CloseWorkerNonce(s.emissionsKeeper, s.Ctx(), topic, workerNonce)
+	s.Require().NoError(err)
+}
+
+func (s *TestSuite) CloseReputerNonce(topic types.Topic, reputerNonce types.Nonce) {
+	err := actorutils.CloseReputerNonce(s.emissionsKeeper, s.Ctx(), topic, reputerNonce)
+	s.Require().NoError(err)
+}
+
+func (s *TestSuite) EndBlock() {
+	err := s.emissionsKeeper.SetRewardCurrentBlockEmission(s.Ctx(), cosmosMath.NewInt(100))
+	s.Require().NoError(err)
+	err = s.emissionsAppModule.EndBlock(s.Ctx())
+	s.Require().NoError(err)
+}
+
+func (s *TestSuite) InsertReputerLossBundle(topicID uint64, nonce int64, reputerIndexes []int, opts ...Option) error {
+	if len(reputerIndexes) == 0 {
+		return errors.New("no reputer indexes provided")
+	}
+	lossBundles := s.GenerateLossBundles(nonce, topicID, reputerIndexes, opts...)
+	for _, payload := range lossBundles.ReputerValueBundles {
+		_, err := s.emissionsMsgServer.InsertReputerPayload(s.Ctx(), &types.InsertReputerPayloadRequest{
+			Sender:             payload.ValueBundle.Reputer,
+			ReputerValueBundle: payload,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *TestSuite) FullTopicSetup(workerIndexes, reputerIndexes []int, options ...Option) types.Topic {
+	p := new(customParams)
+	for _, opt := range options {
+		opt(p)
+	}
+
+	topicId := p.topicID
+	// Create topic if not exists
+	if topicId == 0 && len(reputerIndexes) > 0 {
+		topicId = s.SetupTopic(s.addrs[reputerIndexes[0]], options...)
+	}
+
+	// Register workers
+	if len(workerIndexes) > 0 {
+		s.SetupParticipants(topicId, workerIndexes, false, options...)
+	}
+
+	// Register reputers
+	if len(reputerIndexes) > 0 {
+		s.SetupParticipants(topicId, reputerIndexes, true, options...)
+	}
+
+	topic, err := s.emissionsKeeper.GetTopic(s.Ctx(), topicId)
+	s.Require().NoError(err)
+
+	return topic
+}
+
+func (s *TestSuite) FullTopicPass(workerIndexes, reputerIndexes []int, options ...Option) (uint64, int64) {
+	p := new(customParams)
+	for _, opt := range options {
+		opt(p)
+	}
+
+	topic := s.FullTopicSetup(
+		workerIndexes,
+		reputerIndexes,
+		options...,
+	)
+
+	p.topicID = topic.Id
+
+	var err error
+	nonce := p.block
+	if nonce == 0 {
+		nonce, _, err = s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.Ctx(), p.topicID)
+		s.Require().NoError(err)
+		s.T().Logf("Moving nonce to post inferences for TopicId: %d, Next block: %v", p.topicID, nonce)
+		s.WithBlockHeight(nonce)
+		s.EndBlock()
+	}
+
+	topic, err = s.emissionsKeeper.GetTopic(s.Ctx(), topic.Id)
+	s.Require().NoError(err)
+
+	workerNonces, err := s.emissionsKeeper.GetUnfulfilledWorkerNonces(s.Ctx(), topic.Id)
+	s.Require().NoError(err)
+
+	if len(workerNonces.Nonces) > 0 {
+		s.SetupInferences(p.topicID, workerNonces.Nonces[0].BlockHeight, workerIndexes, p.workerValues...)
+		wswBlock := nonce + topic.WorkerSubmissionWindow
+		s.T().Logf("Moving nonce to end of worker submission window for TopicId: %d, Next block: %v", p.topicID, wswBlock)
+		s.WithBlockHeight(wswBlock)
+		s.EndBlock()
+	}
+
+	epochEndBlock := nonce + topic.EpochLength
+	s.T().Logf("Moving nonce to end of first epoch for TopicId: %d, Next block: %v", p.topicID, epochEndBlock)
+	s.WithBlockHeight(epochEndBlock)
+	s.EndBlock()
+
+	reputerNonces, err := s.emissionsKeeper.GetUnfulfilledReputerNonces(s.Ctx(), p.topicID)
+	s.Require().NoError(err)
+
+	if len(reputerNonces.Nonces) > 0 {
+		reputerTxBlockHeight := reputerNonces.Nonces[0].ReputerNonce.BlockHeight + topic.GroundTruthLag + 1
+		s.T().Logf("Moving nonce to insert loss bundles from reputers for TopicId: %d, Next block: %v, Nonce: %v", p.topicID, reputerTxBlockHeight, nonce)
+		s.WithBlockHeight(reputerTxBlockHeight)
+		err = s.InsertReputerLossBundle(topic.GetId(), reputerNonces.Nonces[0].ReputerNonce.BlockHeight, reputerIndexes, options...)
+		s.Require().NoError(err)
+	}
+
+	rewardsBlockHeight := nonce + topic.GroundTruthLag + topic.EpochLength
+	s.T().Logf("Moving nonce to rewards end blocker for TopicId: %d, Next block: %v", p.topicID, rewardsBlockHeight)
+	s.WithBlockHeight(rewardsBlockHeight)
+	s.EndBlock()
+
+	return topic.GetId(), nonce
+}

--- a/test/testutil/testdata.go
+++ b/test/testutil/testdata.go
@@ -4,15 +4,18 @@ import (
 	"encoding/csv"
 	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"strings"
+
+	cosmosMath "cosmossdk.io/math"
+	"github.com/cometbft/cometbft/crypto/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/utils"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var valueBundleBufferPool = utils.NewBytesPool(1024, 0)
@@ -34,6 +37,23 @@ func GenerateTestAccounts(count int) (
 		addrsStr[i] = addrs[i].String()
 	}
 	return privKeys, pubKeyHexStr, addrs, addrsStr
+}
+
+//nolint:gosec
+func GenerateTestStakes(count int) []cosmosMath.Int {
+	minStake := int64(200000)
+	maxStake := int64(1200000)
+
+	stakes := make([]cosmosMath.Int, count)
+	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
+
+	for i := 0; i < count; i++ {
+		randomValue := minStake + rand.Int63n(maxStake-minStake)
+
+		stakes[i] = cosmosMath.NewInt(randomValue).Mul(cosmosOneE18)
+	}
+
+	return stakes
 }
 
 func GetSimulatedValuesGetterForEpoch(

--- a/utils/ptr/ptr.go
+++ b/utils/ptr/ptr.go
@@ -1,0 +1,5 @@
+package ptr
+
+func To[T any](val T) *T {
+	return &val
+}

--- a/x/emissions/keeper/actor_penalties_test.go
+++ b/x/emissions/keeper/actor_penalties_test.go
@@ -4,17 +4,18 @@ import (
 	"testing"
 
 	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/stretchr/testify/require"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	"github.com/cosmos/cosmos-sdk/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 // nolint: exhaustruct
 func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInferer() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	givenTopic := types.Topic{
 		Id:                  uint64(1),
@@ -28,9 +29,9 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInferer() {
 		Address:     "allo1l6nc88z4uqs00nnnaqkwjvlk4lxq3k4und7kzy",
 		Score:       alloraMath.MustNewDecFromString("300"),
 	}
-	s.Require().NoError(keeper.SetTopicInitialInfererEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
+	s.Require().NoError(k.SetTopicInitialInfererEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
 
-	newScore, err := keeper.ApplyLivenessPenaltyToInferer(ctx, givenTopic, 105, givenPreviousScore)
+	newScore, err := k.ApplyLivenessPenaltyToInferer(ctx, givenTopic, 105, givenPreviousScore)
 	s.Require().NoError(err)
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
@@ -42,8 +43,8 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToInferer() {
 
 // nolint: exhaustruct
 func (s *KeeperTestSuite) TestApplyLivenessPenaltyToForecaster() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	givenTopic := types.Topic{
 		Id:                  uint64(1),
@@ -57,9 +58,9 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToForecaster() {
 		Address:     "allo1l6nc88z4uqs00nnnaqkwjvlk4lxq3k4und7kzy",
 		Score:       alloraMath.MustNewDecFromString("300"),
 	}
-	s.Require().NoError(keeper.SetTopicInitialForecasterEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
+	s.Require().NoError(k.SetTopicInitialForecasterEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
 
-	newScore, err := keeper.ApplyLivenessPenaltyToForecaster(ctx, givenTopic, 105, givenPreviousScore)
+	newScore, err := k.ApplyLivenessPenaltyToForecaster(ctx, givenTopic, 105, givenPreviousScore)
 	s.Require().NoError(err)
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)
@@ -71,8 +72,8 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToForecaster() {
 
 // nolint: exhaustruct
 func (s *KeeperTestSuite) TestApplyLivenessPenaltyToReputer() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	givenTopic := types.Topic{
 		Id:                  uint64(1),
@@ -87,9 +88,9 @@ func (s *KeeperTestSuite) TestApplyLivenessPenaltyToReputer() {
 		Address:     "allo1l6nc88z4uqs00nnnaqkwjvlk4lxq3k4und7kzy",
 		Score:       alloraMath.MustNewDecFromString("300"),
 	}
-	s.Require().NoError(keeper.SetTopicInitialReputerEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
+	s.Require().NoError(k.SetTopicInitialReputerEmaScore(ctx, givenTopic.Id, alloraMath.MustNewDecFromString("200")))
 
-	newScore, err := keeper.ApplyLivenessPenaltyToReputer(ctx, givenTopic, 105, givenPreviousScore)
+	newScore, err := k.ApplyLivenessPenaltyToReputer(ctx, givenTopic, 105, givenPreviousScore)
 	s.Require().NoError(err)
 	s.Require().Equal(givenPreviousScore.TopicId, newScore.TopicId)
 	s.Require().Equal(givenPreviousScore.Address, newScore.Address)

--- a/x/emissions/keeper/actor_utils/losses_test.go
+++ b/x/emissions/keeper/actor_utils/losses_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/keeper/actor_utils/losses_test.go
+++ b/x/emissions/keeper/actor_utils/losses_test.go
@@ -2,143 +2,24 @@ package actorutils_test
 
 import (
 	"testing"
-	"time"
 
-	"cosmossdk.io/core/header"
-	clog "cosmossdk.io/log"
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
-
-	storetypes "cosmossdk.io/store/types"
-	"github.com/allora-network/allora-chain/app/params"
-	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
-	"github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
-	"github.com/cosmos/cosmos-sdk/codec/address"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/testutil"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	auth "github.com/cosmos/cosmos-sdk/x/auth"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/stretchr/testify/suite"
-)
 
-const (
-	multiPerm  = "multiple permissions account"
-	randomPerm = "random permission"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
+	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type ActorUtilsTestSuite struct {
-	suite.Suite
-
-	ctx             sdk.Context
-	accountKeeper   keeper.AccountKeeper
-	bankKeeper      keeper.BankKeeper
-	emissionsKeeper keeper.Keeper
-	appModule       module.AppModule
-	key             *storetypes.KVStoreKey
-	privKeys        []secp256k1.PrivKey
-	addrs           []sdk.AccAddress
-	addrsStr        []string
-	pubKeyHexStr    []string
-}
-
-func (a *ActorUtilsTestSuite) SetupTest() {
-	key := storetypes.NewKVStoreKey("emissions")
-	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(a.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()}) // nolint: exhaustruct
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
-	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
-
-	maccPerms := map[string][]string{
-		"fee_collector":                         {"minter"},
-		"mint":                                  {"minter"},
-		emissionstypes.AlloraStakingAccountName: {"burner", "minter", "staking"},
-		emissionstypes.AlloraRewardsAccountName: {"minter"},
-		emissionstypes.AlloraPendingRewardForDelegatorAccountName: {"minter"},
-		"bonded_tokens_pool":     {"burner", "staking"},
-		"not_bonded_tokens_pool": {"burner", "staking"},
-		multiPerm:                {"burner", "minter", "staking"},
-		randomPerm:               {"random"},
-	}
-
-	accountKeeper := authkeeper.NewAccountKeeper(
-		encCfg.Codec,
-		storeService,
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
-		params.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress("gov").String(),
-	)
-
-	a.privKeys, a.pubKeyHexStr, a.addrs, a.addrsStr = alloratestutil.GenerateTestAccounts(50)
-
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		clog.NewNopLogger(),
-	)
-
-	a.ctx = ctx
-	a.accountKeeper = accountKeeper
-	a.bankKeeper = bankKeeper
-	a.emissionsKeeper = keeper.NewKeeper(
-		encCfg.Codec,
-		addressCodec,
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName,
-	)
-	a.key = key
-	appModule := module.NewAppModule(encCfg.Codec, a.emissionsKeeper)
-	defaultGenesis := appModule.DefaultGenesis(encCfg.Codec)
-	appModule.InitGenesis(ctx, encCfg.Codec, defaultGenesis)
-	a.appModule = appModule
-
-	// Add all tests addresses in whitelists
-	for _, addr := range a.addrsStr {
-		err := a.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
-		a.Require().NoError(err)
-	}
-
-	err := a.emissionsKeeper.SetTopic(a.ctx, 1, emissionstypes.Topic{
-		Id:                       1,
-		Creator:                  a.addrsStr[49],
-		Metadata:                 "metadata",
-		LossMethod:               "mse",
-		EpochLastEnded:           0,
-		EpochLength:              100,
-		GroundTruthLag:           100,
-		WorkerSubmissionWindow:   100,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            false,
-		InitialRegret:            alloraMath.MustNewDecFromString("0.0001"),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.0001"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.0001"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.0001"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.0001"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.0001"),
-	})
-	a.Require().NoError(err)
+	testutil.TestSuite
 }
 
 func TestModuleTestSuite(t *testing.T) {
-	suite.Run(t, new(ActorUtilsTestSuite))
+	suite.Run(t, &ActorUtilsTestSuite{
+		testutil.NewTestSuite("actor_utils_losses"),
+	})
 }
 
 func (a *ActorUtilsTestSuite) signValueBundle(valueBundle *emissionstypes.ValueBundle, privateKey secp256k1.PrivKey) []byte {
@@ -158,16 +39,16 @@ func (a *ActorUtilsTestSuite) TestFilterUnacceptedWorkersFromReputerValueBundle(
 		BlockHeight: 1,
 	}
 
-	inferer1 := a.addrsStr[0]
-	inferer2 := a.addrsStr[1]
-	inferer4 := a.addrsStr[3]
-	inferer5 := a.addrsStr[4]
+	inferer1 := a.AddrsStr(0)
+	inferer2 := a.AddrsStr(1)
+	inferer4 := a.AddrsStr(3)
+	inferer5 := a.AddrsStr(4)
 
-	forecaster1 := a.addrsStr[5]
-	forecaster2 := a.addrsStr[6]
-	forecaster3 := a.addrsStr[7]
-	forecaster4 := a.addrsStr[8]
-	forecaster5 := a.addrsStr[9]
+	forecaster1 := a.AddrsStr(5)
+	forecaster2 := a.AddrsStr(6)
+	forecaster3 := a.AddrsStr(7)
+	forecaster4 := a.AddrsStr(8)
+	forecaster5 := a.AddrsStr(9)
 
 	infererLossBundle := emissionstypes.Inferences{
 		Inferences: []*emissionstypes.Inference{
@@ -191,7 +72,7 @@ func (a *ActorUtilsTestSuite) TestFilterUnacceptedWorkersFromReputerValueBundle(
 			},
 		},
 	}
-	err := a.emissionsKeeper.InsertActiveInferences(a.ctx, 1, workerNonce.BlockHeight, infererLossBundle)
+	err := a.EmissionsKeeper().InsertActiveInferences(a.Ctx(), 1, workerNonce.BlockHeight, infererLossBundle)
 	a.Require().NoError(err)
 
 	forecasterLossBundle := emissionstypes.Forecasts{
@@ -224,7 +105,7 @@ func (a *ActorUtilsTestSuite) TestFilterUnacceptedWorkersFromReputerValueBundle(
 			},
 		},
 	}
-	err = a.emissionsKeeper.InsertActiveForecasts(a.ctx, 1, workerNonce.BlockHeight, forecasterLossBundle)
+	err = a.EmissionsKeeper().InsertActiveForecasts(a.Ctx(), 1, workerNonce.BlockHeight, forecasterLossBundle)
 	a.Require().NoError(err)
 
 	// Prepare a sample ReputerValueBundle
@@ -233,7 +114,7 @@ func (a *ActorUtilsTestSuite) TestFilterUnacceptedWorkersFromReputerValueBundle(
 		ReputerRequestNonce: &emissionstypes.ReputerRequestNonce{
 			ReputerNonce: &workerNonce,
 		},
-		Reputer:       a.addrsStr[40],
+		Reputer:       a.AddrsStr(40),
 		ExtraData:     nil,
 		CombinedValue: alloraMath.NewDecFromInt64(1000),
 		InfererValues: []*emissionstypes.WorkerAttributedValue{
@@ -274,14 +155,14 @@ func (a *ActorUtilsTestSuite) TestFilterUnacceptedWorkersFromReputerValueBundle(
 			{Worker: forecaster5, Value: alloraMath.NewDecFromInt64(1300)}, // Should be filtered out
 		},
 	}
-	signature := a.signValueBundle(valueBundle, a.privKeys[40])
+	signature := a.signValueBundle(valueBundle, a.PrivKeys(40))
 	reputerValueBundle := &emissionstypes.ReputerValueBundle{
 		Signature:   signature,
-		Pubkey:      a.pubKeyHexStr[40],
+		Pubkey:      a.PubKeyHexStr(40),
 		ValueBundle: valueBundle,
 	}
 
-	acceptedBundle, err := actorutils.FilterUnacceptedWorkersFromReputerValueBundle(&a.emissionsKeeper, a.ctx, 1, emissionstypes.ReputerRequestNonce{ReputerNonce: &workerNonce}, reputerValueBundle)
+	acceptedBundle, err := actorutils.FilterUnacceptedWorkersFromReputerValueBundle(a.EmissionsKeeper(), a.Ctx(), 1, emissionstypes.ReputerRequestNonce{ReputerNonce: &workerNonce}, reputerValueBundle)
 	a.Require().NoError(err)
 
 	// Validate the bundle

--- a/x/emissions/keeper/actor_utils/worker_test.go
+++ b/x/emissions/keeper/actor_utils/worker_test.go
@@ -2,231 +2,62 @@ package actorutils_test
 
 import (
 	"testing"
-	"time"
 
-	"cosmossdk.io/core/header"
-	"cosmossdk.io/log"
-	cosmosMath "cosmossdk.io/math"
-	storetypes "cosmossdk.io/store/types"
-	"github.com/allora-network/allora-chain/app/params"
-	alloralog "github.com/allora-network/allora-chain/log"
-	alloraMath "github.com/allora-network/allora-chain/math"
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
-	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
-	"github.com/allora-network/allora-chain/x/emissions/module"
-	"github.com/allora-network/allora-chain/x/emissions/types"
-	mintkeeper "github.com/allora-network/allora-chain/x/mint/keeper"
-	mint "github.com/allora-network/allora-chain/x/mint/module"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/testutil"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	auth "github.com/cosmos/cosmos-sdk/x/auth"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/stretchr/testify/suite"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
+	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type WorkerTestSuite struct {
-	suite.Suite
-
-	ctx                sdk.Context
-	accountKeeper      authkeeper.AccountKeeper
-	bankKeeper         bankkeeper.BaseKeeper
-	emissionsKeeper    keeper.Keeper
-	emissionsAppModule module.AppModule
-	mintAppModule      mint.AppModule
-	msgServer          types.MsgServiceServer
-	key                *storetypes.KVStoreKey
-	privKeys           []secp256k1.PrivKey
-	addrs              []sdk.AccAddress
-	addrsStr           []string
-	pubKeyHexStr       []string
-}
-
-func (s *WorkerTestSuite) SetupTest() {
-	key := storetypes.NewKVStoreKey("emissions")
-	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	// Set logger to show logs from the rewards module too
-	logger := alloralog.NewTestLogger(s.T()).With("module", "rewards")
-	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()}).WithLogger(logger) // nolint: exhaustruct
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
-
-	maccPerms := map[string][]string{
-		"fee_collector":                {"minter"},
-		"mint":                         {"minter"},
-		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName: {"minter"},
-		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
-		"ecosystem":              {"minter"},
-		"bonded_tokens_pool":     {"burner", "staking"},
-		"not_bonded_tokens_pool": {"burner", "staking"},
-		multiPerm:                {"burner", "minter", "staking"},
-		randomPerm:               {"random"},
-	}
-
-	accountKeeper := authkeeper.NewAccountKeeper(
-		encCfg.Codec,
-		storeService,
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
-		params.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress("gov").String(),
-	)
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		log.NewNopLogger(),
-	)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-	stakingKeeper := stakingkeeper.NewKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.NewModuleAddress("gov").String(),
-		codecAddress.NewBech32Codec(sdk.Bech32PrefixValAddr),
-		codecAddress.NewBech32Codec(sdk.Bech32PrefixConsAddr),
-	)
-	mintKeeper := mintkeeper.NewKeeper(
-		encCfg.Codec,
-		storeService,
-		stakingKeeper,
-		accountKeeper,
-		bankKeeper,
-		emissionsKeeper,
-		authtypes.FeeCollectorName,
-	)
-
-	s.ctx = ctx
-	s.accountKeeper = accountKeeper
-	s.bankKeeper = bankKeeper
-	s.emissionsKeeper = emissionsKeeper
-	s.key = key
-	emissionsAppModule := module.NewAppModule(encCfg.Codec, s.emissionsKeeper)
-	defaultEmissionsGenesis := emissionsAppModule.DefaultGenesis(encCfg.Codec)
-	emissionsAppModule.InitGenesis(ctx, encCfg.Codec, defaultEmissionsGenesis)
-	s.msgServer = msgserver.NewMsgServerImpl(s.emissionsKeeper)
-	s.emissionsAppModule = emissionsAppModule
-	mintAppModule := mint.NewAppModule(encCfg.Codec, mintKeeper, accountKeeper)
-	defaultMintGenesis := mintAppModule.DefaultGenesis(encCfg.Codec)
-	mintAppModule.InitGenesis(ctx, encCfg.Codec, defaultMintGenesis)
-	s.mintAppModule = mintAppModule
-
-	// Fund the rewards account generously
-	s.FundAccount(10000000000, s.accountKeeper.GetModuleAddress(types.AlloraRewardsAccountName))
-
-	s.privKeys, s.pubKeyHexStr, s.addrs, s.addrsStr = alloratestutil.GenerateTestAccounts(50)
-	for _, addr := range s.addrs {
-		s.FundAccount(10000000000, addr)
-	}
-
-	// Add all tests addresses in whitelists
-	for _, addr := range s.addrsStr {
-		err := s.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToGlobalWhitelist(ctx, addr)
-		s.Require().NoError(err)
-	}
-	// topic id must not start at 0
-	id, err := s.emissionsKeeper.IncrementTopicId(s.ctx)
-	s.Require().NoError(err)
-	s.Require().NotEqual(0, id)
-}
-
-func (s *WorkerTestSuite) FundAccount(amount int64, accAddress sdk.AccAddress) {
-	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(amount)))
-	err := s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, accAddress, initialStakeCoins)
-	s.Require().NoError(err)
+	testutil.TestSuite
 }
 
 func TestWorkerTestSuite(t *testing.T) {
-	suite.Run(t, new(WorkerTestSuite))
+	suite.Run(t, &WorkerTestSuite{
+		testutil.NewTestSuite("actor_utils_worker"),
+	})
 }
 
 func (s *WorkerTestSuite) TestCloseWorkerNonce() {
 	// Create a topic
 	blockHeight := int64(101)
-	s.ctx = s.ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
 	// Create topic using MsgServer like in rewards_test.go
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		AllowNegative:            false,
-		EpochLength:              100,
-		GroundTruthLag:           100,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
+	topicId := s.CreateTopic()
 
 	// Get the topic
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
 	// Register workers using MsgServer
-	worker0 := s.addrsStr[0]
-	worker1 := s.addrsStr[1]
+	worker0 := s.AddrsStr(0)
+	worker1 := s.AddrsStr(1)
 
 	workerRegMsg0 := &types.RegisterRequest{
 		Sender:    worker0,
 		TopicId:   topicId,
 		IsReputer: false,
-		Owner:     s.addrsStr[4],
+		Owner:     s.AddrsStr(4),
 	}
-	_, err = s.msgServer.Register(s.ctx, workerRegMsg0)
+	_, err = s.EmissionsMsgServer().Register(s.Ctx(), workerRegMsg0)
 	s.Require().NoError(err)
 
 	workerRegMsg1 := &types.RegisterRequest{
 		Sender:    worker1,
 		TopicId:   topicId,
 		IsReputer: false,
-		Owner:     s.addrsStr[4],
+		Owner:     s.AddrsStr(4),
 	}
-	_, err = s.msgServer.Register(s.ctx, workerRegMsg1)
+	_, err = s.EmissionsMsgServer().Register(s.Ctx(), workerRegMsg1)
 	s.Require().NoError(err)
 
 	// Add worker nonce
 	nonce := types.Nonce{BlockHeight: blockHeight}
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &nonce)
+	err = s.EmissionsKeeper().AddWorkerNonce(s.Ctx(), topicId, &nonce)
 	s.Require().NoError(err)
 
 	// Create and insert inferences
@@ -246,49 +77,49 @@ func (s *WorkerTestSuite) TestCloseWorkerNonce() {
 			},
 		},
 	}
-	err = s.emissionsKeeper.InsertInference(s.ctx, topicId, *inferences.Inferences[0])
+	err = s.EmissionsKeeper().InsertInference(s.Ctx(), topicId, *inferences.Inferences[0])
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.InsertInference(s.ctx, topicId, *inferences.Inferences[1])
+	err = s.EmissionsKeeper().InsertInference(s.Ctx(), topicId, *inferences.Inferences[1])
 	s.Require().NoError(err)
 
 	// Artificially add the workers as active inferers
-	err = s.emissionsKeeper.AddActiveInferer(s.ctx, topicId, worker0)
+	err = s.EmissionsKeeper().AddActiveInferer(s.Ctx(), topicId, worker0)
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddActiveInferer(s.ctx, topicId, worker1)
+	err = s.EmissionsKeeper().AddActiveInferer(s.Ctx(), topicId, worker1)
 	s.Require().NoError(err)
 
 	// ------------------------------------------------------------------------------------------------
 	// Move the blockheight until end of wsw
 	// ------------------------------------------------------------------------------------------------
-	s.ctx = s.ctx.WithBlockHeight(blockHeight + topic.WorkerSubmissionWindow)
+	s.WithBlockHeight(blockHeight + topic.WorkerSubmissionWindow)
 
 	// Test closing the worker nonce
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, nonce)
+	err = actorutils.CloseWorkerNonce(s.EmissionsKeeper(), s.Ctx(), topic, nonce)
 	s.Require().NoError(err)
 
 	// Verify nonce is no longer unfulfilled
-	isUnfulfilled, err := s.emissionsKeeper.IsWorkerNonceUnfulfilled(s.ctx, topicId, &nonce)
+	isUnfulfilled, err := s.EmissionsKeeper().IsWorkerNonceUnfulfilled(s.Ctx(), topicId, &nonce)
 	s.Require().NoError(err)
 	s.Require().False(isUnfulfilled, "Nonce should no longer be unfulfilled")
 
 	// Verify network inferences were created
-	networkInferences, err := s.emissionsKeeper.GetNetworkInferences(s.ctx, topicId, blockHeight)
+	networkInferences, err := s.EmissionsKeeper().GetNetworkInferences(s.Ctx(), topicId, blockHeight)
 	s.Require().NoError(err)
 	s.Require().NotNil(networkInferences, "Network inferences should exist")
 
 	// Verify outlier resistant network inferences were created
-	outlierResistantInferences, err := s.emissionsKeeper.GetOutlierResistantNetworkInferences(s.ctx, topicId, blockHeight)
+	outlierResistantInferences, err := s.EmissionsKeeper().GetOutlierResistantNetworkInferences(s.Ctx(), topicId, blockHeight)
 	s.Require().NoError(err)
 	s.Require().NotNil(outlierResistantInferences, "Outlier resistant network inferences should exist")
 }
 
 func (s *WorkerTestSuite) TestCloseWorkerNonceFailures() {
 	blockHeight := int64(101)
-	s.ctx = s.ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
 	// Create topic using MsgServer
 	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[0],
+		Creator:                  s.AddrsStr(0),
 		Metadata:                 "test",
 		LossMethod:               "mse",
 		AllowNegative:            false,
@@ -305,40 +136,40 @@ func (s *WorkerTestSuite) TestCloseWorkerNonceFailures() {
 		EnableWorkerWhitelist:    true,
 		EnableReputerWhitelist:   true,
 	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
+	res, err := s.EmissionsMsgServer().CreateNewTopic(s.Ctx(), newTopicMsg)
 	s.Require().NoError(err)
 	topicId := res.TopicId
 
 	// Get the topic
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
 	// Test 1: Closing without valid nonce
 	nonce := types.Nonce{BlockHeight: blockHeight}
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, nonce)
+	err = actorutils.CloseWorkerNonce(s.EmissionsKeeper(), s.Ctx(), topic, nonce)
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, types.ErrUnfulfilledNonceNotFound)
 
 	// Test 2: Closing without active inferers
 	topic.EpochLastEnded = blockHeight - 100 // Fix the window
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &nonce)
+	err = s.EmissionsKeeper().AddWorkerNonce(s.Ctx(), topicId, &nonce)
 	s.Require().NoError(err)
 
 	// Move to end of worker submission window
-	s.ctx = s.ctx.WithBlockHeight(blockHeight + topic.WorkerSubmissionWindow)
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, nonce)
+	s.WithBlockHeight(blockHeight + topic.WorkerSubmissionWindow)
+	err = actorutils.CloseWorkerNonce(s.EmissionsKeeper(), s.Ctx(), topic, nonce)
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, types.ErrNoQualifiedInferers)
 }
 
 func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesCatchesOutliers() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	require := s.Require()
 
 	// Create topic using MsgServer
 	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[0],
+		Creator:                  s.AddrsStr(0),
 		Metadata:                 "test",
 		LossMethod:               "mse",
 		AllowNegative:            false,
@@ -355,18 +186,18 @@ func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesCatchesOutliers() 
 		EnableWorkerWhitelist:    true,
 		EnableReputerWhitelist:   true,
 	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
+	res, err := s.EmissionsMsgServer().CreateNewTopic(s.Ctx(), newTopicMsg)
 	s.Require().NoError(err)
 	topicId := res.TopicId
 	blockHeight := int64(100)
 
 	// Set up workers/forecasters using existing suite addresses
-	worker0 := s.addrsStr[0]
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
-	forecaster0 := s.addrsStr[4]
-	forecaster1 := s.addrsStr[5]
+	worker0 := s.AddrsStr(0)
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
+	forecaster0 := s.AddrsStr(4)
+	forecaster1 := s.AddrsStr(5)
 
 	// Create inferences where worker3 is an obvious outlier
 	inferences := &types.Inferences{
@@ -442,7 +273,7 @@ func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesCatchesOutliers() 
 	require.NoError(err)
 
 	// Call the function we're testing
-	err = actorutils.ProcessAndStoreNetworkInferences(&keeper, ctx, topicId, blockHeight, inferences, forecasts)
+	err = actorutils.ProcessAndStoreNetworkInferences(keeper, ctx, topicId, blockHeight, inferences, forecasts)
 	require.NoError(err)
 
 	// Retrieve both regular and outlier-resistant network inferences
@@ -487,13 +318,13 @@ func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesCatchesOutliers() 
 }
 
 func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesNoOutliers() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	require := s.Require()
 
 	// Create topic using MsgServer
 	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[0],
+		Creator:                  s.AddrsStr(0),
 		Metadata:                 "test",
 		LossMethod:               "mse",
 		AllowNegative:            false,
@@ -510,18 +341,18 @@ func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesNoOutliers() {
 		EnableWorkerWhitelist:    true,
 		EnableReputerWhitelist:   true,
 	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
+	res, err := s.EmissionsMsgServer().CreateNewTopic(s.Ctx(), newTopicMsg)
 	s.Require().NoError(err)
 	topicId := res.TopicId
 	blockHeight := int64(100)
 
 	// Set up workers/forecasters using existing suite addresses
-	worker0 := s.addrsStr[0]
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
-	forecaster0 := s.addrsStr[4]
-	forecaster1 := s.addrsStr[5]
+	worker0 := s.AddrsStr(0)
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
+	forecaster0 := s.AddrsStr(4)
+	forecaster1 := s.AddrsStr(5)
 
 	// Create inferences where all values are within normal bounds
 	inferences := &types.Inferences{
@@ -597,7 +428,7 @@ func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesNoOutliers() {
 	require.NoError(err)
 
 	// Call the function we're testing
-	err = actorutils.ProcessAndStoreNetworkInferences(&keeper, ctx, topicId, blockHeight, inferences, forecasts)
+	err = actorutils.ProcessAndStoreNetworkInferences(keeper, ctx, topicId, blockHeight, inferences, forecasts)
 	require.NoError(err)
 
 	// Retrieve both regular and outlier-resistant network inferences

--- a/x/emissions/keeper/actor_utils/worker_test.go
+++ b/x/emissions/keeper/actor_utils/worker_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/keeper/ema_scores_test.go
+++ b/x/emissions/keeper/ema_scores_test.go
@@ -1,309 +1,157 @@
 package keeper_test
 
 import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (s *KeeperTestSuite) TestCalcAndSaveInfererScoreEmaIfNewUpdate() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+func (s *KeeperTestSuite) TestCalcAndSaveScoreEmaForActiveSet() {
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topic := s.MockTopic()
 
-	topic := types.Topic{
-		Id:                       uint64(1),
-		WorkerSubmissionWindow:   10,
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.2"),
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "",
-		LossMethod:               "",
-		EpochLastEnded:           0,
-		EpochLength:              10,
-		GroundTruthLag:           10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.ZeroDec(),
-		AllowNegative:            false,
-		Epsilon:                  alloraMath.ZeroDec(),
-		InitialRegret:            alloraMath.ZeroDec(),
-		ActiveInfererQuantile:    alloraMath.ZeroDec(),
-		ActiveForecasterQuantile: alloraMath.ZeroDec(),
-		ActiveReputerQuantile:    alloraMath.ZeroDec(),
+	testCases := []struct {
+		name              string
+		actorType         string
+		actorIndex        int
+		initialScore      string
+		updateBlockOffset types.BlockHeight
+		calcAndSaveFunc   func(context.Context, types.Topic, string, types.Score) (types.Score, error)
+		getFunc           func(context.Context, uint64, string) (types.Score, error)
+	}{
+		{
+			name:              "inferer new update",
+			actorType:         "inferer",
+			actorIndex:        1,
+			initialScore:      "0.2",
+			updateBlockOffset: 5,
+			calcAndSaveFunc:   k.CalcAndSaveInfererScoreEmaForActiveSet,
+			getFunc:           k.GetInfererScoreEma,
+		},
+		{
+			name:              "forecaster new update",
+			actorType:         "forecaster",
+			actorIndex:        1,
+			initialScore:      "0.5",
+			updateBlockOffset: 5,
+			calcAndSaveFunc:   k.CalcAndSaveForecasterScoreEmaForActiveSet,
+			getFunc:           k.GetForecasterScoreEma,
+		},
+		{
+			name:              "reputer new update",
+			actorType:         "reputer",
+			actorIndex:        2,
+			initialScore:      "0.5",
+			updateBlockOffset: 10,
+			calcAndSaveFunc:   k.CalcAndSaveReputerScoreEmaForActiveSet,
+			getFunc:           k.GetReputerScoreEma,
+		},
 	}
-	worker := s.addrsStr[1]
-	block := types.BlockHeight(100)
 
-	// Test case 1: New update
-	newScore := types.Score{
-		TopicId:     topic.Id,
-		BlockHeight: block,
-		Address:     worker,
-		Score:       alloraMath.MustNewDecFromString("0.2"),
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			block := types.BlockHeight(100)
+			actor := s.AddrsStr(tc.actorIndex)
+
+			// Test case 1: New update
+			newScore := types.Score{
+				TopicId:     topic.Id,
+				BlockHeight: block,
+				Address:     actor,
+				Score:       alloraMath.MustNewDecFromString(tc.initialScore),
+			}
+
+			emaScore, err := tc.calcAndSaveFunc(ctx, topic, actor, newScore)
+			s.Require().NoError(err)
+			s.Require().Equal(tc.initialScore, emaScore.Score.String())
+
+			// Verify the EMA score was saved
+			savedScore, err := tc.getFunc(ctx, topic.Id, actor)
+			s.Require().NoError(err)
+			s.Require().Equal(newScore.Score, savedScore.Score)
+
+			// Test case 2: Don't update blockheight of score
+			newScore.BlockHeight = block + tc.updateBlockOffset
+			emaScore, err = tc.calcAndSaveFunc(ctx, topic, actor, newScore)
+			s.Require().NoError(err)
+			s.Require().Equal(tc.initialScore, emaScore.Score.String())
+
+			// Verify the blockheight of the EMA score was not updated
+			savedScoreAgain, err := tc.getFunc(ctx, topic.Id, actor)
+			s.Require().NoError(err)
+			s.Require().Equal(savedScore.BlockHeight, savedScoreAgain.BlockHeight)
+		})
 	}
-	emaScore, err := keeper.CalcAndSaveInfererScoreEmaForActiveSet(ctx, topic, worker, newScore)
-	s.Require().NoError(err)
-	s.Require().Equal("0.2", emaScore.Score.String())
-
-	// Verify the EMA score was saved
-	savedScore, err := keeper.GetInfererScoreEma(ctx, topic.Id, worker)
-	s.Require().NoError(err)
-	s.Require().Equal(newScore.Score, savedScore.Score)
-
-	// Test case 2: Don't update blockheight of score
-	newScore.BlockHeight = block + 5
-	emaScore, err = keeper.CalcAndSaveInfererScoreEmaForActiveSet(ctx, topic, worker, newScore)
-	s.Require().NoError(err)
-	s.Require().Equal("0.2", emaScore.Score.String())
-
-	// Verify the blockheight of the EMA score was not updated
-	savedScoreAgain, err := keeper.GetInfererScoreEma(ctx, topic.Id, worker)
-	s.Require().NoError(err)
-	s.Require().Equal(savedScore.BlockHeight, savedScoreAgain.BlockHeight)
 }
 
-func (s *KeeperTestSuite) TestCalcAndSaveForecasterScoreEmaIfNewUpdate() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-
-	topic := types.Topic{
-		Id:                       uint64(1),
-		WorkerSubmissionWindow:   10,
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.2"),
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "",
-		LossMethod:               "",
-		EpochLastEnded:           0,
-		EpochLength:              10,
-		GroundTruthLag:           10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.ZeroDec(),
-		AllowNegative:            false,
-		Epsilon:                  alloraMath.ZeroDec(),
-		InitialRegret:            alloraMath.ZeroDec(),
-		ActiveInfererQuantile:    alloraMath.ZeroDec(),
-		ActiveForecasterQuantile: alloraMath.ZeroDec(),
-		ActiveReputerQuantile:    alloraMath.ZeroDec(),
-	}
-	worker := s.addrsStr[1]
-	block := types.BlockHeight(100)
-
-	// Test case 1: New update
-	newScore := types.Score{
-		TopicId:     topic.Id,
-		BlockHeight: block,
-		Address:     worker,
-		Score:       alloraMath.MustNewDecFromString("0.5"),
-	}
-	emaScore, err := keeper.CalcAndSaveForecasterScoreEmaForActiveSet(ctx, topic, worker, newScore)
-	s.Require().NoError(err)
-	s.Require().Equal("0.5", emaScore.Score.String())
-
-	// Verify the EMA score was saved
-	savedScore, err := keeper.GetForecasterScoreEma(ctx, topic.Id, worker)
-	s.Require().NoError(err)
-	s.Require().Equal(newScore.Score, savedScore.Score)
-
-	// Test case 2: Not update blockheight of score
-	newScore.BlockHeight = block + 5
-	emaScore, err = keeper.CalcAndSaveForecasterScoreEmaForActiveSet(ctx, topic, worker, newScore)
-	s.Require().NoError(err)
-	s.Require().Equal("0.5", emaScore.Score.String())
-
-	// Verify the blockheight of the EMA score was not updated
-	savedScoreAgain, err := keeper.GetForecasterScoreEma(ctx, topic.Id, worker)
-	s.Require().NoError(err)
-	s.Require().Equal(savedScore.BlockHeight, savedScoreAgain.BlockHeight)
-}
-
-func (s *KeeperTestSuite) TestCalcAndSaveReputerScoreEmaIfNewUpdate() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-
-	topic := types.Topic{
-		Creator:                  s.addrsStr[0],
-		Id:                       uint64(1),
-		EpochLength:              20,
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.2"),
-		Metadata:                 "",
-		LossMethod:               "",
-		EpochLastEnded:           0,
-		GroundTruthLag:           20,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.ZeroDec(),
-		AllowNegative:            false,
-		Epsilon:                  alloraMath.ZeroDec(),
-		InitialRegret:            alloraMath.ZeroDec(),
-		WorkerSubmissionWindow:   20,
-		ActiveInfererQuantile:    alloraMath.ZeroDec(),
-		ActiveForecasterQuantile: alloraMath.ZeroDec(),
-		ActiveReputerQuantile:    alloraMath.ZeroDec(),
-	}
-	reputer := s.addrsStr[2]
-	block := types.BlockHeight(100)
-
-	// Test case 1: New update
-	newScore := types.Score{
-		TopicId:     topic.Id,
-		BlockHeight: block,
-		Address:     reputer,
-		Score:       alloraMath.MustNewDecFromString("0.5"),
-	}
-	emaScore, err := keeper.CalcAndSaveReputerScoreEmaForActiveSet(ctx, topic, reputer, newScore)
-	s.Require().NoError(err)
-	s.Require().Equal("0.5", emaScore.Score.String())
-
-	// Verify the EMA score was saved
-	savedScore, err := keeper.GetReputerScoreEma(ctx, topic.Id, reputer)
-	s.Require().NoError(err)
-	s.Require().Equal(newScore.Score, savedScore.Score)
-
-	// Test case 2: Don't update blockheight of score
-	newScore.BlockHeight = block + 10
-	emaScore, err = keeper.CalcAndSaveReputerScoreEmaForActiveSet(ctx, topic, reputer, newScore)
-	s.Require().NoError(err)
-	s.Require().Equal("0.5", emaScore.Score.String())
-
-	// Verify the blockheight of the EMA score was not updated
-	savedScoreAgain, err := keeper.GetReputerScoreEma(ctx, topic.Id, reputer)
-	s.Require().NoError(err)
-	s.Require().Equal(savedScore.BlockHeight, savedScoreAgain.BlockHeight)
-}
-
-func (s *KeeperTestSuite) TestCalcAndSaveInfererScoreEmaWithLastSavedTopicQuantile() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-
-	topic := types.Topic{
-		Id:                       uint64(1),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.2"),
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "",
-		LossMethod:               "",
-		EpochLastEnded:           0,
-		EpochLength:              100,
-		GroundTruthLag:           100,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.ZeroDec(),
-		AllowNegative:            false,
-		Epsilon:                  alloraMath.ZeroDec(),
-		InitialRegret:            alloraMath.ZeroDec(),
-		WorkerSubmissionWindow:   100,
-		ActiveInfererQuantile:    alloraMath.ZeroDec(),
-		ActiveForecasterQuantile: alloraMath.ZeroDec(),
-		ActiveReputerQuantile:    alloraMath.ZeroDec(),
-	}
-	worker := s.addrsStr[1]
-	block := types.BlockHeight(100)
-
-	// Set up a previous topic quantile score
+func (s *KeeperTestSuite) TestCalcAndSaveScoreEmaWithLastSavedTopicQuantile() {
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topic := s.MockTopic()
 	previousQuantileScore := alloraMath.MustNewDecFromString("0.8")
-	err := keeper.SetPreviousTopicQuantileInfererScoreEma(ctx, topic.Id, previousQuantileScore)
-	s.Require().NoError(err)
 
-	score := types.Score{
-		TopicId:     topic.Id,
-		BlockHeight: block,
-		Address:     worker,
-		Score:       previousQuantileScore,
+	testCases := []struct {
+		name            string
+		actorType       string
+		actorIndex      int
+		setupQuantile   func(context.Context, uint64, alloraMath.Dec) error
+		calcAndSaveFunc func(sdk.Context, types.Topic, int64, types.Score) error
+		getFunc         func(context.Context, uint64, string) (types.Score, error)
+	}{
+		{
+			name:            "inferer with topic quantile",
+			actorType:       "inferer",
+			actorIndex:      1,
+			setupQuantile:   k.SetPreviousTopicQuantileInfererScoreEma,
+			calcAndSaveFunc: k.CalcAndSaveInfererScoreEmaWithLastSavedTopicQuantile,
+			getFunc:         k.GetInfererScoreEma,
+		},
+		{
+			name:            "forecaster with topic quantile",
+			actorType:       "forecaster",
+			actorIndex:      1,
+			setupQuantile:   k.SetPreviousTopicQuantileForecasterScoreEma,
+			calcAndSaveFunc: k.CalcAndSaveForecasterScoreEmaWithLastSavedTopicQuantile,
+			getFunc:         k.GetForecasterScoreEma,
+		},
+		{
+			name:            "reputer with topic quantile",
+			actorType:       "reputer",
+			actorIndex:      2,
+			setupQuantile:   k.SetPreviousTopicQuantileReputerScoreEma,
+			calcAndSaveFunc: k.CalcAndSaveReputerScoreEmaWithLastSavedTopicQuantile,
+			getFunc:         k.GetReputerScoreEma,
+		},
 	}
-	err = keeper.CalcAndSaveInfererScoreEmaWithLastSavedTopicQuantile(ctx, topic, block, score)
-	s.Require().NoError(err)
 
-	// Verify the EMA score was calculated and saved
-	savedScore, err := keeper.GetInfererScoreEma(ctx, topic.Id, worker)
-	s.Require().NoError(err)
-	s.Require().Equal(previousQuantileScore, savedScore.Score)
-	s.Require().Equal(block, savedScore.BlockHeight)
-}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			actor := s.AddrsStr(tc.actorIndex)
+			block := types.BlockHeight(100)
 
-func (s *KeeperTestSuite) TestCalcAndSaveForecasterScoreEmaWithLastSavedTopicQuantile() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+			// Set up a previous topic quantile score
+			err := tc.setupQuantile(ctx, topic.Id, previousQuantileScore)
+			s.Require().NoError(err)
 
-	topic := types.Topic{
-		Id:                       uint64(1),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.2"),
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "",
-		LossMethod:               "",
-		EpochLastEnded:           0,
-		EpochLength:              100,
-		GroundTruthLag:           100,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.ZeroDec(),
-		AllowNegative:            false,
-		Epsilon:                  alloraMath.ZeroDec(),
-		InitialRegret:            alloraMath.ZeroDec(),
-		WorkerSubmissionWindow:   100,
-		ActiveInfererQuantile:    alloraMath.ZeroDec(),
-		ActiveForecasterQuantile: alloraMath.ZeroDec(),
-		ActiveReputerQuantile:    alloraMath.ZeroDec(),
+			score := types.Score{
+				TopicId:     topic.Id,
+				BlockHeight: block,
+				Address:     actor,
+				Score:       previousQuantileScore,
+			}
+
+			err = tc.calcAndSaveFunc(ctx, topic, block, score)
+			s.Require().NoError(err)
+
+			// Verify the EMA score was calculated and saved
+			savedScore, err := tc.getFunc(ctx, topic.Id, actor)
+			s.Require().NoError(err)
+			s.Require().Equal(previousQuantileScore, savedScore.Score)
+			s.Require().Equal(block, savedScore.BlockHeight)
+		})
 	}
-	worker := s.addrsStr[1]
-	block := types.BlockHeight(100)
-
-	// Set up a previous topic quantile score
-	previousQuantileScore := alloraMath.MustNewDecFromString("0.8")
-	err := keeper.SetPreviousTopicQuantileForecasterScoreEma(ctx, topic.Id, previousQuantileScore)
-	s.Require().NoError(err)
-
-	score := types.Score{
-		TopicId:     topic.Id,
-		BlockHeight: block,
-		Address:     worker,
-		Score:       previousQuantileScore,
-	}
-	err = keeper.CalcAndSaveForecasterScoreEmaWithLastSavedTopicQuantile(ctx, topic, block, score)
-	s.Require().NoError(err)
-
-	// Verify the EMA score was calculated and saved
-	savedScore, err := keeper.GetForecasterScoreEma(ctx, topic.Id, worker)
-	s.Require().NoError(err)
-	s.Require().Equal(previousQuantileScore, savedScore.Score)
-	s.Require().Equal(block, savedScore.BlockHeight)
-}
-
-func (s *KeeperTestSuite) TestCalcAndSaveReputerScoreEmaWithLastSavedTopicQuantile() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-
-	topic := types.Topic{
-		Id:                       uint64(1),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.2"),
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "",
-		LossMethod:               "",
-		EpochLastEnded:           0,
-		EpochLength:              100,
-		GroundTruthLag:           100,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.ZeroDec(),
-		AllowNegative:            false,
-		Epsilon:                  alloraMath.ZeroDec(),
-		InitialRegret:            alloraMath.ZeroDec(),
-		WorkerSubmissionWindow:   100,
-		ActiveInfererQuantile:    alloraMath.ZeroDec(),
-		ActiveForecasterQuantile: alloraMath.ZeroDec(),
-		ActiveReputerQuantile:    alloraMath.ZeroDec(),
-	}
-	reputer := s.addrsStr[2]
-	block := types.BlockHeight(100)
-
-	// Set up a previous topic quantile score
-	previousQuantileScore := alloraMath.MustNewDecFromString("0.8")
-	err := keeper.SetPreviousTopicQuantileReputerScoreEma(ctx, topic.Id, previousQuantileScore)
-	s.Require().NoError(err)
-
-	score := types.Score{
-		TopicId:     topic.Id,
-		BlockHeight: block,
-		Address:     reputer,
-		Score:       previousQuantileScore,
-	}
-	err = keeper.CalcAndSaveReputerScoreEmaWithLastSavedTopicQuantile(ctx, topic, block, score)
-	s.Require().NoError(err)
-
-	// Verify the EMA score was calculated and saved
-	savedScore, err := keeper.GetReputerScoreEma(ctx, topic.Id, reputer)
-	s.Require().NoError(err)
-	s.Require().Equal(previousQuantileScore, savedScore.Score)
-	s.Require().Equal(block, savedScore.BlockHeight)
 }

--- a/x/emissions/keeper/genesis_test.go
+++ b/x/emissions/keeper/genesis_test.go
@@ -8,24 +8,24 @@ import (
 
 // at minimum test that an import can be done from an export without error
 func (s *KeeperTestSuite) TestImportExportGenesisNoError() {
-	testAddr := s.addrs[0].String()
-	err := s.emissionsKeeper.AddWhitelistAdmin(s.ctx, testAddr)
+	testAddr := s.AddrsStr(0)
+	err := s.EmissionsKeeper().AddWhitelistAdmin(s.Ctx(), testAddr)
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.SetTopicStake(s.ctx, 2, cosmossdk_io_math.OneInt())
+	err = s.EmissionsKeeper().SetTopicStake(s.Ctx(), 1, cosmossdk_io_math.OneInt())
 	s.Require().NoError(err)
-	genesisState, err := s.emissionsKeeper.ExportGenesis(s.ctx)
+	genesisState, err := s.EmissionsKeeper().ExportGenesis(s.Ctx())
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.InitGenesis(s.ctx, genesisState)
+	err = s.EmissionsKeeper().InitGenesis(s.Ctx(), genesisState)
 	s.Require().NoError(err)
 
 	for _, addr := range types.DefaultCoreTeamAddresses() {
-		admin, err := s.emissionsKeeper.IsWhitelistAdmin(s.ctx, addr)
+		admin, err := s.EmissionsKeeper().IsWhitelistAdmin(s.Ctx(), addr)
 		s.Require().NoError(err)
 		s.Require().Equal(admin, true)
 	}
-	admin, err := s.emissionsKeeper.IsWhitelistAdmin(s.ctx, testAddr)
+	admin, err := s.EmissionsKeeper().IsWhitelistAdmin(s.Ctx(), testAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(admin, true)
 }

--- a/x/emissions/keeper/inference_synthesis/forecast_implied_test.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied_test.go
@@ -104,7 +104,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 				Forecaster: "forecaster0",
 				ForecastElements: []*emissionstypes.ForecastElement{
 					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("3")},
-					{Inferer: s.addrsStr[1], Value: alloraMath.MustNewDecFromString("4")},
+					{Inferer: s.AddrsStr(1), Value: alloraMath.MustNewDecFromString("4")},
 				},
 			},
 		},
@@ -115,17 +115,17 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 	}
 	inferenceByWorker := map[string]*emissionstypes.Inference{
 		"worker0":     {Value: alloraMath.MustNewDecFromString("1")},
-		s.addrsStr[1]: {Value: alloraMath.MustNewDecFromString("2")},
+		s.AddrsStr(1): {Value: alloraMath.MustNewDecFromString("2")},
 	}
 
 	allInferersAreNew := false
-	inferers := []string{"worker0", s.addrsStr[1]}
+	inferers := []string{"worker0", s.AddrsStr(1)}
 	forecasters := []string{"forecaster0"}
 	forecastByWorker := map[string]*emissionstypes.Forecast{"forecaster0": forecasts.Forecasts[0]}
 	zero := alloraMath.ZeroDec()
 	infererRegrets := map[string]*alloraMath.Dec{
 		"worker0":     &zero,
-		s.addrsStr[1]: &zero,
+		s.AddrsStr(1): &zero,
 	}
 	forecasterRegrets := map[string]*alloraMath.Dec{
 
@@ -134,7 +134,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 
 	result, _, _, err := inferencesynthesis.CalcForecastImpliedInferences(
 		inferencesynthesis.CalcForecastImpliedInferencesArgs{
-			Logger:               s.ctx.Logger(),
+			Logger:               s.Ctx().Logger(),
 			TopicId:              topicId,
 			AllInferersAreNew:    allInferersAreNew,
 			Inferers:             inferers,
@@ -181,7 +181,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 			{
 				Forecaster: "worker0",
 				ForecastElements: []*emissionstypes.ForecastElement{
-					{Inferer: s.addrsStr[1], Value: alloraMath.MustNewDecFromString("4")},
+					{Inferer: s.AddrsStr(1), Value: alloraMath.MustNewDecFromString("4")},
 				},
 			},
 		},
@@ -192,18 +192,18 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 	}
 	inferenceByWorker := map[string]*emissionstypes.Inference{
 		"worker0":     {Value: alloraMath.MustNewDecFromString("1")},
-		s.addrsStr[1]: {Value: alloraMath.MustNewDecFromString("2")},
+		s.AddrsStr(1): {Value: alloraMath.MustNewDecFromString("2")},
 	}
 
 	topicId := uint64(1)
 	allInferersAreNew := false
-	inferers := []string{"worker0", s.addrsStr[1]}
+	inferers := []string{"worker0", s.AddrsStr(1)}
 	forecasters := []string{"worker0"}
 	forecastByWorker := map[string]*emissionstypes.Forecast{"worker0": forecasts.Forecasts[0]}
 	zero := alloraMath.ZeroDec()
 	infererRegrets := map[string]*alloraMath.Dec{
 		"worker0":     &zero,
-		s.addrsStr[1]: &zero,
+		s.AddrsStr(1): &zero,
 	}
 	forecasterRegrets := map[string]*alloraMath.Dec{
 		"worker0": &zero,
@@ -211,7 +211,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 
 	result, _, _, err := inferencesynthesis.CalcForecastImpliedInferences(
 		inferencesynthesis.CalcForecastImpliedInferencesArgs{
-			Logger:               s.ctx.Logger(),
+			Logger:               s.Ctx().Logger(),
 			TopicId:              topicId,
 			AllInferersAreNew:    allInferersAreNew,
 			Inferers:             inferers,
@@ -259,16 +259,16 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesThreeWork
 				Forecaster: "worker0",
 				ForecastElements: []*emissionstypes.ForecastElement{
 					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("1")},
-					{Inferer: s.addrsStr[1], Value: alloraMath.MustNewDecFromString("2")},
-					{Inferer: s.addrsStr[2], Value: alloraMath.MustNewDecFromString("3")},
+					{Inferer: s.AddrsStr(1), Value: alloraMath.MustNewDecFromString("2")},
+					{Inferer: s.AddrsStr(2), Value: alloraMath.MustNewDecFromString("3")},
 				},
 			},
 			{
-				Forecaster: s.addrsStr[1],
+				Forecaster: s.AddrsStr(1),
 				ForecastElements: []*emissionstypes.ForecastElement{
 					{Inferer: "worker0", Value: alloraMath.MustNewDecFromString("4")},
-					{Inferer: s.addrsStr[1], Value: alloraMath.MustNewDecFromString("5")},
-					{Inferer: s.addrsStr[2], Value: alloraMath.MustNewDecFromString("6")},
+					{Inferer: s.AddrsStr(1), Value: alloraMath.MustNewDecFromString("5")},
+					{Inferer: s.AddrsStr(2), Value: alloraMath.MustNewDecFromString("6")},
 				},
 			},
 		},
@@ -276,37 +276,37 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesThreeWork
 
 	expected := map[string]*emissionstypes.Inference{
 		"worker0":     {Value: alloraMath.MustNewDecFromString("1.158380376510523897775902553985830")},
-		s.addrsStr[1]: {Value: alloraMath.MustNewDecFromString("1.149124717287201046499545990921485")},
-		s.addrsStr[2]: nil,
+		s.AddrsStr(1): {Value: alloraMath.MustNewDecFromString("1.149124717287201046499545990921485")},
+		s.AddrsStr(2): nil,
 	}
 	inferenceByWorker := map[string]*emissionstypes.Inference{
 		"worker0":     {Value: alloraMath.MustNewDecFromString("1")},
-		s.addrsStr[1]: {Value: alloraMath.MustNewDecFromString("2")},
-		s.addrsStr[2]: {Value: alloraMath.MustNewDecFromString("3")},
+		s.AddrsStr(1): {Value: alloraMath.MustNewDecFromString("2")},
+		s.AddrsStr(2): {Value: alloraMath.MustNewDecFromString("3")},
 	}
 
 	topicId := uint64(1)
 	allInferersAreNew := false
-	inferers := []string{"worker0", s.addrsStr[1], s.addrsStr[2]}
-	forecasters := []string{"worker0", s.addrsStr[1]}
+	inferers := []string{"worker0", s.AddrsStr(1), s.AddrsStr(2)}
+	forecasters := []string{"worker0", s.AddrsStr(1)}
 	forecastByWorker := map[string]*emissionstypes.Forecast{
 		"worker0":     forecasts.Forecasts[0],
-		s.addrsStr[1]: forecasts.Forecasts[1],
+		s.AddrsStr(1): forecasts.Forecasts[1],
 	}
 	zero := alloraMath.ZeroDec()
 	infererRegrets := map[string]*alloraMath.Dec{
 		"worker0":     &zero,
-		s.addrsStr[1]: &zero,
-		s.addrsStr[2]: &zero,
+		s.AddrsStr(1): &zero,
+		s.AddrsStr(2): &zero,
 	}
 	forecasterRegrets := map[string]*alloraMath.Dec{
 		"worker0":     &zero,
-		s.addrsStr[1]: &zero,
+		s.AddrsStr(1): &zero,
 	}
 
 	result, _, _, err := inferencesynthesis.CalcForecastImpliedInferences(
 		inferencesynthesis.CalcForecastImpliedInferencesArgs{
-			Logger:               s.ctx.Logger(),
+			Logger:               s.Ctx().Logger(),
 			TopicId:              topicId,
 			AllInferersAreNew:    allInferersAreNew,
 			Inferers:             inferers,
@@ -352,12 +352,12 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch2() {
 	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
 	epoch2Get := epochGet[302]
 
-	worker0 := s.addrsStr[0]
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
-	worker4 := s.addrsStr[4]
-	forecaster0 := s.addrsStr[5]
+	worker0 := s.AddrsStr(0)
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
+	worker4 := s.AddrsStr(4)
+	forecaster0 := s.AddrsStr(5)
 
 	forecasts := &emissionstypes.Forecasts{
 		Forecasts: []*emissionstypes.Forecast{
@@ -407,7 +407,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch2() {
 
 	result, _, _, err := inferencesynthesis.CalcForecastImpliedInferences(
 		inferencesynthesis.CalcForecastImpliedInferencesArgs{
-			Logger:               s.ctx.Logger(),
+			Logger:               s.Ctx().Logger(),
 			TopicId:              topicId,
 			AllInferersAreNew:    allInferersAreNew,
 			Inferers:             inferers,
@@ -445,12 +445,12 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch3() {
 	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
 	epoch3Get := epochGet[303]
 
-	worker0 := s.addrsStr[0]
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
-	worker4 := s.addrsStr[4]
-	forecaster0 := s.addrsStr[5]
+	worker0 := s.AddrsStr(0)
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
+	worker4 := s.AddrsStr(4)
+	forecaster0 := s.AddrsStr(5)
 
 	forecasts := &emissionstypes.Forecasts{
 		Forecasts: []*emissionstypes.Forecast{
@@ -500,7 +500,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch3() {
 
 	result, _, _, err := inferencesynthesis.CalcForecastImpliedInferences(
 		inferencesynthesis.CalcForecastImpliedInferencesArgs{
-			Logger:               s.ctx.Logger(),
+			Logger:               s.Ctx().Logger(),
 			TopicId:              topicId,
 			AllInferersAreNew:    allInferersAreNew,
 			Inferers:             inferers,

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
@@ -16,16 +16,17 @@ import (
 	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type InferenceSynthesisTestSuite struct {
-	alloratestutil.TestSuite
+	testutil.TestSuite
 }
 
 func TestInferenceSynthesisTestSuite(t *testing.T) {
 	suite.Run(t, &InferenceSynthesisTestSuite{
-		alloratestutil.NewTestSuite("inference_synthesis"),
+		testutil.NewTestSuite("inference_synthesis"),
 	})
 }
 

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
@@ -3,154 +3,30 @@ package inferencesynthesis_test
 import (
 	"strconv"
 	"testing"
-	"time"
 
 	"cosmossdk.io/log"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 
-	"cosmossdk.io/core/header"
 	cosmosMath "cosmossdk.io/math"
 
-	storetypes "cosmossdk.io/store/types"
-	"github.com/allora-network/allora-chain/app/params"
-	alloralog "github.com/allora-network/allora-chain/log"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
-	"github.com/allora-network/allora-chain/x/emissions/module"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
-	"github.com/cosmos/cosmos-sdk/codec/address"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/testutil"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	auth "github.com/cosmos/cosmos-sdk/x/auth"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/stretchr/testify/suite"
-)
-
-const (
-	multiPerm  = "multiple permissions account"
-	randomPerm = "random permission"
 )
 
 type InferenceSynthesisTestSuite struct {
-	suite.Suite
-
-	ctx             sdk.Context
-	accountKeeper   keeper.AccountKeeper
-	bankKeeper      keeper.BankKeeper
-	emissionsKeeper keeper.Keeper
-	appModule       module.AppModule
-	key             *storetypes.KVStoreKey
-	privKeys        []secp256k1.PrivKey
-	addrs           []sdk.AccAddress
-	addrsStr        []string
-	pubKeyHexStr    []string
-}
-
-func (s *InferenceSynthesisTestSuite) SetupTest() {
-	key := storetypes.NewKVStoreKey("emissions")
-	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	// Set logger to show logs from the rewards module too
-	logger := alloralog.NewTestLogger(s.T()).With("module", "inference_synthesis")
-	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{
-		Height:  1,
-		Hash:    []byte("1"),
-		AppHash: []byte("1"),
-		ChainID: "localnet",
-		Time:    time.Now(),
-	}).WithLogger(logger)
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
-	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
-
-	maccPerms := map[string][]string{
-		"fee_collector":                         {"minter"},
-		"mint":                                  {"minter"},
-		emissionstypes.AlloraStakingAccountName: {"burner", "minter", "staking"},
-		emissionstypes.AlloraRewardsAccountName: {"minter"},
-		emissionstypes.AlloraPendingRewardForDelegatorAccountName: {"minter"},
-		"bonded_tokens_pool":     {"burner", "staking"},
-		"not_bonded_tokens_pool": {"burner", "staking"},
-		multiPerm:                {"burner", "minter", "staking"},
-		randomPerm:               {"random"},
-	}
-
-	accountKeeper := authkeeper.NewAccountKeeper(
-		encCfg.Codec,
-		storeService,
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
-		params.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress("gov").String(),
-	)
-
-	s.privKeys, s.pubKeyHexStr, s.addrs, s.addrsStr = alloratestutil.GenerateTestAccounts(15)
-
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		log.NewNopLogger(),
-	)
-
-	s.ctx = ctx
-	s.accountKeeper = accountKeeper
-	s.bankKeeper = bankKeeper
-	s.emissionsKeeper = keeper.NewKeeper(
-		encCfg.Codec,
-		addressCodec,
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName,
-	)
-	s.key = key
-	appModule := module.NewAppModule(encCfg.Codec, s.emissionsKeeper)
-	defaultGenesis := appModule.DefaultGenesis(encCfg.Codec)
-	appModule.InitGenesis(ctx, encCfg.Codec, defaultGenesis)
-	s.appModule = appModule
-
-	// Add all tests addresses in whitelists
-	for _, addr := range s.addrsStr {
-		err := s.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
-		s.Require().NoError(err)
-	}
-
-	err := s.emissionsKeeper.SetTopic(s.ctx, 1, emissionstypes.Topic{
-		Id:                       1,
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "metadata",
-		LossMethod:               "mse",
-		EpochLastEnded:           0,
-		EpochLength:              100,
-		GroundTruthLag:           100,
-		WorkerSubmissionWindow:   100,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            false,
-		InitialRegret:            alloraMath.MustNewDecFromString("0.0001"),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.01"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.01"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.01"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.01"),
-	})
-	s.Require().NoError(err)
+	alloratestutil.TestSuite
 }
 
 func TestInferenceSynthesisTestSuite(t *testing.T) {
-	suite.Run(t, new(InferenceSynthesisTestSuite))
+	suite.Run(t, &InferenceSynthesisTestSuite{
+		alloratestutil.NewTestSuite("inference_synthesis"),
+	})
 }
 
 func (s *InferenceSynthesisTestSuite) signValueBundle(
@@ -164,29 +40,6 @@ func (s *InferenceSynthesisTestSuite) signValueBundle(
 	valueBundleSignature, err := privateKey.Sign(src)
 	require.NoError(err, "Sign should not return an error")
 	return valueBundleSignature
-}
-
-func (s *InferenceSynthesisTestSuite) mockTopic() emissionstypes.Topic {
-	return emissionstypes.Topic{
-		Id:                     1,
-		Creator:                s.addrsStr[0],
-		Metadata:               "metadata",
-		LossMethod:             "mse",
-		EpochLastEnded:         0,
-		EpochLength:            100,
-		GroundTruthLag:         100,
-		WorkerSubmissionWindow: 100,
-		PNorm:                  alloraMath.NewDecFromInt64(3),
-		AlphaRegret:            alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:          false,
-		Epsilon:                alloraMath.MustNewDecFromString("0.01"),
-		// Set Initial Regret
-		InitialRegret:            alloraMath.OneDec(),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.01"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.01"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.01"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.01"),
-	}
 }
 
 // ConvertInferencesToWorkerAttributedValues converts an Inferences type to a slice of WorkerAttributedValue
@@ -212,7 +65,7 @@ func (s *InferenceSynthesisTestSuite) mockEmptyValueBundle(
 		ReputerRequestNonce: &emissionstypes.ReputerRequestNonce{
 			ReputerNonce: &emissionstypes.Nonce{BlockHeight: 200},
 		},
-		Reputer:                       s.addrsStr[9],
+		Reputer:                       s.AddrsStr(9),
 		ExtraData:                     nil,
 		CombinedValue:                 combinedAndNaiveValue,
 		InfererValues:                 infererValues,
@@ -231,7 +84,7 @@ func (s *InferenceSynthesisTestSuite) getValueBundleForCombinedLoss(topicId uint
 		ReputerRequestNonce: &emissionstypes.ReputerRequestNonce{
 			ReputerNonce: &emissionstypes.Nonce{BlockHeight: blockHeight},
 		},
-		Reputer:                       s.addrsStr[0],
+		Reputer:                       s.AddrsStr(0),
 		ExtraData:                     nil,
 		CombinedValue:                 combinedLoss,
 		InfererValues:                 nil,
@@ -265,8 +118,8 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 	cNorm alloraMath.Dec,
 	epochGetters map[int]func(header string) alloraMath.Dec,
 ) {
-	k = s.emissionsKeeper
-	ctx = s.ctx
+	k = *s.EmissionsKeeper()
+	ctx = s.Ctx()
 	topicId = uint64(1)
 	blockHeight := int64(1)
 
@@ -278,16 +131,16 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 	if epochNumber > 0 {
 		epochPrevGet := epochGetters[epochNumber-1]
 		networkLossPrevious = epochPrevGet("network_loss")
-		worker0 := s.addrsStr[0]
-		worker1 := s.addrsStr[1]
-		worker2 := s.addrsStr[2]
-		worker3 := s.addrsStr[3]
-		worker4 := s.addrsStr[4]
+		worker0 := s.AddrsStr(0)
+		worker1 := s.AddrsStr(1)
+		worker2 := s.AddrsStr(2)
+		worker3 := s.AddrsStr(3)
+		worker4 := s.AddrsStr(4)
 		workerList := []string{worker0, worker1, worker2, worker3, worker4}
 
-		forecaster5 := s.addrsStr[8]
-		forecaster6 := s.addrsStr[9]
-		forecaster7 := s.addrsStr[10]
+		forecaster5 := s.AddrsStr(8)
+		forecaster6 := s.AddrsStr(9)
+		forecaster7 := s.AddrsStr(10)
 		forecasterList := make([]string, 8)
 		forecasterList[5] = forecaster5
 		forecasterList[6] = forecaster6
@@ -304,8 +157,8 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 				worker4: epochPrevGet("inference_regret_worker_4"),
 			}
 		for inferer, regret := range infererNetworkRegrets {
-			err := s.emissionsKeeper.SetInfererNetworkRegret(
-				s.ctx,
+			err := s.EmissionsKeeper().SetInfererNetworkRegret(
+				s.Ctx(),
 				topicId,
 				inferer,
 				emissionstypes.TimestampedValue{BlockHeight: blockHeight, Value: regret},
@@ -320,8 +173,8 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 			forecaster7: epochPrevGet("inference_regret_worker_7"),
 		}
 		for forecaster, regret := range forecasterNetworkRegrets {
-			err := s.emissionsKeeper.SetForecasterNetworkRegret(
-				s.ctx,
+			err := s.EmissionsKeeper().SetForecasterNetworkRegret(
+				s.Ctx(),
 				topicId,
 				forecaster,
 				emissionstypes.TimestampedValue{BlockHeight: blockHeight, Value: regret},
@@ -339,8 +192,8 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 				worker4: epochPrevGet("naive_inference_regret_worker_4"),
 			}
 		for inferer, regret := range infererNaiveNetworkRegrets {
-			err := s.emissionsKeeper.SetNaiveInfererNetworkRegret(
-				s.ctx,
+			err := s.EmissionsKeeper().SetNaiveInfererNetworkRegret(
+				s.Ctx(),
 				topicId,
 				inferer,
 				emissionstypes.TimestampedValue{BlockHeight: blockHeight, Value: regret},
@@ -354,7 +207,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 			infererName2 := workerList[infererIndex2]
 			headerName := "inference_regret_worker_" + strconv.Itoa(infererIndex) + "_oneout_" + strconv.Itoa(infererIndex2)
 			err := k.SetOneOutInfererInfererNetworkRegret(
-				s.ctx,
+				s.Ctx(),
 				topicId,
 				infererName2,
 				infererName,
@@ -377,7 +230,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 			forecasterName := forecasterList[forecasterIndex]
 			headerName := "inference_regret_worker_" + strconv.Itoa(forecasterIndex) + "_oneout_" + strconv.Itoa(infererIndex)
 			err := k.SetOneOutInfererForecasterNetworkRegret(
-				s.ctx,
+				s.Ctx(),
 				topicId,
 				infererName,
 				forecasterName,
@@ -400,7 +253,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 			forecasterName := forecasterList[forecasterIndex]
 			headerName := "inference_regret_worker_" + strconv.Itoa(infererIndex) + "_oneout_" + strconv.Itoa(forecasterIndex)
 			err := k.SetOneOutForecasterInfererNetworkRegret(
-				s.ctx,
+				s.Ctx(),
 				topicId,
 				forecasterName,
 				infererName,
@@ -423,7 +276,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 			forecasterName2 := forecasterList[forecasterIndex2]
 			headerName := "inference_regret_worker_" + strconv.Itoa(forecasterIndex) + "_oneout_" + strconv.Itoa(forecasterIndex2)
 			err := k.SetOneOutForecasterForecasterNetworkRegret(
-				s.ctx,
+				s.Ctx(),
 				topicId,
 				forecasterName2,
 				forecasterName,
@@ -446,7 +299,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 			infererName := workerList[infererIndex]
 			headerName := "inference_regret_worker_" + strconv.Itoa(infererIndex) + "_onein_" + strconv.Itoa(forecasterIndex)
 			err := k.SetOneInForecasterNetworkRegret(
-				s.ctx,
+				s.Ctx(),
 				topicId,
 				forecasterName,
 				infererName,
@@ -461,7 +314,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 			forecasterName := forecasterList[forecaster+5]
 			headerName := "inference_regret_worker_5_onein_" + strconv.Itoa(forecaster)
 			err := k.SetOneInForecasterNetworkRegret(
-				s.ctx,
+				s.Ctx(),
 				topicId,
 				forecasterName,
 				forecasterName,
@@ -494,8 +347,8 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 		stakeInt, ok := cosmosMath.NewIntFromString(stakeValueFloored.String())
 		s.Require().True(ok)
 
-		workerString := s.addrsStr[workerIndex]
-		err = k.AddReputerStake(s.ctx, topicId, workerString, stakeInt)
+		workerString := s.AddrsStr(workerIndex)
+		err = k.AddReputerStake(s.Ctx(), topicId, workerString, stakeInt)
 		s.Require().NoError(err)
 	}
 
@@ -506,7 +359,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 
 	for infererIndex := 0; infererIndex < 5; infererIndex++ {
 		inferences.Inferences = append(inferences.Inferences, &emissionstypes.Inference{
-			Inferer:     s.addrsStr[infererIndex],
+			Inferer:     s.AddrsStr(infererIndex),
 			Value:       epochGet("inference_" + strconv.Itoa(infererIndex)),
 			ExtraData:   nil,
 			Proof:       "",
@@ -523,12 +376,12 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 		forecastElements := make([]*emissionstypes.ForecastElement, 0)
 		for infererIndex := 0; infererIndex < 5; infererIndex++ {
 			forecastElements = append(forecastElements, &emissionstypes.ForecastElement{
-				Inferer: s.addrsStr[infererIndex],
+				Inferer: s.AddrsStr(infererIndex),
 				Value:   epochGet("forecasted_loss_" + strconv.Itoa(forecasterIndex) + "_for_" + strconv.Itoa(infererIndex)),
 			})
 		}
 		forecasts.Forecasts = append(forecasts.Forecasts, &emissionstypes.Forecast{
-			Forecaster:       s.addrsStr[forecasterIndex+8],
+			Forecaster:       s.AddrsStr(forecasterIndex + 8),
 			ForecastElements: forecastElements,
 			TopicId:          topicId,
 			BlockHeight:      blockHeight,
@@ -546,7 +399,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 	moduleParams.EpsilonSafeDiv = epsilonSafeDiv
 	moduleParams.CNorm = cNorm
 
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	topic.Id = topicId
 	topic.PNorm = pNorm
 	topic.Epsilon = epsilonTopic
@@ -594,7 +447,7 @@ func (s *InferenceSynthesisTestSuite) getNetworkCalcArgs(
 	forecastImpliedInferenceByWorker map[string]*emissionstypes.Inference,
 ) {
 	topicId := uint64(1)
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	topic.Id = topicId
 	topic.Epsilon = epsilonTopic
 	topic.PNorm = pNorm
@@ -608,8 +461,8 @@ func (s *InferenceSynthesisTestSuite) getNetworkCalcArgs(
 	var err error
 	var calcArgs inferencesynthesis.CalcNetworkInferencesArgs
 	calcArgs, err = inferencesynthesis.GetCalcNetworkInferenceArgs(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		inferences,
 		forecasts,
@@ -631,10 +484,10 @@ func (s *InferenceSynthesisTestSuite) incrementRegretsInTopic(
 ) {
 	for index := 0; index < times; index++ {
 		if actorType == emissionstypes.ActorType_ACTOR_TYPE_INFERER_UNSPECIFIED {
-			err := s.emissionsKeeper.IncrementCountInfererInclusionsInTopic(s.ctx, topicId, actor)
+			err := s.EmissionsKeeper().IncrementCountInfererInclusionsInTopic(s.Ctx(), topicId, actor)
 			s.Require().NoError(err)
 		} else if actorType == emissionstypes.ActorType_ACTOR_TYPE_FORECASTER {
-			err := s.emissionsKeeper.IncrementCountForecasterInclusionsInTopic(s.ctx, topicId, actor)
+			err := s.EmissionsKeeper().IncrementCountForecasterInclusionsInTopic(s.Ctx(), topicId, actor)
 			s.Require().NoError(err)
 		}
 	}
@@ -720,11 +573,11 @@ func (s *InferenceSynthesisTestSuite) testCorrectOneOutInfererValuesForEpoch(epo
 		forecasters, forecastByWorker, _, forecasterRegrets,
 		networkCombinedLoss, epsilonTopic, epsilonSafeDiv, pNorm, cNorm, epochGet := s.getEpochValueBundleByEpoch(epoch)
 
-	worker0 := s.addrsStr[0]
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
-	worker4 := s.addrsStr[4]
+	worker0 := s.AddrsStr(0)
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
+	worker4 := s.AddrsStr(4)
 
 	expectedValues := map[string]alloraMath.Dec{
 		worker0: epochGet[epoch]("network_inference_oneout_0"),
@@ -803,9 +656,9 @@ func (s *InferenceSynthesisTestSuite) testCorrectOneOutForecasterValuesForEpoch(
 		})
 	s.Require().NoError(err)
 
-	forecaster0 := s.addrsStr[8]
-	forecaster1 := s.addrsStr[9]
-	forecaster2 := s.addrsStr[10]
+	forecaster0 := s.AddrsStr(8)
+	forecaster1 := s.AddrsStr(9)
+	forecaster2 := s.AddrsStr(10)
 
 	expectedValues := map[string]alloraMath.Dec{
 		forecaster0: epochGet[epoch]("network_inference_oneout_5"),
@@ -862,9 +715,9 @@ func (s *InferenceSynthesisTestSuite) testCorrectOneInForecasterValuesForEpoch(e
 		})
 	s.Require().NoError(err)
 
-	forecaster0 := s.addrsStr[8]
-	forecaster1 := s.addrsStr[9]
-	forecaster2 := s.addrsStr[10]
+	forecaster0 := s.AddrsStr(8)
+	forecaster1 := s.AddrsStr(9)
+	forecaster2 := s.AddrsStr(10)
 
 	expectedValues := map[string]alloraMath.Dec{
 		forecaster0: epochGet[epoch]("network_naive_inference_onein_0"),
@@ -897,14 +750,14 @@ func (s *InferenceSynthesisTestSuite) TestCorrectOneInForecasterValuesEpoch4() {
 }
 
 func (s *InferenceSynthesisTestSuite) TestBuildNetworkInferencesIncompleteData() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
+	k := *s.EmissionsKeeper()
+	ctx := s.Ctx()
 	topicId := uint64(1)
 	blockHeightInferences := int64(390)
 	blockHeightForecaster := int64(380)
 
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
 
 	// Set up input data
 	inferences := &emissionstypes.Inferences{
@@ -984,14 +837,14 @@ func (s *InferenceSynthesisTestSuite) TestBuildNetworkInferencesIncompleteData()
 }
 
 func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesTwoWorkerTwoForecasters() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
+	k := *s.EmissionsKeeper()
+	ctx := s.Ctx()
 	topicId := uint64(1)
 	blockHeight := int64(300)
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
-	worker4 := s.addrsStr[4]
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
+	worker4 := s.AddrsStr(4)
 
 	// Set up input data
 	inferences := &emissionstypes.Inferences{
@@ -1097,17 +950,17 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesTwoWorkerTwoForec
 }
 
 func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesThreeWorkerThreeForecasters() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
+	k := *s.EmissionsKeeper()
+	ctx := s.Ctx()
 	topicId := uint64(1)
 	blockHeight := int64(300)
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
 
-	forecaster1 := s.addrsStr[4]
-	forecaster2 := s.addrsStr[5]
-	forecaster3 := s.addrsStr[6]
+	forecaster1 := s.AddrsStr(4)
+	forecaster2 := s.AddrsStr(5)
+	forecaster3 := s.AddrsStr(6)
 
 	// Set up input data
 	inferences := &emissionstypes.Inferences{
@@ -1244,17 +1097,17 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesThreeWorkerThreeF
 }
 
 func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesThreeWorkerTwoForecastersValidOneForecasterInvalid() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
+	k := *s.EmissionsKeeper()
+	ctx := s.Ctx()
 	topicId := uint64(1)
 	blockHeight := int64(300)
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
 
-	forecaster1 := s.addrsStr[4]
-	forecaster2 := s.addrsStr[5]
-	forecaster3 := s.addrsStr[6]
+	forecaster1 := s.AddrsStr(4)
+	forecaster2 := s.AddrsStr(5)
+	forecaster3 := s.AddrsStr(6)
 
 	// Set up input data
 	inferences := &emissionstypes.Inferences{
@@ -1398,12 +1251,12 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesThreeWorkerTwoFor
 }
 
 func (s *InferenceSynthesisTestSuite) TestCalcOneInInferencesTwoForecastersOldTwoInferersNewOneOldOneNew() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
+	k := *s.EmissionsKeeper()
+	ctx := s.Ctx()
 	topicId := uint64(1)
 
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
 
 	// Set up input data
 	inferences := &emissionstypes.Inferences{
@@ -1502,16 +1355,16 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneInInferencesTwoForecastersOldTw
 }
 
 func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
+	k := *s.EmissionsKeeper()
+	ctx := s.Ctx()
 	topicId := uint64(1)
 	blockHeight := int64(300)
 
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
-	forecaster1 := s.addrsStr[4]
-	forecaster2 := s.addrsStr[5]
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
+	forecaster1 := s.AddrsStr(4)
+	forecaster2 := s.AddrsStr(5)
 
 	// Set up input data with 3 inferers and 2 forecasters
 	inferences := &emissionstypes.Inferences{
@@ -1647,15 +1500,15 @@ func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences() {
 }
 
 func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences2inferers2forecasters() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
+	k := *s.EmissionsKeeper()
+	ctx := s.Ctx()
 	topicId := uint64(1)
 	blockHeight := int64(300)
 
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	forecaster1 := s.addrsStr[3]
-	forecaster2 := s.addrsStr[4]
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	forecaster1 := s.AddrsStr(3)
+	forecaster2 := s.AddrsStr(4)
 
 	// Set up input data with 2 inferers and 2 forecasters
 	inferences := &emissionstypes.Inferences{

--- a/x/emissions/keeper/inference_synthesis/network_inferences_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	"github.com/stretchr/testify/assert"
 
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
@@ -81,8 +81,8 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesWhenNoInferences()
 
 	_, err :=
 		inferencesynthesis.GetNetworkInferences(
-			s.ctx,
-			s.emissionsKeeper,
+			s.Ctx(),
+			*s.EmissionsKeeper(),
 			topicId,
 			&blockHeight,
 			inferences,
@@ -94,8 +94,8 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesWhenNoInferences()
 
 	_, err =
 		inferencesynthesis.GetNetworkInferences(
-			s.ctx,
-			s.emissionsKeeper,
+			s.Ctx(),
+			*s.EmissionsKeeper(),
 			topicId,
 			nil,
 			inferences,
@@ -112,7 +112,7 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 	epoch3Get := epochGet[303]
 
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := *s.EmissionsKeeper()
 
 	topicId := uint64(1)
 	blockHeight := int64(300)
@@ -120,20 +120,20 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 
 	simpleNonce := emissionstypes.Nonce{BlockHeight: blockHeight}
 
-	topic := s.mockTopic()
-	err := s.emissionsKeeper.SetTopic(s.ctx, topicId, topic)
+	topic := s.MockTopic()
+	err := s.EmissionsKeeper().SetTopic(s.Ctx(), topicId, topic)
 	s.Require().NoError(err)
 
-	inferer0 := s.addrsStr[0]
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
-	inferer3 := s.addrsStr[3]
-	inferer4 := s.addrsStr[4]
+	inferer0 := s.AddrsStr(0)
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
+	inferer4 := s.AddrsStr(4)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
-	forecaster0 := s.addrsStr[5]
-	forecaster1 := s.addrsStr[6]
-	forecaster2 := s.addrsStr[7]
+	forecaster0 := s.AddrsStr(5)
+	forecaster1 := s.AddrsStr(6)
+	forecaster2 := s.AddrsStr(7)
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
 	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch3Get)
@@ -142,10 +142,10 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 
 	// Set Previous Loss
 	valueBundlePrevious := s.mockEmptyValueBundle(epoch2Get("network_loss"), infererValues)
-	err = keeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, blockHeightPreviousLosses, valueBundlePrevious)
+	err = keeper.InsertNetworkLossBundleAtBlock(s.Ctx(), topicId, blockHeightPreviousLosses, valueBundlePrevious)
 	require.NoError(err)
 
-	err = keeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
+	err = keeper.InsertActiveInferences(s.Ctx(), topicId, simpleNonce.BlockHeight, inferences)
 	s.Require().NoError(err)
 
 	forecasts, err := testutil.GetForecastsFromCsv(
@@ -157,11 +157,11 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 	)
 	s.Require().NoError(err)
 
-	err = keeper.InsertActiveForecasts(s.ctx, topicId, simpleNonce.BlockHeight, forecasts)
+	err = keeper.InsertActiveForecasts(s.Ctx(), topicId, simpleNonce.BlockHeight, forecasts)
 	s.Require().NoError(err)
 
 	// Set regrets from the previous epoch
-	err = testutil.SetRegretsFromPreviousEpoch(s.ctx, s.emissionsKeeper, topicId,
+	err = testutil.SetRegretsFromPreviousEpoch(s.Ctx(), *s.EmissionsKeeper(), topicId,
 		blockHeight,
 		infererAddresses,
 		forecasterAddresses,
@@ -170,16 +170,15 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlock() {
 	s.Require().NoError(err)
 
 	// Calculate
-	result, err :=
-		inferencesynthesis.GetNetworkInferences(
-			s.ctx,
-			s.emissionsKeeper,
-			topicId,
-			&blockHeight,
-			&inferences,
-			&forecasts,
-			false,
-		)
+	result, err := inferencesynthesis.GetNetworkInferences(
+		s.Ctx(),
+		*s.EmissionsKeeper(),
+		topicId,
+		&blockHeight,
+		&inferences,
+		&forecasts,
+		false,
+	)
 	require.NoError(err)
 	s.Require().Equal(result.LossBlockHeight, blockHeightPreviousLosses)
 	valueBundle := result.NetworkInferences
@@ -324,34 +323,33 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithNoPrevi
 	blockHeight := int64(300)
 	simpleNonce := emissionstypes.Nonce{BlockHeight: blockHeight}
 
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	topic.InitialRegret = alloraMath.ZeroDec()
-	err := s.emissionsKeeper.SetTopic(s.ctx, topicId, topic)
+	err := s.EmissionsKeeper().SetTopic(s.Ctx(), topicId, topic)
 	s.Require().NoError(err)
 
-	inferer0 := s.addrsStr[0]
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
-	inferer3 := s.addrsStr[3]
-	inferer4 := s.addrsStr[4]
+	inferer0 := s.AddrsStr(0)
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
+	inferer4 := s.AddrsStr(4)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
 	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch2Get)
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
+	err = s.EmissionsKeeper().InsertActiveInferences(s.Ctx(), topicId, simpleNonce.BlockHeight, inferences)
 	s.Require().NoError(err)
 
-	result, err :=
-		inferencesynthesis.GetNetworkInferences(
-			s.ctx,
-			s.emissionsKeeper,
-			topicId,
-			&blockHeight,
-			&inferences,
-			nil,
-			false,
-		)
+	result, err := inferencesynthesis.GetNetworkInferences(
+		s.Ctx(),
+		*s.EmissionsKeeper(),
+		topicId,
+		&blockHeight,
+		&inferences,
+		nil,
+		false,
+	)
 	s.Require().NoError(err)
 	testutil.InEpsilon5(s.T(), result.NetworkInferences.CombinedValue, "0.1997509073157136")
 }
@@ -365,16 +363,16 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOneOldI
 	blockHeightPreviousLosses := int64(200)
 	simpleNonce := emissionstypes.Nonce{BlockHeight: blockHeight}
 
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	topic.InitialRegret = alloraMath.MustNewDecFromString("-1.8331309069480215")
-	err := s.emissionsKeeper.SetTopic(s.ctx, topicId, topic)
+	err := s.EmissionsKeeper().SetTopic(s.Ctx(), topicId, topic)
 	s.Require().NoError(err)
 
-	inferer0 := s.addrsStr[0]
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
-	inferer3 := s.addrsStr[3]
-	inferer4 := s.addrsStr[4]
+	inferer0 := s.AddrsStr(0)
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
+	inferer4 := s.AddrsStr(4)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
 	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch2Get)
@@ -382,28 +380,27 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOneOldI
 	infererValues := s.ConvertInferencesToWorkerAttributedValues(inferences)
 	// Set Previous Loss
 	valueBundlePrevious := s.mockEmptyValueBundle(epoch1Get("network_loss"), infererValues)
-	err = s.emissionsKeeper.InsertNetworkLossBundleAtBlock(
-		s.ctx, topicId, blockHeightPreviousLosses, valueBundlePrevious)
+	err = s.EmissionsKeeper().InsertNetworkLossBundleAtBlock(
+		s.Ctx(), topicId, blockHeightPreviousLosses, valueBundlePrevious)
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
+	err = s.EmissionsKeeper().InsertActiveInferences(s.Ctx(), topicId, simpleNonce.BlockHeight, inferences)
 	s.Require().NoError(err)
 
 	// Set regrets from the previous epoch
 	err = testutil.SetRegretsFromPreviousEpoch(
-		s.ctx, s.emissionsKeeper, topicId, blockHeight, []string{inferer0}, []string{}, epoch1Get)
+		s.Ctx(), *s.EmissionsKeeper(), topicId, blockHeight, []string{inferer0}, []string{}, epoch1Get)
 	s.Require().NoError(err)
 
-	result, err :=
-		inferencesynthesis.GetNetworkInferences(
-			s.ctx,
-			s.emissionsKeeper,
-			topicId,
-			&blockHeight,
-			&inferences,
-			nil,
-			false,
-		)
+	result, err := inferencesynthesis.GetNetworkInferences(
+		s.Ctx(),
+		*s.EmissionsKeeper(),
+		topicId,
+		&blockHeight,
+		&inferences,
+		nil,
+		false,
+	)
 	s.Require().NoError(err)
 	valueBundle := result.NetworkInferences
 
@@ -438,22 +435,22 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOldInfe
 	blockHeightPreviousLosses := int64(200)
 	simpleNonce := emissionstypes.Nonce{BlockHeight: blockHeight}
 
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	topic.InitialRegret = alloraMath.MustNewDecFromString("-3.7780955644806307")
 
-	err := s.emissionsKeeper.SetTopic(s.ctx, topicId, topic)
+	err := s.EmissionsKeeper().SetTopic(s.Ctx(), topicId, topic)
 	s.Require().NoError(err)
 
-	inferer0 := s.addrsStr[0]
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
-	inferer3 := s.addrsStr[3]
-	inferer4 := s.addrsStr[4]
+	inferer0 := s.AddrsStr(0)
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
+	inferer4 := s.AddrsStr(4)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
-	forecaster0 := s.addrsStr[5]
-	forecaster1 := s.addrsStr[6]
-	forecaster2 := s.addrsStr[7]
+	forecaster0 := s.AddrsStr(5)
+	forecaster1 := s.AddrsStr(6)
+	forecaster2 := s.AddrsStr(7)
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
 	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch2Get)
@@ -462,22 +459,22 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOldInfe
 
 	// Set Previous Loss
 	emptyValueBundle := s.mockEmptyValueBundle(epoch1Get("network_loss"), infererValues)
-	err = s.emissionsKeeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, blockHeightPreviousLosses, emptyValueBundle)
+	err = s.EmissionsKeeper().InsertNetworkLossBundleAtBlock(s.Ctx(), topicId, blockHeightPreviousLosses, emptyValueBundle)
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
+	err = s.EmissionsKeeper().InsertActiveInferences(s.Ctx(), topicId, simpleNonce.BlockHeight, inferences)
 	s.Require().NoError(err)
 
 	forecasts, err := testutil.GetForecastsFromCsv(topicId, blockHeight, infererAddresses, forecasterAddresses, epoch2Get)
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.InsertActiveForecasts(s.ctx, topicId, simpleNonce.BlockHeight, forecasts)
+	err = s.EmissionsKeeper().InsertActiveForecasts(s.Ctx(), topicId, simpleNonce.BlockHeight, forecasts)
 	s.Require().NoError(err)
 
 	// Set regrets from the previous epoch
 	err = testutil.SetRegretsFromPreviousEpoch(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		blockHeight,
 		infererAddresses,
@@ -487,16 +484,15 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOldInfe
 	s.Require().NoError(err)
 
 	// Calculate
-	result, err :=
-		inferencesynthesis.GetNetworkInferences(
-			s.ctx,
-			s.emissionsKeeper,
-			topicId,
-			&blockHeight,
-			&inferences,
-			&forecasts,
-			false,
-		)
+	result, err := inferencesynthesis.GetNetworkInferences(
+		s.Ctx(),
+		*s.EmissionsKeeper(),
+		topicId,
+		&blockHeight,
+		&inferences,
+		&forecasts,
+		false,
+	)
 	s.Require().NoError(err)
 	valueBundle := result.NetworkInferences
 
@@ -586,21 +582,21 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOldInfe
 
 	simpleNonce := emissionstypes.Nonce{BlockHeight: blockHeight}
 
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	topic.InitialRegret = alloraMath.MustNewDecFromString("-3.0557074373274475")
-	err := s.emissionsKeeper.SetTopic(s.ctx, topicId, topic)
+	err := s.EmissionsKeeper().SetTopic(s.Ctx(), topicId, topic)
 	s.Require().NoError(err)
 
-	inferer0 := s.addrsStr[0]
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
-	inferer3 := s.addrsStr[3]
-	inferer4 := s.addrsStr[4]
+	inferer0 := s.AddrsStr(0)
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
+	inferer4 := s.AddrsStr(4)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
-	forecaster0 := s.addrsStr[5]
-	forecaster1 := s.addrsStr[6]
-	forecaster2 := s.addrsStr[7]
+	forecaster0 := s.AddrsStr(5)
+	forecaster1 := s.AddrsStr(6)
+	forecaster2 := s.AddrsStr(7)
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
 	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeight, infererAddresses, epoch2Get)
@@ -609,36 +605,35 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesAtBlockWithOldInfe
 
 	// Set Previous Loss
 	emptyValueBundle := s.mockEmptyValueBundle(epoch1Get("network_loss"), infererValues)
-	err = s.emissionsKeeper.InsertNetworkLossBundleAtBlock(
-		s.ctx, topicId, blockHeightPreviousLosses,
+	err = s.EmissionsKeeper().InsertNetworkLossBundleAtBlock(
+		s.Ctx(), topicId, blockHeightPreviousLosses,
 		emptyValueBundle,
 	)
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
+	err = s.EmissionsKeeper().InsertActiveInferences(s.Ctx(), topicId, simpleNonce.BlockHeight, inferences)
 	s.Require().NoError(err)
 
 	forecasts, err := testutil.GetForecastsFromCsv(topicId, blockHeight, infererAddresses, forecasterAddresses, epoch2Get)
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.InsertActiveForecasts(s.ctx, topicId, simpleNonce.BlockHeight, forecasts)
+	err = s.EmissionsKeeper().InsertActiveForecasts(s.Ctx(), topicId, simpleNonce.BlockHeight, forecasts)
 	s.Require().NoError(err)
 
 	// Set regrets from the previous epoch
-	err = testutil.SetRegretsFromPreviousEpoch(s.ctx, s.emissionsKeeper, topicId, blockHeight, infererAddresses, []string{}, epoch1Get)
+	err = testutil.SetRegretsFromPreviousEpoch(s.Ctx(), *s.EmissionsKeeper(), topicId, blockHeight, infererAddresses, []string{}, epoch1Get)
 	s.Require().NoError(err)
 
 	// Calculate
-	result, err :=
-		inferencesynthesis.GetNetworkInferences(
-			s.ctx,
-			s.emissionsKeeper,
-			topicId,
-			&blockHeight,
-			&inferences,
-			&forecasts,
-			false,
-		)
+	result, err := inferencesynthesis.GetNetworkInferences(
+		s.Ctx(),
+		*s.EmissionsKeeper(),
+		topicId,
+		&blockHeight,
+		&inferences,
+		&forecasts,
+		false,
+	)
 	s.Require().NoError(err)
 	valueBundle := result.NetworkInferences
 
@@ -724,27 +719,27 @@ func (s *InferenceSynthesisTestSuite) TestGetLatestNetworkInferenceFromCsv() {
 	epoch3Get := epochGet[303]
 
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := *s.EmissionsKeeper()
 
 	topicId := uint64(1)
 	blockHeightInferences := int64(300)
 	blockHeightPreviousLosses := int64(200)
 	simpleNonce := emissionstypes.Nonce{BlockHeight: blockHeightInferences}
 
-	topic := s.mockTopic()
-	err := s.emissionsKeeper.SetTopic(s.ctx, topicId, topic)
+	topic := s.MockTopic()
+	err := s.EmissionsKeeper().SetTopic(s.Ctx(), topicId, topic)
 	require.NoError(err)
 
-	inferer0 := s.addrsStr[0]
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
-	inferer3 := s.addrsStr[3]
-	inferer4 := s.addrsStr[4]
+	inferer0 := s.AddrsStr(0)
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
+	inferer4 := s.AddrsStr(4)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
-	forecaster0 := s.addrsStr[5]
-	forecaster1 := s.addrsStr[6]
-	forecaster2 := s.addrsStr[7]
+	forecaster0 := s.AddrsStr(5)
+	forecaster1 := s.AddrsStr(6)
+	forecaster2 := s.AddrsStr(7)
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
 	inferences, err := testutil.GetInferencesFromCsv(topicId, blockHeightInferences, infererAddresses, epoch3Get)
@@ -752,35 +747,34 @@ func (s *InferenceSynthesisTestSuite) TestGetLatestNetworkInferenceFromCsv() {
 	infererValues := s.ConvertInferencesToWorkerAttributedValues(inferences)
 	// Set Previous Loss
 	valueBundlePrevious := s.mockEmptyValueBundle(epoch2Get("network_loss"), infererValues)
-	err = keeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, blockHeightPreviousLosses, valueBundlePrevious)
+	err = keeper.InsertNetworkLossBundleAtBlock(s.Ctx(), topicId, blockHeightPreviousLosses, valueBundlePrevious)
 	require.NoError(err)
 
-	err = keeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
+	err = keeper.InsertActiveInferences(s.Ctx(), topicId, simpleNonce.BlockHeight, inferences)
 	require.NoError(err)
 
 	forecasts, err := testutil.GetForecastsFromCsv(
 		topicId, blockHeightInferences, infererAddresses, forecasterAddresses, epoch3Get)
 	require.NoError(err)
 
-	err = keeper.InsertActiveForecasts(s.ctx, topicId, simpleNonce.BlockHeight, forecasts)
+	err = keeper.InsertActiveForecasts(s.Ctx(), topicId, simpleNonce.BlockHeight, forecasts)
 	require.NoError(err)
 
 	// Set regrets from the previous epoch
 	err = testutil.SetRegretsFromPreviousEpoch(
-		s.ctx, s.emissionsKeeper, topicId, blockHeightInferences, infererAddresses, forecasterAddresses, epoch2Get)
+		s.Ctx(), *s.EmissionsKeeper(), topicId, blockHeightInferences, infererAddresses, forecasterAddresses, epoch2Get)
 	require.NoError(err)
 
 	// Calculate
-	result, err :=
-		inferencesynthesis.GetNetworkInferences(
-			s.ctx,
-			s.emissionsKeeper,
-			topicId,
-			&blockHeightInferences,
-			&inferences,
-			&forecasts,
-			false,
-		)
+	result, err := inferencesynthesis.GetNetworkInferences(
+		s.Ctx(),
+		*s.EmissionsKeeper(),
+		topicId,
+		&blockHeightInferences,
+		&inferences,
+		&forecasts,
+		false,
+	)
 	require.NoError(err)
 	valueBundle := result.NetworkInferences
 
@@ -862,13 +856,13 @@ func (s *InferenceSynthesisTestSuite) TestGetLatestNetworkInferenceFromCsv() {
 
 func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesWithMedianCalculation() {
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := *s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(300)
 
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
-	inferer3 := s.addrsStr[3]
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
 
 	inferences := emissionstypes.Inferences{
 		Inferences: []*emissionstypes.Inference{
@@ -894,11 +888,11 @@ func (s *InferenceSynthesisTestSuite) TestGetNetworkInferencesWithMedianCalculat
 	}
 
 	nonce := emissionstypes.Nonce{BlockHeight: blockHeight}
-	err := keeper.InsertActiveInferences(s.ctx, topicId, nonce.BlockHeight, inferences)
+	err := keeper.InsertActiveInferences(s.Ctx(), topicId, nonce.BlockHeight, inferences)
 	s.Require().NoError(err)
 
 	result, err := inferencesynthesis.GetNetworkInferences(
-		s.ctx,
+		s.Ctx(),
 		keeper,
 		topicId,
 		&blockHeight,

--- a/x/emissions/keeper/inference_synthesis/network_losses_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_losses_test.go
@@ -2,6 +2,7 @@ package inferencesynthesis_test
 
 import (
 	cosmosMath "cosmossdk.io/math"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/test/testutil"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
@@ -76,43 +77,43 @@ func (s *InferenceSynthesisTestSuite) getTestCasesOneWorker() []struct {
 		ReputerRequestNonce: &emissions.ReputerRequestNonce{
 			ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 		},
-		Reputer:       s.addrsStr[1],
+		Reputer:       s.AddrsStr(1),
 		ExtraData:     nil,
 		CombinedValue: alloraMath.MustNewDecFromString("0.1"),
 		NaiveValue:    alloraMath.MustNewDecFromString("0.1"),
 		InfererValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		ForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneInForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutInfererForecasterValues: nil,
 	}
-	signature := s.signValueBundle(valueBundle, s.privKeys[1])
+	signature := s.signValueBundle(valueBundle, s.PrivKeys(1))
 	return []struct {
 		name            string
 		stakesByReputer map[inferencesynthesis.Worker]cosmosMath.Int
@@ -124,21 +125,21 @@ func (s *InferenceSynthesisTestSuite) getTestCasesOneWorker() []struct {
 		{
 			name: "simple one reputer combined loss",
 			stakesByReputer: map[inferencesynthesis.Worker]cosmosMath.Int{
-				s.addrsStr[1]: inferencesynthesis.CosmosIntOneE18(), // 1 token
+				s.AddrsStr(1): inferencesynthesis.CosmosIntOneE18(), // 1 token
 			},
 			reportedLosses: emissions.ReputerValueBundles{
 				ReputerValueBundles: []*emissions.ReputerValueBundle{
 					{
 						ValueBundle: valueBundle,
 						Signature:   signature,
-						Pubkey:      s.pubKeyHexStr[1],
+						Pubkey:      s.PubKeyHexStr(1),
 					},
 				},
 			},
 			epsilon: alloraMath.MustNewDecFromString("1e-4"),
 			expectedOutput: emissions.ValueBundle{
 				TopicId: uint64(1),
-				Reputer: s.addrsStr[1],
+				Reputer: s.AddrsStr(1),
 				ReputerRequestNonce: &emissions.ReputerRequestNonce{
 					ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 				},
@@ -147,31 +148,31 @@ func (s *InferenceSynthesisTestSuite) getTestCasesOneWorker() []struct {
 				NaiveValue:    alloraMath.MustNewDecFromString("0.1587401051968199"),
 				InfererValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.1587401051968199"),
 					},
 				},
 				ForecasterValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.1587401051968199"),
 					},
 				},
 				OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.1587401051968199"),
 					},
 				},
 				OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.1587401051968199"),
 					},
 				},
 				OneInForecasterValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.1587401051968199"),
 					},
 				},
@@ -195,63 +196,63 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkers() []struct {
 		ReputerRequestNonce: &emissions.ReputerRequestNonce{
 			ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 		},
-		Reputer:       s.addrsStr[1],
+		Reputer:       s.AddrsStr(1),
 		ExtraData:     nil,
 		CombinedValue: alloraMath.MustNewDecFromString("0.1"),
 		NaiveValue:    alloraMath.MustNewDecFromString("0.1"),
 		InfererValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		ForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneInForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutInfererForecasterValues: nil,
 	}
-	signature1 := s.signValueBundle(&valueBundle1, s.privKeys[1])
+	signature1 := s.signValueBundle(&valueBundle1, s.PrivKeys(1))
 
 	valueBundle2 := emissions.ValueBundle{
 		ExtraData: nil,
@@ -259,62 +260,62 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkers() []struct {
 		ReputerRequestNonce: &emissions.ReputerRequestNonce{
 			ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 		},
-		Reputer:       s.addrsStr[2],
+		Reputer:       s.AddrsStr(2),
 		CombinedValue: alloraMath.MustNewDecFromString("0.2"),
 		NaiveValue:    alloraMath.MustNewDecFromString("0.2"),
 		InfererValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		ForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneInForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneOutInfererForecasterValues: nil,
 	}
-	signature2 := s.signValueBundle(&valueBundle2, s.privKeys[2])
+	signature2 := s.signValueBundle(&valueBundle2, s.PrivKeys(2))
 	return []struct {
 		name            string
 		stakesByReputer map[inferencesynthesis.Worker]cosmosMath.Int
@@ -326,27 +327,27 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkers() []struct {
 		{
 			name: "simple two reputer combined loss",
 			stakesByReputer: map[inferencesynthesis.Worker]cosmosMath.Int{
-				s.addrsStr[1]: inferencesynthesis.CosmosIntOneE18(),           // 1 token
-				s.addrsStr[2]: inferencesynthesis.CosmosIntOneE18().MulRaw(2), // 2 tokens
+				s.AddrsStr(1): inferencesynthesis.CosmosIntOneE18(),           // 1 token
+				s.AddrsStr(2): inferencesynthesis.CosmosIntOneE18().MulRaw(2), // 2 tokens
 			},
 			reportedLosses: emissions.ReputerValueBundles{
 				ReputerValueBundles: []*emissions.ReputerValueBundle{
 					{
 						ValueBundle: &valueBundle1,
 						Signature:   signature1,
-						Pubkey:      s.pubKeyHexStr[1],
+						Pubkey:      s.PubKeyHexStr(1),
 					},
 					{
 						ValueBundle: &valueBundle2,
 						Signature:   signature2,
-						Pubkey:      s.pubKeyHexStr[2],
+						Pubkey:      s.PubKeyHexStr(2),
 					},
 				},
 			},
 			epsilon: alloraMath.MustNewDecFromString("1e-4"),
 			expectedOutput: emissions.ValueBundle{
 				TopicId: uint64(1),
-				Reputer: s.addrsStr[1],
+				Reputer: s.AddrsStr(1),
 				ReputerRequestNonce: &emissions.ReputerRequestNonce{
 					ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 				},
@@ -355,51 +356,51 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkers() []struct {
 				NaiveValue:    alloraMath.MustNewDecFromString("0.166666666"),
 				InfererValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 				},
 				ForecasterValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 				},
 				OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 				},
 				OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 				},
 				OneInForecasterValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.166666666"),
 					},
 				},
@@ -423,63 +424,63 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkersBadTopicId() []struc
 		ReputerRequestNonce: &emissions.ReputerRequestNonce{
 			ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 		},
-		Reputer:       s.addrsStr[1],
+		Reputer:       s.AddrsStr(1),
 		ExtraData:     nil,
 		CombinedValue: alloraMath.MustNewDecFromString("0.1"),
 		NaiveValue:    alloraMath.MustNewDecFromString("0.1"),
 		InfererValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		ForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneInForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutInfererForecasterValues: nil,
 	}
-	signature1 := s.signValueBundle(&valueBundle1, s.privKeys[1])
+	signature1 := s.signValueBundle(&valueBundle1, s.PrivKeys(1))
 
 	valueBundle2 := emissions.ValueBundle{
 		ExtraData: nil,
@@ -487,62 +488,62 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkersBadTopicId() []struc
 		ReputerRequestNonce: &emissions.ReputerRequestNonce{
 			ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 		},
-		Reputer:       s.addrsStr[2],
+		Reputer:       s.AddrsStr(2),
 		CombinedValue: alloraMath.MustNewDecFromString("0.2"),
 		NaiveValue:    alloraMath.MustNewDecFromString("0.2"),
 		InfererValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		ForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneInForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneOutInfererForecasterValues: nil,
 	}
-	signature2 := s.signValueBundle(&valueBundle2, s.privKeys[2])
+	signature2 := s.signValueBundle(&valueBundle2, s.PrivKeys(2))
 	return []struct {
 		name            string
 		stakesByReputer map[inferencesynthesis.Worker]cosmosMath.Int
@@ -554,27 +555,27 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkersBadTopicId() []struc
 		{
 			name: "simple two reputer combined loss",
 			stakesByReputer: map[inferencesynthesis.Worker]cosmosMath.Int{
-				s.addrsStr[1]: inferencesynthesis.CosmosIntOneE18(),           // 1 token
-				s.addrsStr[2]: inferencesynthesis.CosmosIntOneE18().MulRaw(2), // 2 tokens
+				s.AddrsStr(1): inferencesynthesis.CosmosIntOneE18(),           // 1 token
+				s.AddrsStr(2): inferencesynthesis.CosmosIntOneE18().MulRaw(2), // 2 tokens
 			},
 			reportedLosses: emissions.ReputerValueBundles{
 				ReputerValueBundles: []*emissions.ReputerValueBundle{
 					{
 						ValueBundle: &valueBundle1,
 						Signature:   signature1,
-						Pubkey:      s.pubKeyHexStr[1],
+						Pubkey:      s.PubKeyHexStr(1),
 					},
 					{
 						ValueBundle: &valueBundle2,
 						Signature:   signature2,
-						Pubkey:      s.pubKeyHexStr[2],
+						Pubkey:      s.PubKeyHexStr(2),
 					},
 				},
 			},
 			epsilon: alloraMath.MustNewDecFromString("1e-4"),
 			expectedOutput: emissions.ValueBundle{
 				TopicId: uint64(1),
-				Reputer: s.addrsStr[1],
+				Reputer: s.AddrsStr(1),
 				ReputerRequestNonce: &emissions.ReputerRequestNonce{
 					ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 				},
@@ -583,51 +584,51 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkersBadTopicId() []struc
 				NaiveValue:    alloraMath.MustNewDecFromString("0.2"),
 				InfererValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
 				ForecasterValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
 				OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
 				OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
 				OneInForecasterValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
@@ -651,63 +652,63 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkersBadBlockHeight() []s
 		ReputerRequestNonce: &emissions.ReputerRequestNonce{
 			ReputerNonce: &emissions.Nonce{BlockHeight: 1234}, // bad block height - this bundle should be ignored
 		},
-		Reputer:       s.addrsStr[1],
+		Reputer:       s.AddrsStr(1),
 		ExtraData:     nil,
 		CombinedValue: alloraMath.MustNewDecFromString("0.1"),
 		NaiveValue:    alloraMath.MustNewDecFromString("0.1"),
 		InfererValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		ForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneInForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.1"),
 			},
 		},
 		OneOutInfererForecasterValues: nil,
 	}
-	signature1 := s.signValueBundle(&valueBundle1, s.privKeys[1])
+	signature1 := s.signValueBundle(&valueBundle1, s.PrivKeys(1))
 
 	valueBundle2 := emissions.ValueBundle{
 		ExtraData: nil,
@@ -715,62 +716,62 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkersBadBlockHeight() []s
 		ReputerRequestNonce: &emissions.ReputerRequestNonce{
 			ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 		},
-		Reputer:       s.addrsStr[2],
+		Reputer:       s.AddrsStr(2),
 		CombinedValue: alloraMath.MustNewDecFromString("0.2"),
 		NaiveValue:    alloraMath.MustNewDecFromString("0.2"),
 		InfererValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		ForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneInForecasterValues: []*emissions.WorkerAttributedValue{
 			{
-				Worker: s.addrsStr[1],
+				Worker: s.AddrsStr(1),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 			{
-				Worker: s.addrsStr[2],
+				Worker: s.AddrsStr(2),
 				Value:  alloraMath.MustNewDecFromString("0.2"),
 			},
 		},
 		OneOutInfererForecasterValues: nil,
 	}
-	signature2 := s.signValueBundle(&valueBundle2, s.privKeys[2])
+	signature2 := s.signValueBundle(&valueBundle2, s.PrivKeys(2))
 	return []struct {
 		name            string
 		stakesByReputer map[inferencesynthesis.Worker]cosmosMath.Int
@@ -782,27 +783,27 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkersBadBlockHeight() []s
 		{
 			name: "simple two reputer combined loss",
 			stakesByReputer: map[inferencesynthesis.Worker]cosmosMath.Int{
-				s.addrsStr[1]: inferencesynthesis.CosmosIntOneE18(),           // 1 token
-				s.addrsStr[2]: inferencesynthesis.CosmosIntOneE18().MulRaw(2), // 2 tokens
+				s.AddrsStr(1): inferencesynthesis.CosmosIntOneE18(),           // 1 token
+				s.AddrsStr(2): inferencesynthesis.CosmosIntOneE18().MulRaw(2), // 2 tokens
 			},
 			reportedLosses: emissions.ReputerValueBundles{
 				ReputerValueBundles: []*emissions.ReputerValueBundle{
 					{
 						ValueBundle: &valueBundle1,
 						Signature:   signature1,
-						Pubkey:      s.pubKeyHexStr[1],
+						Pubkey:      s.PubKeyHexStr(1),
 					},
 					{
 						ValueBundle: &valueBundle2,
 						Signature:   signature2,
-						Pubkey:      s.pubKeyHexStr[2],
+						Pubkey:      s.PubKeyHexStr(2),
 					},
 				},
 			},
 			epsilon: alloraMath.MustNewDecFromString("1e-4"),
 			expectedOutput: emissions.ValueBundle{
 				TopicId: uint64(1),
-				Reputer: s.addrsStr[1],
+				Reputer: s.AddrsStr(1),
 				ReputerRequestNonce: &emissions.ReputerRequestNonce{
 					ReputerNonce: &emissions.Nonce{BlockHeight: 100},
 				},
@@ -811,51 +812,51 @@ func (s *InferenceSynthesisTestSuite) getTestCasesTwoWorkersBadBlockHeight() []s
 				NaiveValue:    alloraMath.MustNewDecFromString("0.2"),
 				InfererValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
 				ForecasterValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
 				OneOutInfererValues: []*emissions.WithheldWorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
 				OneOutForecasterValues: []*emissions.WithheldWorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
 				OneInForecasterValues: []*emissions.WorkerAttributedValue{
 					{
-						Worker: s.addrsStr[1],
+						Worker: s.AddrsStr(1),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 					{
-						Worker: s.addrsStr[2],
+						Worker: s.AddrsStr(2),
 						Value:  alloraMath.MustNewDecFromString("0.2"),
 					},
 				},
@@ -875,7 +876,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkLosses() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			output, err := inferencesynthesis.CalcNetworkLosses(s.ctx, topicId, block, tc.stakesByReputer, tc.reportedLosses)
+			output, err := inferencesynthesis.CalcNetworkLosses(s.Ctx(), topicId, block, tc.stakesByReputer, tc.reportedLosses)
 			if tc.expectedError != nil {
 				require.Error(err)
 				require.EqualError(err, tc.expectedError.Error())
@@ -893,49 +894,49 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkLossesFromCsv() {
 	topicId := uint64(1)
 	blockHeight := int64(301)
 
-	reputer0 := s.addrsStr[0]
-	reputer1 := s.addrsStr[1]
-	reputer2 := s.addrsStr[2]
-	reputer3 := s.addrsStr[3]
-	reputer4 := s.addrsStr[4]
+	reputer0 := s.AddrsStr(0)
+	reputer1 := s.AddrsStr(1)
+	reputer2 := s.AddrsStr(2)
+	reputer3 := s.AddrsStr(3)
+	reputer4 := s.AddrsStr(4)
 	reputers := []testutil.ReputerKey{
 		{
 			Address:    reputer0,
-			PrivateKey: s.privKeys[0],
-			PubKeyHex:  s.pubKeyHexStr[0],
+			PrivateKey: s.PrivKeys(0),
+			PubKeyHex:  s.PubKeyHexStr(0),
 		},
 		{
 			Address:    reputer1,
-			PrivateKey: s.privKeys[1],
-			PubKeyHex:  s.pubKeyHexStr[1],
+			PrivateKey: s.PrivKeys(1),
+			PubKeyHex:  s.PubKeyHexStr(1),
 		},
 		{
 			Address:    reputer2,
-			PrivateKey: s.privKeys[2],
-			PubKeyHex:  s.pubKeyHexStr[2],
+			PrivateKey: s.PrivKeys(2),
+			PubKeyHex:  s.PubKeyHexStr(2),
 		},
 		{
 			Address:    reputer3,
-			PrivateKey: s.privKeys[3],
-			PubKeyHex:  s.pubKeyHexStr[3],
+			PrivateKey: s.PrivKeys(3),
+			PubKeyHex:  s.PubKeyHexStr(3),
 		},
 		{
 			Address:    reputer4,
-			PrivateKey: s.privKeys[4],
-			PubKeyHex:  s.pubKeyHexStr[4],
+			PrivateKey: s.PrivKeys(4),
+			PubKeyHex:  s.PubKeyHexStr(4),
 		},
 	}
 
-	inferer0 := s.addrsStr[5]
-	inferer1 := s.addrsStr[6]
-	inferer2 := s.addrsStr[7]
-	inferer3 := s.addrsStr[8]
-	inferer4 := s.addrsStr[9]
+	inferer0 := s.AddrsStr(5)
+	inferer1 := s.AddrsStr(6)
+	inferer2 := s.AddrsStr(7)
+	inferer3 := s.AddrsStr(8)
+	inferer4 := s.AddrsStr(9)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
-	forecaster0 := s.addrsStr[10]
-	forecaster1 := s.addrsStr[11]
-	forecaster2 := s.addrsStr[12]
+	forecaster0 := s.AddrsStr(10)
+	forecaster1 := s.AddrsStr(11)
+	forecaster2 := s.AddrsStr(12)
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
 	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
@@ -981,7 +982,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkLossesFromCsv() {
 	)
 	s.Require().NoError(err)
 
-	networkLosses, err := inferencesynthesis.CalcNetworkLosses(s.ctx, topicId, blockHeight, stakesByReputer, reportedLosses)
+	networkLosses, err := inferencesynthesis.CalcNetworkLosses(s.Ctx(), topicId, blockHeight, stakesByReputer, reportedLosses)
 	s.Require().NoError(err)
 
 	expectedNetworkLosses, err := testutil.GetNetworkLossFromCsv(
@@ -1007,7 +1008,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkLossesCombined() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			output, err := inferencesynthesis.CalcNetworkLosses(s.ctx, topicId, block, tc.stakesByReputer, tc.reportedLosses)
+			output, err := inferencesynthesis.CalcNetworkLosses(s.Ctx(), topicId, block, tc.stakesByReputer, tc.reportedLosses)
 			if tc.expectedError != nil {
 				require.Error(err)
 				require.EqualError(err, tc.expectedError.Error())
@@ -1036,7 +1037,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkLossesCombinedBadCasesWrong
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			output, err := inferencesynthesis.CalcNetworkLosses(s.ctx, topicId, block, tc.stakesByReputer, tc.reportedLosses)
+			output, err := inferencesynthesis.CalcNetworkLosses(s.Ctx(), topicId, block, tc.stakesByReputer, tc.reportedLosses)
 			if tc.expectedError != nil {
 				require.Error(err)
 				require.EqualError(err, tc.expectedError.Error())
@@ -1066,7 +1067,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkLossesCombinedBadCasesWrong
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			output, err := inferencesynthesis.CalcNetworkLosses(s.ctx, topicId, block, tc.stakesByReputer, tc.reportedLosses)
+			output, err := inferencesynthesis.CalcNetworkLosses(s.Ctx(), topicId, block, tc.stakesByReputer, tc.reportedLosses)
 			if tc.expectedError != nil {
 				require.Error(err)
 				require.EqualError(err, tc.expectedError.Error())

--- a/x/emissions/keeper/inference_synthesis/network_regrets_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_regrets_test.go
@@ -15,7 +15,7 @@ func (s *InferenceSynthesisTestSuite) TestConvertValueBundleToNetworkLossesByWor
 	require := s.Require()
 	valueBundle := emissionstypes.ValueBundle{
 		TopicId: uint64(1),
-		Reputer: s.addrsStr[1],
+		Reputer: s.AddrsStr(1),
 		ReputerRequestNonce: &emissionstypes.ReputerRequestNonce{
 			ReputerNonce: &emissionstypes.Nonce{BlockHeight: 100},
 		},
@@ -23,24 +23,24 @@ func (s *InferenceSynthesisTestSuite) TestConvertValueBundleToNetworkLossesByWor
 		CombinedValue: alloraMath.MustNewDecFromString("0.1"),
 		NaiveValue:    alloraMath.MustNewDecFromString("0.1"),
 		InfererValues: []*emissionstypes.WorkerAttributedValue{
-			{Worker: s.addrsStr[1], Value: alloraMath.MustNewDecFromString("0.1")},
-			{Worker: s.addrsStr[2], Value: alloraMath.MustNewDecFromString("0.2")},
+			{Worker: s.AddrsStr(1), Value: alloraMath.MustNewDecFromString("0.1")},
+			{Worker: s.AddrsStr(2), Value: alloraMath.MustNewDecFromString("0.2")},
 		},
 		ForecasterValues: []*emissionstypes.WorkerAttributedValue{
-			{Worker: s.addrsStr[1], Value: alloraMath.MustNewDecFromString("0.1")},
-			{Worker: s.addrsStr[2], Value: alloraMath.MustNewDecFromString("0.2")},
+			{Worker: s.AddrsStr(1), Value: alloraMath.MustNewDecFromString("0.1")},
+			{Worker: s.AddrsStr(2), Value: alloraMath.MustNewDecFromString("0.2")},
 		},
 		OneOutInfererValues: []*emissionstypes.WithheldWorkerAttributedValue{
-			{Worker: s.addrsStr[1], Value: alloraMath.MustNewDecFromString("0.1")},
-			{Worker: s.addrsStr[2], Value: alloraMath.MustNewDecFromString("0.2")},
+			{Worker: s.AddrsStr(1), Value: alloraMath.MustNewDecFromString("0.1")},
+			{Worker: s.AddrsStr(2), Value: alloraMath.MustNewDecFromString("0.2")},
 		},
 		OneOutForecasterValues: []*emissionstypes.WithheldWorkerAttributedValue{
-			{Worker: s.addrsStr[1], Value: alloraMath.MustNewDecFromString("0.1")},
-			{Worker: s.addrsStr[2], Value: alloraMath.MustNewDecFromString("0.2")},
+			{Worker: s.AddrsStr(1), Value: alloraMath.MustNewDecFromString("0.1")},
+			{Worker: s.AddrsStr(2), Value: alloraMath.MustNewDecFromString("0.2")},
 		},
 		OneInForecasterValues: []*emissionstypes.WorkerAttributedValue{
-			{Worker: s.addrsStr[1], Value: alloraMath.MustNewDecFromString("0.1")},
-			{Worker: s.addrsStr[2], Value: alloraMath.MustNewDecFromString("0.2")},
+			{Worker: s.AddrsStr(1), Value: alloraMath.MustNewDecFromString("0.1")},
+			{Worker: s.AddrsStr(2), Value: alloraMath.MustNewDecFromString("0.2")},
 		},
 		OneOutInfererForecasterValues: nil,
 	}
@@ -54,16 +54,16 @@ func (s *InferenceSynthesisTestSuite) TestConvertValueBundleToNetworkLossesByWor
 	// Check if each worker's losses are set correctly
 	expectedLoss := alloraMath.MustNewDecFromString("0.1")
 	expectedLoss2 := alloraMath.MustNewDecFromString("0.2")
-	require.Equal(expectedLoss, result.InfererLosses[s.addrsStr[1]])
-	require.Equal(expectedLoss2, result.InfererLosses[s.addrsStr[2]])
-	require.Equal(expectedLoss, result.ForecasterLosses[s.addrsStr[1]])
-	require.Equal(expectedLoss2, result.ForecasterLosses[s.addrsStr[2]])
-	require.Equal(expectedLoss, result.OneOutInfererLosses[s.addrsStr[1]])
-	require.Equal(expectedLoss2, result.OneOutInfererLosses[s.addrsStr[2]])
-	require.Equal(expectedLoss, result.OneOutForecasterLosses[s.addrsStr[1]])
-	require.Equal(expectedLoss2, result.OneOutForecasterLosses[s.addrsStr[2]])
-	require.Equal(expectedLoss, result.OneInForecasterLosses[s.addrsStr[1]])
-	require.Equal(expectedLoss2, result.OneInForecasterLosses[s.addrsStr[2]])
+	require.Equal(expectedLoss, result.InfererLosses[s.AddrsStr(1)])
+	require.Equal(expectedLoss2, result.InfererLosses[s.AddrsStr(2)])
+	require.Equal(expectedLoss, result.ForecasterLosses[s.AddrsStr(1)])
+	require.Equal(expectedLoss2, result.ForecasterLosses[s.AddrsStr(2)])
+	require.Equal(expectedLoss, result.OneOutInfererLosses[s.AddrsStr(1)])
+	require.Equal(expectedLoss2, result.OneOutInfererLosses[s.AddrsStr(2)])
+	require.Equal(expectedLoss, result.OneOutForecasterLosses[s.AddrsStr(1)])
+	require.Equal(expectedLoss2, result.OneOutForecasterLosses[s.AddrsStr(2)])
+	require.Equal(expectedLoss, result.OneInForecasterLosses[s.AddrsStr(1)])
+	require.Equal(expectedLoss2, result.OneInForecasterLosses[s.AddrsStr(2)])
 }
 
 func (s *InferenceSynthesisTestSuite) TestComputeAndBuildEMRegret() {
@@ -109,20 +109,20 @@ func (s *InferenceSynthesisTestSuite) TestComputeAndBuildEMRegret() {
 // by the topic's initial regret.
 func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsTwoWorkers() {
 	require := s.Require()
-	k := s.emissionsKeeper
+	k := *s.EmissionsKeeper()
 
 	topicId := uint64(1)
 	// Create new topic
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	topic.InitialRegret = alloraMath.ZeroDec()
 	// Need to use "0.5" to set limit inclusions count as 2=(1/0.5)
 	topic.AlphaRegret = alloraMath.MustNewDecFromString("0.5")
-	err := s.emissionsKeeper.SetTopic(s.ctx, topicId, topic)
+	err := s.EmissionsKeeper().SetTopic(s.Ctx(), topicId, topic)
 	require.NoError(err)
 
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
 
 	pNorm := alloraMath.MustNewDecFromString("0.1")
 	cNorm := alloraMath.MustNewDecFromString("0.1")
@@ -138,7 +138,7 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsTwoWorkers() {
 	valueBundle := emissionstypes.ValueBundle{
 		TopicId:             topicId,
 		ReputerRequestNonce: &reputerRequestNonce,
-		Reputer:             s.addrsStr[9],
+		Reputer:             s.AddrsStr(9),
 		ExtraData:           nil,
 		CombinedValue:       alloraMath.NewDecFromInt64(500),
 		InfererValues: []*emissionstypes.WorkerAttributedValue{
@@ -166,56 +166,56 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsTwoWorkers() {
 
 	// Need to more than 2 experienced actor
 	// For this need to call SetInfererNetwork, SetForecasterNetworkRegret for worker1, worker2
-	err = k.SetInfererNetworkRegret(s.ctx, topicId, worker1, regretVal)
+	err = k.SetInfererNetworkRegret(s.Ctx(), topicId, worker1, regretVal)
 	require.NoError(err)
-	err = k.SetInfererNetworkRegret(s.ctx, topicId, worker2, regretVal)
+	err = k.SetInfererNetworkRegret(s.Ctx(), topicId, worker2, regretVal)
 	require.NoError(err)
-	err = k.SetForecasterNetworkRegret(s.ctx, topicId, worker1, regretVal)
+	err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, worker1, regretVal)
 	require.NoError(err)
-	err = k.SetForecasterNetworkRegret(s.ctx, topicId, worker2, regretVal)
+	err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, worker2, regretVal)
 	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker1, worker1, regretVal)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker1, worker1, regretVal)
 	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker1, worker2, regretVal)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker1, worker2, regretVal)
 	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker2, worker1, regretVal)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker2, worker1, regretVal)
 	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker2, worker2, regretVal)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker2, worker2, regretVal)
 	require.NoError(err)
 
 	s.incrementRegretsInTopic(topicId, worker1, 2, emissionstypes.ActorType_ACTOR_TYPE_INFERER_UNSPECIFIED)
 	s.incrementRegretsInTopic(topicId, worker2, 2, emissionstypes.ActorType_ACTOR_TYPE_INFERER_UNSPECIFIED)
 	// New potential participant should start with zero regret at this point since the initial regret in the topic is zero
 	// It will be updated after the first regret calculation
-	worker3LastRegret, worker3NoPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, worker3)
+	worker3LastRegret, worker3NoPriorRegret, err := k.GetInfererNetworkRegret(s.Ctx(), topicId, worker3)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetForecasterNetworkRegret(s.ctx, topicId, worker3)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetForecasterNetworkRegret(s.Ctx(), topicId, worker3)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker1)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker3, worker1)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker2)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker3, worker2)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker3)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker3, worker3)
 	require.NoError(err)
 	require.Equal(worker3LastRegret.Value, alloraMath.ZeroDec())
 	require.True(worker3NoPriorRegret)
 
 	_, err = inferencesynthesis.GetCalcSetNetworkRegrets(
 		inferencesynthesis.GetCalcSetNetworkRegretsArgs{
-			Ctx:                   s.ctx,
-			K:                     s.emissionsKeeper,
+			Ctx:                   s.Ctx(),
+			K:                     *s.EmissionsKeeper(),
 			TopicId:               topicId,
 			NetworkLosses:         valueBundle,
 			Nonce:                 nonce,
@@ -232,48 +232,48 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsTwoWorkers() {
 
 	// New potential participant should not start with zero regret since we already have participants with prior regrets which will
 	// be used to calculate the initial regret in the topic
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetInfererNetworkRegret(s.ctx, topicId, worker3)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetInfererNetworkRegret(s.Ctx(), topicId, worker3)
 	require.NoError(err)
 	require.NotEqual(worker3LastRegret.Value.String(), alloraMath.ZeroDec().String())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetForecasterNetworkRegret(s.ctx, topicId, worker3)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetForecasterNetworkRegret(s.Ctx(), topicId, worker3)
 	require.NoError(err)
 	require.NotEqual(worker3LastRegret.Value.String(), alloraMath.ZeroDec().String())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker1)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker3, worker1)
 	require.NoError(err)
 	require.NotEqual(worker3LastRegret.Value.String(), alloraMath.ZeroDec().String())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker2)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker3, worker2)
 	require.NoError(err)
 	require.NotEqual(worker3LastRegret.Value.String(), alloraMath.ZeroDec().String())
 	require.True(worker3NoPriorRegret)
 
-	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker3)
+	worker3LastRegret, worker3NoPriorRegret, err = k.GetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker3, worker3)
 	require.NoError(err)
 	require.NotEqual(worker3LastRegret.Value.String(), alloraMath.ZeroDec().String())
 	require.True(worker3NoPriorRegret)
 
 	// Get topic initial regret
-	topic, err = k.GetTopic(s.ctx, topicId)
+	topic, err = k.GetTopic(s.Ctx(), topicId)
 	require.NoError(err)
 
 	for _, acc := range bothAccs {
-		lastRegret, noPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, acc)
+		lastRegret, noPriorRegret, err := k.GetInfererNetworkRegret(s.Ctx(), topicId, acc)
 		require.NoError(err)
 		require.True(alloraMath.InDelta(topic.InitialRegret, lastRegret.Value, alloraMath.MustNewDecFromString("0.001")))
 		require.False(noPriorRegret)
 
-		lastRegret, noPriorRegret, err = k.GetForecasterNetworkRegret(s.ctx, topicId, acc)
+		lastRegret, noPriorRegret, err = k.GetForecasterNetworkRegret(s.Ctx(), topicId, acc)
 		require.NoError(err)
 		require.True(alloraMath.InDelta(topic.InitialRegret, lastRegret.Value, alloraMath.MustNewDecFromString("0.001")))
 		require.False(noPriorRegret)
 
 		for _, accInner := range bothAccs {
-			lastRegret, _, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, acc, accInner)
+			lastRegret, _, err = k.GetOneInForecasterNetworkRegret(s.Ctx(), topicId, acc, accInner)
 			require.NoError(err)
 		}
 	}
@@ -281,11 +281,11 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsTwoWorkers() {
 
 func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsThreeWorkers() {
 	require := s.Require()
-	k := s.emissionsKeeper
+	k := *s.EmissionsKeeper()
 
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
-	worker3 := s.addrsStr[3]
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
+	worker3 := s.AddrsStr(3)
 
 	pNorm := alloraMath.MustNewDecFromString("0.1")
 	cNorm := alloraMath.MustNewDecFromString("0.1")
@@ -295,7 +295,7 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsThreeWorkers()
 
 	valueBundle := emissionstypes.ValueBundle{
 		TopicId: uint64(1),
-		Reputer: s.addrsStr[1],
+		Reputer: s.AddrsStr(1),
 		ReputerRequestNonce: &emissionstypes.ReputerRequestNonce{
 			ReputerNonce: &emissionstypes.Nonce{BlockHeight: 100},
 		},
@@ -331,45 +331,45 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsThreeWorkers()
 		Value:       alloraMath.MustNewDecFromString("200"),
 	}
 
-	err := k.SetInfererNetworkRegret(s.ctx, topicId, worker1, timestampedValue)
+	err := k.SetInfererNetworkRegret(s.Ctx(), topicId, worker1, timestampedValue)
 	require.NoError(err)
-	err = k.SetInfererNetworkRegret(s.ctx, topicId, worker2, timestampedValue)
+	err = k.SetInfererNetworkRegret(s.Ctx(), topicId, worker2, timestampedValue)
 	require.NoError(err)
-	err = k.SetInfererNetworkRegret(s.ctx, topicId, worker3, timestampedValue)
-	require.NoError(err)
-
-	err = k.SetForecasterNetworkRegret(s.ctx, topicId, worker1, timestampedValue)
-	require.NoError(err)
-	err = k.SetForecasterNetworkRegret(s.ctx, topicId, worker2, timestampedValue)
-	require.NoError(err)
-	err = k.SetForecasterNetworkRegret(s.ctx, topicId, worker2, timestampedValue)
+	err = k.SetInfererNetworkRegret(s.Ctx(), topicId, worker3, timestampedValue)
 	require.NoError(err)
 
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker1, worker1, timestampedValue)
+	err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, worker1, timestampedValue)
 	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker1, worker2, timestampedValue)
+	err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, worker2, timestampedValue)
 	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker1, worker3, timestampedValue)
-	require.NoError(err)
-
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker2, worker1, timestampedValue)
-	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker2, worker2, timestampedValue)
-	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker2, worker3, timestampedValue)
+	err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, worker2, timestampedValue)
 	require.NoError(err)
 
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker1, timestampedValue)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker1, worker1, timestampedValue)
 	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker2, timestampedValue)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker1, worker2, timestampedValue)
 	require.NoError(err)
-	err = k.SetOneInForecasterNetworkRegret(s.ctx, topicId, worker3, worker3, timestampedValue)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker1, worker3, timestampedValue)
+	require.NoError(err)
+
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker2, worker1, timestampedValue)
+	require.NoError(err)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker2, worker2, timestampedValue)
+	require.NoError(err)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker2, worker3, timestampedValue)
+	require.NoError(err)
+
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker3, worker1, timestampedValue)
+	require.NoError(err)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker3, worker2, timestampedValue)
+	require.NoError(err)
+	err = k.SetOneInForecasterNetworkRegret(s.Ctx(), topicId, worker3, worker3, timestampedValue)
 	require.NoError(err)
 
 	_, err = inferencesynthesis.GetCalcSetNetworkRegrets(
 		inferencesynthesis.GetCalcSetNetworkRegretsArgs{
-			Ctx:                   s.ctx,
-			K:                     s.emissionsKeeper,
+			Ctx:                   s.Ctx(),
+			K:                     *s.EmissionsKeeper(),
 			TopicId:               topicId,
 			NetworkLosses:         valueBundle,
 			Nonce:                 nonce,
@@ -387,15 +387,15 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsThreeWorkers()
 	// expectedOneIn := alloraMath.MustNewDecFromString("180")
 
 	for _, workerAcc := range allWorkerAccs {
-		lastRegret, _, err := k.GetInfererNetworkRegret(s.ctx, topicId, workerAcc)
+		lastRegret, _, err := k.GetInfererNetworkRegret(s.Ctx(), topicId, workerAcc)
 		require.NoError(err)
 		require.True(alloraMath.InDelta(expected, lastRegret.Value, alloraMath.MustNewDecFromString("0.0001")))
 
-		lastRegret, _, err = k.GetForecasterNetworkRegret(s.ctx, topicId, workerAcc)
+		lastRegret, _, err = k.GetForecasterNetworkRegret(s.Ctx(), topicId, workerAcc)
 		require.NoError(err)
 
 		for _, innerWorkerAcc := range allWorkerAccs {
-			lastRegret, _, err = k.GetOneInForecasterNetworkRegret(s.ctx, topicId, workerAcc, innerWorkerAcc)
+			lastRegret, _, err = k.GetOneInForecasterNetworkRegret(s.Ctx(), topicId, workerAcc, innerWorkerAcc)
 			require.NoError(err)
 		}
 	}
@@ -403,7 +403,7 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsThreeWorkers()
 
 func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsFromCsv() {
 	require := s.Require()
-	k := s.emissionsKeeper
+	k := *s.EmissionsKeeper()
 	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
 	epochPrevGet := epochGet[300]
 	epoch301Get := epochGet[301]
@@ -417,21 +417,21 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsFromCsv() {
 	initialRegretQuantile := alloraMath.MustNewDecFromString("0.5")
 	pnormSafeDiv := alloraMath.MustNewDecFromString("1.0")
 
-	inferer0 := s.addrs[0].String()
-	inferer1 := s.addrs[1].String()
-	inferer2 := s.addrs[2].String()
-	inferer3 := s.addrs[3].String()
-	inferer4 := s.addrs[4].String()
+	inferer0 := s.AddrsStr(0)
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
+	inferer4 := s.AddrsStr(4)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
-	forecaster0 := s.addrs[5].String()
-	forecaster1 := s.addrs[6].String()
-	forecaster2 := s.addrs[7].String()
+	forecaster0 := s.AddrsStr(5)
+	forecaster1 := s.AddrsStr(6)
+	forecaster2 := s.AddrsStr(7)
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
-	reputer0 := s.addrs[8].String()
+	reputer0 := s.AddrsStr(8)
 
-	err := testutil.SetRegretsFromPreviousEpoch(s.ctx, s.emissionsKeeper, topicId, blockHeight, infererAddresses, forecasterAddresses, epochPrevGet)
+	err := testutil.SetRegretsFromPreviousEpoch(s.Ctx(), *s.EmissionsKeeper(), topicId, blockHeight, infererAddresses, forecasterAddresses, epochPrevGet)
 	require.NoError(err)
 
 	networkLosses, err := testutil.GetNetworkLossFromCsv(
@@ -446,8 +446,8 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsFromCsv() {
 
 	_, err = inferencesynthesis.GetCalcSetNetworkRegrets(
 		inferencesynthesis.GetCalcSetNetworkRegretsArgs{
-			Ctx:                   s.ctx,
-			K:                     s.emissionsKeeper,
+			Ctx:                   s.Ctx(),
+			K:                     *s.EmissionsKeeper(),
 			TopicId:               topicId,
 			NetworkLosses:         networkLosses,
 			Nonce:                 nonce,
@@ -461,13 +461,13 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsFromCsv() {
 	require.NoError(err)
 
 	checkRegret := func(worker string, expected alloraMath.Dec, getter func(context.Context, uint64, string) (emissionstypes.TimestampedValue, bool, error)) {
-		regret, _, err := getter(s.ctx, topicId, worker)
+		regret, _, err := getter(s.Ctx(), topicId, worker)
 		require.NoError(err)
 		testutil.InEpsilon5(s.T(), expected, regret.Value.String())
 	}
 
 	checkOneOutRegret := func(worker string, innerWorker string, expected alloraMath.Dec, getter func(context.Context, uint64, string, string) (emissionstypes.TimestampedValue, bool, error)) {
-		regret, _, err := getter(s.ctx, topicId, worker, innerWorker)
+		regret, _, err := getter(s.Ctx(), topicId, worker, innerWorker)
 		require.NoError(err)
 		testutil.InEpsilon5(s.T(), expected, regret.Value.String())
 	}
@@ -526,7 +526,7 @@ func (s *InferenceSynthesisTestSuite) TestGetCalcSetNetworkRegretsFromCsv() {
 // We then compare the resulting regrets to see if the higher losses result in lower regrets.
 func (s *InferenceSynthesisTestSuite) TestHigherLossesLowerRegret() {
 	require := s.Require()
-	k := s.emissionsKeeper
+	k := *s.EmissionsKeeper()
 
 	topicId := uint64(1)
 	blockHeight := int64(1003)
@@ -538,14 +538,14 @@ func (s *InferenceSynthesisTestSuite) TestHigherLossesLowerRegret() {
 	initialRegretQuantile := alloraMath.MustNewDecFromString("0.5")
 	pnormSafeDiv := alloraMath.MustNewDecFromString("1.0")
 
-	worker0 := s.addrsStr[0]
-	worker1 := s.addrsStr[1]
-	worker2 := s.addrsStr[2]
+	worker0 := s.AddrsStr(0)
+	worker1 := s.AddrsStr(1)
+	worker2 := s.AddrsStr(2)
 
 	networkLossesValueBundle0 := emissionstypes.ValueBundle{
 		TopicId:             topicId,
 		ReputerRequestNonce: &emissionstypes.ReputerRequestNonce{ReputerNonce: &nonce},
-		Reputer:             s.addrsStr[9],
+		Reputer:             s.AddrsStr(9),
 		ExtraData:           nil,
 		CombinedValue:       alloraMath.MustNewDecFromString("0.1"),
 		InfererValues: []*emissionstypes.WorkerAttributedValue{
@@ -572,7 +572,7 @@ func (s *InferenceSynthesisTestSuite) TestHigherLossesLowerRegret() {
 	networkLossesValueBundle1 := emissionstypes.ValueBundle{
 		TopicId:             topicId,
 		ReputerRequestNonce: &emissionstypes.ReputerRequestNonce{ReputerNonce: &nonce},
-		Reputer:             s.addrsStr[9],
+		Reputer:             s.AddrsStr(9),
 		ExtraData:           nil,
 		CombinedValue:       alloraMath.MustNewDecFromString("0.1"),
 		InfererValues: []*emissionstypes.WorkerAttributedValue{
@@ -612,18 +612,18 @@ func (s *InferenceSynthesisTestSuite) TestHigherLossesLowerRegret() {
 			Value:       alloraMath.MustNewDecFromString("0.3"),
 		}
 
-		err := k.SetInfererNetworkRegret(s.ctx, topicId, worker0, timestampedValue0_1)
+		err := k.SetInfererNetworkRegret(s.Ctx(), topicId, worker0, timestampedValue0_1)
 		require.NoError(err)
-		err = k.SetInfererNetworkRegret(s.ctx, topicId, worker1, timestampedValue0_2)
+		err = k.SetInfererNetworkRegret(s.Ctx(), topicId, worker1, timestampedValue0_2)
 		require.NoError(err)
-		err = k.SetInfererNetworkRegret(s.ctx, topicId, worker2, timestampedValue0_3)
+		err = k.SetInfererNetworkRegret(s.Ctx(), topicId, worker2, timestampedValue0_3)
 		require.NoError(err)
 
-		err = k.SetForecasterNetworkRegret(s.ctx, topicId, worker0, timestampedValue0_1)
+		err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, worker0, timestampedValue0_1)
 		require.NoError(err)
-		err = k.SetForecasterNetworkRegret(s.ctx, topicId, worker1, timestampedValue0_2)
+		err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, worker1, timestampedValue0_2)
 		require.NoError(err)
-		err = k.SetForecasterNetworkRegret(s.ctx, topicId, worker2, timestampedValue0_3)
+		err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, worker2, timestampedValue0_3)
 		require.NoError(err)
 	}
 
@@ -633,8 +633,8 @@ func (s *InferenceSynthesisTestSuite) TestHigherLossesLowerRegret() {
 
 	_, err := inferencesynthesis.GetCalcSetNetworkRegrets(
 		inferencesynthesis.GetCalcSetNetworkRegretsArgs{
-			Ctx:                   s.ctx,
-			K:                     s.emissionsKeeper,
+			Ctx:                   s.Ctx(),
+			K:                     *s.EmissionsKeeper(),
 			TopicId:               topicId,
 			NetworkLosses:         networkLossesValueBundle0,
 			Nonce:                 nonce,
@@ -649,23 +649,23 @@ func (s *InferenceSynthesisTestSuite) TestHigherLossesLowerRegret() {
 
 	// Record resulting regrets
 
-	infererRegret0_0, noPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, worker0)
+	infererRegret0_0, noPriorRegret, err := k.GetInfererNetworkRegret(s.Ctx(), topicId, worker0)
 	require.NoError(err)
 	require.False(noPriorRegret)
-	infererRegret0_1, noPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, worker1)
+	infererRegret0_1, noPriorRegret, err := k.GetInfererNetworkRegret(s.Ctx(), topicId, worker1)
 	require.NoError(err)
 	require.False(noPriorRegret)
-	infererRegret0_2, noPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, worker2)
+	infererRegret0_2, noPriorRegret, err := k.GetInfererNetworkRegret(s.Ctx(), topicId, worker2)
 	require.NoError(err)
 	require.False(noPriorRegret)
 
-	forecasterRegret0_0, noPriorRegret, err := k.GetForecasterNetworkRegret(s.ctx, topicId, worker0)
+	forecasterRegret0_0, noPriorRegret, err := k.GetForecasterNetworkRegret(s.Ctx(), topicId, worker0)
 	require.NoError(err)
 	require.False(noPriorRegret)
-	forecasterRegret0_1, noPriorRegret, err := k.GetForecasterNetworkRegret(s.ctx, topicId, worker1)
+	forecasterRegret0_1, noPriorRegret, err := k.GetForecasterNetworkRegret(s.Ctx(), topicId, worker1)
 	require.NoError(err)
 	require.False(noPriorRegret)
-	forecasterRegret0_2, noPriorRegret, err := k.GetForecasterNetworkRegret(s.ctx, topicId, worker2)
+	forecasterRegret0_2, noPriorRegret, err := k.GetForecasterNetworkRegret(s.Ctx(), topicId, worker2)
 	require.NoError(err)
 	require.False(noPriorRegret)
 
@@ -675,8 +675,8 @@ func (s *InferenceSynthesisTestSuite) TestHigherLossesLowerRegret() {
 
 	_, err = inferencesynthesis.GetCalcSetNetworkRegrets(
 		inferencesynthesis.GetCalcSetNetworkRegretsArgs{
-			Ctx:                   s.ctx,
-			K:                     s.emissionsKeeper,
+			Ctx:                   s.Ctx(),
+			K:                     *s.EmissionsKeeper(),
 			TopicId:               topicId,
 			NetworkLosses:         networkLossesValueBundle1,
 			Nonce:                 nonce,
@@ -691,23 +691,23 @@ func (s *InferenceSynthesisTestSuite) TestHigherLossesLowerRegret() {
 
 	// Record resulting regrets
 
-	infererRegret1_0, noPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, worker0)
+	infererRegret1_0, noPriorRegret, err := k.GetInfererNetworkRegret(s.Ctx(), topicId, worker0)
 	require.NoError(err)
 	require.False(noPriorRegret)
-	infererRegret1_1, noPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, worker1)
+	infererRegret1_1, noPriorRegret, err := k.GetInfererNetworkRegret(s.Ctx(), topicId, worker1)
 	require.NoError(err)
 	require.False(noPriorRegret)
-	infererRegret1_2, noPriorRegret, err := k.GetInfererNetworkRegret(s.ctx, topicId, worker2)
+	infererRegret1_2, noPriorRegret, err := k.GetInfererNetworkRegret(s.Ctx(), topicId, worker2)
 	require.NoError(err)
 	require.False(noPriorRegret)
 
-	forecasterRegret1_0, noPriorRegret, err := k.GetForecasterNetworkRegret(s.ctx, topicId, worker0)
+	forecasterRegret1_0, noPriorRegret, err := k.GetForecasterNetworkRegret(s.Ctx(), topicId, worker0)
 	require.NoError(err)
 	require.False(noPriorRegret)
-	forecasterRegret1_1, noPriorRegret, err := k.GetForecasterNetworkRegret(s.ctx, topicId, worker1)
+	forecasterRegret1_1, noPriorRegret, err := k.GetForecasterNetworkRegret(s.Ctx(), topicId, worker1)
 	require.NoError(err)
 	require.False(noPriorRegret)
-	forecasterRegret1_2, noPriorRegret, err := k.GetForecasterNetworkRegret(s.ctx, topicId, worker2)
+	forecasterRegret1_2, noPriorRegret, err := k.GetForecasterNetworkRegret(s.Ctx(), topicId, worker2)
 	require.NoError(err)
 	require.False(noPriorRegret)
 
@@ -778,7 +778,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcTopicInitialRegret() {
 // 4. With more workers and varying performance levels, the initial regret should be statistically meaningful
 func (s *InferenceSynthesisTestSuite) TestUpdateTopicInitialRegret() {
 	require := s.Require()
-	k := s.emissionsKeeper
+	k := *s.EmissionsKeeper()
 
 	topicId := uint64(1)
 	blockHeight := int64(1003)
@@ -791,37 +791,37 @@ func (s *InferenceSynthesisTestSuite) TestUpdateTopicInitialRegret() {
 
 	// Set initial Regret to check if this value is updated
 	initialRegret := alloraMath.ZeroDec()
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	topic.AlphaRegret = alloraMath.MustNewDecFromString("0.5")
-	err := s.emissionsKeeper.SetTopic(s.ctx, topicId, topic)
+	err := s.EmissionsKeeper().SetTopic(s.Ctx(), topicId, topic)
 	s.Require().NoError(err)
 
 	// Create 8 inferer addresses
 	infererAddresses := make([]string, 8)
 	for i := 0; i < 8; i++ {
-		infererAddresses[i] = s.addrs[i].String()
+		infererAddresses[i] = s.AddrsStr(i)
 	}
 
 	// Create 4 forecaster addresses
 	forecasterAddresses := make([]string, 4)
 	for i := 0; i < 4; i++ {
-		forecasterAddresses[i] = s.addrs[i+8].String()
+		forecasterAddresses[i] = s.AddrsStr(i + 8)
 	}
 
-	reputer := s.addrs[12].String()
+	reputer := s.AddrsStr(12)
 
 	// Make all workers experienced by giving them 2 inclusions
 	for _, worker := range infererAddresses {
-		err = k.IncrementCountInfererInclusionsInTopic(s.ctx, topicId, worker)
+		err = k.IncrementCountInfererInclusionsInTopic(s.Ctx(), topicId, worker)
 		require.NoError(err)
-		err = k.IncrementCountInfererInclusionsInTopic(s.ctx, topicId, worker)
+		err = k.IncrementCountInfererInclusionsInTopic(s.Ctx(), topicId, worker)
 		require.NoError(err)
 	}
 
 	for _, worker := range forecasterAddresses {
-		err = k.IncrementCountForecasterInclusionsInTopic(s.ctx, topicId, worker)
+		err = k.IncrementCountForecasterInclusionsInTopic(s.Ctx(), topicId, worker)
 		require.NoError(err)
-		err = k.IncrementCountForecasterInclusionsInTopic(s.ctx, topicId, worker)
+		err = k.IncrementCountForecasterInclusionsInTopic(s.Ctx(), topicId, worker)
 		require.NoError(err)
 	}
 
@@ -832,7 +832,7 @@ func (s *InferenceSynthesisTestSuite) TestUpdateTopicInitialRegret() {
 			BlockHeight: blockHeight,
 			Value:       value,
 		}
-		err = k.SetInfererNetworkRegret(s.ctx, topicId, worker, timestampedValue)
+		err = k.SetInfererNetworkRegret(s.Ctx(), topicId, worker, timestampedValue)
 		require.NoError(err)
 	}
 
@@ -842,7 +842,7 @@ func (s *InferenceSynthesisTestSuite) TestUpdateTopicInitialRegret() {
 			BlockHeight: blockHeight,
 			Value:       value,
 		}
-		err = k.SetForecasterNetworkRegret(s.ctx, topicId, worker, timestampedValue)
+		err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, worker, timestampedValue)
 		require.NoError(err)
 	}
 
@@ -882,7 +882,7 @@ func (s *InferenceSynthesisTestSuite) TestUpdateTopicInitialRegret() {
 
 	// Calculate and set network regrets
 	_, err = inferencesynthesis.GetCalcSetNetworkRegrets(inferencesynthesis.GetCalcSetNetworkRegretsArgs{
-		Ctx:                   s.ctx,
+		Ctx:                   s.Ctx(),
 		K:                     k,
 		TopicId:               topicId,
 		NetworkLosses:         networkLosses,
@@ -897,7 +897,7 @@ func (s *InferenceSynthesisTestSuite) TestUpdateTopicInitialRegret() {
 	require.NoError(err)
 
 	// Verify that initial regret was updated
-	topic, err = s.emissionsKeeper.GetTopic(s.ctx, topicId)
+	topic, err = s.EmissionsKeeper().GetTopic(s.Ctx(), topicId)
 	require.NoError(err)
 	require.NotEqual(topic.InitialRegret, initialRegret)
 
@@ -930,7 +930,7 @@ func (s *InferenceSynthesisTestSuite) TestUpdateTopicInitialRegret() {
 // are no experienced workers but enough total workers to use the fallback mechanism.
 func (s *InferenceSynthesisTestSuite) TestCalcSetNetworkRegretsWithFallbackRegrets() {
 	require := s.Require()
-	k := s.emissionsKeeper
+	k := *s.EmissionsKeeper()
 
 	// Setup topic
 	topicId := uint64(1)
@@ -944,36 +944,36 @@ func (s *InferenceSynthesisTestSuite) TestCalcSetNetworkRegretsWithFallbackRegre
 	pnormSafeDiv := alloraMath.MustNewDecFromString("1.0")
 
 	// Create topic
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	topic.AlphaRegret = alpha
-	err := k.SetTopic(s.ctx, topicId, topic)
+	err := k.SetTopic(s.Ctx(), topicId, topic)
 	require.NoError(err)
 
 	// Setup workers
-	inferer0 := s.addrsStr[0]
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
-	inferer3 := s.addrsStr[3]
-	inferer4 := s.addrsStr[4]
-	inferer5 := s.addrsStr[5]
-	inferer6 := s.addrsStr[6]
-	inferer7 := s.addrsStr[7]
-	inferer8 := s.addrsStr[8]
-	inferer9 := s.addrsStr[9]
+	inferer0 := s.AddrsStr(0)
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
+	inferer4 := s.AddrsStr(4)
+	inferer5 := s.AddrsStr(5)
+	inferer6 := s.AddrsStr(6)
+	inferer7 := s.AddrsStr(7)
+	inferer8 := s.AddrsStr(8)
+	inferer9 := s.AddrsStr(9)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4,
 		inferer5, inferer6, inferer7, inferer8, inferer9}
 
-	forecaster0 := s.addrsStr[10]
-	forecaster1 := s.addrsStr[11]
+	forecaster0 := s.AddrsStr(10)
+	forecaster1 := s.AddrsStr(11)
 	forecasterAddresses := []string{forecaster0, forecaster1}
 
 	// Add workers with only 1 inclusion each (not experienced)
 	for _, worker := range infererAddresses {
-		err := k.IncrementCountInfererInclusionsInTopic(s.ctx, topicId, worker)
+		err := k.IncrementCountInfererInclusionsInTopic(s.Ctx(), topicId, worker)
 		require.NoError(err)
 	}
 	for _, worker := range forecasterAddresses {
-		err := k.IncrementCountForecasterInclusionsInTopic(s.ctx, topicId, worker)
+		err := k.IncrementCountForecasterInclusionsInTopic(s.Ctx(), topicId, worker)
 		require.NoError(err)
 	}
 
@@ -989,15 +989,15 @@ func (s *InferenceSynthesisTestSuite) TestCalcSetNetworkRegretsWithFallbackRegre
 
 	for i, inferer := range infererAddresses {
 		if i < 5 {
-			err = k.SetInfererNetworkRegret(s.ctx, topicId, inferer, timestampedValue0_1)
+			err = k.SetInfererNetworkRegret(s.Ctx(), topicId, inferer, timestampedValue0_1)
 		} else {
-			err = k.SetInfererNetworkRegret(s.ctx, topicId, inferer, timestampedValue0_2)
+			err = k.SetInfererNetworkRegret(s.Ctx(), topicId, inferer, timestampedValue0_2)
 		}
 		require.NoError(err)
 	}
 
 	for _, forecaster := range forecasterAddresses {
-		err = k.SetForecasterNetworkRegret(s.ctx, topicId, forecaster, timestampedValue0_2)
+		err = k.SetForecasterNetworkRegret(s.Ctx(), topicId, forecaster, timestampedValue0_2)
 		require.NoError(err)
 	}
 
@@ -1005,7 +1005,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcSetNetworkRegretsWithFallbackRegre
 	networkLosses := emissionstypes.ValueBundle{
 		TopicId:             topicId,
 		ReputerRequestNonce: &emissionstypes.ReputerRequestNonce{ReputerNonce: &nonce},
-		Reputer:             s.addrsStr[12],
+		Reputer:             s.AddrsStr(12),
 		ExtraData:           nil,
 		CombinedValue:       alloraMath.MustNewDecFromString("0.1"),
 		InfererValues: []*emissionstypes.WorkerAttributedValue{
@@ -1034,7 +1034,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcSetNetworkRegretsWithFallbackRegre
 	// Call GetCalcSetNetworkRegrets
 	_, err = inferencesynthesis.GetCalcSetNetworkRegrets(
 		inferencesynthesis.GetCalcSetNetworkRegretsArgs{
-			Ctx:                   s.ctx,
+			Ctx:                   s.Ctx(),
 			K:                     k,
 			TopicId:               topicId,
 			NetworkLosses:         networkLosses,
@@ -1049,7 +1049,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcSetNetworkRegretsWithFallbackRegre
 	require.NoError(err)
 
 	// Get the updated topic
-	updatedTopic, err := k.GetTopic(s.ctx, topicId)
+	updatedTopic, err := k.GetTopic(s.Ctx(), topicId)
 	require.NoError(err)
 
 	// Since we're using fallback regrets (no experienced workers),
@@ -1059,9 +1059,9 @@ func (s *InferenceSynthesisTestSuite) TestCalcSetNetworkRegretsWithFallbackRegre
 		var regret emissionstypes.TimestampedValue
 		var err error
 		if slices.Contains(infererAddresses, worker) {
-			regret, _, err = k.GetInfererNetworkRegret(s.ctx, topicId, worker)
+			regret, _, err = k.GetInfererNetworkRegret(s.Ctx(), topicId, worker)
 		} else {
-			regret, _, err = k.GetForecasterNetworkRegret(s.ctx, topicId, worker)
+			regret, _, err = k.GetForecasterNetworkRegret(s.Ctx(), topicId, worker)
 		}
 		require.NoError(err)
 		expectedRegrets = append(expectedRegrets, regret.Value)

--- a/x/emissions/keeper/inference_synthesis/weights_test.go
+++ b/x/emissions/keeper/inference_synthesis/weights_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	synth "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 )
 
 type WeightsTestSuite struct {

--- a/x/emissions/keeper/inference_synthesis/weights_test.go
+++ b/x/emissions/keeper/inference_synthesis/weights_test.go
@@ -2,148 +2,22 @@ package inferencesynthesis_test
 
 import (
 	"testing"
-	"time"
 
-	"cosmossdk.io/core/header"
-	"cosmossdk.io/log"
-	storetypes "cosmossdk.io/store/types"
-	"github.com/allora-network/allora-chain/app/params"
-	alloralog "github.com/allora-network/allora-chain/log"
-	alloraMath "github.com/allora-network/allora-chain/math"
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
-
-	synth "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
-	"github.com/allora-network/allora-chain/x/emissions/module"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	"github.com/cosmos/cosmos-sdk/codec/address"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/testutil"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	auth "github.com/cosmos/cosmos-sdk/x/auth"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/stretchr/testify/suite"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
+	synth "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 )
 
 type WeightsTestSuite struct {
-	suite.Suite
-
-	ctx             sdk.Context
-	accountKeeper   keeper.AccountKeeper
-	bankKeeper      keeper.BankKeeper
-	emissionsKeeper keeper.Keeper
-	appModule       module.AppModule
-	key             *storetypes.KVStoreKey
-	privKeys        []secp256k1.PrivKey
-	addrs           []sdk.AccAddress
-	addrsStr        []string
-	pubKeyHexStr    []string
+	testutil.TestSuite
 }
 
 func TestWeightsTestSuite(t *testing.T) {
-	suite.Run(t, new(WeightsTestSuite))
-}
-
-func (s *WeightsTestSuite) SetupTest() {
-	// Setup similar to network_inference_builder_test.go
-	key := storetypes.NewKVStoreKey("emissions")
-	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	// Set logger to show logs from the rewards module too
-	logger := alloralog.NewTestLogger(s.T()).With("module", "inference_synthesis")
-	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{
-		Height:  1,
-		Hash:    []byte("1"),
-		AppHash: []byte("1"),
-		ChainID: "localnet",
-		Time:    time.Now(),
-	}).WithLogger(logger)
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
-	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
-
-	maccPerms := map[string][]string{
-		"fee_collector":                         {"minter"},
-		"mint":                                  {"minter"},
-		emissionstypes.AlloraStakingAccountName: {"burner", "minter", "staking"},
-		emissionstypes.AlloraRewardsAccountName: {"minter"},
-		emissionstypes.AlloraPendingRewardForDelegatorAccountName: {"minter"},
-		"bonded_tokens_pool":     {"burner", "staking"},
-		"not_bonded_tokens_pool": {"burner", "staking"},
-		multiPerm:                {"burner", "minter", "staking"},
-		randomPerm:               {"random"},
-	}
-
-	accountKeeper := authkeeper.NewAccountKeeper(
-		encCfg.Codec,
-		storeService,
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
-		params.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress("gov").String(),
-	)
-	s.privKeys, s.pubKeyHexStr, s.addrs, s.addrsStr = alloratestutil.GenerateTestAccounts(5)
-
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		log.NewNopLogger(),
-	)
-
-	s.ctx = ctx
-	s.accountKeeper = accountKeeper
-	s.bankKeeper = bankKeeper
-	s.emissionsKeeper = keeper.NewKeeper(
-		encCfg.Codec,
-		addressCodec,
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName,
-	)
-
-	s.key = key
-	appModule := module.NewAppModule(encCfg.Codec, s.emissionsKeeper)
-	defaultGenesis := appModule.DefaultGenesis(encCfg.Codec)
-	appModule.InitGenesis(ctx, encCfg.Codec, defaultGenesis)
-	s.appModule = appModule
-
-	// Add all tests addresses in whitelists
-	for _, addr := range s.addrsStr {
-		err := s.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
-		s.Require().NoError(err)
-	}
-
-	err := s.emissionsKeeper.SetTopic(s.ctx, 1, emissionstypes.Topic{
-		Id:                       1,
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "metadata",
-		LossMethod:               "mse",
-		EpochLastEnded:           0,
-		EpochLength:              100,
-		GroundTruthLag:           100,
-		WorkerSubmissionWindow:   100,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            false,
-		InitialRegret:            alloraMath.MustNewDecFromString("0.0001"),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.01"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.01"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.01"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.01"),
+	suite.Run(t, &WeightsTestSuite{
+		testutil.NewTestSuite("inference_synthesis_weights"),
 	})
-	s.Require().NoError(err)
 }
 
 func (s *WeightsTestSuite) TestNormalizeWeights() {
@@ -157,36 +31,36 @@ func (s *WeightsTestSuite) TestNormalizeWeights() {
 			name: "simple case - three weights",
 			weights: synth.RegretInformedWeights{
 				Inferers: map[string]alloraMath.Dec{
-					s.addrsStr[0]: alloraMath.MustNewDecFromString("2.0"),
-					s.addrsStr[1]: alloraMath.MustNewDecFromString("3.0"),
+					s.AddrsStr(0): alloraMath.MustNewDecFromString("2.0"),
+					s.AddrsStr(1): alloraMath.MustNewDecFromString("3.0"),
 				},
 				Forecasters: map[string]alloraMath.Dec{
-					s.addrsStr[2]: alloraMath.MustNewDecFromString("5.0"),
+					s.AddrsStr(2): alloraMath.MustNewDecFromString("5.0"),
 				},
 			},
 			expectError: false,
 			expected: map[string]alloraMath.Dec{
-				s.addrsStr[0]: alloraMath.MustNewDecFromString("0.2"), // 2/10
-				s.addrsStr[1]: alloraMath.MustNewDecFromString("0.3"), // 3/10
-				s.addrsStr[2]: alloraMath.MustNewDecFromString("0.5"), // 5/10
+				s.AddrsStr(0): alloraMath.MustNewDecFromString("0.2"), // 2/10
+				s.AddrsStr(1): alloraMath.MustNewDecFromString("0.3"), // 3/10
+				s.AddrsStr(2): alloraMath.MustNewDecFromString("0.5"), // 5/10
 			},
 		},
 		{
 			name: "equal weights",
 			weights: synth.RegretInformedWeights{
 				Inferers: map[string]alloraMath.Dec{
-					s.addrsStr[0]: alloraMath.MustNewDecFromString("1.0"),
-					s.addrsStr[1]: alloraMath.MustNewDecFromString("1.0"),
+					s.AddrsStr(0): alloraMath.MustNewDecFromString("1.0"),
+					s.AddrsStr(1): alloraMath.MustNewDecFromString("1.0"),
 				},
 				Forecasters: map[string]alloraMath.Dec{
-					s.addrsStr[2]: alloraMath.MustNewDecFromString("1.0"),
+					s.AddrsStr(2): alloraMath.MustNewDecFromString("1.0"),
 				},
 			},
 			expectError: false,
 			expected: map[string]alloraMath.Dec{
-				s.addrsStr[0]: alloraMath.MustNewDecFromString("0.333333333333333333"),
-				s.addrsStr[1]: alloraMath.MustNewDecFromString("0.333333333333333333"),
-				s.addrsStr[2]: alloraMath.MustNewDecFromString("0.333333333333333333"),
+				s.AddrsStr(0): alloraMath.MustNewDecFromString("0.333333333333333333"),
+				s.AddrsStr(1): alloraMath.MustNewDecFromString("0.333333333333333333"),
+				s.AddrsStr(2): alloraMath.MustNewDecFromString("0.333333333333333333"),
 			},
 		},
 		{
@@ -202,11 +76,11 @@ func (s *WeightsTestSuite) TestNormalizeWeights() {
 			name: "zero weights",
 			weights: synth.RegretInformedWeights{
 				Inferers: map[string]alloraMath.Dec{
-					s.addrsStr[0]: alloraMath.ZeroDec(),
-					s.addrsStr[1]: alloraMath.ZeroDec(),
+					s.AddrsStr(0): alloraMath.ZeroDec(),
+					s.AddrsStr(1): alloraMath.ZeroDec(),
 				},
 				Forecasters: map[string]alloraMath.Dec{
-					s.addrsStr[2]: alloraMath.ZeroDec(),
+					s.AddrsStr(2): alloraMath.ZeroDec(),
 				},
 			},
 			expectError: true,
@@ -264,20 +138,20 @@ func (s *WeightsTestSuite) TestStoreLatestNormalizedWeights() {
 		topicId := uint64(1)
 		weights := synth.RegretInformedWeights{
 			Inferers: map[string]alloraMath.Dec{
-				s.addrsStr[0]: alloraMath.MustNewDecFromString("0.2"),
-				s.addrsStr[1]: alloraMath.MustNewDecFromString("0.3"),
+				s.AddrsStr(0): alloraMath.MustNewDecFromString("0.2"),
+				s.AddrsStr(1): alloraMath.MustNewDecFromString("0.3"),
 			},
 			Forecasters: map[string]alloraMath.Dec{
-				s.addrsStr[2]: alloraMath.MustNewDecFromString("0.5"),
+				s.AddrsStr(2): alloraMath.MustNewDecFromString("0.5"),
 			},
 		}
 
-		err := synth.StoreLatestNormalizedWeights(s.ctx, s.emissionsKeeper, topicId, weights)
+		err := synth.StoreLatestNormalizedWeights(s.Ctx(), *s.EmissionsKeeper(), topicId, weights)
 		s.Require().NoError(err)
 
 		// Verify stored weights
 		for worker, expectedWeight := range weights.Inferers { // nolint: maprange // reason: order not relevant
-			storedWeight, err := s.emissionsKeeper.GetLatestInfererWeight(s.ctx, topicId, worker)
+			storedWeight, err := s.EmissionsKeeper().GetLatestInfererWeight(s.Ctx(), topicId, worker)
 			s.Require().NoError(err)
 			s.Require().True(expectedWeight.Equal(storedWeight))
 		}
@@ -286,23 +160,23 @@ func (s *WeightsTestSuite) TestStoreLatestNormalizedWeights() {
 
 func (s *WeightsTestSuite) TestGatherWorkerRegrets() {
 	s.Run("gather regrets from workers", func() {
-		inferers := []string{s.addrsStr[0], s.addrsStr[1]}
-		forecasters := []string{s.addrsStr[2]}
+		inferers := []string{s.AddrsStr(0), s.AddrsStr(1)}
+		forecasters := []string{s.AddrsStr(2)}
 
 		dec1 := alloraMath.MustNewDecFromString("0.1")
 		dec2 := alloraMath.MustNewDecFromString("0.2")
 		dec3 := alloraMath.MustNewDecFromString("0.3")
 
 		infererToRegret := map[string]*alloraMath.Dec{
-			s.addrsStr[0]: &dec1,
-			s.addrsStr[1]: &dec2,
+			s.AddrsStr(0): &dec1,
+			s.AddrsStr(1): &dec2,
 		}
 		forecasterToRegret := map[string]*alloraMath.Dec{
-			s.addrsStr[2]: &dec3,
+			s.AddrsStr(2): &dec3,
 		}
 
 		regrets, infererRegrets, forecasterRegrets, err := synth.GatherWorkerRegrets(
-			s.ctx.Logger(),
+			s.Ctx().Logger(),
 			inferers,
 			forecasters,
 			infererToRegret,
@@ -391,21 +265,21 @@ func (s *WeightsTestSuite) TestCalcStdDevForWeights() {
 	}{
 		{
 			name:        "all weights above threshold",
-			inferers:    []string{s.addrsStr[0], s.addrsStr[1]},
-			forecasters: []string{s.addrsStr[2]},
+			inferers:    []string{s.AddrsStr(0), s.AddrsStr(1)},
+			forecasters: []string{s.AddrsStr(2)},
 			infererWeights: map[string]alloraMath.Dec{
-				s.addrsStr[0]: alloraMath.MustNewDecFromString("0.4"),
-				s.addrsStr[1]: alloraMath.MustNewDecFromString("0.3"),
+				s.AddrsStr(0): alloraMath.MustNewDecFromString("0.4"),
+				s.AddrsStr(1): alloraMath.MustNewDecFromString("0.3"),
 			},
 			forecasterWeights: map[string]alloraMath.Dec{
-				s.addrsStr[2]: alloraMath.MustNewDecFromString("0.3"),
+				s.AddrsStr(2): alloraMath.MustNewDecFromString("0.3"),
 			},
 			infererRegrets: map[string]*alloraMath.Dec{
-				s.addrsStr[0]: decPtr("0.1"),
-				s.addrsStr[1]: decPtr("0.2"),
+				s.AddrsStr(0): decPtr("0.1"),
+				s.AddrsStr(1): decPtr("0.2"),
 			},
 			forecasterRegrets: map[string]*alloraMath.Dec{
-				s.addrsStr[2]: decPtr("0.3"),
+				s.AddrsStr(2): decPtr("0.3"),
 			},
 			negligibleThreshold: alloraMath.MustNewDecFromString("0.1"),
 			epsilonTopic:        alloraMath.MustNewDecFromString("0.01"),
@@ -414,21 +288,21 @@ func (s *WeightsTestSuite) TestCalcStdDevForWeights() {
 		},
 		{
 			name:        "some weights below threshold",
-			inferers:    []string{s.addrsStr[0], s.addrsStr[1]},
-			forecasters: []string{s.addrsStr[2]},
+			inferers:    []string{s.AddrsStr(0), s.AddrsStr(1)},
+			forecasters: []string{s.AddrsStr(2)},
 			infererWeights: map[string]alloraMath.Dec{
-				s.addrsStr[0]: alloraMath.MustNewDecFromString("0.05"), // below threshold
-				s.addrsStr[1]: alloraMath.MustNewDecFromString("0.3"),
+				s.AddrsStr(0): alloraMath.MustNewDecFromString("0.05"), // below threshold
+				s.AddrsStr(1): alloraMath.MustNewDecFromString("0.3"),
 			},
 			forecasterWeights: map[string]alloraMath.Dec{
-				s.addrsStr[2]: alloraMath.MustNewDecFromString("0.3"),
+				s.AddrsStr(2): alloraMath.MustNewDecFromString("0.3"),
 			},
 			infererRegrets: map[string]*alloraMath.Dec{
-				s.addrsStr[0]: decPtr("0.1"),
-				s.addrsStr[1]: decPtr("0.2"),
+				s.AddrsStr(0): decPtr("0.1"),
+				s.AddrsStr(1): decPtr("0.2"),
 			},
 			forecasterRegrets: map[string]*alloraMath.Dec{
-				s.addrsStr[2]: decPtr("0.3"),
+				s.AddrsStr(2): decPtr("0.3"),
 			},
 			negligibleThreshold: alloraMath.MustNewDecFromString("0.1"),
 			epsilonTopic:        alloraMath.MustNewDecFromString("0.01"),
@@ -437,21 +311,21 @@ func (s *WeightsTestSuite) TestCalcStdDevForWeights() {
 		},
 		{
 			name:        "less than 2 non-negligible weights",
-			inferers:    []string{s.addrsStr[0], s.addrsStr[1]},
-			forecasters: []string{s.addrsStr[2]},
+			inferers:    []string{s.AddrsStr(0), s.AddrsStr(1)},
+			forecasters: []string{s.AddrsStr(2)},
 			infererWeights: map[string]alloraMath.Dec{
-				s.addrsStr[0]: alloraMath.MustNewDecFromString("0.05"), // below threshold
-				s.addrsStr[1]: alloraMath.MustNewDecFromString("0.05"), // below threshold
+				s.AddrsStr(0): alloraMath.MustNewDecFromString("0.05"), // below threshold
+				s.AddrsStr(1): alloraMath.MustNewDecFromString("0.05"), // below threshold
 			},
 			forecasterWeights: map[string]alloraMath.Dec{
-				s.addrsStr[2]: alloraMath.MustNewDecFromString("0.3"),
+				s.AddrsStr(2): alloraMath.MustNewDecFromString("0.3"),
 			},
 			infererRegrets: map[string]*alloraMath.Dec{
-				s.addrsStr[0]: decPtr("0.1"),
-				s.addrsStr[1]: decPtr("0.2"),
+				s.AddrsStr(0): decPtr("0.1"),
+				s.AddrsStr(1): decPtr("0.2"),
 			},
 			forecasterRegrets: map[string]*alloraMath.Dec{
-				s.addrsStr[2]: decPtr("0.3"),
+				s.AddrsStr(2): decPtr("0.3"),
 			},
 			negligibleThreshold: alloraMath.MustNewDecFromString("0.1"),
 			epsilonTopic:        alloraMath.MustNewDecFromString("0.01"),
@@ -464,18 +338,18 @@ func (s *WeightsTestSuite) TestCalcStdDevForWeights() {
 		s.Run(tc.name, func() {
 			// Store weights in keeper
 			for worker, weight := range tc.infererWeights { // nolint: maprange // reason: order not relevant
-				err := s.emissionsKeeper.SetLatestInfererWeight(s.ctx, 1, worker, weight)
+				err := s.EmissionsKeeper().SetLatestInfererWeight(s.Ctx(), 1, worker, weight)
 				s.Require().NoError(err)
 			}
 			for worker, weight := range tc.forecasterWeights { // nolint: maprange // reason: order not relevant
-				err := s.emissionsKeeper.SetLatestForecasterWeight(s.ctx, 1, worker, weight)
+				err := s.EmissionsKeeper().SetLatestForecasterWeight(s.Ctx(), 1, worker, weight)
 				s.Require().NoError(err)
 			}
 
 			result, err := synth.CalcRegretStdDevFilteredByWeights(synth.CalcRegretStdDevFilteredByWeightsArgs{
-				Ctx:                 s.ctx,
-				K:                   &s.emissionsKeeper,
-				Logger:              s.ctx.Logger(),
+				Ctx:                 s.Ctx(),
+				K:                   s.EmissionsKeeper(),
+				Logger:              s.Ctx().Logger(),
 				TopicId:             1, // topicId
 				Inferers:            tc.inferers,
 				Forecasters:         tc.forecasters,
@@ -510,14 +384,14 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 		{
 			name: "basic calculation with single inferer and forecaster",
 			args: synth.CalcWeightsGivenWorkersArgs{
-				Logger:      s.ctx.Logger(),
-				Inferers:    []string{s.addrsStr[0]},
-				Forecasters: []string{s.addrsStr[1]},
+				Logger:      s.Ctx().Logger(),
+				Inferers:    []string{s.AddrsStr(0)},
+				Forecasters: []string{s.AddrsStr(1)},
 				InfererToRegret: map[string]*alloraMath.Dec{
-					s.addrsStr[0]: decPtr("1.0"),
+					s.AddrsStr(0): decPtr("1.0"),
 				},
 				ForecasterToRegret: map[string]*alloraMath.Dec{
-					s.addrsStr[1]: decPtr("2.0"),
+					s.AddrsStr(1): decPtr("2.0"),
 				},
 				EpsilonTopic:      alloraMath.MustNewDecFromString("0.01"),
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
@@ -528,20 +402,20 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 			checkResult: func(result synth.RegretInformedWeights) {
 				s.Require().Len(result.Inferers, 1)
 				s.Require().Len(result.Forecasters, 1)
-				s.Require().True(result.Inferers[s.addrsStr[0]].Lt(result.Forecasters[s.addrsStr[1]]))
+				s.Require().True(result.Inferers[s.AddrsStr(0)].Lt(result.Forecasters[s.AddrsStr(1)]))
 			},
 		},
 		{
 			name: "basic calculation with negative inferer and positive forecaster",
 			args: synth.CalcWeightsGivenWorkersArgs{
-				Logger:      s.ctx.Logger(),
-				Inferers:    []string{s.addrsStr[0]},
-				Forecasters: []string{s.addrsStr[1]},
+				Logger:      s.Ctx().Logger(),
+				Inferers:    []string{s.AddrsStr(0)},
+				Forecasters: []string{s.AddrsStr(1)},
 				InfererToRegret: map[string]*alloraMath.Dec{
-					s.addrsStr[0]: decPtr("-1.0"),
+					s.AddrsStr(0): decPtr("-1.0"),
 				},
 				ForecasterToRegret: map[string]*alloraMath.Dec{
-					s.addrsStr[1]: decPtr("2.0"),
+					s.AddrsStr(1): decPtr("2.0"),
 				},
 				EpsilonTopic:      alloraMath.MustNewDecFromString("0.01"),
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
@@ -553,20 +427,20 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				s.T().Logf("Single worker test results:")
 				s.Require().Len(result.Inferers, 1)
 				s.Require().Len(result.Forecasters, 1)
-				s.Require().True(result.Inferers[s.addrsStr[0]].Lt(result.Forecasters[s.addrsStr[1]]))
+				s.Require().True(result.Inferers[s.AddrsStr(0)].Lt(result.Forecasters[s.AddrsStr(1)]))
 			},
 		},
 		{
 			name: "basic calculation with positive inferer and negative forecaster",
 			args: synth.CalcWeightsGivenWorkersArgs{
-				Logger:      s.ctx.Logger(),
-				Inferers:    []string{s.addrsStr[0]},
-				Forecasters: []string{s.addrsStr[1]},
+				Logger:      s.Ctx().Logger(),
+				Inferers:    []string{s.AddrsStr(0)},
+				Forecasters: []string{s.AddrsStr(1)},
 				InfererToRegret: map[string]*alloraMath.Dec{
-					s.addrsStr[0]: decPtr("1.0"),
+					s.AddrsStr(0): decPtr("1.0"),
 				},
 				ForecasterToRegret: map[string]*alloraMath.Dec{
-					s.addrsStr[1]: decPtr("-2.0"),
+					s.AddrsStr(1): decPtr("-2.0"),
 				},
 				EpsilonTopic:      alloraMath.MustNewDecFromString("0.01"),
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
@@ -577,22 +451,22 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 			checkResult: func(result synth.RegretInformedWeights) {
 				s.Require().Len(result.Inferers, 1)
 				s.Require().Len(result.Forecasters, 1)
-				s.Require().True(result.Inferers[s.addrsStr[0]].Gt(result.Forecasters[s.addrsStr[1]]))
+				s.Require().True(result.Inferers[s.AddrsStr(0)].Gt(result.Forecasters[s.AddrsStr(1)]))
 			},
 		},
 		{
 			name: "calculation with multiple workers and mixed positive and negative regrets",
 			args: synth.CalcWeightsGivenWorkersArgs{
-				Logger:      s.ctx.Logger(),
-				Inferers:    []string{s.addrsStr[0], s.addrsStr[1]},
-				Forecasters: []string{s.addrsStr[2], s.addrsStr[3]},
+				Logger:      s.Ctx().Logger(),
+				Inferers:    []string{s.AddrsStr(0), s.AddrsStr(1)},
+				Forecasters: []string{s.AddrsStr(2), s.AddrsStr(3)},
 				InfererToRegret: map[string]*alloraMath.Dec{
-					s.addrsStr[0]: decPtr("-1.0"),
-					s.addrsStr[1]: decPtr("2.0"),
+					s.AddrsStr(0): decPtr("-1.0"),
+					s.AddrsStr(1): decPtr("2.0"),
 				},
 				ForecasterToRegret: map[string]*alloraMath.Dec{
-					s.addrsStr[2]: decPtr("1.5"),
-					s.addrsStr[3]: decPtr("-0.5"),
+					s.AddrsStr(2): decPtr("1.5"),
+					s.AddrsStr(3): decPtr("-0.5"),
 				},
 				EpsilonTopic:      alloraMath.MustNewDecFromString("0.01"),
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
@@ -605,18 +479,18 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				s.Require().Len(result.Forecasters, 2)
 
 				// Check that worker with higher regret has a higher weight
-				s.Require().True(result.Inferers[s.addrsStr[0]].Lt(result.Inferers[s.addrsStr[1]]))
-				s.Require().True(result.Forecasters[s.addrsStr[2]].Gt(result.Forecasters[s.addrsStr[3]]))
+				s.Require().True(result.Inferers[s.AddrsStr(0)].Lt(result.Inferers[s.AddrsStr(1)]))
+				s.Require().True(result.Forecasters[s.AddrsStr(2)].Gt(result.Forecasters[s.AddrsStr(3)]))
 				// compare mixed
-				s.Require().True(result.Forecasters[s.addrsStr[3]].Gt(result.Inferers[s.addrsStr[0]]))
-				s.Require().True(result.Forecasters[s.addrsStr[2]].Lt(result.Inferers[s.addrsStr[1]]))
+				s.Require().True(result.Forecasters[s.AddrsStr(3)].Gt(result.Inferers[s.AddrsStr(0)]))
+				s.Require().True(result.Forecasters[s.AddrsStr(2)].Lt(result.Inferers[s.AddrsStr(1)]))
 
 			},
 		},
 		{ // nolint: exhaustruct
 			name: "empty workers should error",
 			args: synth.CalcWeightsGivenWorkersArgs{
-				Logger:             s.ctx.Logger(),
+				Logger:             s.Ctx().Logger(),
 				Inferers:           []string{},
 				Forecasters:        []string{},
 				InfererToRegret:    map[string]*alloraMath.Dec{},
@@ -631,9 +505,9 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 		{ // nolint: exhaustruct
 			name: "missing regret values should error",
 			args: synth.CalcWeightsGivenWorkersArgs{
-				Logger:             s.ctx.Logger(),
-				Inferers:           []string{s.addrsStr[0]},
-				Forecasters:        []string{s.addrsStr[1]},
+				Logger:             s.Ctx().Logger(),
+				Inferers:           []string{s.AddrsStr(0)},
+				Forecasters:        []string{s.AddrsStr(1)},
 				InfererToRegret:    map[string]*alloraMath.Dec{},
 				ForecasterToRegret: map[string]*alloraMath.Dec{},
 				EpsilonTopic:       alloraMath.MustNewDecFromString("0.01"),

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -13,17 +13,17 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
+	testutil "github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type KeeperTestSuite struct {
-	alloratestutil.TestSuite
+	testutil.TestSuite
 }
 
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, &KeeperTestSuite{
-		alloratestutil.NewTestSuite("emissions_keeper"),
+		testutil.NewTestSuite("emissions_keeper"),
 	})
 }
 
@@ -2110,16 +2110,16 @@ func (s *KeeperTestSuite) TestGetActiveTopicIdsAtBlock() {
 
 	// Create topics using CreateTopic with functional options
 	topic1Id := s.CreateTopic(
-		alloratestutil.WithEpochLength(5),
-		alloratestutil.WithWorkerSubmissionWindow(5),
+		testutil.WithEpochLength(5),
+		testutil.WithWorkerSubmissionWindow(5),
 	)
 	s.CreateTopic(
-		alloratestutil.WithEpochLength(5),
-		alloratestutil.WithWorkerSubmissionWindow(5),
+		testutil.WithEpochLength(5),
+		testutil.WithWorkerSubmissionWindow(5),
 	) // Inactive topic
 	topic3Id := s.CreateTopic(
-		alloratestutil.WithEpochLength(15),
-		alloratestutil.WithWorkerSubmissionWindow(15),
+		testutil.WithEpochLength(15),
+		testutil.WithWorkerSubmissionWindow(15),
 	)
 
 	err = k.ActivateTopic(ctx, topic1Id)
@@ -2156,20 +2156,20 @@ func (s *KeeperTestSuite) TestTopicGoesInactivateOnEpochEndBlockIfLowWeight() {
 	epochLength4 := int64(5)
 
 	topic1Id := s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength1),
-		alloratestutil.WithWorkerSubmissionWindow(epochLength1),
+		testutil.WithEpochLength(epochLength1),
+		testutil.WithWorkerSubmissionWindow(epochLength1),
 	)
 	topic2Id := s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength2),
-		alloratestutil.WithWorkerSubmissionWindow(epochLength2),
+		testutil.WithEpochLength(epochLength2),
+		testutil.WithWorkerSubmissionWindow(epochLength2),
 	)
 	topic3Id := s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength3),
-		alloratestutil.WithWorkerSubmissionWindow(epochLength3),
+		testutil.WithEpochLength(epochLength3),
+		testutil.WithWorkerSubmissionWindow(epochLength3),
 	)
 	topic4Id := s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength4),
-		alloratestutil.WithWorkerSubmissionWindow(epochLength4),
+		testutil.WithEpochLength(epochLength4),
+		testutil.WithWorkerSubmissionWindow(epochLength4),
 	)
 
 	setTopicWeight := func(topicId uint64, revenue, stake int64) {
@@ -3371,8 +3371,8 @@ func (s *KeeperTestSuite) TestActiveTopicStakeRemoval() {
 
 	// Create a topic and activate it
 	s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength),
-		alloratestutil.WithWorkerSubmissionWindow(epochLength),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithWorkerSubmissionWindow(epochLength),
 	)
 	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err)
@@ -3428,8 +3428,8 @@ func (s *KeeperTestSuite) TestDelegateStakeRemoval() {
 
 	// Create a topic and activate it
 	s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength),
-		alloratestutil.WithWorkerSubmissionWindow(epochLength),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithWorkerSubmissionWindow(epochLength),
 	)
 	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err)
@@ -3485,8 +3485,8 @@ func (s *KeeperTestSuite) TestInactiveTopicStakeRemoval() {
 
 	// Create a topic but do NOT activate it
 	s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength),
-		alloratestutil.WithWorkerSubmissionWindow(epochLength),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithWorkerSubmissionWindow(epochLength),
 	)
 
 	// Verify the topic is not active
@@ -3540,8 +3540,8 @@ func (s *KeeperTestSuite) TestTopicWeightRecalculationAfterStakeRemoval() {
 
 	// Create and activate topic
 	s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength),
-		alloratestutil.WithWorkerSubmissionWindow(epochLength),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithWorkerSubmissionWindow(epochLength),
 	)
 	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err)
@@ -3615,8 +3615,8 @@ func (s *KeeperTestSuite) TestTopicWeightRecalculationWithMultipleTopics() {
 
 	// Create and activate both topics
 	topicId1, topicId2 :=
-		s.CreateTopic(alloratestutil.WithEpochLength(epochLength)),
-		s.CreateTopic(alloratestutil.WithEpochLength(epochLength))
+		s.CreateTopic(testutil.WithEpochLength(epochLength)),
+		s.CreateTopic(testutil.WithEpochLength(epochLength))
 	err = k.ActivateTopic(ctx, topicId1)
 	s.Require().NoError(err)
 	err = k.ActivateTopic(ctx, topicId2)
@@ -3922,7 +3922,7 @@ func getNewAddress() string {
 func (s *KeeperTestSuite) TestAppendInferenceWithResetActiveWorkers() {
 	ctx := s.Ctx()
 	k := s.EmissionsKeeper()
-	topicId := s.CreateTopic(alloratestutil.WithEpochLength(10801), alloratestutil.WithGroundTruthLag(10801))
+	topicId := s.CreateTopic(testutil.WithEpochLength(10801), testutil.WithGroundTruthLag(10801))
 	nonce := types.Nonce{BlockHeight: 10}
 	blockHeightInferences := int64(10)
 
@@ -5295,10 +5295,10 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendInference() {
 	groundTruthLag := int64(1000)
 
 	topicId := s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength),
-		alloratestutil.WithGroundTruthLag(groundTruthLag),
-		alloratestutil.WithInitialRegret("0.5"),
-		alloratestutil.WithEpochLastEnded(10000),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithGroundTruthLag(groundTruthLag),
+		testutil.WithInitialRegret("0.5"),
+		testutil.WithEpochLastEnded(10000),
 	)
 	worker := s.AddrsStr(0)
 	blockHeight := int64(10000)
@@ -5350,9 +5350,9 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendForecast() {
 	groundTruthLag := int64(1000)
 
 	topicId := s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength),
-		alloratestutil.WithGroundTruthLag(groundTruthLag),
-		alloratestutil.WithEpochLastEnded(10000),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithGroundTruthLag(groundTruthLag),
+		testutil.WithEpochLastEnded(10000),
 	)
 	worker := s.AddrsStr(0)
 	blockHeight := int64(10000)
@@ -5410,9 +5410,9 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendReputerLoss() {
 	groundTruthLag := int64(1000)
 
 	topicId := s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength),
-		alloratestutil.WithGroundTruthLag(groundTruthLag),
-		alloratestutil.WithEpochLastEnded(10000),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithGroundTruthLag(groundTruthLag),
+		testutil.WithEpochLastEnded(10000),
 	)
 	reputer := s.AddrsStr(0)
 	blockHeight := int64(10000)
@@ -5652,8 +5652,8 @@ func (s *KeeperTestSuite) TestRemoveTopicFromPreviousTopicWeights() {
 
 	// Create and activate topic
 	topicId := s.CreateTopic(
-		alloratestutil.WithEpochLength(epochLength),
-		alloratestutil.WithWorkerSubmissionWindow(workerSubmissionWindow),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithWorkerSubmissionWindow(workerSubmissionWindow),
 	)
 	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err)

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -12,7 +12,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
@@ -26,15 +25,6 @@ func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, &KeeperTestSuite{
 		alloratestutil.NewTestSuite("emissions_keeper"),
 	})
-}
-
-func (s *KeeperTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
-	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
-
-	err := s.BankKeeper().MintCoins(s.Ctx(), types.AlloraStakingAccountName, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
-	err = s.BankKeeper().SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
 }
 
 // WORKER NONCE TESTS
@@ -3973,6 +3963,7 @@ func (s *KeeperTestSuite) TestAppendInferenceWithResetActiveWorkers() {
 	// Create first set of inferences
 	inferences := make([]*types.Inference, 5)
 	for i := range inferences {
+		//nolint:exhaustruct
 		inferences[i] = &types.Inference{
 			TopicId:     topicId,
 			BlockHeight: blockHeightInferences,
@@ -4012,6 +4003,7 @@ func (s *KeeperTestSuite) TestAppendInferenceWithResetActiveWorkers() {
 	blockHeightInferences = blockHeightInferences + topic.EpochLength
 	inferences = make([]*types.Inference, 5)
 	for i := 1; i <= len(inferences); i++ {
+		//nolint:exhaustruct
 		inferences[i-1] = &types.Inference{
 			TopicId:     topicId,
 			BlockHeight: blockHeightInferences,
@@ -4130,7 +4122,6 @@ func (s *KeeperTestSuite) TestAppendForecast() {
 	newForecast := types.Forecast{
 		TopicId:     topicId,
 		BlockHeight: blockHeightInferences,
-		Forecaster:  "",
 		ForecastElements: []*types.ForecastElement{
 			{
 				Inferer: workers[0],
@@ -4223,6 +4214,7 @@ func (s *KeeperTestSuite) TestAppendForecastWithResetActiveForecasters() {
 	// Create forecasts for all workers
 	allForecasts := types.Forecasts{Forecasts: make([]*types.Forecast, len(workers))}
 	for i, worker := range workers {
+		//nolint:exhaustruct
 		allForecasts.Forecasts[i] = &types.Forecast{
 			TopicId:          topicId,
 			BlockHeight:      blockHeightInferences,

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -2,252 +2,59 @@ package keeper_test
 
 import (
 	"encoding/binary"
+	"fmt"
+	"strings"
 	"testing"
-	"time"
 
 	"cosmossdk.io/collections"
-	cosmosAddress "cosmossdk.io/core/address"
-	"cosmossdk.io/core/header"
-	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
-	storetypes "cosmossdk.io/store/types"
+	"github.com/cometbft/cometbft/crypto/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
-	"github.com/allora-network/allora-chain/x/emissions/module"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	minttypes "github.com/allora-network/allora-chain/x/mint/types"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/codec/address"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/testutil"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/stretchr/testify/suite"
-)
-
-const (
-	multiPerm  = "multiple permissions account"
-	randomPerm = "random permission"
 )
 
 type KeeperTestSuite struct {
-	suite.Suite
-
-	ctx             sdk.Context
-	codec           codec.Codec
-	addressCodec    cosmosAddress.Codec
-	accountKeeper   authkeeper.AccountKeeper
-	bankKeeper      bankkeeper.BaseKeeper
-	emissionsKeeper keeper.Keeper
-	appModule       module.AppModule
-	msgServer       types.MsgServiceServer
-	privKeys        []secp256k1.PrivKey
-	addrs           []sdk.AccAddress
-	addrsStr        []string
-	pubKeyHexStr    []string
-}
-
-func (s *KeeperTestSuite) SetupTest() {
-	var (
-		keyEmissions          = storetypes.NewKVStoreKey("emissions")
-		keyAccount            = storetypes.NewKVStoreKey("account")
-		keyBank               = storetypes.NewKVStoreKey("bank")
-		storeServiceEmissions = runtime.NewKVStoreService(keyEmissions)
-		storeServiceAccount   = runtime.NewKVStoreService(keyAccount)
-		storeServiceBank      = runtime.NewKVStoreService(keyBank)
-	)
-
-	// It's simply test suite setup so just ignore the exhaustruct linter
-	//nolint:exhaustruct
-	ctx := testutil.DefaultContextWithKeys(map[string]*storetypes.KVStoreKey{
-		"emissions": keyEmissions,
-		"account":   keyAccount,
-		"bank":      keyBank,
-	}, map[string]*storetypes.TransientStoreKey{
-		"transient_test": storetypes.NewTransientStoreKey("transient_test"),
-	}, nil).WithHeaderInfo(header.Info{Time: time.Now()})
-
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
-	s.codec = encCfg.Codec
-	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
-	s.addressCodec = addressCodec
-
-	maccPerms := map[string][]string{
-		"fee_collector":                {"minter"},
-		"mint":                         {"minter"},
-		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName: {"minter"},
-		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
-		minttypes.EcosystemModuleName:                    nil,
-		"bonded_tokens_pool":                             {"burner", "staking"},
-		"not_bonded_tokens_pool":                         {"burner", "staking"},
-		multiPerm:                                        {"burner", "minter", "staking"},
-		randomPerm:                                       {"random"},
-	}
-
-	accountKeeper := authkeeper.NewAccountKeeper(
-		encCfg.Codec,
-		storeServiceAccount,
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
-		params.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress("gov").String(),
-	)
-
-	s.privKeys, s.pubKeyHexStr, s.addrs, s.addrsStr = alloratestutil.GenerateTestAccounts(10)
-
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		encCfg.Codec,
-		storeServiceBank,
-		accountKeeper,
-		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		log.NewNopLogger(),
-	)
-
-	s.ctx = ctx
-	s.accountKeeper = accountKeeper
-	s.bankKeeper = bankKeeper
-	s.emissionsKeeper = keeper.NewKeeper(
-		encCfg.Codec,
-		addressCodec,
-		storeServiceEmissions,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-	// s.key = key
-	appModule := module.NewAppModule(encCfg.Codec, s.emissionsKeeper)
-	defaultGenesis := appModule.DefaultGenesis(encCfg.Codec)
-	appModule.InitGenesis(ctx, encCfg.Codec, defaultGenesis)
-	s.msgServer = msgserver.NewMsgServerImpl(s.emissionsKeeper)
-
-	s.appModule = appModule
-
-	// Add all tests addresses in whitelists
-	for _, addr := range s.addrsStr {
-		err := s.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToGlobalWhitelist(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, addr)
-		s.Require().NoError(err)
-	}
+	alloratestutil.TestSuite
 }
 
 func TestKeeperTestSuite(t *testing.T) {
-	suite.Run(t, new(KeeperTestSuite))
+	suite.Run(t, &KeeperTestSuite{
+		alloratestutil.NewTestSuite("emissions_keeper"),
+	})
 }
 
 func (s *KeeperTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
 
-	err := s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
+	err := s.BankKeeper().MintCoins(s.Ctx(), types.AlloraStakingAccountName, creatorInitialBalanceCoins)
 	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
+	err = s.BankKeeper().SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
 	s.Require().NoError(err)
 }
 
-func (s *KeeperTestSuite) mockTopic() types.Topic {
-	return types.Topic{
-		Id:                       123,
-		Creator:                  s.addrsStr[9],
-		Metadata:                 "metadata",
-		LossMethod:               "method",
-		EpochLastEnded:           123,
-		EpochLength:              135,
-		GroundTruthLag:           135,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		AllowNegative:            false,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		InitialRegret:            alloraMath.MustNewDecFromString("0.5"),
-		WorkerSubmissionWindow:   135,
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-	}
-}
-
-func (s *KeeperTestSuite) signValueBundle(valueBundle *types.ValueBundle, privateKey secp256k1.PrivKey) []byte {
-	require := s.Require()
-	src := make([]byte, 0)
-	src, err := valueBundle.XXX_Marshal(src, true)
-	require.NoError(err, "Marshall reputer value bundle should not return an error")
-
-	valueBundleSignature, err := privateKey.Sign(src)
-	require.NoError(err, "Sign should not return an error")
-
-	return valueBundleSignature
-}
-
-func (s *KeeperTestSuite) CreateOneTopic(epochLen int64) uint64 {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	// Create a topic first
-	metadata := "Some metadata for the new topic"
-	// Create a CreateNewTopicRequest message
-
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[0],
-		Metadata:                 metadata,
-		LossMethod:               "method",
-		EpochLength:              epochLen,
-		GroundTruthLag:           epochLen,
-		WorkerSubmissionWindow:   epochLen,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-
-	s.MintTokensToAddress(s.addrs[0], types.DefaultParams().CreateTopicFee)
-
-	result, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.NoError(err, "CreateTopic fails on first creation")
-
-	return result.TopicId
-}
-
-/// WORKER NONCE TESTS
+// WORKER NONCE TESTS
 
 func (s *KeeperTestSuite) TestAddWorkerNonce() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 
-	unfulfilledNonces, err := keeper.GetUnfulfilledWorkerNonces(ctx, topicId)
+	unfulfilledNonces, err := k.GetUnfulfilledWorkerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces")
 
 	s.Require().Empty(unfulfilledNonces.Nonces, "Unfulfilled nonces should be empty")
 
 	// Set worker nonce
 	newNonce := &types.Nonce{BlockHeight: 42}
-	err = keeper.AddWorkerNonce(ctx, topicId, newNonce)
+	err = k.AddWorkerNonce(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 
-	unfulfilledNonces, err = keeper.GetUnfulfilledWorkerNonces(ctx, topicId)
+	unfulfilledNonces, err = k.GetUnfulfilledWorkerNonces(ctx, topicId)
 	s.Require().NoError(err)
 
 	s.Require().Len(unfulfilledNonces.Nonces, 1, "Unfulfilled nonces should not be empty")
@@ -257,68 +64,68 @@ func (s *KeeperTestSuite) TestAddWorkerNonce() {
 }
 
 func (s *KeeperTestSuite) TestNewlyAddedWorkerNonceIsUnfulfilled() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	newNonce := &types.Nonce{BlockHeight: 42}
 
-	isUnfulfilled, err := keeper.IsWorkerNonceUnfulfilled(ctx, topicId, newNonce)
+	isUnfulfilled, err := k.IsWorkerNonceUnfulfilled(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 	s.Require().False(isUnfulfilled, "non existent nonce should not be listed as unfulfilled")
 
 	// Set worker nonce
-	err = keeper.AddWorkerNonce(ctx, topicId, newNonce)
+	err = k.AddWorkerNonce(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 
-	isUnfulfilled, err = keeper.IsWorkerNonceUnfulfilled(ctx, topicId, newNonce)
+	isUnfulfilled, err = k.IsWorkerNonceUnfulfilled(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 	s.Require().True(isUnfulfilled, "new nonce should be unfulfilled")
 }
 
 func (s *KeeperTestSuite) TestCanFulfillNewWorkerNonce() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	newNonce := &types.Nonce{BlockHeight: 42}
 
 	// Set worker nonce
-	err := keeper.AddWorkerNonce(ctx, topicId, newNonce)
+	err := k.AddWorkerNonce(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 
-	isUnfulfilled, err := keeper.IsWorkerNonceUnfulfilled(ctx, topicId, newNonce)
+	isUnfulfilled, err := k.IsWorkerNonceUnfulfilled(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 	s.Require().True(isUnfulfilled, "new nonce should not be unfulfilled")
 
 	// Fulfill the nonce
-	success, err := keeper.FulfillWorkerNonce(ctx, topicId, newNonce)
+	success, err := k.FulfillWorkerNonce(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 	s.Require().True(success, "nonce should be able to be fulfilled")
 
 	// Check that the nonce is no longer unfulfilled
-	isUnfulfilled, err = keeper.IsWorkerNonceUnfulfilled(ctx, topicId, newNonce)
+	isUnfulfilled, err = k.IsWorkerNonceUnfulfilled(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 	s.Require().False(isUnfulfilled, "new nonce should be fulfilled")
 }
 
 func (s *KeeperTestSuite) TestGetMultipleUnfulfilledWorkerNonces() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 
 	// Initially, ensure no unfulfilled nonces exist
-	initialNonces, err := keeper.GetUnfulfilledWorkerNonces(ctx, topicId)
+	initialNonces, err := k.GetUnfulfilledWorkerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces")
 	s.Require().Empty(initialNonces.Nonces, "Initial unfulfilled nonces should be empty")
 
 	// Set multiple worker nonces
 	nonceValues := []int64{42, 43, 44}
 	for _, val := range nonceValues {
-		err = keeper.AddWorkerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
+		err = k.AddWorkerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
 		s.Require().NoError(err, "Failed to add worker nonce")
 	}
 
 	// Retrieve and verify the nonces
-	retrievedNonces, err := keeper.GetUnfulfilledWorkerNonces(ctx, topicId)
+	retrievedNonces, err := k.GetUnfulfilledWorkerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces after adding")
 	s.Require().Len(retrievedNonces.Nonces, len(nonceValues), "Should match the number of added nonces")
 
@@ -329,36 +136,36 @@ func (s *KeeperTestSuite) TestGetMultipleUnfulfilledWorkerNonces() {
 }
 
 func (s *KeeperTestSuite) TestGetAndFulfillMultipleUnfulfilledWorkerNonces() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 
 	// Initially, ensure no unfulfilled nonces exist
-	initialNonces, err := keeper.GetUnfulfilledWorkerNonces(ctx, topicId)
+	initialNonces, err := k.GetUnfulfilledWorkerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces")
 	s.Require().Empty(initialNonces.Nonces, "Initial unfulfilled nonces should be empty")
 
 	// Set multiple worker nonces
 	nonceValues := []int64{42, 43, 44, 45, 46}
 	for _, val := range nonceValues {
-		err = keeper.AddWorkerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
+		err = k.AddWorkerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
 		s.Require().NoError(err, "Failed to add worker nonce")
 	}
 	// Retrieve and verify the nonces
-	retrievedNonces, err := keeper.GetUnfulfilledWorkerNonces(ctx, topicId)
+	retrievedNonces, err := k.GetUnfulfilledWorkerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces after fulfilling some")
 	s.Require().Len(retrievedNonces.Nonces, len(nonceValues), "Should match the number of unfulfilled nonces")
 
 	// Fulfill some nonces: 43 and 45
 	fulfillNonces := []int64{43, 45}
 	for _, val := range fulfillNonces {
-		success, err := keeper.FulfillWorkerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
+		success, err := k.FulfillWorkerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
 		s.Require().True(success, "Nonce should be successfully fulfilled")
 		s.Require().NoError(err, "Error fulfilling nonce")
 	}
 
 	// Retrieve and verify the nonces
-	retrievedNonces, err = keeper.GetUnfulfilledWorkerNonces(ctx, topicId)
+	retrievedNonces, err = k.GetUnfulfilledWorkerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces after fulfilling some")
 	s.Require().Len(retrievedNonces.Nonces, len(nonceValues)-len(fulfillNonces), "Should match the number of unfulfilled nonces")
 
@@ -370,8 +177,8 @@ func (s *KeeperTestSuite) TestGetAndFulfillMultipleUnfulfilledWorkerNonces() {
 }
 
 func (s *KeeperTestSuite) TestWorkerNonceLimitEnforcement() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	maxUnfulfilledRequests := 3
 	// Set the maximum number of unfulfilled worker nonces
@@ -379,18 +186,18 @@ func (s *KeeperTestSuite) TestWorkerNonceLimitEnforcement() {
 	params.MaxUnfulfilledWorkerRequests = uint64(maxUnfulfilledRequests)
 
 	// Set the maximum number of unfulfilled worker nonces via the SetParams method
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err, "Error retrieving nonces after addition")
 
 	// Initially add nonces to exceed the maxUnfulfilledRequests
 	nonceValues := []int64{10, 20, 30, 40, 50}
 	for _, val := range nonceValues {
-		err = keeper.AddWorkerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
+		err = k.AddWorkerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
 		s.Require().NoError(err, "Failed to add worker nonce")
 	}
 
 	// Retrieve and verify the nonces to check if only the last 'maxUnfulfilledRequests' are retained
-	unfulfilledNonces, err := keeper.GetUnfulfilledWorkerNonces(ctx, topicId)
+	unfulfilledNonces, err := k.GetUnfulfilledWorkerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces after addition")
 	s.Require().Len(unfulfilledNonces.Nonces, maxUnfulfilledRequests, "Should only contain max unfulfilled nonces")
 
@@ -401,24 +208,24 @@ func (s *KeeperTestSuite) TestWorkerNonceLimitEnforcement() {
 	}
 }
 
-/// REPUTER NONCE TESTS
+// REPUTER NONCE TESTS
 
 func (s *KeeperTestSuite) TestAddReputerNonce() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 
-	unfulfilledNonces, err := keeper.GetUnfulfilledReputerNonces(ctx, topicId)
+	unfulfilledNonces, err := k.GetUnfulfilledReputerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces")
 
 	s.Require().Empty(unfulfilledNonces.Nonces, "Unfulfilled nonces should be empty")
 
 	// Set reputer nonce
 	newReputerNonce := &types.Nonce{BlockHeight: 42}
-	err = keeper.AddReputerNonce(ctx, topicId, newReputerNonce)
+	err = k.AddReputerNonce(ctx, topicId, newReputerNonce)
 	s.Require().NoError(err)
 
-	unfulfilledNonces, err = keeper.GetUnfulfilledReputerNonces(ctx, topicId)
+	unfulfilledNonces, err = k.GetUnfulfilledReputerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces after addition")
 
 	s.Require().Len(unfulfilledNonces.Nonces, 1, "Unfulfilled nonces should not be empty")
@@ -431,77 +238,77 @@ func (s *KeeperTestSuite) TestAddReputerNonce() {
 }
 
 func (s *KeeperTestSuite) TestNewlyAddedReputerNonceIsUnfulfilled() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	newReputerNonce := &types.Nonce{BlockHeight: 42}
 
-	isUnfulfilled, err := keeper.IsReputerNonceUnfulfilled(ctx, topicId, newReputerNonce)
+	isUnfulfilled, err := k.IsReputerNonceUnfulfilled(ctx, topicId, newReputerNonce)
 	s.Require().NoError(err)
 	s.Require().False(isUnfulfilled, "Non-existent nonce should not be listed as unfulfilled")
 
 	// Set reputer nonce
-	err = keeper.AddReputerNonce(ctx, topicId, newReputerNonce)
+	err = k.AddReputerNonce(ctx, topicId, newReputerNonce)
 	s.Require().NoError(err)
 
-	isUnfulfilled, err = keeper.IsReputerNonceUnfulfilled(ctx, topicId, newReputerNonce)
+	isUnfulfilled, err = k.IsReputerNonceUnfulfilled(ctx, topicId, newReputerNonce)
 	s.Require().NoError(err)
 	s.Require().True(isUnfulfilled, "New nonce should be unfulfilled")
 }
 
 func (s *KeeperTestSuite) TestCanFulfillNewReputerNonce() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	newReputerNonce := &types.Nonce{BlockHeight: 42}
 
 	// Set reputer nonce
-	err := keeper.AddReputerNonce(ctx, topicId, newReputerNonce)
+	err := k.AddReputerNonce(ctx, topicId, newReputerNonce)
 	s.Require().NoError(err)
 
 	// Check that the nonce is the correct nonce
-	isUnfulfilled, err := keeper.IsReputerNonceUnfulfilled(ctx, topicId, newReputerNonce)
+	isUnfulfilled, err := k.IsReputerNonceUnfulfilled(ctx, topicId, newReputerNonce)
 	s.Require().NoError(err)
 	s.Require().True(isUnfulfilled, "New nonce should be unfulfilled")
 
 	// Fulfill the nonce
-	nonceIsUnfulfilled, err := keeper.FulfillReputerNonce(ctx, topicId, newReputerNonce)
+	nonceIsUnfulfilled, err := k.FulfillReputerNonce(ctx, topicId, newReputerNonce)
 	s.Require().NoError(err)
 	s.Require().True(nonceIsUnfulfilled, "Nonce should be able to be fulfilled")
 
 	// Check that the nonce is no longer unfulfilled
-	isUnfulfilled, err = keeper.IsReputerNonceUnfulfilled(ctx, topicId, newReputerNonce)
+	isUnfulfilled, err = k.IsReputerNonceUnfulfilled(ctx, topicId, newReputerNonce)
 	s.Require().NoError(err)
 	s.Require().False(isUnfulfilled, "New nonce should be fulfilled")
 }
 
 func (s *KeeperTestSuite) TestGetAndFulfillMultipleUnfulfilledReputerNonces() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 
 	// Initially, ensure no unfulfilled nonces exist
-	initialNonces, err := keeper.GetUnfulfilledReputerNonces(ctx, topicId)
+	initialNonces, err := k.GetUnfulfilledReputerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces")
 	s.Require().Empty(initialNonces.Nonces, "Initial unfulfilled nonces should be empty")
 
 	// Set multiple reputer nonces
 	nonceValues := []int64{42, 43, 44, 45, 46}
 	for _, val := range nonceValues {
-		err = keeper.AddReputerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
+		err = k.AddReputerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
 		s.Require().NoError(err, "Failed to add reputer nonce")
 	}
 
 	// Fulfill some nonces: 43 and 45
 	fulfillNonces := []int64{43, 45}
 	for _, val := range fulfillNonces {
-		nonceIsUnfulfilled, err := keeper.FulfillReputerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
+		nonceIsUnfulfilled, err := k.FulfillReputerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
 		s.Require().NoError(err, "Error fulfilling nonce")
 		s.Require().True(nonceIsUnfulfilled, "Nonce should be able to be fulfilled")
 	}
 
 	// Retrieve and verify the nonces
-	retrievedNonces, err := keeper.GetUnfulfilledReputerNonces(ctx, topicId)
+	retrievedNonces, err := k.GetUnfulfilledReputerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces after fulfilling some")
 	s.Require().Len(retrievedNonces.Nonces, len(nonceValues)-len(fulfillNonces), "Should match the number of unfulfilled nonces")
 
@@ -513,8 +320,8 @@ func (s *KeeperTestSuite) TestGetAndFulfillMultipleUnfulfilledReputerNonces() {
 }
 
 func (s *KeeperTestSuite) TestReputerNonceLimitEnforcement() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	maxUnfulfilledRequests := 3
 
@@ -523,18 +330,18 @@ func (s *KeeperTestSuite) TestReputerNonceLimitEnforcement() {
 	params.MaxUnfulfilledReputerRequests = uint64(maxUnfulfilledRequests)
 
 	// Set the maximum number of unfulfilled reputer nonces via the SetParams method
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err, "Failed to set parameters")
 
 	// Initially add nonces to exceed the maxUnfulfilledRequests
 	nonceValues := []int64{10, 20, 30, 40, 50}
 	for _, val := range nonceValues {
-		err := keeper.AddReputerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
+		err := k.AddReputerNonce(ctx, topicId, &types.Nonce{BlockHeight: val})
 		s.Require().NoError(err, "Failed to add reputer nonce")
 	}
 
 	// Retrieve and verify the nonces to check if only the last 'maxUnfulfilledRequests' are retained
-	unfulfilledNonces, err := keeper.GetUnfulfilledReputerNonces(ctx, topicId)
+	unfulfilledNonces, err := k.GetUnfulfilledReputerNonces(ctx, topicId)
 	s.Require().NoError(err, "Error retrieving nonces after addition")
 	s.Require().Len(unfulfilledNonces.Nonces, maxUnfulfilledRequests, "Should only contain max unfulfilled nonces")
 
@@ -545,82 +352,82 @@ func (s *KeeperTestSuite) TestReputerNonceLimitEnforcement() {
 	}
 }
 
-/// REGRET TESTS
+// REGRET TESTS
 
 func (s *KeeperTestSuite) TestSetAndGetInfererNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[1]
+	worker := s.AddrsStr(1)
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(10)}
 
 	// Set Inferer Network Regret
-	err := keeper.SetInfererNetworkRegret(ctx, topicId, worker, regret)
+	err := k.SetInfererNetworkRegret(ctx, topicId, worker, regret)
 	s.Require().NoError(err)
 
 	// Get Inferer Network Regret
-	gotRegret, _, err := keeper.GetInfererNetworkRegret(ctx, topicId, worker)
+	gotRegret, _, err := k.GetInfererNetworkRegret(ctx, topicId, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(regret, gotRegret)
 }
 
 func (s *KeeperTestSuite) TestSetAndGetForecasterNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[3] // Assuming sdk.AccAddress is initialized with a string representing the address
+	worker := s.AddrsStr(3) // Assuming sdk.AccAddress is initialized with a string representing the address
 
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(20)}
 
 	// Set Forecaster Network Regret
-	err := keeper.SetForecasterNetworkRegret(ctx, topicId, worker, regret)
+	err := k.SetForecasterNetworkRegret(ctx, topicId, worker, regret)
 	s.Require().NoError(err)
 
 	// Get Forecaster Network Regret
-	gotRegret, _, err := keeper.GetForecasterNetworkRegret(ctx, topicId, worker)
+	gotRegret, _, err := k.GetForecasterNetworkRegret(ctx, topicId, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(regret, gotRegret)
 	s.Require().Equal(regret.BlockHeight, gotRegret.BlockHeight)
 }
 
 func (s *KeeperTestSuite) TestSetAndGetOneInForecasterNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	forecaster := s.addrsStr[3]
-	inferer := s.addrsStr[1]
+	forecaster := s.AddrsStr(3)
+	inferer := s.AddrsStr(1)
 
 	regret := types.TimestampedValue{BlockHeight: 200, Value: alloraMath.NewDecFromInt64(30)}
 
 	// Set One-In Forecaster Network Regret
-	err := keeper.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster, inferer, regret)
+	err := k.SetOneInForecasterNetworkRegret(ctx, topicId, forecaster, inferer, regret)
 	s.Require().NoError(err)
 
 	// Get One-In Forecaster Network Regret
-	gotRegret, _, err := keeper.GetOneInForecasterNetworkRegret(ctx, topicId, forecaster, inferer)
+	gotRegret, _, err := k.GetOneInForecasterNetworkRegret(ctx, topicId, forecaster, inferer)
 	s.Require().NoError(err)
 	s.Require().Equal(regret, gotRegret)
 	s.Require().Equal(regret.BlockHeight, gotRegret.BlockHeight)
 }
 
 func (s *KeeperTestSuite) TestDifferentTopicIdsYieldDifferentInfererRegrets() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	worker := s.addrsStr[1]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	worker := s.AddrsStr(1)
 
 	// Topic IDs
-	topicId1 := s.CreateOneTopic(10800)
-	topicId2 := s.CreateOneTopic(10800)
+	topicId1 := s.CreateTopic()
+	topicId2 := s.CreateTopic()
 
 	// Zero regret for initial check
 	noRegret := types.TimestampedValue{BlockHeight: 0, Value: alloraMath.NewDecFromInt64(0)}
 
 	// Initial regrets should be zero
-	gotRegret1, _, err := keeper.GetInfererNetworkRegret(ctx, topicId1, worker)
+	gotRegret1, _, err := k.GetInfererNetworkRegret(ctx, topicId1, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(noRegret, gotRegret1, "Initial regret should be zero for Topic ID 1")
 
-	gotRegret2, _, err := keeper.GetInfererNetworkRegret(ctx, topicId2, worker)
+	gotRegret2, _, err := k.GetInfererNetworkRegret(ctx, topicId2, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(noRegret, gotRegret2, "Initial regret should be zero for Topic ID 2")
 
@@ -629,18 +436,18 @@ func (s *KeeperTestSuite) TestDifferentTopicIdsYieldDifferentInfererRegrets() {
 	regret2 := types.TimestampedValue{BlockHeight: 200, Value: alloraMath.NewDecFromInt64(20)}
 
 	// Set regrets for the same worker under different topic IDs
-	err = keeper.SetInfererNetworkRegret(ctx, topicId1, worker, regret1)
+	err = k.SetInfererNetworkRegret(ctx, topicId1, worker, regret1)
 	s.Require().NoError(err)
-	err = keeper.SetInfererNetworkRegret(ctx, topicId2, worker, regret2)
+	err = k.SetInfererNetworkRegret(ctx, topicId2, worker, regret2)
 	s.Require().NoError(err)
 
 	// Get and compare regrets after setting them
-	gotRegret1, _, err = keeper.GetInfererNetworkRegret(ctx, topicId1, worker)
+	gotRegret1, _, err = k.GetInfererNetworkRegret(ctx, topicId1, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(regret1, gotRegret1)
 	s.Require().Equal(regret1.BlockHeight, gotRegret1.BlockHeight)
 
-	gotRegret2, _, err = keeper.GetInfererNetworkRegret(ctx, topicId2, worker)
+	gotRegret2, _, err = k.GetInfererNetworkRegret(ctx, topicId2, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(regret2, gotRegret2)
 	s.Require().Equal(regret2.BlockHeight, gotRegret2.BlockHeight)
@@ -649,36 +456,36 @@ func (s *KeeperTestSuite) TestDifferentTopicIdsYieldDifferentInfererRegrets() {
 }
 
 func (s *KeeperTestSuite) TestDifferentTopicIdsYieldDifferentForecasterRegrets() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	worker := s.addrsStr[1]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	worker := s.AddrsStr(1)
 
 	// Topic IDs
-	topicId1 := s.CreateOneTopic(10800)
-	topicId2 := s.CreateOneTopic(10800)
+	topicId1 := s.CreateTopic()
+	topicId2 := s.CreateTopic()
 
 	// Regrets
 	noRagret := types.TimestampedValue{BlockHeight: 0, Value: alloraMath.NewDecFromInt64(0)}
 	regret1 := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(10)}
 	regret2 := types.TimestampedValue{BlockHeight: 200, Value: alloraMath.NewDecFromInt64(20)}
 
-	gotRegret1, _, err := keeper.GetForecasterNetworkRegret(ctx, topicId1, worker)
+	gotRegret1, _, err := k.GetForecasterNetworkRegret(ctx, topicId1, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(noRagret, gotRegret1)
 
 	// Set regrets for the same worker under different topic IDs
-	err = keeper.SetForecasterNetworkRegret(ctx, topicId1, worker, regret1)
+	err = k.SetForecasterNetworkRegret(ctx, topicId1, worker, regret1)
 	s.Require().NoError(err)
-	err = keeper.SetForecasterNetworkRegret(ctx, topicId2, worker, regret2)
+	err = k.SetForecasterNetworkRegret(ctx, topicId2, worker, regret2)
 	s.Require().NoError(err)
 
 	// Get and compare regrets
-	gotRegret1, _, err = keeper.GetForecasterNetworkRegret(ctx, topicId1, worker)
+	gotRegret1, _, err = k.GetForecasterNetworkRegret(ctx, topicId1, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(regret1, gotRegret1)
 	s.Require().Equal(regret1.BlockHeight, gotRegret1.BlockHeight)
 
-	gotRegret2, _, err := keeper.GetForecasterNetworkRegret(ctx, topicId2, worker)
+	gotRegret2, _, err := k.GetForecasterNetworkRegret(ctx, topicId2, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(regret2, gotRegret2)
 	s.Require().Equal(regret2.BlockHeight, gotRegret2.BlockHeight)
@@ -687,26 +494,22 @@ func (s *KeeperTestSuite) TestDifferentTopicIdsYieldDifferentForecasterRegrets()
 }
 
 func (s *KeeperTestSuite) TestDifferentTopicIdsYieldDifferentOneInForecasterNetworkRegrets() {
-	ctx := s.ctx
-	s.CreateOneTopic(10800) // Topic 1
-	s.CreateOneTopic(10800) // Topic 2
-	keeper := s.emissionsKeeper
-	forecaster := s.addrsStr[3]
-	inferer := s.addrsStr[1]
-
-	// Topic IDs
-	topicId1 := uint64(1)
-	topicId2 := uint64(2)
+	ctx := s.Ctx()
+	topicId1 := s.CreateTopic() // Topic 1
+	topicId2 := s.CreateTopic() // Topic 2
+	k := s.EmissionsKeeper()
+	forecaster := s.AddrsStr(3)
+	inferer := s.AddrsStr(1)
 
 	// Zero regret for initial checks
 	noRegret := types.TimestampedValue{BlockHeight: 0, Value: alloraMath.NewDecFromInt64(0)}
 
 	// Initial regrets should be zero
-	gotRegret1, _, err := keeper.GetOneInForecasterNetworkRegret(ctx, topicId1, forecaster, inferer)
+	gotRegret1, _, err := k.GetOneInForecasterNetworkRegret(ctx, topicId1, forecaster, inferer)
 	s.Require().NoError(err)
 	s.Require().Equal(noRegret, gotRegret1, "Initial regret should be zero for Topic ID 1")
 
-	gotRegret2, _, err := keeper.GetOneInForecasterNetworkRegret(ctx, topicId2, forecaster, inferer)
+	gotRegret2, _, err := k.GetOneInForecasterNetworkRegret(ctx, topicId2, forecaster, inferer)
 	s.Require().NoError(err)
 	s.Require().Equal(noRegret, gotRegret2, "Initial regret should be zero for Topic ID 2")
 
@@ -715,18 +518,18 @@ func (s *KeeperTestSuite) TestDifferentTopicIdsYieldDifferentOneInForecasterNetw
 	regret2 := types.TimestampedValue{BlockHeight: 200, Value: alloraMath.NewDecFromInt64(20)}
 
 	// Set regrets for the same forecaster-inferer pair under different topic IDs
-	err = keeper.SetOneInForecasterNetworkRegret(ctx, topicId1, forecaster, inferer, regret1)
+	err = k.SetOneInForecasterNetworkRegret(ctx, topicId1, forecaster, inferer, regret1)
 	s.Require().NoError(err)
-	err = keeper.SetOneInForecasterNetworkRegret(ctx, topicId2, forecaster, inferer, regret2)
+	err = k.SetOneInForecasterNetworkRegret(ctx, topicId2, forecaster, inferer, regret2)
 	s.Require().NoError(err)
 
 	// Get and compare regrets after setting them
-	gotRegret1, _, err = keeper.GetOneInForecasterNetworkRegret(ctx, topicId1, forecaster, inferer)
+	gotRegret1, _, err = k.GetOneInForecasterNetworkRegret(ctx, topicId1, forecaster, inferer)
 	s.Require().NoError(err)
 	s.Require().Equal(regret1, gotRegret1)
 	s.Require().Equal(regret1.BlockHeight, gotRegret1.BlockHeight)
 
-	gotRegret2, _, err = keeper.GetOneInForecasterNetworkRegret(ctx, topicId2, forecaster, inferer)
+	gotRegret2, _, err = k.GetOneInForecasterNetworkRegret(ctx, topicId2, forecaster, inferer)
 	s.Require().NoError(err)
 	s.Require().Equal(regret2, gotRegret2)
 	s.Require().Equal(regret2.BlockHeight, gotRegret2.BlockHeight)
@@ -735,368 +538,368 @@ func (s *KeeperTestSuite) TestDifferentTopicIdsYieldDifferentOneInForecasterNetw
 }
 
 func (s *KeeperTestSuite) TestSetAndGetNaiveInfererNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	inferer := s.addrsStr[1]
+	inferer := s.AddrsStr(1)
 
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(10)}
 
-	err := keeper.SetNaiveInfererNetworkRegret(ctx, topicId, inferer, regret)
+	err := k.SetNaiveInfererNetworkRegret(ctx, topicId, inferer, regret)
 	s.Require().NoError(err)
 
-	gotRegret, _, err := keeper.GetNaiveInfererNetworkRegret(ctx, topicId, inferer)
+	gotRegret, _, err := k.GetNaiveInfererNetworkRegret(ctx, topicId, inferer)
 	s.Require().NoError(err)
 	s.Require().Equal(regret, gotRegret)
 }
 
 func (s *KeeperTestSuite) TestSetAndGetLatestOneOutInfererInfererNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
 
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(15)}
 
-	err := keeper.SetOneOutInfererInfererNetworkRegret(ctx, topicId, inferer1, inferer2, regret)
+	err := k.SetOneOutInfererInfererNetworkRegret(ctx, topicId, inferer1, inferer2, regret)
 	s.Require().NoError(err)
 
-	gotRegret, _, err := keeper.GetOneOutInfererInfererNetworkRegret(ctx, topicId, inferer1, inferer2)
+	gotRegret, _, err := k.GetOneOutInfererInfererNetworkRegret(ctx, topicId, inferer1, inferer2)
 	s.Require().NoError(err)
 	s.Require().Equal(regret, gotRegret)
 }
 
 func (s *KeeperTestSuite) TestSetAndGetLatestOneOutInfererForecasterNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	inferer := s.addrsStr[1]
-	forecaster := s.addrsStr[3]
+	inferer := s.AddrsStr(1)
+	forecaster := s.AddrsStr(3)
 
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(20)}
 
-	err := keeper.SetOneOutInfererForecasterNetworkRegret(ctx, topicId, inferer, forecaster, regret)
+	err := k.SetOneOutInfererForecasterNetworkRegret(ctx, topicId, inferer, forecaster, regret)
 	s.Require().NoError(err)
 
-	gotRegret, _, err := keeper.GetOneOutInfererForecasterNetworkRegret(ctx, topicId, inferer, forecaster)
+	gotRegret, _, err := k.GetOneOutInfererForecasterNetworkRegret(ctx, topicId, inferer, forecaster)
 	s.Require().NoError(err)
 	s.Require().Equal(regret, gotRegret)
 }
 
 func (s *KeeperTestSuite) TestSetAndGetLatestOneOutForecasterInfererNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	forecaster := s.addrsStr[3]
-	inferer := s.addrsStr[1]
+	forecaster := s.AddrsStr(3)
+	inferer := s.AddrsStr(1)
 
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(25)}
 
-	err := keeper.SetOneOutForecasterInfererNetworkRegret(ctx, topicId, forecaster, inferer, regret)
+	err := k.SetOneOutForecasterInfererNetworkRegret(ctx, topicId, forecaster, inferer, regret)
 	s.Require().NoError(err)
 
-	gotRegret, _, err := keeper.GetOneOutForecasterInfererNetworkRegret(ctx, topicId, forecaster, inferer)
+	gotRegret, _, err := k.GetOneOutForecasterInfererNetworkRegret(ctx, topicId, forecaster, inferer)
 	s.Require().NoError(err)
 	s.Require().Equal(regret, gotRegret)
 }
 
 func (s *KeeperTestSuite) TestSetAndGetLatestOneOutForecasterForecasterNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	forecaster1 := s.addrsStr[3]
-	forecaster2 := s.addrsStr[4]
+	forecaster1 := s.AddrsStr(3)
+	forecaster2 := s.AddrsStr(4)
 
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(30)}
 
-	err := keeper.SetOneOutForecasterForecasterNetworkRegret(ctx, topicId, forecaster1, forecaster2, regret)
+	err := k.SetOneOutForecasterForecasterNetworkRegret(ctx, topicId, forecaster1, forecaster2, regret)
 	s.Require().NoError(err)
 
-	gotRegret, _, err := keeper.GetOneOutForecasterForecasterNetworkRegret(ctx, topicId, forecaster1, forecaster2)
+	gotRegret, _, err := k.GetOneOutForecasterForecasterNetworkRegret(ctx, topicId, forecaster1, forecaster2)
 	s.Require().NoError(err)
 	s.Require().Equal(regret, gotRegret)
 }
 
-// / PARAMS TESTS
+// PARAMS TESTS
 func (s *KeeperTestSuite) TestSetGetMaxTopicsPerBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := uint64(100)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.MaxActiveTopicsPerBlock = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.MaxActiveTopicsPerBlock
 	s.Require().Equal(expectedValue, actualValue)
 }
 
 func (s *KeeperTestSuite) TestSetGetRemoveStakeDelayWindow() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := types.BlockHeight(50)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.RemoveStakeDelayWindow = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.RemoveStakeDelayWindow
 	s.Require().Equal(expectedValue, actualValue)
 }
 
 func (s *KeeperTestSuite) TestSetGetValidatorsVsAlloraPercentReward() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := alloraMath.MustNewDecFromString("0.25") // Assume a function to create LegacyDec
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.ValidatorsVsAlloraPercentReward = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.ValidatorsVsAlloraPercentReward
 	s.Require().Equal(expectedValue, actualValue)
 }
 
 func (s *KeeperTestSuite) TestGetParamsMinTopicUnmetDemand() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := alloraMath.NewDecFromInt64(300)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.MinTopicWeight = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.MinTopicWeight
 	s.Require().Equal(expectedValue, actualValue)
 }
 
 func (s *KeeperTestSuite) TestGetParamsRequiredMinimumStake() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue, ok := cosmosMath.NewIntFromString("500")
 	s.Require().True(ok)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.RequiredMinimumStake = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.RequiredMinimumStake
 	s.Require().Equal(expectedValue, actualValue)
 }
 
 func (s *KeeperTestSuite) TestGetParamsMinEpochLength() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := types.BlockHeight(720)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.MinEpochLength = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.MinEpochLength
 	s.Require().Equal(expectedValue, actualValue)
 }
 
 func (s *KeeperTestSuite) TestGetParamsEpsilon() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := alloraMath.MustNewDecFromString("0.1234")
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.EpsilonReputer = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.EpsilonReputer
 	s.Require().True(expectedValue.Equal(actualValue))
 }
 
 func (s *KeeperTestSuite) TestGetParamsTopicCreationFee() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := cosmosMath.NewInt(1000)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.CreateTopicFee = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.CreateTopicFee
 	s.Require().True(expectedValue.Equal(actualValue))
 }
 
 func (s *KeeperTestSuite) TestGetParamsRegistrationFee() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := cosmosMath.NewInt(500)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.RegistrationFee = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.RegistrationFee
 	s.Require().True(expectedValue.Equal(actualValue))
 }
 
 func (s *KeeperTestSuite) TestGetParamsMaxSamplesToScaleScores() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := uint64(1500)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.MaxSamplesToScaleScores = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.MaxSamplesToScaleScores
 	s.Require().Equal(expectedValue, actualValue)
 }
 
 func (s *KeeperTestSuite) TestGetParamsMaxTopInferersToReward() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := uint64(50) // Example expected value
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.MaxTopInferersToReward = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.MaxTopInferersToReward
 	s.Require().Equal(expectedValue, actualValue, "The retrieved MaxTopInferersToReward should match the expected value")
 }
 
 func (s *KeeperTestSuite) TestGetParamsMaxTopForecastersToReward() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := uint64(50) // Example expected value
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.MaxTopForecastersToReward = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
 
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.MaxTopForecastersToReward
 	s.Require().Equal(expectedValue, actualValue, "The retrieved MaxTopForecastersToReward should match the expected value")
 }
 
 func (s *KeeperTestSuite) TestGetParamsMaxTopForecasterElementToSubmit() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := uint64(50) // Example expected value
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.MaxElementsPerForecast = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
 
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.MaxElementsPerForecast
 	s.Require().Equal(expectedValue, actualValue, "The retrieved MaxElementsPerForecast should match the expected value")
 }
 
 func (s *KeeperTestSuite) TestGetMinEpochLengthRecordLimit() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := int64(10)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.MinEpochLengthRecordLimit = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.MinEpochLengthRecordLimit
 	s.Require().Equal(expectedValue, actualValue, "The retrieved MinEpochLengthRecordLimit should be equal to the expected value")
 }
 
 func (s *KeeperTestSuite) TestGetMaxSerializedMsgLength() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	expectedValue := int64(2048)
 
 	// Set the parameter
 	params := types.DefaultParams()
 	params.MaxSerializedMsgLength = expectedValue
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Get the parameter
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	actualValue := moduleParams.MaxSerializedMsgLength
 	s.Require().Equal(expectedValue, actualValue, "The retrieved MaxSerializedMsgLength should be equal to the expected value")
 }
 
-/// INFERENCES, FORECASTS
+// INFERENCES, FORECASTS
 
 func (s *KeeperTestSuite) TestGetInferencesAtBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	block := types.BlockHeight(100)
 	expectedInferences := types.Inferences{
@@ -1118,24 +921,24 @@ func (s *KeeperTestSuite) TestGetInferencesAtBlock() {
 
 	// Assume InsertActiveInferences correctly sets up inferences
 	nonce := types.Nonce{BlockHeight: block} // Assuming block type cast to int64 if needed
-	err := keeper.InsertActiveInferences(ctx, topicId, nonce.BlockHeight, expectedInferences)
+	err := k.InsertActiveInferences(ctx, topicId, nonce.BlockHeight, expectedInferences)
 	s.Require().NoError(err)
 
 	// Retrieve inferences
-	actualInferences, err := keeper.GetInferencesAtBlock(ctx, topicId, block, false)
+	actualInferences, err := k.GetInferencesAtBlock(ctx, topicId, block, false)
 	s.Require().NoError(err)
 	s.Require().Equal(&expectedInferences, actualInferences)
 }
 
 func (s *KeeperTestSuite) TestGetInferencesAtBlockOutlierResistant() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	block := types.BlockHeight(100)
 	// Force setting values of MAD and last_median to 10
-	err := keeper.SetLastMedianInferences(ctx, topicId, alloraMath.NewDecFromInt64(150))
+	err := k.SetLastMedianInferences(ctx, topicId, alloraMath.NewDecFromInt64(150))
 	s.Require().NoError(err)
-	err = keeper.SetMadInferences(ctx, topicId, alloraMath.NewDecFromInt64(10))
+	err = k.SetMadInferences(ctx, topicId, alloraMath.NewDecFromInt64(10))
 	s.Require().NoError(err)
 
 	// Create a set of inferences with a high value to test outlier resistant filtering
@@ -1164,15 +967,15 @@ func (s *KeeperTestSuite) TestGetInferencesAtBlockOutlierResistant() {
 
 	// Insert directly as active inferences
 	nonce := types.Nonce{BlockHeight: block}
-	err = keeper.InsertActiveInferences(ctx, topicId, nonce.BlockHeight, expectedInferences)
+	err = k.InsertActiveInferences(ctx, topicId, nonce.BlockHeight, expectedInferences)
 	s.Require().NoError(err)
 
 	// Confirm the non-or keeps all inferences
-	actualInferences, err := keeper.GetInferencesAtBlock(ctx, topicId, block, false)
+	actualInferences, err := k.GetInferencesAtBlock(ctx, topicId, block, false)
 	s.Require().NoError(err)
 	s.Require().Len(actualInferences.Inferences, 3)
 
-	actualInferences, err = keeper.GetInferencesAtBlock(ctx, topicId, block, true)
+	actualInferences, err = k.GetInferencesAtBlock(ctx, topicId, block, true)
 	s.Require().NoError(err)
 	s.Require().Len(actualInferences.Inferences, 2)
 	s.Require().Equal(alloraMath.NewDecFromInt64(100), actualInferences.Inferences[0].Value)
@@ -1181,13 +984,13 @@ func (s *KeeperTestSuite) TestGetInferencesAtBlockOutlierResistant() {
 }
 
 func (s *KeeperTestSuite) TestGetLatestTopicInferences() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	topicId := uint64(1)
 
 	// Initially, there should be no inferences, so we expect an empty result
-	emptyInferences, emptyBlockHeight, err := keeper.GetLatestTopicInferences(ctx, topicId, false)
+	emptyInferences, emptyBlockHeight, err := k.GetLatestTopicInferences(ctx, topicId, false)
 	s.Require().NoError(err, "Retrieving latest inferences when none exist should not result in an error")
 	s.Require().Equal(&types.Inferences{Inferences: []*types.Inference{}}, emptyInferences, "Expected no inferences initially")
 	s.Require().Equal(types.BlockHeight(0), emptyBlockHeight, "Expected block height to be zero initially")
@@ -1206,7 +1009,7 @@ func (s *KeeperTestSuite) TestGetLatestTopicInferences() {
 		Inferences: []*types.Inference{&newInference1},
 	}
 	nonce1 := types.Nonce{BlockHeight: blockHeight1}
-	err = keeper.InsertActiveInferences(ctx, topicId, nonce1.BlockHeight, inferences1)
+	err = k.InsertActiveInferences(ctx, topicId, nonce1.BlockHeight, inferences1)
 	s.Require().NoError(err, "Inserting first set of inferences should not fail")
 
 	// Insert second set of inferences
@@ -1223,24 +1026,24 @@ func (s *KeeperTestSuite) TestGetLatestTopicInferences() {
 		Inferences: []*types.Inference{&newInference2},
 	}
 	nonce2 := types.Nonce{BlockHeight: blockHeight2}
-	err = keeper.InsertActiveInferences(ctx, topicId, nonce2.BlockHeight, inferences2)
+	err = k.InsertActiveInferences(ctx, topicId, nonce2.BlockHeight, inferences2)
 	s.Require().NoError(err, "Inserting second set of inferences should not fail")
 
 	// Retrieve the latest inferences
-	latestInferences, latestBlockHeight, err := keeper.GetLatestTopicInferences(ctx, topicId, false)
+	latestInferences, latestBlockHeight, err := k.GetLatestTopicInferences(ctx, topicId, false)
 	s.Require().NoError(err, "Retrieving latest inferences should not fail")
 	s.Require().Equal(&inferences2, latestInferences, "Latest inferences should match the second inserted set")
 	s.Require().Equal(blockHeight2, latestBlockHeight, "Latest block height should match the second inserted set")
 }
 
 func (s *KeeperTestSuite) TestGetWorkerLatestInferenceByTopicId() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	topicId := uint64(1)
 	workerAccStr := "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec"
 
-	_, err := keeper.GetWorkerLatestInferenceByTopicId(ctx, topicId, workerAccStr)
+	_, err := k.GetWorkerLatestInferenceByTopicId(ctx, topicId, workerAccStr)
 	s.Require().Error(err, "Retrieving an inference that does not exist should result in an error")
 
 	blockHeight1 := int64(12345)
@@ -1252,7 +1055,7 @@ func (s *KeeperTestSuite) TestGetWorkerLatestInferenceByTopicId() {
 		ExtraData:   []byte("data"),
 		Proof:       "proof123",
 	}
-	err = keeper.InsertInference(ctx, topicId, newInference1)
+	err = k.InsertInference(ctx, topicId, newInference1)
 	s.Require().NoError(err, "Inserting inferences should not fail")
 
 	blockHeight2 := int64(12346)
@@ -1264,17 +1067,17 @@ func (s *KeeperTestSuite) TestGetWorkerLatestInferenceByTopicId() {
 		ExtraData:   []byte("data"),
 		Proof:       "proof123",
 	}
-	err = keeper.InsertInference(ctx, topicId, newInference2)
+	err = k.InsertInference(ctx, topicId, newInference2)
 	s.Require().NoError(err, "Inserting inferences should not fail")
 
-	retrievedInference, err := keeper.GetWorkerLatestInferenceByTopicId(ctx, topicId, workerAccStr)
+	retrievedInference, err := k.GetWorkerLatestInferenceByTopicId(ctx, topicId, workerAccStr)
 	s.Require().NoError(err, "Retrieving an existing inference should not fail")
 	s.Require().Equal(newInference2, retrievedInference, "Retrieved inference should match the inserted one")
 }
 
 func (s *KeeperTestSuite) TestGetForecastsAtBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	block := types.BlockHeight(100)
 	expectedForecasts := types.Forecasts{
@@ -1314,98 +1117,90 @@ func (s *KeeperTestSuite) TestGetForecastsAtBlock() {
 
 	// Assume InsertActiveForecasts correctly sets up forecasts
 	nonce := types.Nonce{BlockHeight: block}
-	err := keeper.InsertActiveForecasts(ctx, topicId, nonce.BlockHeight, expectedForecasts)
+	err := k.InsertActiveForecasts(ctx, topicId, nonce.BlockHeight, expectedForecasts)
 	s.Require().NoError(err)
 
 	// Retrieve forecasts
-	actualForecasts, err := keeper.GetForecastsAtBlock(ctx, topicId, block)
+	actualForecasts, err := k.GetForecastsAtBlock(ctx, topicId, block)
 	s.Require().NoError(err)
 	s.Require().Equal(&expectedForecasts, actualForecasts)
 }
 
 func (s *KeeperTestSuite) TestInsertActiveReputerLosses() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	topicId := uint64(1)
 	block := types.BlockHeight(100)
 
+	//nolint:exhaustruct
 	valueBundle := &types.ValueBundle{
 		TopicId: topicId,
 		ReputerRequestNonce: &types.ReputerRequestNonce{
 			ReputerNonce: &types.Nonce{BlockHeight: block},
 		},
-		Reputer:                       s.addrsStr[0],
-		ExtraData:                     []byte("data"),
-		CombinedValue:                 alloraMath.MustNewDecFromString("123"),
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		Reputer:       s.AddrsStr(0),
+		ExtraData:     []byte("data"),
+		CombinedValue: alloraMath.MustNewDecFromString("123"),
+		InfererValues: s.createDefaultInfererValues(),
+		NaiveValue:    alloraMath.MustNewDecFromString("123"),
 	}
-	signature := s.signValueBundle(valueBundle, s.privKeys[0])
+	signature := s.SignValueBundle(valueBundle, s.PrivKeys(0))
 	reputerLossBundles := types.ReputerValueBundles{
 		ReputerValueBundles: []*types.ReputerValueBundle{
 			{
 				ValueBundle: valueBundle,
 				Signature:   signature,
-				Pubkey:      s.pubKeyHexStr[0],
+				Pubkey:      s.PubKeyHexStr(0),
 			},
 		},
 	}
 
 	// Test inserting data
-	err := s.emissionsKeeper.InsertActiveReputerLosses(ctx, topicId, block, reputerLossBundles)
+	err := s.EmissionsKeeper().InsertActiveReputerLosses(ctx, topicId, block, reputerLossBundles)
 	require.NoError(err, "InsertActiveReputerLosses should not return an error")
 
 	// Retrieve data to verify insertion
-	result, err := s.emissionsKeeper.GetReputerLossBundlesAtBlock(ctx, topicId, block)
+	result, err := s.EmissionsKeeper().GetReputerLossBundlesAtBlock(ctx, topicId, block)
 	require.NoError(err)
 	require.NotNil(result)
 	require.Equal(&reputerLossBundles, result, "Retrieved data should match inserted data")
 }
 
 func (s *KeeperTestSuite) TestGetReputerLossBundlesAtBlock() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	topicId := uint64(1)
 	block := types.BlockHeight(100)
 
 	// Test getting data before any insert, should return error or nil
-	result, err := s.emissionsKeeper.GetReputerLossBundlesAtBlock(ctx, topicId, block)
+	result, err := s.EmissionsKeeper().GetReputerLossBundlesAtBlock(ctx, topicId, block)
 	require.NoError(err)
 	require.Empty(result.ReputerValueBundles, "Result should be empty for non-existent data")
 }
 
 func (s *KeeperTestSuite) TestInsertNetworkLossBundleAtBlock() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	topicId := uint64(1)
 	block := types.BlockHeight(100)
+	//nolint:exhaustruct
 	lossBundle := types.ValueBundle{
 		TopicId: topicId,
 		ReputerRequestNonce: &types.ReputerRequestNonce{
 			ReputerNonce: &types.Nonce{BlockHeight: block},
 		},
-		Reputer:                       "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
-		ExtraData:                     []byte("data"),
-		CombinedValue:                 alloraMath.MustNewDecFromString("123"),
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		Reputer:       "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+		ExtraData:     []byte("data"),
+		CombinedValue: alloraMath.MustNewDecFromString("123"),
+		InfererValues: s.createDefaultInfererValues(),
+		NaiveValue:    alloraMath.MustNewDecFromString("123"),
 	}
 
-	err := s.emissionsKeeper.InsertNetworkLossBundleAtBlock(ctx, topicId, block, lossBundle)
+	err := s.EmissionsKeeper().InsertNetworkLossBundleAtBlock(ctx, topicId, block, lossBundle)
 	require.NoError(err, "InsertNetworkLossBundleAtBlock should not return an error")
 
 	// Verify the insertion
-	result, err := s.emissionsKeeper.GetNetworkLossBundleAtBlock(ctx, topicId, block)
+	result, err := s.EmissionsKeeper().GetNetworkLossBundleAtBlock(ctx, topicId, block)
 	require.NoError(err)
 	require.NotNil(result)
 	require.Equal(&lossBundle, result, "Retrieved data should match inserted data")
@@ -1413,72 +1208,64 @@ func (s *KeeperTestSuite) TestInsertNetworkLossBundleAtBlock() {
 
 // this unit test needs to be completely rewritten, PROTO-2575
 func (s *KeeperTestSuite) TestGetNetworkLossBundleAtBlock() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	topicId := uint64(1)
 	block := types.BlockHeight(100)
 
 	// Attempt to retrieve before insertion
-	result, err := s.emissionsKeeper.GetNetworkLossBundleAtBlock(ctx, topicId, block)
+	result, err := s.EmissionsKeeper().GetNetworkLossBundleAtBlock(ctx, topicId, block)
 	require.NoError(err, "Should not return error for empty loss bundle")
 	require.NotNil(result)
 	require.Equal(topicId, result.TopicId, "Result should be not be nil for non-existent data")
 }
 
 func (s *KeeperTestSuite) TestGetLatestNetworkLossBundle() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
 
 	// Initially, there should be no loss bundle, so we expect a zero result
-	emptyLossBundle, err := keeper.GetLatestNetworkLossBundle(ctx, topicId)
+	emptyLossBundle, err := k.GetLatestNetworkLossBundle(ctx, topicId)
 	s.Require().ErrorIs(err, types.ErrNotFound)
 	s.Require().Nil(emptyLossBundle, "Expected no network loss bundle initially")
 
 	// Insert first network loss bundle
 	blockHeight1 := types.BlockHeight(100)
+	//nolint:exhaustruct
 	lossBundle1 := types.ValueBundle{
 		TopicId: topicId,
 		ReputerRequestNonce: &types.ReputerRequestNonce{
 			ReputerNonce: &types.Nonce{BlockHeight: blockHeight1},
 		},
-		Reputer:                       "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
-		ExtraData:                     []byte("data"),
-		CombinedValue:                 alloraMath.MustNewDecFromString("123"),
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		Reputer:       "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+		ExtraData:     []byte("data"),
+		CombinedValue: alloraMath.MustNewDecFromString("123"),
+		InfererValues: s.createDefaultInfererValues(),
+		NaiveValue:    alloraMath.MustNewDecFromString("123"),
 	}
-	err = keeper.InsertNetworkLossBundleAtBlock(ctx, topicId, blockHeight1, lossBundle1)
+	err = k.InsertNetworkLossBundleAtBlock(ctx, topicId, blockHeight1, lossBundle1)
 	s.Require().NoError(err, "Inserting first network loss bundle should not fail")
 
 	// Insert second network loss bundle
 	blockHeight2 := types.BlockHeight(200)
+	//nolint:exhaustruct
 	lossBundle2 := types.ValueBundle{
 		TopicId: topicId,
 		ReputerRequestNonce: &types.ReputerRequestNonce{
 			ReputerNonce: &types.Nonce{BlockHeight: blockHeight2},
 		},
-		Reputer:                       "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
-		ExtraData:                     []byte("data"),
-		CombinedValue:                 alloraMath.MustNewDecFromString("456"),
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		Reputer:       "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve",
+		ExtraData:     []byte("data"),
+		CombinedValue: alloraMath.MustNewDecFromString("456"),
+		InfererValues: s.createDefaultInfererValues(),
+		NaiveValue:    alloraMath.MustNewDecFromString("123"),
 	}
-	err = keeper.InsertNetworkLossBundleAtBlock(ctx, topicId, blockHeight2, lossBundle2)
+	err = k.InsertNetworkLossBundleAtBlock(ctx, topicId, blockHeight2, lossBundle2)
 	s.Require().NoError(err, "Inserting second network loss bundle should not fail")
 
 	// Retrieve the latest network loss bundle
-	latestLossBundle, err := keeper.GetLatestNetworkLossBundle(ctx, topicId)
+	latestLossBundle, err := k.GetLatestNetworkLossBundle(ctx, topicId)
 	s.Require().NoError(err, "Retrieving latest network loss bundle should not fail")
 	s.Require().Equal(&lossBundle2, latestLossBundle, "Latest network loss bundle should match the second inserted set")
 }
@@ -1488,25 +1275,25 @@ func (s *KeeperTestSuite) TestGetLatestNetworkLossBundle() {
 // ########################################
 
 func (s *KeeperTestSuite) TestGetSetTotalStake() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	// Set total stake
 	newTotalStake := cosmosMath.NewInt(1000)
-	err := keeper.SetTotalStake(ctx, newTotalStake)
+	err := k.SetTotalStake(ctx, newTotalStake)
 	s.Require().NoError(err)
 
 	// Check total stake
-	totalStake, err := keeper.GetTotalStake(ctx)
+	totalStake, err := k.GetTotalStake(ctx)
 	s.Require().NoError(err)
 	s.Require().Equal(newTotalStake, totalStake)
 }
 
 func (s *KeeperTestSuite) TestAddReputerStake() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputerAddr := s.addrs[0].String()
+	reputerAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(500)
 
 	// Initial Values
@@ -1514,86 +1301,86 @@ func (s *KeeperTestSuite) TestAddReputerStake() {
 	initialTopicStake := cosmosMath.NewInt(0)
 
 	// Add stake
-	err := keeper.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
+	err := k.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Check updated stake for delegator
-	delegatorStake, err := keeper.GetStakeReputerAuthority(ctx, topicId, reputerAddr)
+	delegatorStake, err := k.GetStakeReputerAuthority(ctx, topicId, reputerAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(stakeAmount, delegatorStake, "Delegator stake should be equal to stake amount after addition")
 
 	// Check updated topic stake
-	topicStake, err := keeper.GetTopicStake(ctx, topicId)
+	topicStake, err := k.GetTopicStake(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(initialTopicStake.Add(stakeAmount), topicStake, "Topic stake should be incremented by stake amount after addition")
 
 	// Check updated total stake
-	totalStake, err := keeper.GetTotalStake(ctx)
+	totalStake, err := k.GetTotalStake(ctx)
 	s.Require().NoError(err)
 	s.Require().Equal(initialTotalStake.Add(stakeAmount), totalStake, "Total stake should be incremented by stake amount after addition")
 }
 
 func (s *KeeperTestSuite) TestAddDelegateStake() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	delegatorAddr := s.addrsStr[0]
-	reputerAddr := s.addrsStr[1]
+	delegatorAddr := s.AddrsStr(0)
+	reputerAddr := s.AddrsStr(1)
 	initialStakeAmount := cosmosMath.NewInt(500)
 	additionalStakeAmount := cosmosMath.NewInt(300)
 
 	// Setup initial stake
-	err := keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
+	err := k.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
 	s.Require().NoError(err)
 
 	// Check updated stake for delegator
-	delegatorStake, err := keeper.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
+	delegatorStake, err := k.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(initialStakeAmount, delegatorStake, "Total delegator stake should be the sum of initial and additional stake amounts")
 
 	// Add additional stake
-	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, additionalStakeAmount)
+	err = k.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, additionalStakeAmount)
 	s.Require().NoError(err)
 
 	// Check updated stake for delegator
-	delegatorStake, err = keeper.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
+	delegatorStake, err = k.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(initialStakeAmount.Add(additionalStakeAmount), delegatorStake, "Total delegator stake should be the sum of initial and additional stake amounts")
 }
 
 func (s *KeeperTestSuite) TestAddReputerStakeZeroAmount() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	delegatorAddr := s.addrs[0].String()
+	delegatorAddr := s.AddrsStr(0)
 	zeroStakeAmount := cosmosMath.NewInt(0)
 
 	// Try to add zero stake
-	err := keeper.AddReputerStake(ctx, topicId, delegatorAddr, zeroStakeAmount)
+	err := k.AddReputerStake(ctx, topicId, delegatorAddr, zeroStakeAmount)
 	s.Require().ErrorIs(err, types.ErrInvalidValue)
 }
 
 func (s *KeeperTestSuite) TestRemoveStake() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputerAddr := s.addrs[0].String()
+	reputerAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(500)
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	startBlock := ctx.BlockHeight()
 	endBlock := startBlock + moduleParams.RemoveStakeDelayWindow
 
 	// Setup initial stake
-	err = keeper.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
+	err = k.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Capture the initial total and topic stakes after adding stake
-	initialTotalStake, err := keeper.GetTotalStake(ctx)
+	initialTotalStake, err := k.GetTotalStake(ctx)
 	s.Require().NoError(err)
 
 	// make a request to remove stake
-	err = keeper.SetStakeRemoval(ctx, types.StakeRemovalInfo{
+	err = k.SetStakeRemoval(ctx, types.StakeRemovalInfo{
 		TopicId:               topicId,
 		Reputer:               reputerAddr,
 		Amount:                stakeAmount,
@@ -1603,44 +1390,44 @@ func (s *KeeperTestSuite) TestRemoveStake() {
 	s.Require().NoError(err)
 
 	// Remove stake
-	err = keeper.RemoveReputerStake(ctx, endBlock, topicId, reputerAddr, stakeAmount)
+	err = k.RemoveReputerStake(ctx, endBlock, topicId, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Check updated stake for delegator after removal
-	delegatorStake, err := keeper.GetStakeReputerAuthority(ctx, topicId, reputerAddr)
+	delegatorStake, err := k.GetStakeReputerAuthority(ctx, topicId, reputerAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(cosmosMath.ZeroInt(), delegatorStake, "Delegator stake should be zero after removal")
 
 	// Check updated topic stake after removal
-	topicStake, err := keeper.GetTopicStake(ctx, topicId)
+	topicStake, err := k.GetTopicStake(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(cosmosMath.ZeroInt(), topicStake, "Topic stake should be zero after removal")
 
 	// Check updated total stake after removal
-	finalTotalStake, err := keeper.GetTotalStake(ctx)
+	finalTotalStake, err := k.GetTotalStake(ctx)
 	s.Require().NoError(err)
 	s.Require().True(initialTotalStake.Sub(stakeAmount).Equal(finalTotalStake), "Total stake should be decremented by stake amount after removal")
 }
 
 func (s *KeeperTestSuite) TestRemovePartialStakeFromDelegator() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	delegatorAddr := s.addrsStr[0]
-	reputerAddr := s.addrsStr[1]
+	delegatorAddr := s.AddrsStr(0)
+	reputerAddr := s.AddrsStr(1)
 	initialStakeAmount := cosmosMath.NewInt(1000)
 	removeStakeAmount := cosmosMath.NewInt(500)
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	startBlock := ctx.BlockHeight()
 	endBlock := startBlock + moduleParams.RemoveStakeDelayWindow
 
 	// Setup initial stake
-	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
+	err = k.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
 	s.Require().NoError(err)
 
 	// make a request to remove stake
-	err = keeper.SetDelegateStakeRemoval(ctx, types.DelegateStakeRemovalInfo{
+	err = k.SetDelegateStakeRemoval(ctx, types.DelegateStakeRemovalInfo{
 		BlockRemovalStarted:   startBlock,
 		BlockRemovalCompleted: endBlock,
 		TopicId:               topicId,
@@ -1651,38 +1438,38 @@ func (s *KeeperTestSuite) TestRemovePartialStakeFromDelegator() {
 	s.Require().NoError(err)
 
 	// Remove a portion of stake
-	err = keeper.RemoveDelegateStake(ctx, endBlock, topicId, delegatorAddr, reputerAddr, removeStakeAmount)
+	err = k.RemoveDelegateStake(ctx, endBlock, topicId, delegatorAddr, reputerAddr, removeStakeAmount)
 	s.Require().NoError(err)
 
 	// Check remaining stake for delegator
-	remainingStake, err := keeper.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
+	remainingStake, err := k.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(initialStakeAmount.Sub(removeStakeAmount), remainingStake, "Remaining delegator stake should be initial minus removed amount")
 
 	// Check remaining stake for delegator
-	stakeUponReputer, err := keeper.GetDelegateStakeUponReputer(ctx, topicId, reputerAddr)
+	stakeUponReputer, err := k.GetDelegateStakeUponReputer(ctx, topicId, reputerAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(initialStakeAmount.Sub(removeStakeAmount), stakeUponReputer, "Remaining reputer stake should be initial minus removed amount")
 }
 
 func (s *KeeperTestSuite) TestRemoveEntireStakeFromDelegator() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	delegatorAddr := s.addrsStr[0]
-	reputerAddr := s.addrsStr[1]
+	delegatorAddr := s.AddrsStr(0)
+	reputerAddr := s.AddrsStr(1)
 	initialStakeAmount := cosmosMath.NewInt(1000)
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	startBlock := ctx.BlockHeight()
 	endBlock := startBlock + moduleParams.RemoveStakeDelayWindow
 
 	// Setup initial stake
-	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
+	err = k.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
 	s.Require().NoError(err)
 
 	// make a request to remove stake
-	err = keeper.SetDelegateStakeRemoval(ctx, types.DelegateStakeRemovalInfo{
+	err = k.SetDelegateStakeRemoval(ctx, types.DelegateStakeRemovalInfo{
 		BlockRemovalStarted:   startBlock,
 		BlockRemovalCompleted: endBlock,
 		TopicId:               topicId,
@@ -1693,77 +1480,77 @@ func (s *KeeperTestSuite) TestRemoveEntireStakeFromDelegator() {
 	s.Require().NoError(err)
 
 	// Remove a portion of stake
-	err = keeper.RemoveDelegateStake(ctx, endBlock, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
+	err = k.RemoveDelegateStake(ctx, endBlock, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
 	s.Require().NoError(err)
 
 	// Check remaining stake for delegator
-	remainingStake, err := keeper.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
+	remainingStake, err := k.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(cosmosMath.ZeroInt(), remainingStake, "Remaining delegator stake should be initial minus removed amount")
 
 	// Check remaining stake for Reputer
-	stakeUponReputer, err := keeper.GetDelegateStakeUponReputer(ctx, topicId, reputerAddr)
+	stakeUponReputer, err := k.GetDelegateStakeUponReputer(ctx, topicId, reputerAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(cosmosMath.ZeroInt(), stakeUponReputer, "Remaining reputer stake should be initial minus removed amount")
 }
 
 func (s *KeeperTestSuite) TestRemoveStakeZeroAmount() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputerAddr := s.addrsStr[0]
+	reputerAddr := s.AddrsStr(0)
 	initialStakeAmount := cosmosMath.NewInt(500)
 	zeroStakeAmount := cosmosMath.NewInt(0)
 
 	// Setup initial stake
-	err := keeper.AddReputerStake(ctx, topicId, reputerAddr, initialStakeAmount)
+	err := k.AddReputerStake(ctx, topicId, reputerAddr, initialStakeAmount)
 	s.Require().NoError(err)
 
 	// Try to remove zero stake
-	err = keeper.RemoveReputerStake(ctx, ctx.BlockHeight(), topicId, reputerAddr, zeroStakeAmount)
+	err = k.RemoveReputerStake(ctx, ctx.BlockHeight(), topicId, reputerAddr, zeroStakeAmount)
 	s.Require().NoError(err)
 }
 
 func (s *KeeperTestSuite) TestRemoveStakeNonExistingDelegatorOrTarget() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	nonExistingDelegatorAddr := s.addrsStr[0]
+	nonExistingDelegatorAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(500)
 
 	// Try to remove stake with non-existing delegator or target
-	err := keeper.RemoveReputerStake(ctx, ctx.BlockHeight(), topicId, nonExistingDelegatorAddr, stakeAmount)
+	err := k.RemoveReputerStake(ctx, ctx.BlockHeight(), topicId, nonExistingDelegatorAddr, stakeAmount)
 	s.Require().Error(err)
 }
 
 func (s *KeeperTestSuite) TestGetAllStakeForDelegator() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	delegatorAddr := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	delegatorAddr := s.AddrsStr(0)
 
 	// Mock setup
 	topicId := uint64(1)
-	targetAddr := s.addrsStr[1]
+	targetAddr := s.AddrsStr(1)
 	stakeAmount := cosmosMath.NewInt(500)
 
 	// Add stake to create bonds
-	err := keeper.AddDelegateStake(ctx, topicId, delegatorAddr, targetAddr, stakeAmount)
+	err := k.AddDelegateStake(ctx, topicId, delegatorAddr, targetAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Add stake to create bonds
-	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, targetAddr, stakeAmount.Mul(cosmosMath.NewInt(2)))
+	err = k.AddDelegateStake(ctx, topicId, delegatorAddr, targetAddr, stakeAmount.Mul(cosmosMath.NewInt(2)))
 	s.Require().NoError(err)
 
 	// Get all bonds for delegator
-	amount, err := keeper.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
+	amount, err := k.GetStakeFromDelegatorInTopic(ctx, topicId, delegatorAddr)
 
 	s.Require().NoError(err, "Getting all bonds for delegator should not return an error")
 	s.Require().Equal(stakeAmount.Mul(cosmosMath.NewInt(3)), amount, "The total amount is incorrect")
 }
 
 func (s *KeeperTestSuite) TestSetGetDeleteStakeRemovalByAddressWithDetailedPlacement() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	topic0 := uint64(101)
 	reputer0 := "allo146fyx5akdrcpn2ypjpg4tra2l7q2wevs05pz2n"
@@ -1788,15 +1575,15 @@ func (s *KeeperTestSuite) TestSetGetDeleteStakeRemovalByAddressWithDetailedPlace
 	}
 
 	// Set stake removal information
-	err := keeper.SetStakeRemoval(ctx, removalInfo0)
+	err := k.SetStakeRemoval(ctx, removalInfo0)
 	s.Require().NoError(err)
-	err = keeper.SetStakeRemoval(ctx, removalInfo1)
+	err = k.SetStakeRemoval(ctx, removalInfo1)
 	s.Require().NoError(err)
 
 	// Topic 101
 
 	// Retrieve the stake removal information
-	retrievedInfo, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(ctx, removalInfo0.BlockRemovalCompleted, 1)
+	retrievedInfo, limitHit, err := k.GetStakeRemovalsUpUntilBlock(ctx, removalInfo0.BlockRemovalCompleted, 1)
 	s.Require().NoError(err)
 	s.Require().Len(retrievedInfo, 1, "There should be only one delegate stake removal information for the block")
 	s.Require().False(limitHit, "The limit should not be hit")
@@ -1809,7 +1596,7 @@ func (s *KeeperTestSuite) TestSetGetDeleteStakeRemovalByAddressWithDetailedPlace
 	// Topic 102
 
 	// Retrieve the stake removal information
-	retrievedInfo, limitHit, err = keeper.GetStakeRemovalsUpUntilBlock(ctx, removalInfo1.BlockRemovalCompleted, 2)
+	retrievedInfo, limitHit, err = k.GetStakeRemovalsUpUntilBlock(ctx, removalInfo1.BlockRemovalCompleted, 2)
 	s.Require().NoError(err)
 	s.Require().Len(retrievedInfo, 2, "There should be only one delegate stake removal information for the block")
 	s.Require().False(limitHit, "The limit should not be hit")
@@ -1820,42 +1607,42 @@ func (s *KeeperTestSuite) TestSetGetDeleteStakeRemovalByAddressWithDetailedPlace
 	s.Require().Equal(removalInfo1.Amount, retrievedInfo[1].Amount, "Amounts should match for all placements")
 
 	// delete 101
-	err = keeper.DeleteStakeRemoval(ctx, removalInfo0.BlockRemovalCompleted, removalInfo0.TopicId, removalInfo0.Reputer)
+	err = k.DeleteStakeRemoval(ctx, removalInfo0.BlockRemovalCompleted, removalInfo0.TopicId, removalInfo0.Reputer)
 	s.Require().NoError(err)
-	removals, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(ctx, removalInfo0.BlockRemovalCompleted, 100)
+	removals, limitHit, err := k.GetStakeRemovalsUpUntilBlock(ctx, removalInfo0.BlockRemovalCompleted, 100)
 	s.Require().NoError(err)
 	s.Require().Empty(removals)
 	s.Require().False(limitHit, "The limit should not be hit")
 
 	// delete 102
-	err = keeper.DeleteStakeRemoval(ctx, removalInfo1.BlockRemovalCompleted, removalInfo1.TopicId, removalInfo1.Reputer)
+	err = k.DeleteStakeRemoval(ctx, removalInfo1.BlockRemovalCompleted, removalInfo1.TopicId, removalInfo1.Reputer)
 	s.Require().NoError(err)
-	removals, limitHit, err = keeper.GetStakeRemovalsUpUntilBlock(ctx, removalInfo1.BlockRemovalCompleted, 100)
+	removals, limitHit, err = k.GetStakeRemovalsUpUntilBlock(ctx, removalInfo1.BlockRemovalCompleted, 100)
 	s.Require().NoError(err)
 	s.Require().Empty(removals)
 	s.Require().False(limitHit, "The limit should not be hit")
 }
 
 func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockNotFound() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	// Attempt to retrieve stake removal info for an address with no set info
-	removals, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(ctx, 202, 100)
+	removals, limitHit, err := k.GetStakeRemovalsUpUntilBlock(ctx, 202, 100)
 	s.Require().NoError(err)
 	s.Require().Empty(removals)
 	s.Require().False(limitHit, "The limit should not be hit")
 }
 
 func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitPreviousBlocks() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicIdStart := uint64(100)
 	blockRemovalsStart := int64(12)
 	blockRemovalsEnd := int64(13)
 
 	topicId := topicIdStart
-	reputer := s.addrsStr[2]
+	reputer := s.AddrsStr(2)
 	removalInfo := types.StakeRemovalInfo{
 		BlockRemovalStarted:   blockRemovalsStart,
 		BlockRemovalCompleted: blockRemovalsEnd,
@@ -1863,10 +1650,10 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitPreviousBlocks() 
 		Reputer:               reputer,
 		Amount:                cosmosMath.NewInt(100),
 	}
-	err := keeper.SetStakeRemoval(ctx, removalInfo)
+	err := k.SetStakeRemoval(ctx, removalInfo)
 	s.Require().NoError(err)
 
-	retrievedInfo, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(
+	retrievedInfo, limitHit, err := k.GetStakeRemovalsUpUntilBlock(
 		ctx,
 		blockRemovalsEnd+1, // note how we are getting a block AFTER blockRemovalsEnd
 		1000,
@@ -1877,14 +1664,14 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitPreviousBlocks() 
 }
 
 func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitExactBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicIdStart := uint64(100)
 	blockRemovalsStart := int64(12)
 	blockRemovalsEnd := int64(13)
 
 	topicId := topicIdStart
-	reputer := s.addrsStr[2]
+	reputer := s.AddrsStr(2)
 	removalInfo := types.StakeRemovalInfo{
 		BlockRemovalStarted:   blockRemovalsStart,
 		BlockRemovalCompleted: blockRemovalsEnd,
@@ -1892,10 +1679,10 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitExactBlock() {
 		Reputer:               reputer,
 		Amount:                cosmosMath.NewInt(100),
 	}
-	err := keeper.SetStakeRemoval(ctx, removalInfo)
+	err := k.SetStakeRemoval(ctx, removalInfo)
 	s.Require().NoError(err)
 
-	retrievedInfo, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(
+	retrievedInfo, limitHit, err := k.GetStakeRemovalsUpUntilBlock(
 		ctx,
 		blockRemovalsEnd,
 		1000,
@@ -1906,8 +1693,8 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitExactBlock() {
 }
 
 func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitGreaterThanNumRemovals() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	numRemovals := int64(5)
 	topicIdStart := uint64(100)
 	blockRemovalsStart := int64(12)
@@ -1915,7 +1702,7 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitGreaterThanNumRem
 
 	for i := int64(0); i < numRemovals; i++ {
 		topicId := topicIdStart + uint64(i)
-		reputer := s.addrsStr[2]
+		reputer := s.AddrsStr(2)
 		// Create a sample stake removal information
 		removalInfo := types.StakeRemovalInfo{
 			BlockRemovalStarted:   blockRemovalsStart + i,
@@ -1924,10 +1711,10 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitGreaterThanNumRem
 			Reputer:               reputer,
 			Amount:                cosmosMath.NewInt(100),
 		}
-		err := keeper.SetStakeRemoval(ctx, removalInfo)
+		err := k.SetStakeRemoval(ctx, removalInfo)
 		s.Require().NoError(err)
 	}
-	retrievedInfo, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(
+	retrievedInfo, limitHit, err := k.GetStakeRemovalsUpUntilBlock(
 		ctx,
 		blockRemovalsEnd+numRemovals,
 		uint64(numRemovals),
@@ -1938,8 +1725,8 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitGreaterThanNumRem
 }
 
 func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitLessThanNumRemovals() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	numRemovals := int64(5)
 	limitRemovals := numRemovals - 2
 	topicIdStart := uint64(100)
@@ -1948,7 +1735,7 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitLessThanNumRemova
 
 	for i := int64(0); i < numRemovals; i++ {
 		topicId := topicIdStart + uint64(i)
-		reputer := s.addrsStr[2]
+		reputer := s.AddrsStr(2)
 		// Create a sample stake removal information
 		removalInfo := types.StakeRemovalInfo{
 			BlockRemovalStarted:   blockRemovalsStart + i,
@@ -1957,10 +1744,10 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitLessThanNumRemova
 			Reputer:               reputer,
 			Amount:                cosmosMath.NewInt(100),
 		}
-		err := keeper.SetStakeRemoval(ctx, removalInfo)
+		err := k.SetStakeRemoval(ctx, removalInfo)
 		s.Require().NoError(err)
 	}
-	retrievedInfo, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(
+	retrievedInfo, limitHit, err := k.GetStakeRemovalsUpUntilBlock(
 		ctx,
 		blockRemovalsEnd+numRemovals,
 		uint64(limitRemovals),
@@ -1971,8 +1758,8 @@ func (s *KeeperTestSuite) TestGetStakeRemovalsUpUntilBlockLimitLessThanNumRemova
 }
 
 func (s *KeeperTestSuite) TestSetGetDeleteDelegateStakeRemovalByAddress() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	topic0 := uint64(201)
 	reputer0 := "allo146fyx5akdrcpn2ypjpg4tra2l7q2wevs05pz2n"
@@ -2001,15 +1788,15 @@ func (s *KeeperTestSuite) TestSetGetDeleteDelegateStakeRemovalByAddress() {
 	}
 
 	// Set delegate stake removal information
-	err := keeper.SetDelegateStakeRemoval(ctx, removalInfo0)
+	err := k.SetDelegateStakeRemoval(ctx, removalInfo0)
 	s.Require().NoError(err)
-	err = keeper.SetDelegateStakeRemoval(ctx, removalInfo1)
+	err = k.SetDelegateStakeRemoval(ctx, removalInfo1)
 	s.Require().NoError(err)
 
 	// Topic 201
 
 	// Retrieve the delegate stake removal information
-	retrievedInfo, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, removalInfo0.BlockRemovalCompleted, 100)
+	retrievedInfo, limitHit, err := k.GetDelegateStakeRemovalsUpUntilBlock(ctx, removalInfo0.BlockRemovalCompleted, 100)
 	s.Require().NoError(err)
 	s.Require().Len(retrievedInfo, 1, "There should be only one delegate stake removal information for the block")
 	s.Require().False(limitHit)
@@ -2022,7 +1809,7 @@ func (s *KeeperTestSuite) TestSetGetDeleteDelegateStakeRemovalByAddress() {
 	// Topic 202
 
 	// Retrieve the delegate stake removal information
-	retrievedInfo, limitHit, err = keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, removalInfo1.BlockRemovalCompleted, 100)
+	retrievedInfo, limitHit, err = k.GetDelegateStakeRemovalsUpUntilBlock(ctx, removalInfo1.BlockRemovalCompleted, 100)
 	s.Require().NoError(err)
 	s.Require().Len(retrievedInfo, 2)
 	s.Require().False(limitHit)
@@ -2033,25 +1820,25 @@ func (s *KeeperTestSuite) TestSetGetDeleteDelegateStakeRemovalByAddress() {
 	s.Require().Equal(removalInfo1.Amount, retrievedInfo[1].Amount, "Amounts should match for all placements")
 
 	// delete 101
-	err = keeper.DeleteDelegateStakeRemoval(ctx, removalInfo0.BlockRemovalCompleted, removalInfo0.TopicId, removalInfo0.Reputer, removalInfo0.Delegator)
+	err = k.DeleteDelegateStakeRemoval(ctx, removalInfo0.BlockRemovalCompleted, removalInfo0.TopicId, removalInfo0.Reputer, removalInfo0.Delegator)
 	s.Require().NoError(err)
-	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, removalInfo0.BlockRemovalCompleted, 100)
+	removals, limitHit, err := k.GetDelegateStakeRemovalsUpUntilBlock(ctx, removalInfo0.BlockRemovalCompleted, 100)
 	s.Require().NoError(err)
 	s.Require().Empty(removals)
 	s.Require().False(limitHit)
 
 	// delete 102
-	err = keeper.DeleteDelegateStakeRemoval(ctx, removalInfo1.BlockRemovalCompleted, removalInfo1.TopicId, removalInfo1.Reputer, removalInfo1.Delegator)
+	err = k.DeleteDelegateStakeRemoval(ctx, removalInfo1.BlockRemovalCompleted, removalInfo1.TopicId, removalInfo1.Reputer, removalInfo1.Delegator)
 	s.Require().NoError(err)
-	removals, limitHit, err = keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, removalInfo1.BlockRemovalCompleted, 100)
+	removals, limitHit, err = k.GetDelegateStakeRemovalsUpUntilBlock(ctx, removalInfo1.BlockRemovalCompleted, 100)
 	s.Require().NoError(err)
 	s.Require().Empty(removals)
 	s.Require().False(limitHit)
 }
 
 func (s *KeeperTestSuite) TestGetDeleteDelegateStake() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	// Create sample delegate stake removal information
 	removalInfo := types.DelegateStakeRemovalInfo{
@@ -2064,10 +1851,10 @@ func (s *KeeperTestSuite) TestGetDeleteDelegateStake() {
 	}
 
 	// Set delegate stake removal information
-	err := keeper.SetDelegateStakeRemoval(ctx, removalInfo)
+	err := k.SetDelegateStakeRemoval(ctx, removalInfo)
 	s.Require().NoError(err)
 
-	_, err = keeper.GetDelegateStakeRemoval(ctx,
+	_, err = k.GetDelegateStakeRemoval(ctx,
 		removalInfo.BlockRemovalStarted,
 		removalInfo.TopicId,
 		removalInfo.Delegator,
@@ -2076,7 +1863,7 @@ func (s *KeeperTestSuite) TestGetDeleteDelegateStake() {
 	// index is on BlockRemovalCompleted not BlockRemovalStarted
 	s.Require().Error(err)
 
-	retrievedInfo, err := keeper.GetDelegateStakeRemoval(ctx,
+	retrievedInfo, err := k.GetDelegateStakeRemoval(ctx,
 		removalInfo.BlockRemovalCompleted,
 		removalInfo.TopicId,
 		removalInfo.Delegator,
@@ -2092,35 +1879,35 @@ func (s *KeeperTestSuite) TestGetDeleteDelegateStake() {
 }
 
 func (s *KeeperTestSuite) TestGetDelegateStakeRemovalByAddressNotFound() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	// Attempt to retrieve delegate stake removal info for an address with no set info
-	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, 201, 100)
+	removals, limitHit, err := k.GetDelegateStakeRemovalsUpUntilBlock(ctx, 201, 100)
 	s.Require().NoError(err)
 	s.Require().Empty(removals)
 	s.Require().False(limitHit, "The limit should not be hit")
 }
 
 func (s *KeeperTestSuite) TestSetParams() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	params := types.DefaultParams()
 	// Set params
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Check params
-	paramsFromKeeper, err := keeper.GetParams(ctx)
+	paramsFromKeeper, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	s.Require().Equal(params, paramsFromKeeper, "Params should be equal to the set params")
 }
 
-// / REPUTERS AND WORKER
+// REPUTERS AND WORKER
 func (s *KeeperTestSuite) TestInsertWorker() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	worker := "allo15lvs3m3urm4kts4tp2um5u3aeuz3whqrhz47r5"
 	topicId := uint64(401)
 
@@ -2131,10 +1918,10 @@ func (s *KeeperTestSuite) TestInsertWorker() {
 	}
 
 	// Attempt to insert the worker for multiple topics
-	err := keeper.InsertWorker(ctx, topicId, worker, workerInfo)
+	err := k.InsertWorker(ctx, topicId, worker, workerInfo)
 	s.Require().NoError(err)
 
-	node, err := keeper.GetWorkerInfo(ctx, worker)
+	node, err := k.GetWorkerInfo(ctx, worker)
 
 	s.Require().NoError(err)
 	s.Require().Equal(workerInfo.Owner, node.Owner)
@@ -2142,8 +1929,8 @@ func (s *KeeperTestSuite) TestInsertWorker() {
 }
 
 func (s *KeeperTestSuite) TestRemoveWorker() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	worker := "allo15lvs3m3urm4kts4tp2um5u3aeuz3whqrhz47r5"
 	topicId := uint64(401) // Assume the worker is associated with this topicId initially
 
@@ -2154,221 +1941,215 @@ func (s *KeeperTestSuite) TestRemoveWorker() {
 	}
 
 	// Insert the worker
-	insertErr := keeper.InsertWorker(ctx, topicId, worker, workerInfo)
+	insertErr := k.InsertWorker(ctx, topicId, worker, workerInfo)
 	s.Require().NoError(insertErr, "Failed to insert worker initially")
 
 	// Verify the worker is registered in the topic
-	isRegisteredPre, preErr := keeper.IsWorkerRegisteredInTopic(ctx, topicId, worker)
+	isRegisteredPre, preErr := k.IsWorkerRegisteredInTopic(ctx, topicId, worker)
 	s.Require().NoError(preErr, "Failed to check worker registration before removal")
 	s.Require().True(isRegisteredPre, "Worker should be registered in the topic before removal")
 
 	// Perform the removal
-	removeErr := keeper.RemoveWorker(ctx, topicId, worker)
+	removeErr := k.RemoveWorker(ctx, topicId, worker)
 	s.Require().NoError(removeErr, "Failed to remove worker")
 
 	// Verify the worker is no longer registered in the topic
-	isRegisteredPost, postErr := keeper.IsWorkerRegisteredInTopic(ctx, topicId, worker)
+	isRegisteredPost, postErr := k.IsWorkerRegisteredInTopic(ctx, topicId, worker)
 	s.Require().NoError(postErr, "Failed to check worker registration after removal")
 	s.Require().False(isRegisteredPost, "Worker should not be registered in the topic after removal")
 }
 
 func (s *KeeperTestSuite) TestInsertReputer() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	reputer := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	reputer := s.AddrsStr(0)
 	topicId := uint64(501)
 
 	// Define sample OffchainNode information for a reputer
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[1],
-		NodeAddress: s.addrsStr[2],
+		Owner:       s.AddrsStr(1),
+		NodeAddress: s.AddrsStr(2),
 	}
 
 	// Attempt to insert the reputer for multiple topics
-	err := keeper.InsertReputer(ctx, topicId, reputer, reputerInfo)
+	err := k.InsertReputer(ctx, topicId, reputer, reputerInfo)
 	s.Require().NoError(err)
 
 	// Optionally check if reputer is registered in each topic using an assumed IsReputerRegisteredInTopic method
-	isRegistered, regErr := keeper.IsReputerRegisteredInTopic(ctx, topicId, reputer)
+	isRegistered, regErr := k.IsReputerRegisteredInTopic(ctx, topicId, reputer)
 	s.Require().NoError(regErr, "Checking reputer registration should not fail")
 	s.Require().True(isRegistered, "Reputer should be registered in each topic")
 }
 
 func (s *KeeperTestSuite) TestGetReputerInfo() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	reputer := "allo17srupely9uux7axep5shdsezva4znz6g30ntdw"
 	topicId := uint64(501)
-	keeper := s.emissionsKeeper
+	k := s.EmissionsKeeper()
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[2],
+		Owner:       s.AddrsStr(2),
 		NodeAddress: reputer,
 	}
 
-	err := keeper.InsertReputer(ctx, topicId, reputer, reputerInfo)
+	err := k.InsertReputer(ctx, topicId, reputer, reputerInfo)
 	s.Require().NoError(err)
 
-	actualReputer, err := keeper.GetReputerInfo(ctx, reputer)
+	actualReputer, err := k.GetReputerInfo(ctx, reputer)
 	s.Require().NoError(err)
 	s.Require().Equal(reputerInfo, actualReputer)
 
 	nonExistentKey := "nonExistentKey123"
-	_, err = keeper.GetReputerInfo(ctx, nonExistentKey)
+	_, err = k.GetReputerInfo(ctx, nonExistentKey)
 	s.Require().Error(err)
 }
 
 func (s *KeeperTestSuite) TestRemoveReputer() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	reputer := "allo17srupely9uux7axep5shdsezva4znz6g30ntdw"
 	topicId := uint64(501)
 
 	// Pre-setup: Insert the reputer for initial setup
-	err := keeper.InsertReputer(ctx, topicId, reputer, types.OffchainNode{
-		Owner:       s.addrsStr[1],
+	err := k.InsertReputer(ctx, topicId, reputer, types.OffchainNode{
+		Owner:       s.AddrsStr(1),
 		NodeAddress: reputer,
 	})
 	s.Require().NoError(err, "InsertReputer failed during setup")
 
 	// Verify the reputer is registered in the topic
-	isRegisteredPre, preErr := keeper.IsReputerRegisteredInTopic(ctx, topicId, reputer)
+	isRegisteredPre, preErr := k.IsReputerRegisteredInTopic(ctx, topicId, reputer)
 	s.Require().NoError(preErr, "Failed to check reputer registration before removal")
 	s.Require().True(isRegisteredPre, "Reputer should be registered in the topic before removal")
 
 	// Perform the removal
-	removeErr := keeper.RemoveReputer(ctx, topicId, reputer)
+	removeErr := k.RemoveReputer(ctx, topicId, reputer)
 	s.Require().NoError(removeErr, "Failed to remove reputer")
 
 	// Verify the reputer is no longer registered in the topic
-	isRegisteredPost, postErr := keeper.IsReputerRegisteredInTopic(ctx, topicId, reputer)
+	isRegisteredPost, postErr := k.IsReputerRegisteredInTopic(ctx, topicId, reputer)
 	s.Require().NoError(postErr, "Failed to check reputer registration after removal")
 	s.Require().False(isRegisteredPost, "Reputer should not be registered in the topic after removal")
 }
 
-/// TOPICS
+// TOPICS
 
 func (s *KeeperTestSuite) TestSetAndGetPreviousTopicWeight() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 
 	// Set previous topic weight
 	weightToSet := alloraMath.NewDecFromInt64(10)
-	err := keeper.SetPreviousTopicWeight(ctx, topicId, weightToSet)
+	err := k.SetPreviousTopicWeight(ctx, topicId, weightToSet)
 	s.Require().NoError(err, "Setting previous topic weight should not fail")
 
 	// Get the previously set topic weight
-	retrievedWeight, noPrior, err := keeper.GetPreviousTopicWeight(ctx, topicId)
+	retrievedWeight, noPrior, err := k.GetPreviousTopicWeight(ctx, topicId)
 	s.Require().NoError(err, "Getting previous topic weight should not fail")
 	s.Require().Equal(weightToSet, retrievedWeight, "Retrieved weight should match the set weight")
 	s.Require().False(noPrior, "Should indicate prior weight for a set topic")
 }
 
 func (s *KeeperTestSuite) TestGetPreviousTopicWeightNotFound() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(2)
 
 	// Attempt to get a weight for a topic that has no set weight
-	retrievedWeight, noPrior, err := keeper.GetPreviousTopicWeight(ctx, topicId)
+	retrievedWeight, noPrior, err := k.GetPreviousTopicWeight(ctx, topicId)
 	s.Require().NoError(err, "Getting weight for an unset topic should not error but return zero value")
 	s.Require().True(alloraMath.ZeroDec().Equal(retrievedWeight), "Weight for an unset topic should be zero")
 	s.Require().True(noPrior, "Should indicate no prior weight for an unset topic")
 }
 
 func (s *KeeperTestSuite) TestInactivateAndActivateTopic() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(3)
 
 	maxActiveTopicsNum := uint64(5)
 	params := types.DefaultParams()
 	params.MaxActiveTopicsPerBlock = maxActiveTopicsNum
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err, "Setting parameters should not fail")
 
 	// Assume topic initially active
-	initialTopic := s.mockTopic()
-	err = keeper.SetTopic(ctx, topicId, initialTopic)
+	initialTopic := s.MockTopic()
+	err = k.SetTopic(ctx, topicId, initialTopic)
 	s.Require().NoError(err, "Setting topic should not fail")
 
 	// Activate the topic
-	err = keeper.ActivateTopic(ctx, topicId)
+	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err, "Reactivating topic should not fail")
 
 	// Check if topic is active
-	topicActive, err := keeper.IsTopicActive(ctx, topicId)
+	topicActive, err := k.IsTopicActive(ctx, topicId)
 	s.Require().NoError(err, "Getting topic should not fail after reactivation")
 	s.Require().True(topicActive, "Topic should be active again")
 
 	// Inactivate the topic
-	err = keeper.InactivateTopic(ctx, topicId)
+	err = k.InactivateTopic(ctx, topicId)
 	s.Require().NoError(err, "Inactivating topic should not fail")
 
 	// Check if topic is inactive
-	topicActive, err = keeper.IsTopicActive(ctx, topicId)
+	topicActive, err = k.IsTopicActive(ctx, topicId)
 	s.Require().NoError(err, "Getting topic should not fail after inactivation")
 	s.Require().False(topicActive, "Topic should be inactive")
 
 	// Activate the topic
-	err = keeper.ActivateTopic(ctx, topicId)
+	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err, "Reactivating topic should not fail")
 
 	// Check if topic is active again
-	topicActive, err = keeper.IsTopicActive(ctx, topicId)
+	topicActive, err = k.IsTopicActive(ctx, topicId)
 	s.Require().NoError(err, "Getting topic should not fail after reactivation")
 	s.Require().True(topicActive, "Topic should be active again")
 }
 
 func (s *KeeperTestSuite) TestGetActiveTopicIdsAtBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	maxActiveTopicsNum := uint64(2)
 	params := types.DefaultParams()
 	params.MaxActiveTopicsPerBlock = maxActiveTopicsNum
 	params.MaxPageLimit = 100
 	params.MinEpochLength = 1
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err, "Setting parameters should not fail")
 
-	topic1 := s.mockTopic()
-	topic1.Id = 1
-	topic1.EpochLength = 5
-	topic1.WorkerSubmissionWindow = topic1.EpochLength
-	topic2 := s.mockTopic()
-	topic2.Id = 2
-	topic2.EpochLength = 5
-	topic2.WorkerSubmissionWindow = topic2.EpochLength
-	topic3 := s.mockTopic()
-	topic3.Id = 3
-	topic3.EpochLength = 15
-	topic3.WorkerSubmissionWindow = topic3.EpochLength
+	// Create topics using CreateTopic with functional options
+	topic1Id := s.CreateTopic(
+		alloratestutil.WithEpochLength(5),
+		alloratestutil.WithWorkerSubmissionWindow(5),
+	)
+	s.CreateTopic(
+		alloratestutil.WithEpochLength(5),
+		alloratestutil.WithWorkerSubmissionWindow(5),
+	) // Inactive topic
+	topic3Id := s.CreateTopic(
+		alloratestutil.WithEpochLength(15),
+		alloratestutil.WithWorkerSubmissionWindow(15),
+	)
 
-	err = keeper.SetTopic(ctx, topic1.Id, topic1)
-	s.Require().NoError(err, "Setting topic should not fail")
-	err = keeper.ActivateTopic(ctx, topic1.Id)
+	err = k.ActivateTopic(ctx, topic1Id)
 	s.Require().NoError(err, "Activating topic should not fail")
-	err = keeper.SetTopic(ctx, topic2.Id, topic2) // Inactive topic
-	s.Require().NoError(err, "Setting topic should not fail")
-	err = keeper.SetTopic(ctx, topic3.Id, topic3)
-	s.Require().NoError(err, "Setting topic should not fail")
-	err = keeper.ActivateTopic(ctx, topic3.Id)
+	err = k.ActivateTopic(ctx, topic3Id)
 	s.Require().NoError(err, "Activating topic should not fail")
 
 	// Fetch only active topics
-	activeTopics, err := keeper.GetActiveTopicIdsAtBlock(ctx, 5)
+	activeTopics, err := k.GetActiveTopicIdsAtBlock(ctx, 5)
 	s.Require().NoError(err, "Fetching active topics should not produce an error")
 	s.Require().Len(activeTopics.TopicIds, 1, "Should retrieve exactly one active topic")
 
-	activeTopics, err = keeper.GetActiveTopicIdsAtBlock(ctx, 15)
+	activeTopics, err = k.GetActiveTopicIdsAtBlock(ctx, 15)
 	s.Require().NoError(err, "Fetching active topics should not produce an error")
 	s.Require().Len(activeTopics.TopicIds, 1, "Should retrieve exactly one active topic")
-	s.Require().Equal(activeTopics.TopicIds[0], topic3.Id, "The details of topic 1 should match")
+	s.Require().Equal(activeTopics.TopicIds[0], topic3Id, "The details of topic 3 should match")
 }
 
 func (s *KeeperTestSuite) TestTopicGoesInactivateOnEpochEndBlockIfLowWeight() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	k := s.EmissionsKeeper()
 
 	params := types.DefaultParams()
 	params.MaxActiveTopicsPerBlock = uint64(3)
@@ -2376,234 +2157,218 @@ func (s *KeeperTestSuite) TestTopicGoesInactivateOnEpochEndBlockIfLowWeight() {
 	params.MinEpochLength = 1
 	params.TopicRewardAlpha = alloraMath.MustNewDecFromString("0.5")
 	params.TopicRewardStakeImportance = alloraMath.MustNewDecFromString("1")
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(s.Ctx(), params)
 	s.Require().NoError(err, "Setting parameters should not fail")
 
-	topic1 := s.mockTopic()
-	topic1.Id = 1
-	topic1.EpochLength = 15
-	topic1.WorkerSubmissionWindow = topic1.EpochLength
-	topic2 := s.mockTopic()
-	topic2.Id = 2
-	topic2.EpochLength = 15
-	topic2.WorkerSubmissionWindow = topic2.EpochLength
-	topic3 := s.mockTopic()
-	topic3.Id = 3
-	topic3.EpochLength = 5
-	topic3.WorkerSubmissionWindow = topic3.EpochLength
-	topic4 := s.mockTopic()
-	topic4.Id = 4
-	topic4.EpochLength = 5
-	topic4.WorkerSubmissionWindow = topic4.EpochLength
+	epochLength1 := int64(15)
+	epochLength2 := int64(15)
+	epochLength3 := int64(5)
+	epochLength4 := int64(5)
+
+	topic1Id := s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength1),
+		alloratestutil.WithWorkerSubmissionWindow(epochLength1),
+	)
+	topic2Id := s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength2),
+		alloratestutil.WithWorkerSubmissionWindow(epochLength2),
+	)
+	topic3Id := s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength3),
+		alloratestutil.WithWorkerSubmissionWindow(epochLength3),
+	)
+	topic4Id := s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength4),
+		alloratestutil.WithWorkerSubmissionWindow(epochLength4),
+	)
 
 	setTopicWeight := func(topicId uint64, revenue, stake int64) {
-		err := keeper.AddTopicFeeRevenue(ctx, topicId, cosmosMath.NewInt(revenue))
+		err := k.AddTopicFeeRevenue(s.Ctx(), topicId, cosmosMath.NewInt(revenue))
 		s.Require().NoError(err, "Adding topic fee revenue should not fail")
-		err = keeper.SetTopicStake(ctx, topicId, cosmosMath.NewInt(stake))
+		err = k.SetTopicStake(s.Ctx(), topicId, cosmosMath.NewInt(stake))
 		s.Require().NoError(err, "Setting topic stake should not fail")
 	}
 
-	setTopicWeight(topic1.Id, 10, 10)
-	err = keeper.SetTopic(ctx, topic1.Id, topic1)
-	s.Require().NoError(err, "Setting topic should not fail")
-	err = keeper.ActivateTopic(ctx, topic1.Id)
+	setTopicWeight(topic1Id, 10, 10)
+	err = k.ActivateTopic(s.Ctx(), topic1Id)
 	s.Require().NoError(err, "Activating topic should not fail")
 
-	setTopicWeight(topic2.Id, 20, 10)
-	err = keeper.SetTopic(ctx, topic2.Id, topic2)
-	s.Require().NoError(err, "Setting topic should not fail")
-	err = keeper.ActivateTopic(ctx, topic2.Id)
+	setTopicWeight(topic2Id, 20, 10)
+	err = k.ActivateTopic(s.Ctx(), topic2Id)
 	s.Require().NoError(err, "Activating topic should not fail")
 
 	// Fetch next page -- should only return topic 5
-	activeTopics, err := keeper.GetActiveTopicIdsAtBlock(ctx, 15)
+	activeTopics, err := k.GetActiveTopicIdsAtBlock(s.Ctx(), 15)
 	s.Require().NoError(err, "Fetching active topics should not produce an error")
 	s.Require().Len(activeTopics.TopicIds, 2, "Should retrieve exactly two active topics")
 
-	ctx = s.ctx.WithBlockHeight(15)
-	err = keeper.AttemptTopicReactivation(ctx, topic1.Id)
+	s.WithBlockHeight(15)
+	err = k.AttemptTopicReactivation(s.Ctx(), topic1Id)
 	s.Require().NoError(err, "Attempting to reactivate topic should not fail")
-	err = keeper.AttemptTopicReactivation(ctx, topic2.Id)
+	err = k.AttemptTopicReactivation(s.Ctx(), topic2Id)
 	s.Require().NoError(err, "Attempting to reactivate topic should not fail")
 
-	ctx = s.ctx.WithBlockHeight(25)
-	setTopicWeight(topic3.Id, 50, 10)
-	err = keeper.SetTopic(ctx, topic3.Id, topic3)
-	s.Require().NoError(err, "Setting topic should not fail")
-	err = keeper.ActivateTopic(ctx, topic3.Id)
+	s.WithBlockHeight(25)
+	setTopicWeight(topic3Id, 50, 10)
+	err = k.ActivateTopic(s.Ctx(), topic3Id)
 	s.Require().NoError(err, "Activating topic should not fail")
 
-	activeTopics, err = keeper.GetActiveTopicIdsAtBlock(ctx, 30)
+	activeTopics, err = k.GetActiveTopicIdsAtBlock(s.Ctx(), 30)
 	s.Require().NoError(err, "Fetching active topics should not produce an error")
 	s.Require().Len(activeTopics.TopicIds, 3, "Should retrieve exactly two active topics")
-	s.Require().Equal(uint64(1), activeTopics.TopicIds[0])
-	s.Require().Equal(uint64(2), activeTopics.TopicIds[1])
-	s.Require().Equal(uint64(3), activeTopics.TopicIds[2])
+	s.Require().Equal(topic1Id, activeTopics.TopicIds[0])
+	s.Require().Equal(topic2Id, activeTopics.TopicIds[1])
+	s.Require().Equal(topic3Id, activeTopics.TopicIds[2])
 
-	ctx = s.ctx.WithBlockHeight(30)
-	setTopicWeight(topic4.Id, 1, 1)
-	isActive, err := keeper.IsTopicActive(ctx, topic4.Id)
+	s.WithBlockHeight(30)
+	setTopicWeight(topic4Id, 1, 1)
+	isActive, err := k.IsTopicActive(s.Ctx(), topic4Id)
 	s.Require().NoError(err, "Is topic active should not produce an error")
 	s.Require().False(isActive, "Topic4 should not be activated")
 }
+
 func (s *KeeperTestSuite) TestIncrementTopicId() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	// Initial check for the current topic ID
-	initialTopicId, err := keeper.IncrementTopicId(ctx)
+	initialTopicId, err := k.IncrementTopicId(ctx)
 	s.Require().NoError(err, "Getting initial topic ID should not fail")
 
 	// Increment the topic ID
-	newTopicId, err := keeper.IncrementTopicId(ctx)
+	newTopicId, err := k.IncrementTopicId(ctx)
 	s.Require().NoError(err, "Incrementing topic ID should not fail")
 	s.Require().Equal(initialTopicId+1, newTopicId, "New topic ID should be one more than the initial topic ID")
 }
 
 func (s *KeeperTestSuite) TestGetNumTopicsWithActualTopicCreation() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
-	nextTopicIdStart, err := keeper.GetNextTopicId(ctx)
+	nextTopicIdStart, err := k.GetNextTopicId(ctx)
 	s.Require().NoError(err, "Fetching the number of topics should not fail")
 
 	// Create multiple topics to simulate actual usage
 	topicsToCreate := 5
 	for i := 1; i <= topicsToCreate; i++ {
-		topicId, err := keeper.IncrementTopicId(ctx)
+		topicId, err := k.IncrementTopicId(ctx)
 		s.Require().NoError(err, "Incrementing topic ID should not fail")
 
-		newTopic := s.mockTopic()
+		newTopic := s.MockTopic()
 		newTopic.Id = topicId
 
-		err = keeper.SetTopic(ctx, topicId, newTopic)
+		err = k.SetTopic(ctx, topicId, newTopic)
 		s.Require().NoError(err, "Setting a new topic should not fail")
 	}
 
 	// Now retrieve the total number of topics
-	nextTopicIdEnd, err := keeper.GetNextTopicId(ctx)
+	nextTopicIdEnd, err := k.GetNextTopicId(ctx)
 	s.Require().NoError(err, "Fetching the number of topics should not fail")
 	s.Require().Equal(uint64(topicsToCreate), nextTopicIdEnd-nextTopicIdStart)
 }
 
 func (s *KeeperTestSuite) TestUpdateAndGetTopicEpochLastEnded() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := uint64(2)
 	epochLastEnded := types.BlockHeight(100)
 
 	// Setup a topic initially
-	initialTopic := s.mockTopic()
-	err := keeper.SetTopic(ctx, topicId, initialTopic)
+	initialTopic := s.MockTopic()
+	err := k.SetTopic(ctx, topicId, initialTopic)
 	s.Require().NoError(err, "Setting a new topic should not fail")
 
 	// Update the epoch last ended
-	err = keeper.UpdateTopicEpochLastEnded(ctx, topicId, epochLastEnded)
+	err = k.UpdateTopicEpochLastEnded(ctx, topicId, epochLastEnded)
 	s.Require().NoError(err, "Updating topic epoch last ended should not fail")
 
 	// Retrieve the last ended epoch for the topic
-	topic, err := keeper.GetTopic(ctx, topicId)
+	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err, "Retrieving topic epoch last ended should not fail")
 	s.Require().Equal(epochLastEnded, topic.EpochLastEnded, "The retrieved epoch last ended should match the updated value")
 }
 
 func (s *KeeperTestSuite) TestTopicExists() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	// Test a topic ID that does not exist
 	nonExistentTopicId := uint64(999) // Assuming this ID has not been used
-	exists, err := keeper.TopicExists(ctx, nonExistentTopicId)
+	exists, err := k.TopicExists(ctx, nonExistentTopicId)
 	s.Require().NoError(err, "Checking existence for a non-existent topic should not fail")
 	s.Require().False(exists, "No topic should exist for an unused topic ID")
 
 	// Create a topic to test existence
-	existentTopicId, err := keeper.IncrementTopicId(ctx)
+	existentTopicId, err := k.IncrementTopicId(ctx)
 	s.Require().NoError(err, "Incrementing topic ID should not fail")
 
-	newTopic := s.mockTopic()
-	err = keeper.SetTopic(ctx, existentTopicId, newTopic)
+	newTopic := s.MockTopic()
+	err = k.SetTopic(ctx, existentTopicId, newTopic)
 	s.Require().NoError(err, "Setting a new topic should not fail")
 
 	// Test the newly created topic ID
-	exists, err = keeper.TopicExists(ctx, existentTopicId)
+	exists, err = k.TopicExists(ctx, existentTopicId)
 	s.Require().NoError(err, "Checking existence for an existent topic should not fail")
 	s.Require().True(exists, "Topic should exist for a newly created topic ID")
 }
 
 func (s *KeeperTestSuite) TestGetTopic() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
-	topicId := uint64(1)
-	_, err := keeper.GetTopic(ctx, topicId)
+	topicId := uint64(2)
+	_, err := k.GetTopic(ctx, topicId)
 	s.Require().ErrorIs(err, types.ErrTopicDoesNotExist, "Retrieving a non-existent topic should result in an error")
 
-	newTopic := s.mockTopic()
+	newTopic := s.MockTopic()
 
-	err = keeper.SetTopic(ctx, topicId, newTopic)
+	err = k.SetTopic(ctx, topicId, newTopic)
 	s.Require().NoError(err, "Setting a new topic should not fail")
 
-	retrievedTopic, err := keeper.GetTopic(ctx, topicId)
+	retrievedTopic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err, "Retrieving an existent topic should not fail")
 	s.Require().Equal(newTopic, retrievedTopic, "Retrieved topic should match the set topic")
 	s.Require().Equal(newTopic.Metadata, retrievedTopic.Metadata, "Retrieved topic should match the set topic")
 }
 
-/// FEE REVENUE
+// FEE REVENUE
 
 func (s *KeeperTestSuite) TestGetTopicFeeRevenue() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := uint64(2)
 
-	newTopic := s.mockTopic()
-	err := keeper.SetTopic(ctx, topicId, newTopic)
+	newTopic := s.MockTopic()
+	err := k.SetTopic(ctx, topicId, newTopic)
 	s.Require().NoError(err, "Setting a new topic should not fail")
 
 	// Test getting revenue for a topic with no existing revenue
-	feeRev, err := keeper.GetTopicFeeRevenue(ctx, topicId)
+	feeRev, err := k.GetTopicFeeRevenue(ctx, topicId)
 	s.Require().NoError(err, "Should not error when revenue does not exist")
 	s.Require().Equal(cosmosMath.ZeroInt(), feeRev, "Revenue should be zero for non-existing entries")
 
 	// Setup a topic with some revenue
 	initialRevenue := cosmosMath.NewInt(100)
 	initialRevenueInt := cosmosMath.NewInt(100)
-	err = keeper.AddTopicFeeRevenue(ctx, topicId, initialRevenue)
+	err = k.AddTopicFeeRevenue(ctx, topicId, initialRevenue)
 	s.Require().NoError(err, "Adding initial revenue should not fail")
 
 	// Test getting revenue for a topic with existing revenue
-	feeRev, err = keeper.GetTopicFeeRevenue(ctx, topicId)
+	feeRev, err = k.GetTopicFeeRevenue(ctx, topicId)
 	s.Require().NoError(err, "Should not error when retrieving existing revenue")
 	s.Require().Equal(feeRev.String(), initialRevenueInt.String(), "Revenue should match the initial setup")
 }
 
 func (s *KeeperTestSuite) TestAddTopicFeeRevenue() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-	block := int64(100)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
-	newTopic := types.Topic{
-		Creator:                  s.addrs[0].String(),
-		Id:                       topicId,
-		Metadata:                 "metadata",
-		LossMethod:               "LOSS",
-		EpochLastEnded:           10,
-		EpochLength:              20,
-		GroundTruthLag:           20,
-		PNorm:                    alloraMath.MustNewDecFromString("3.5"),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.5"),
-		AllowNegative:            false,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.5"),
-		InitialRegret:            alloraMath.MustNewDecFromString("0.5"),
-		WorkerSubmissionWindow:   20,
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.5"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.5"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.5"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.5"),
-	}
-	err := keeper.SetTopic(ctx, topicId, newTopic)
+	block := int64(100)
+	topicId := uint64(2)
+	newTopic := s.MockTopic()
+	newTopic.Id = topicId
+
+	err := k.SetTopic(ctx, topicId, newTopic)
 	s.Require().NoError(err, "Setting a new topic should not fail")
 
 	params := types.DefaultParams()
@@ -2611,32 +2376,32 @@ func (s *KeeperTestSuite) TestAddTopicFeeRevenue() {
 	blocksPerWeek, err := alloraMath.CalculateBlocksPerWeek(params.BlocksPerMonth)
 	s.Require().NoError(err, "error calculating blocks per week")
 
-	err = keeper.DripTopicFeeRevenue(ctx, newTopic, blocksPerWeek, block)
+	err = k.DripTopicFeeRevenue(ctx, newTopic, blocksPerWeek, block)
 	s.Require().NoError(err, "Resetting topic fee revenue should not fail")
 
 	// Add initial revenue
 	initialAmount := cosmosMath.NewInt(100)
-	err = keeper.AddTopicFeeRevenue(ctx, topicId, initialAmount)
+	err = k.AddTopicFeeRevenue(ctx, topicId, initialAmount)
 	s.Require().NoError(err, "Adding initial revenue should not fail")
 
 	// Verify initial revenue
-	feeRev, err := keeper.GetTopicFeeRevenue(ctx, topicId)
+	feeRev, err := k.GetTopicFeeRevenue(ctx, topicId)
 	s.Require().NoError(err, "Getting topic fee revenue should not fail")
 	s.Require().Equal(initialAmount, feeRev, "Initial revenue should be correctly recorded")
 }
 
-/// SCORES
+// SCORES
 
 func (s *KeeperTestSuite) TestGetScoreEmas() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	worker := "allo15lvs3m3urm4kts4tp2um5u3aeuz3whqrhz47r5"
 	forecaster := "allo13kenskkx7e0v253m3kcgwfc67cmx00fgwpgj6h"
 	reputer := "allo144nqxgt6jdrm4srzzgx4dvz04hd8q2e8cel9hu"
 
 	// Test getting latest scores when none are set
-	infererScore, err := keeper.GetInfererScoreEma(ctx, topicId, worker)
+	infererScore, err := k.GetInfererScoreEma(ctx, topicId, worker)
 	s.Require().NoError(err, "Fetching latest inferer score should not fail")
 	s.Require().Equal(types.Score{
 		TopicId:     topicId,
@@ -2645,7 +2410,7 @@ func (s *KeeperTestSuite) TestGetScoreEmas() {
 		Score:       alloraMath.ZeroDec(),
 	}, infererScore, "Inferer score should be zero if not set")
 
-	forecasterScore, err := keeper.GetForecasterScoreEma(ctx, topicId, forecaster)
+	forecasterScore, err := k.GetForecasterScoreEma(ctx, topicId, forecaster)
 	s.Require().NoError(err, "Fetching latest forecaster score should not fail")
 	s.Require().Equal(types.Score{
 		TopicId:     topicId,
@@ -2654,7 +2419,7 @@ func (s *KeeperTestSuite) TestGetScoreEmas() {
 		Score:       alloraMath.ZeroDec(),
 	}, forecasterScore, "Forecaster score should be empty if not set")
 
-	reputerScore, err := keeper.GetReputerScoreEma(ctx, topicId, reputer)
+	reputerScore, err := k.GetReputerScoreEma(ctx, topicId, reputer)
 	s.Require().NoError(err, "Fetching latest reputer score should not fail")
 	s.Require().Equal(types.Score{
 		TopicId:     topicId,
@@ -2665,8 +2430,8 @@ func (s *KeeperTestSuite) TestGetScoreEmas() {
 }
 
 func (s *KeeperTestSuite) TestSetScoreEmas() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	worker := "allo15lvs3m3urm4kts4tp2um5u3aeuz3whqrhz47r5"
 	forecaster := "allo13kenskkx7e0v253m3kcgwfc67cmx00fgwpgj6h"
@@ -2674,30 +2439,30 @@ func (s *KeeperTestSuite) TestSetScoreEmas() {
 	score := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker, Score: alloraMath.NewDecFromInt64(95)}
 
 	// Set an initial score for inferer and attempt to update with an older score
-	err := keeper.SetInfererScoreEma(ctx, topicId, worker, score)
+	err := k.SetInfererScoreEma(ctx, topicId, worker, score)
 	s.Require().NoError(err)
-	infererScore, err := keeper.GetInfererScoreEma(ctx, topicId, worker)
+	infererScore, err := k.GetInfererScoreEma(ctx, topicId, worker)
 	s.Require().NoError(err)
 	s.Require().Equal(score.Score, infererScore.Score, "Newer inferer score should be set")
 
 	// Set a new score for forecaster
-	err = keeper.SetForecasterScoreEma(ctx, topicId, forecaster, score)
+	err = k.SetForecasterScoreEma(ctx, topicId, forecaster, score)
 	s.Require().NoError(err)
-	forecasterScore, err := keeper.GetForecasterScoreEma(ctx, topicId, forecaster)
+	forecasterScore, err := k.GetForecasterScoreEma(ctx, topicId, forecaster)
 	s.Require().NoError(err)
 	s.Require().Equal(score.Score, forecasterScore.Score, "Newer forecaster score should be set")
 
 	// Set a new score for reputer
-	err = keeper.SetReputerScoreEma(ctx, topicId, reputer, score)
+	err = k.SetReputerScoreEma(ctx, topicId, reputer, score)
 	s.Require().NoError(err)
-	reputerScore, err := keeper.GetReputerScoreEma(ctx, topicId, reputer)
+	reputerScore, err := k.GetReputerScoreEma(ctx, topicId, reputer)
 	s.Require().NoError(err)
 	s.Require().Equal(score.Score, reputerScore.Score, "Newer reputer score should be set")
 }
 
 func (s *KeeperTestSuite) TestInsertWorkerInferenceScore() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(100)
 	score := types.Score{
@@ -2712,24 +2477,24 @@ func (s *KeeperTestSuite) TestInsertWorkerInferenceScore() {
 	params := types.DefaultParams()
 	params.MaxSamplesToScaleScores = uint64(maxNumScores)
 	params.MaxTopInferersToReward = 1
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err, "Setting parameters should not fail")
 
 	// Insert scores more than the max limit to test trimming
 	for i := 0; i < maxNumScores+2; i++ {
-		err := keeper.InsertWorkerInferenceScore(ctx, topicId, blockHeight, score)
+		err := k.InsertWorkerInferenceScore(ctx, topicId, blockHeight, score)
 		s.Require().NoError(err, "Inserting worker inference score should not fail")
 	}
 
 	// Fetch scores to check if trimming happened
-	scores, err := keeper.GetWorkerInferenceScoresAtBlock(ctx, topicId, blockHeight)
+	scores, err := k.GetWorkerInferenceScoresAtBlock(ctx, topicId, blockHeight)
 	s.Require().NoError(err, "Fetching scores at block should not fail")
 	s.Require().Len(scores.Scores, maxNumScores, "Scores should not exceed the maximum limit")
 }
 
 func (s *KeeperTestSuite) TestInsertWorkerInferenceScore2() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(100)
 
@@ -2738,7 +2503,7 @@ func (s *KeeperTestSuite) TestInsertWorkerInferenceScore2() {
 	params := types.DefaultParams()
 	params.MaxSamplesToScaleScores = uint64(maxNumScores)
 	params.MaxTopInferersToReward = 1
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err, "Setting parameters should not fail")
 
 	// Insert scores more than the max limit to test trimming
@@ -2750,12 +2515,12 @@ func (s *KeeperTestSuite) TestInsertWorkerInferenceScore2() {
 			Address:     "allo15lvs3m3urm4kts4tp2um5u3aeuz3whqrhz47r5",
 			Score:       scoreValue,
 		}
-		err := keeper.InsertWorkerInferenceScore(ctx, topicId, blockHeight, score)
+		err := k.InsertWorkerInferenceScore(ctx, topicId, blockHeight, score)
 		s.Require().NoError(err, "Inserting worker inference score should not fail")
 	}
 
 	// Fetch scores to check if trimming happened
-	scores, err := keeper.GetWorkerInferenceScoresAtBlock(ctx, topicId, blockHeight)
+	scores, err := k.GetWorkerInferenceScoresAtBlock(ctx, topicId, blockHeight)
 	s.Require().NoError(err, "Fetching scores at block should not fail")
 	s.Require().Len(scores.Scores, maxNumScores, "Scores should not exceed the maximum limit")
 
@@ -2767,10 +2532,10 @@ func (s *KeeperTestSuite) TestInsertWorkerInferenceScore2() {
 }
 
 func (s *KeeperTestSuite) TestGetInferenceScoresUntilBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	workerAddress := s.addrs[0]
+	workerAddress := s.Addrs(0)
 	blockHeight := int64(105)
 
 	// Insert scores for different workers and blocks
@@ -2782,12 +2547,12 @@ func (s *KeeperTestSuite) TestGetInferenceScoresUntilBlock() {
 			Address:     workerAddress.String(),
 			Score:       alloraMath.NewDecFromInt64(blockHeight),
 		}
-		err := keeper.InsertWorkerInferenceScore(ctx, topicId, blockHeight, scoreForWorker)
+		err := k.InsertWorkerInferenceScore(ctx, topicId, blockHeight, scoreForWorker)
 		s.Require().NoError(err, "Inserting worker inference score should not fail")
 	}
 
 	// Get scores for the worker up to block 105
-	scores, err := keeper.GetInferenceScoresUntilBlock(ctx, topicId, blockHeight)
+	scores, err := k.GetInferenceScoresUntilBlock(ctx, topicId, blockHeight)
 	s.Require().NoError(err, "Fetching worker inference scores until block should not fail")
 	s.Require().Len(scores, 6, "Should retrieve correct number of scores up to block 105")
 
@@ -2802,8 +2567,8 @@ func (s *KeeperTestSuite) TestGetInferenceScoresUntilBlock() {
 }
 
 func (s *KeeperTestSuite) TestInsertWorkerForecastScore() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(100)
 
@@ -2812,7 +2577,7 @@ func (s *KeeperTestSuite) TestInsertWorkerForecastScore() {
 	params := types.DefaultParams()
 	params.MaxSamplesToScaleScores = uint64(maxNumScores)
 	params.MaxTopForecastersToReward = 1
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err, "Setting parameters should not fail")
 
 	// Insert scores more than the max limit to test trimming
@@ -2823,19 +2588,19 @@ func (s *KeeperTestSuite) TestInsertWorkerForecastScore() {
 			Address:     "allo15lvs3m3urm4kts4tp2um5u3aeuz3whqrhz47r5",
 			Score:       alloraMath.NewDecFromInt64(int64(90 + i)), // Increment score value to simulate variation
 		}
-		err := keeper.InsertWorkerForecastScore(ctx, topicId, blockHeight, score)
+		err := k.InsertWorkerForecastScore(ctx, topicId, blockHeight, score)
 		s.Require().NoError(err, "Inserting worker forecast score should not fail")
 	}
 
 	// Fetch scores to check if trimming happened
-	scores, err := keeper.GetWorkerForecastScoresAtBlock(ctx, topicId, blockHeight)
+	scores, err := k.GetWorkerForecastScoresAtBlock(ctx, topicId, blockHeight)
 	s.Require().NoError(err, "Fetching forecast scores at block should not fail")
 	s.Require().Len(scores.Scores, maxNumScores, "Scores should not exceed the maximum limit")
 }
 
 func (s *KeeperTestSuite) TestGetForecastScoresUntilBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(105)
 
@@ -2845,21 +2610,21 @@ func (s *KeeperTestSuite) TestGetForecastScoresUntilBlock() {
 			TopicId:     topicId,
 			BlockHeight: i,
 			Score:       alloraMath.NewDecFromInt64(i),
-			Address:     s.addrsStr[0],
+			Address:     s.AddrsStr(0),
 		}
-		err := keeper.InsertWorkerForecastScore(ctx, topicId, i, score)
+		err := k.InsertWorkerForecastScore(ctx, topicId, i, score)
 		s.Require().NoError(err, "Inserting worker forecast score should not fail")
 	}
 
 	// Get forecast scores for the worker up to block 105
-	scores, err := keeper.GetForecastScoresUntilBlock(ctx, topicId, blockHeight)
+	scores, err := k.GetForecastScoresUntilBlock(ctx, topicId, blockHeight)
 	s.Require().NoError(err, "Fetching worker forecast scores until block should not fail")
 	s.Require().Len(scores, 6, "Should retrieve correct number of scores up to block 105")
 }
 
 func (s *KeeperTestSuite) TestGetWorkerForecastScoresAtBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(100)
 
@@ -2868,22 +2633,22 @@ func (s *KeeperTestSuite) TestGetWorkerForecastScoresAtBlock() {
 		score := types.Score{
 			TopicId:     topicId,
 			BlockHeight: blockHeight,
-			Address:     s.addrsStr[i],
+			Address:     s.AddrsStr(i),
 			Score:       alloraMath.NewDecFromInt64(int64(100 + i)),
 		}
-		err := keeper.InsertWorkerForecastScore(ctx, topicId, blockHeight, score)
+		err := k.InsertWorkerForecastScore(ctx, topicId, blockHeight, score)
 		s.Require().NoError(err, "Inserting worker forecast score should not fail")
 	}
 
 	// Fetch scores at the specific block
-	scores, err := keeper.GetWorkerForecastScoresAtBlock(ctx, topicId, blockHeight)
+	scores, err := k.GetWorkerForecastScoresAtBlock(ctx, topicId, blockHeight)
 	s.Require().NoError(err, "Fetching forecast scores at block should not fail")
 	s.Require().Len(scores.Scores, 5, "Should retrieve all scores at the block")
 }
 
 func (s *KeeperTestSuite) TestInsertReputerScore() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(100)
 
@@ -2891,7 +2656,7 @@ func (s *KeeperTestSuite) TestInsertReputerScore() {
 	maxNumScores := 5
 	params := types.DefaultParams()
 	params.MaxSamplesToScaleScores = uint64(maxNumScores)
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err, "Setting parameters should not fail")
 
 	// Insert scores more than the max limit to test trimming
@@ -2902,19 +2667,19 @@ func (s *KeeperTestSuite) TestInsertReputerScore() {
 			Address:     "allo144nqxgt6jdrm4srzzgx4dvz04hd8q2e8cel9hu",
 			Score:       alloraMath.NewDecFromInt64(int64(90 + i)), // Increment score value to simulate variation
 		}
-		err := keeper.InsertReputerScore(ctx, topicId, blockHeight, score)
+		err := k.InsertReputerScore(ctx, topicId, blockHeight, score)
 		s.Require().NoError(err, "Inserting reputer score should not fail")
 	}
 
 	// Fetch scores to check if trimming happened
-	scores, err := keeper.GetReputersScoresAtBlock(ctx, topicId, blockHeight)
+	scores, err := k.GetReputersScoresAtBlock(ctx, topicId, blockHeight)
 	s.Require().NoError(err, "Fetching reputer scores at block should not fail")
 	s.Require().Len(scores.Scores, maxNumScores, "Scores should not exceed the maximum limit")
 }
 
 func (s *KeeperTestSuite) TestGetReputersScoresAtBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(100)
 
@@ -2923,22 +2688,22 @@ func (s *KeeperTestSuite) TestGetReputersScoresAtBlock() {
 		score := types.Score{
 			TopicId:     topicId,
 			BlockHeight: blockHeight,
-			Address:     s.addrsStr[i],
+			Address:     s.AddrsStr(i),
 			Score:       alloraMath.NewDecFromInt64(int64(100 + i)),
 		}
-		err := keeper.InsertReputerScore(ctx, topicId, blockHeight, score)
+		err := k.InsertReputerScore(ctx, topicId, blockHeight, score)
 		s.Require().NoError(err, "Inserting reputer score should not fail")
 	}
 
 	// Fetch scores at the specific block
-	scores, err := keeper.GetReputersScoresAtBlock(ctx, topicId, blockHeight)
+	scores, err := k.GetReputersScoresAtBlock(ctx, topicId, blockHeight)
 	s.Require().NoError(err, "Fetching reputer scores at block should not fail")
 	s.Require().Len(scores.Scores, 5, "Should retrieve all scores at the block")
 }
 
 func (s *KeeperTestSuite) TestSetListeningCoefficient() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	reputer := "allo17srupely9uux7axep5shdsezva4znz6g30ntdw"
 
@@ -2948,23 +2713,23 @@ func (s *KeeperTestSuite) TestSetListeningCoefficient() {
 	}
 
 	// Set the listening coefficient
-	err := keeper.SetListeningCoefficient(ctx, topicId, reputer, coefficient)
+	err := k.SetListeningCoefficient(ctx, topicId, reputer, coefficient)
 	s.Require().NoError(err, "Setting listening coefficient should not fail")
 
 	// Retrieve the set coefficient to verify it was set correctly
-	retrievedCoef, err := keeper.GetListeningCoefficient(ctx, topicId, reputer)
+	retrievedCoef, err := k.GetListeningCoefficient(ctx, topicId, reputer)
 	s.Require().NoError(err, "Fetching listening coefficient should not fail")
 	s.Require().Equal(coefficient.Coefficient, retrievedCoef.Coefficient, "The retrieved coefficient should match the set value")
 }
 
 func (s *KeeperTestSuite) TestGetListeningCoefficient() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	reputer := "allo17srupely9uux7axep5shdsezva4znz6g30ntdw"
 
 	// Attempt to fetch a coefficient before setting it
-	defaultCoef, err := keeper.GetListeningCoefficient(ctx, topicId, reputer)
+	defaultCoef, err := k.GetListeningCoefficient(ctx, topicId, reputer)
 	s.Require().NoError(err, "Fetching coefficient should not fail when not set")
 	s.Require().Equal(alloraMath.NewDecFromInt64(1), defaultCoef.Coefficient, "Should return the default coefficient when not set")
 
@@ -2972,198 +2737,198 @@ func (s *KeeperTestSuite) TestGetListeningCoefficient() {
 	setCoef := types.ListeningCoefficient{
 		Coefficient: alloraMath.NewDecFromInt64(5),
 	}
-	err = keeper.SetListeningCoefficient(ctx, topicId, reputer, setCoef)
+	err = k.SetListeningCoefficient(ctx, topicId, reputer, setCoef)
 	s.Require().NoError(err, "Setting listening coefficient should not fail")
 	// Fetch and verify the coefficient after setting
-	fetchedCoef, err := keeper.GetListeningCoefficient(ctx, topicId, reputer)
+	fetchedCoef, err := k.GetListeningCoefficient(ctx, topicId, reputer)
 	s.Require().NoError(err, "Fetching coefficient should not fail after setting")
 	s.Require().Equal(setCoef.Coefficient, fetchedCoef.Coefficient, "The fetched coefficient should match the set value")
 }
 
-/// REWARD FRACTION
+// REWARD FRACTION
 
 func (s *KeeperTestSuite) TestSetPreviousReputerRewardFraction() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputer := s.addrsStr[2]
+	reputer := s.AddrsStr(2)
 
 	// Define a reward fraction to set
 	rewardFraction := alloraMath.NewDecFromInt64(75) // Assuming 0.75 as a fraction example
 
 	// Set the reward fraction
-	err := keeper.SetPreviousReputerRewardFraction(ctx, topicId, reputer, rewardFraction)
+	err := k.SetPreviousReputerRewardFraction(ctx, topicId, reputer, rewardFraction)
 	s.Require().NoError(err, "Setting previous reputer reward fraction should not fail")
 
 	// Verify by fetching the same
-	fetchedReward, noPrior, err := keeper.GetPreviousReputerRewardFraction(ctx, topicId, reputer)
+	fetchedReward, noPrior, err := k.GetPreviousReputerRewardFraction(ctx, topicId, reputer)
 	s.Require().NoError(err, "Fetching the set reward fraction should not fail")
 	s.Require().True(fetchedReward.Equal(rewardFraction), "The fetched reward fraction should match the set value")
 	s.Require().False(noPrior, "Should not return no prior value when set")
 }
 
 func (s *KeeperTestSuite) TestGetPreviousReputerRewardFraction() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputer := s.addrsStr[2]
+	reputer := s.AddrsStr(2)
 
 	// Attempt to fetch a reward fraction before setting it
-	defaultReward, _, err := keeper.GetPreviousReputerRewardFraction(ctx, topicId, reputer)
+	defaultReward, _, err := k.GetPreviousReputerRewardFraction(ctx, topicId, reputer)
 	s.Require().NoError(err, "Fetching reward fraction should not fail when not set")
 	s.Require().True(defaultReward.IsZero(), "Should return zero reward fraction when not set")
 
 	// Now set a specific reward fraction
 	setReward := alloraMath.NewDecFromInt64(50) // Assuming 0.50 as a fraction example
-	err = keeper.SetPreviousReputerRewardFraction(ctx, topicId, reputer, setReward)
+	err = k.SetPreviousReputerRewardFraction(ctx, topicId, reputer, setReward)
 	s.Require().NoError(err, "Setting previous reputer reward fraction should not fail")
 
 	// Fetch and verify the reward fraction after setting
-	fetchedReward, noPrior, err := keeper.GetPreviousReputerRewardFraction(ctx, topicId, reputer)
+	fetchedReward, noPrior, err := k.GetPreviousReputerRewardFraction(ctx, topicId, reputer)
 	s.Require().NoError(err, "Fetching reward fraction should not fail after setting")
 	s.Require().True(fetchedReward.Equal(setReward), "The fetched reward fraction should match the set value")
 	s.Require().False(noPrior, "Should not return no prior value after setting")
 }
 
 func (s *KeeperTestSuite) TestSetPreviousInferenceRewardFraction() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[1]
+	worker := s.AddrsStr(1)
 
 	// Define a reward fraction to set
 	rewardFraction := alloraMath.NewDecFromInt64(25)
 
 	// Set the reward fraction
-	err := keeper.SetPreviousInferenceRewardFraction(ctx, topicId, worker, rewardFraction)
+	err := k.SetPreviousInferenceRewardFraction(ctx, topicId, worker, rewardFraction)
 	s.Require().NoError(err, "Setting previous inference reward fraction should not fail")
 
 	// Verify by fetching the same
-	fetchedReward, noPrior, err := keeper.GetPreviousInferenceRewardFraction(ctx, topicId, worker)
+	fetchedReward, noPrior, err := k.GetPreviousInferenceRewardFraction(ctx, topicId, worker)
 	s.Require().NoError(err, "Fetching the set reward fraction should not fail")
 	s.Require().True(fetchedReward.Equal(rewardFraction), "The fetched reward fraction should match the set value")
 	s.Require().False(noPrior, "Should not return no prior value when set")
 }
 
 func (s *KeeperTestSuite) TestGetPreviousInferenceRewardFraction() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[1]
+	worker := s.AddrsStr(1)
 
 	// Attempt to fetch a reward fraction before setting it
-	defaultReward, noPrior, err := keeper.GetPreviousInferenceRewardFraction(ctx, topicId, worker)
+	defaultReward, noPrior, err := k.GetPreviousInferenceRewardFraction(ctx, topicId, worker)
 	s.Require().NoError(err, "Fetching reward fraction should not fail when not set")
 	s.Require().True(defaultReward.IsZero(), "Should return zero reward fraction when not set")
 	s.Require().True(noPrior, "Should return no prior value when not set")
 
 	// Now set a specific reward fraction
 	setReward := alloraMath.NewDecFromInt64(75)
-	err = keeper.SetPreviousInferenceRewardFraction(ctx, topicId, worker, setReward)
+	err = k.SetPreviousInferenceRewardFraction(ctx, topicId, worker, setReward)
 	s.Require().NoError(err, "Setting previous inference reward fraction should not fail")
 	// Fetch and verify the reward fraction after setting
-	fetchedReward, noPrior, err := keeper.GetPreviousInferenceRewardFraction(ctx, topicId, worker)
+	fetchedReward, noPrior, err := k.GetPreviousInferenceRewardFraction(ctx, topicId, worker)
 	s.Require().NoError(err, "Fetching reward fraction should not fail after setting")
 	s.Require().True(fetchedReward.Equal(setReward), "The fetched reward fraction should match the set value")
 	s.Require().False(noPrior, "Should not return no prior value after setting")
 }
 
 func (s *KeeperTestSuite) TestSetPreviousForecastRewardFraction() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[3]
+	worker := s.AddrsStr(3)
 
 	// Define a reward fraction to set
 	rewardFraction := alloraMath.NewDecFromInt64(50) // Assume setting the fraction to 0.50
 
 	// Set the forecast reward fraction
-	err := keeper.SetPreviousForecastRewardFraction(ctx, topicId, worker, rewardFraction)
+	err := k.SetPreviousForecastRewardFraction(ctx, topicId, worker, rewardFraction)
 	s.Require().NoError(err, "Setting previous forecast reward fraction should not fail")
 
 	// Verify by fetching the set value
-	fetchedReward, noPrior, err := keeper.GetPreviousForecastRewardFraction(ctx, topicId, worker)
+	fetchedReward, noPrior, err := k.GetPreviousForecastRewardFraction(ctx, topicId, worker)
 	s.Require().NoError(err, "Fetching the set forecast reward fraction should not fail")
 	s.Require().True(fetchedReward.Equal(rewardFraction), "The fetched forecast reward fraction should match the set value")
 	s.Require().False(noPrior, "Should not return no prior value when set")
 }
 
 func (s *KeeperTestSuite) TestGetPreviousForecastRewardFraction() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[3]
+	worker := s.AddrsStr(3)
 
 	// Attempt to fetch the reward fraction before setting it, expecting default value
-	defaultReward, noPrior, err := keeper.GetPreviousForecastRewardFraction(ctx, topicId, worker)
+	defaultReward, noPrior, err := k.GetPreviousForecastRewardFraction(ctx, topicId, worker)
 	s.Require().NoError(err, "Fetching forecast reward fraction should not fail when not set")
 	s.Require().True(defaultReward.IsZero(), "Should return zero forecast reward fraction when not set")
 	s.Require().True(noPrior, "Should return no prior value when not set")
 
 	// Now set a specific reward fraction
 	setReward := alloraMath.NewDecFromInt64(75) // Assume setting it to 0.75
-	err = keeper.SetPreviousForecastRewardFraction(ctx, topicId, worker, setReward)
+	err = k.SetPreviousForecastRewardFraction(ctx, topicId, worker, setReward)
 	s.Require().NoError(err, "Setting previous forecast reward fraction should not fail")
 
 	// Fetch and verify the reward fraction after setting
-	fetchedReward, noPrior, err := keeper.GetPreviousForecastRewardFraction(ctx, topicId, worker)
+	fetchedReward, noPrior, err := k.GetPreviousForecastRewardFraction(ctx, topicId, worker)
 	s.Require().NoError(err, "Fetching forecast reward fraction should not fail after setting")
 	s.Require().True(fetchedReward.Equal(setReward), "The fetched forecast reward fraction should match the set value")
 	s.Require().False(noPrior, "Should not return no prior value after setting")
 }
 
 func (s *KeeperTestSuite) TestSetGetPreviousPercentageRewardToStakedReputers() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	previousPercentageReward := alloraMath.NewDecFromInt64(50)
 
 	// Set the previous percentage reward to staked reputers
-	err := keeper.SetPreviousPercentageRewardToStakedReputers(ctx, previousPercentageReward)
+	err := k.SetPreviousPercentageRewardToStakedReputers(ctx, previousPercentageReward)
 	s.Require().NoError(err, "Setting previous percentage reward to staked reputers should not fail")
 
 	// Get the previous percentage reward to staked reputers
-	fetchedPercentageReward, err := keeper.GetPreviousPercentageRewardToStakedReputers(ctx)
+	fetchedPercentageReward, err := k.GetPreviousPercentageRewardToStakedReputers(ctx)
 	s.Require().NoError(err, "Fetching previous percentage reward to staked reputers should not fail")
 	s.Require().Equal(previousPercentageReward, fetchedPercentageReward, "The fetched percentage reward should match the set value")
 }
 
-/// TOPIC REWARD NONCE
+// TOPIC REWARD NONCE
 
 func (s *KeeperTestSuite) TestGetSetDeleteTopicRewardNonce() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 
 	// Test Get on an unset topicId, should return 0
-	nonce, err := keeper.GetTopicRewardNonce(ctx, topicId)
+	nonce, err := k.GetTopicRewardNonce(ctx, topicId)
 	s.Require().NoError(err, "Getting an unset topic reward nonce should not fail")
 	s.Require().Equal(int64(0), nonce, "Nonce for an unset topicId should be 0")
 
 	// Test Set
 	expectedNonce := int64(12345)
-	err = keeper.SetTopicRewardNonce(ctx, topicId, expectedNonce)
+	err = k.SetTopicRewardNonce(ctx, topicId, expectedNonce)
 	s.Require().NoError(err, "Setting topic reward nonce should not fail")
 
 	// Test Get after Set, should return the set value
-	nonce, err = keeper.GetTopicRewardNonce(ctx, topicId)
+	nonce, err = k.GetTopicRewardNonce(ctx, topicId)
 	s.Require().NoError(err, "Getting set topic reward nonce should not fail")
 	s.Require().Equal(expectedNonce, nonce, "Nonce should match the value set earlier")
 
 	// Test Delete
-	err = keeper.DeleteTopicRewardNonce(ctx, topicId)
+	err = k.DeleteTopicRewardNonce(ctx, topicId)
 	s.Require().NoError(err, "Deleting topic reward nonce should not fail")
 
 	// Test Get after Delete, should return 0
-	nonce, err = keeper.GetTopicRewardNonce(ctx, topicId)
+	nonce, err = k.GetTopicRewardNonce(ctx, topicId)
 	s.Require().NoError(err, "Getting deleted topic reward nonce should not fail")
 	s.Require().Equal(int64(0), nonce, "Nonce should be 0 after deletion")
 }
 
-/// UTILS
+// UTILS
 
 func (s *KeeperTestSuite) TestCalcAppropriatePaginationForUint64Cursor() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	defaultLimit := uint64(20)
 	maxLimit := uint64(50)
@@ -3171,23 +2936,23 @@ func (s *KeeperTestSuite) TestCalcAppropriatePaginationForUint64Cursor() {
 	params := types.DefaultParams()
 	params.DefaultPageLimit = defaultLimit
 	params.MaxPageLimit = maxLimit
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err, "Setting default and max limit parameters should not fail")
 
-	paramsActual, err := keeper.GetParams(ctx)
+	paramsActual, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	s.Require().Equal(maxLimit, paramsActual.MaxPageLimit, "Max limit should be set correctly")
 	s.Require().Equal(defaultLimit, paramsActual.DefaultPageLimit, "Default limit should be set correctly")
 
 	// Test 1: Pagination request is nil
-	limit, cursor, err := keeper.CalcAppropriatePaginationForUint64Cursor(ctx, nil)
+	limit, cursor, err := k.CalcAppropriatePaginationForUint64Cursor(ctx, nil)
 	s.Require().NoError(err, "Should handle nil pagination request without error")
 	s.Require().Equal(defaultLimit, limit, "Limit should default to the default limit")
 	s.Require().Equal(uint64(0), cursor, "Cursor should be 0 when key nil")
 
 	// Test 2: Pagination Key is empty and Limit is zero
 	pagination := &types.SimpleCursorPaginationRequest{Key: []byte{}, Limit: 0}
-	limit, cursor, err = keeper.CalcAppropriatePaginationForUint64Cursor(ctx, pagination)
+	limit, cursor, err = k.CalcAppropriatePaginationForUint64Cursor(ctx, pagination)
 	s.Require().NoError(err, "Should handle empty key and zero limit without error")
 	s.Require().Equal(defaultLimit, limit, "Limit should default to the default limit")
 	s.Require().Equal(uint64(0), cursor, "Cursor should be 0 when key is empty")
@@ -3195,14 +2960,14 @@ func (s *KeeperTestSuite) TestCalcAppropriatePaginationForUint64Cursor() {
 	// Test 3: Valid key and non-zero limit within bounds
 	validKey := binary.BigEndian.AppendUint64(nil, uint64(12345)) // Convert 12345 to big-endian byte slice
 	pagination = &types.SimpleCursorPaginationRequest{Key: validKey, Limit: 30}
-	limit, cursor, err = keeper.CalcAppropriatePaginationForUint64Cursor(ctx, pagination)
+	limit, cursor, err = k.CalcAppropriatePaginationForUint64Cursor(ctx, pagination)
 	s.Require().NoError(err, "Handling valid key and valid limit should not fail")
 	s.Require().Equal(uint64(30), limit, "Limit should be as specified")
 	s.Require().Equal(uint64(12345), cursor, "Cursor should decode correctly from key")
 
 	// Test 4: Limit exceeds maximum limit
 	pagination = &types.SimpleCursorPaginationRequest{Key: validKey, Limit: 60}
-	limit, _, err = keeper.CalcAppropriatePaginationForUint64Cursor(ctx, pagination)
+	limit, _, err = k.CalcAppropriatePaginationForUint64Cursor(ctx, pagination)
 	s.Require().NoError(err, "Handling limit exceeding maximum should not fail")
 	s.Require().Equal(maxLimit, limit, "Limit should be capped at the maximum limit")
 }
@@ -3219,18 +2984,18 @@ func (s *KeeperTestSuite) TestPruneRecordsAfterRewards() {
 				TopicId:     topicId,
 				BlockHeight: block,
 				Value:       alloraMath.NewDecFromInt64(1), // Assuming NewDecFromInt64 exists and is appropriate
-				Inferer:     s.addrsStr[0],
+				Inferer:     s.AddrsStr(0),
 			},
 			{
 				TopicId:     topicId,
 				BlockHeight: block,
 				Value:       alloraMath.NewDecFromInt64(2),
-				Inferer:     s.addrsStr[1],
+				Inferer:     s.AddrsStr(1),
 			},
 		},
 	}
 	nonce := types.Nonce{BlockHeight: block} // Assuming block type cast to int64 if needed
-	err := s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, nonce.BlockHeight, expectedInferences)
+	err := s.EmissionsKeeper().InsertActiveInferences(s.Ctx(), topicId, nonce.BlockHeight, expectedInferences)
 	s.Require().NoError(err, "Inserting inferences should not fail")
 
 	expectedForecasts := types.Forecasts{
@@ -3238,14 +3003,14 @@ func (s *KeeperTestSuite) TestPruneRecordsAfterRewards() {
 			{
 				TopicId:     topicId,
 				BlockHeight: block,
-				Forecaster:  s.addrsStr[6],
+				Forecaster:  s.AddrsStr(6),
 				ForecastElements: []*types.ForecastElement{
 					{
-						Inferer: s.addrsStr[0],
+						Inferer: s.AddrsStr(0),
 						Value:   alloraMath.MustNewDecFromString("1"),
 					},
 					{
-						Inferer: s.addrsStr[1],
+						Inferer: s.AddrsStr(1),
 						Value:   alloraMath.MustNewDecFromString("2"),
 					},
 				},
@@ -3253,75 +3018,70 @@ func (s *KeeperTestSuite) TestPruneRecordsAfterRewards() {
 			{
 				TopicId:     topicId,
 				BlockHeight: block,
-				Forecaster:  s.addrsStr[7],
+				Forecaster:  s.AddrsStr(7),
 				ForecastElements: []*types.ForecastElement{
 					{
-						Inferer: s.addrsStr[0],
+						Inferer: s.AddrsStr(0),
 						Value:   alloraMath.MustNewDecFromString("3"),
 					},
 					{
-						Inferer: s.addrsStr[1],
+						Inferer: s.AddrsStr(1),
 						Value:   alloraMath.MustNewDecFromString("4"),
 					},
 				},
 			},
 		},
 	}
-	err = s.emissionsKeeper.InsertActiveForecasts(s.ctx, topicId, nonce.BlockHeight, expectedForecasts)
+	err = s.EmissionsKeeper().InsertActiveForecasts(s.Ctx(), topicId, nonce.BlockHeight, expectedForecasts)
 	s.Require().NoError(err)
 
 	reputerLossBundles := types.ReputerValueBundles{
 		ReputerValueBundles: []*types.ReputerValueBundle{},
 	}
-	err = s.emissionsKeeper.InsertActiveReputerLosses(s.ctx, topicId, block, reputerLossBundles)
+	err = s.EmissionsKeeper().InsertActiveReputerLosses(s.Ctx(), topicId, block, reputerLossBundles)
 	s.Require().NoError(err, "InsertActiveReputerLosses should not return an error")
 
 	reputerRequestNonce := &types.ReputerRequestNonce{
 		ReputerNonce: &types.Nonce{BlockHeight: block},
 	}
+	//nolint:exhaustruct
 	networkLosses := types.ValueBundle{
-		Reputer:                       s.addrsStr[4],
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000117005278862668"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		Reputer:             s.AddrsStr(4),
+		CombinedValue:       alloraMath.MustNewDecFromString(".0000117005278862668"),
+		ReputerRequestNonce: reputerRequestNonce,
+		TopicId:             topicId,
+		InfererValues:       s.createDefaultInfererValues(),
+		NaiveValue:          alloraMath.MustNewDecFromString("0.0"),
 	}
-	err = s.emissionsKeeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, block, networkLosses)
+	err = s.EmissionsKeeper().InsertNetworkLossBundleAtBlock(s.Ctx(), topicId, block, networkLosses)
 	s.Require().NoError(err, "InsertNetworkLossBundleAtBlock should not return an error")
 
 	// Check if the records are set
-	_, err = s.emissionsKeeper.GetInferencesAtBlock(s.ctx, topicId, block, false)
+	_, err = s.EmissionsKeeper().GetInferencesAtBlock(s.Ctx(), topicId, block, false)
 	s.Require().NoError(err, "Getting inferences should not fail")
-	_, err = s.emissionsKeeper.GetForecastsAtBlock(s.ctx, topicId, block)
+	_, err = s.EmissionsKeeper().GetForecastsAtBlock(s.Ctx(), topicId, block)
 	s.Require().NoError(err, "Getting forecasts should not fail")
-	lossBundles, err := s.emissionsKeeper.GetReputerLossBundlesAtBlock(s.ctx, topicId, block)
+	lossBundles, err := s.EmissionsKeeper().GetReputerLossBundlesAtBlock(s.Ctx(), topicId, block)
 	s.Require().NoError(err, "Getting reputer loss bundles should not fail")
 	s.Require().NotNil(lossBundles)
-	_, err = s.emissionsKeeper.GetNetworkLossBundleAtBlock(s.ctx, topicId, block)
+	_, err = s.EmissionsKeeper().GetNetworkLossBundleAtBlock(s.Ctx(), topicId, block)
 	s.Require().NoError(err, "Getting network loss bundle should not fail")
 
 	// Prune records in the subsequent block
-	err = s.emissionsKeeper.PruneRecordsAfterRewards(s.ctx, topicId, block+1)
+	err = s.EmissionsKeeper().PruneRecordsAfterRewards(s.Ctx(), topicId, block+1)
 	s.Require().NoError(err, "Pruning records after rewards should not fail")
 
 	// Check if the records are pruned
-	inferences, err := s.emissionsKeeper.GetInferencesAtBlock(s.ctx, topicId, block, false)
+	inferences, err := s.EmissionsKeeper().GetInferencesAtBlock(s.Ctx(), topicId, block, false)
 	s.Require().NoError(err, "Getting inferences should not fail")
 	s.Require().Empty(inferences.Inferences, "Must be pruned")
-	forecasts, err := s.emissionsKeeper.GetForecastsAtBlock(s.ctx, topicId, block)
+	forecasts, err := s.EmissionsKeeper().GetForecastsAtBlock(s.Ctx(), topicId, block)
 	s.Require().NoError(err, "Getting forecasts should not fail")
 	s.Require().Empty(forecasts.Forecasts, "Must be pruned")
-	lossbundles, err := s.emissionsKeeper.GetReputerLossBundlesAtBlock(s.ctx, topicId, block)
+	lossbundles, err := s.EmissionsKeeper().GetReputerLossBundlesAtBlock(s.Ctx(), topicId, block)
 	s.Require().NoError(err, "Getting reputer loss bundles should not fail")
 	s.Require().Empty(lossbundles.ReputerValueBundles, "Must be pruned")
-	networkBundles, err := s.emissionsKeeper.GetNetworkLossBundleAtBlock(s.ctx, topicId, block)
+	networkBundles, err := s.EmissionsKeeper().GetNetworkLossBundleAtBlock(s.Ctx(), topicId, block)
 	s.Require().NoError(err, "Getting network loss bundle should not fail but be empty")
 	s.Require().Equal(topicId, networkBundles.TopicId, "topic id returned")
 	s.Require().Empty(networkBundles.InfererValues, "inferer values is empty")
@@ -3335,18 +3095,18 @@ func (s *KeeperTestSuite) TestPruneRecordsAfterRewards() {
 }
 
 func (s *KeeperTestSuite) TestPruneWorkerNoncesLogicNoNonces() {
-	keeper := s.emissionsKeeper
+	k := s.EmissionsKeeper()
 	topicId1 := uint64(1)
 	blockHeightThreshold := int64(10)
-	err := keeper.DeleteUnfulfilledWorkerNonces(s.ctx, topicId1)
+	err := k.DeleteUnfulfilledWorkerNonces(s.Ctx(), topicId1)
 	s.Require().NoError(err, "Failed to delete unfulfilled worker nonces, topicId1")
 
 	// Call pruneWorkerNonces
-	err = s.emissionsKeeper.PruneWorkerNonces(s.ctx, topicId1, blockHeightThreshold)
+	err = s.EmissionsKeeper().PruneWorkerNonces(s.Ctx(), topicId1, blockHeightThreshold)
 	s.Require().ErrorIs(err, collections.ErrNotFound)
 
 	// Check remaining nonces
-	nonces, err := s.emissionsKeeper.GetUnfulfilledWorkerNonces(s.ctx, topicId1)
+	nonces, err := s.EmissionsKeeper().GetUnfulfilledWorkerNonces(s.Ctx(), topicId1)
 	s.Require().NoError(err)
 	s.Require().Empty(nonces.Nonces)
 }
@@ -3384,24 +3144,24 @@ func (s *KeeperTestSuite) TestPruneWorkerNoncesLogicCorrectness() {
 			expectedNonces:       []*types.Nonce{{BlockHeight: 15}, {BlockHeight: 20}},
 		},
 	}
-	keeper := s.emissionsKeeper
+	k := s.EmissionsKeeper()
 	topicId1 := uint64(1)
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			err := keeper.DeleteUnfulfilledWorkerNonces(s.ctx, topicId1)
+			err := k.DeleteUnfulfilledWorkerNonces(s.Ctx(), topicId1)
 			s.Require().NoError(err, "Failed to delete unfulfilled worker nonces, topicId1")
 			// Set multiple worker nonces
 			for _, val := range tt.nonces {
-				err := keeper.AddWorkerNonce(s.ctx, topicId1, val)
+				err := k.AddWorkerNonce(s.Ctx(), topicId1, val)
 				s.Require().NoError(err, "Failed to add worker nonce, topicId1")
 			}
 
 			// Call pruneWorkerNonces
-			err = s.emissionsKeeper.PruneWorkerNonces(s.ctx, topicId1, tt.blockHeightThreshold)
+			err = s.EmissionsKeeper().PruneWorkerNonces(s.Ctx(), topicId1, tt.blockHeightThreshold)
 			s.Require().NoError(err)
 
 			// Check remaining nonces
-			nonces, err := s.emissionsKeeper.GetUnfulfilledWorkerNonces(s.ctx, topicId1)
+			nonces, err := s.EmissionsKeeper().GetUnfulfilledWorkerNonces(s.Ctx(), topicId1)
 			s.Require().NoError(err)
 			// for loop nonces
 			for _, nonce := range nonces.Nonces {
@@ -3467,24 +3227,24 @@ func (s *KeeperTestSuite) TestPruneReputerNoncesLogicCorrectness() {
 				{ReputerNonce: &types.Nonce{BlockHeight: 20}}},
 		},
 	}
-	keeper := s.emissionsKeeper
+	k := s.EmissionsKeeper()
 	topicId1 := uint64(1)
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			err := keeper.DeleteUnfulfilledReputerNonces(s.ctx, topicId1)
+			err := k.DeleteUnfulfilledReputerNonces(s.Ctx(), topicId1)
 			s.Require().NoError(err, "Failed to delete unfulfilled reputer nonces, topicId1")
 			// Set multiple reputer nonces
 			for _, val := range tt.nonces {
-				err := keeper.AddReputerNonce(s.ctx, topicId1, val.ReputerNonce)
+				err := k.AddReputerNonce(s.Ctx(), topicId1, val.ReputerNonce)
 				s.Require().NoError(err, "Failed to add reputer nonce, topicId1")
 			}
 
 			// Call PruneReputerNonces
-			err = s.emissionsKeeper.PruneReputerNonces(s.ctx, topicId1, tt.blockHeightThreshold)
+			err = s.EmissionsKeeper().PruneReputerNonces(s.Ctx(), topicId1, tt.blockHeightThreshold)
 			s.Require().NoError(err)
 
 			// Check remaining nonces
-			nonces, err := s.emissionsKeeper.GetUnfulfilledReputerNonces(s.ctx, topicId1)
+			nonces, err := s.EmissionsKeeper().GetUnfulfilledReputerNonces(s.Ctx(), topicId1)
 			s.Require().NoError(err)
 			// for loop nonces
 			for _, nonce := range nonces.Nonces {
@@ -3498,7 +3258,7 @@ func (s *KeeperTestSuite) TestPruneReputerNoncesLogicCorrectness() {
 }
 
 func (s *KeeperTestSuite) TestGetTargetWeight() {
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	if err != nil {
 		s.T().Fatalf("Failed to get parameters: %v", err)
 	}
@@ -3556,7 +3316,7 @@ func (s *KeeperTestSuite) TestGetTargetWeight() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			got, err := s.emissionsKeeper.GetTargetWeight(tc.topicStake, tc.topicFeeRevenue, tc.stakeImportance, tc.feeImportance)
+			got, err := s.EmissionsKeeper().GetTargetWeight(tc.topicStake, tc.topicFeeRevenue, tc.stakeImportance, tc.feeImportance)
 			if tc.expectError {
 				s.Require().Error(err, "Expected an error for case: %s", tc.name)
 			} else {
@@ -3569,38 +3329,38 @@ func (s *KeeperTestSuite) TestGetTargetWeight() {
 
 func (s *KeeperTestSuite) TestDeleteUnfulfilledWorkerNonces() {
 	topicId := uint64(1)
-	keeper := s.emissionsKeeper
+	k := s.EmissionsKeeper()
 	// Setup initial nonces
-	err := keeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{BlockHeight: 10})
+	err := k.AddWorkerNonce(s.Ctx(), topicId, &types.Nonce{BlockHeight: 10})
 	s.Require().NoError(err)
-	err = keeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{BlockHeight: 20})
+	err = k.AddWorkerNonce(s.Ctx(), topicId, &types.Nonce{BlockHeight: 20})
 	s.Require().NoError(err)
 
 	// Call DeleteUnfulfilledWorkerNonces
-	err = s.emissionsKeeper.DeleteUnfulfilledWorkerNonces(s.ctx, topicId)
+	err = s.EmissionsKeeper().DeleteUnfulfilledWorkerNonces(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
 	// Check that the nonces were removed
-	nonces, err := s.emissionsKeeper.GetUnfulfilledWorkerNonces(s.ctx, topicId)
+	nonces, err := s.EmissionsKeeper().GetUnfulfilledWorkerNonces(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	s.Require().Empty(nonces.Nonces)
 }
 
 func (s *KeeperTestSuite) TestDeleteUnfulfilledreputerNonces() {
 	topicId := uint64(1)
-	keeper := s.emissionsKeeper
+	k := s.EmissionsKeeper()
 	// Setup initial nonces
-	err := keeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{BlockHeight: 50})
+	err := k.AddReputerNonce(s.Ctx(), topicId, &types.Nonce{BlockHeight: 50})
 	s.Require().NoError(err)
-	err = keeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{BlockHeight: 60})
+	err = k.AddReputerNonce(s.Ctx(), topicId, &types.Nonce{BlockHeight: 60})
 	s.Require().NoError(err)
 
 	// Call DeleteUnfulfilledWorkerNonces
-	err = s.emissionsKeeper.DeleteUnfulfilledReputerNonces(s.ctx, topicId)
+	err = s.EmissionsKeeper().DeleteUnfulfilledReputerNonces(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
 	// Check that the nonces were removed
-	nonces, err := s.emissionsKeeper.GetUnfulfilledReputerNonces(s.ctx, topicId)
+	nonces, err := s.EmissionsKeeper().GetUnfulfilledReputerNonces(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	s.Require().Empty(nonces.Nonces)
 }
@@ -3608,42 +3368,41 @@ func (s *KeeperTestSuite) TestDeleteUnfulfilledreputerNonces() {
 // TestActiveTopicStakeRemoval tests that when a stake is removed from an active topic,
 // it correctly updates the stake
 func (s *KeeperTestSuite) TestActiveTopicStakeRemoval() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputerAddr := s.addrs[0].String()
+	reputerAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(500)
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	startBlock := ctx.BlockHeight()
 	endBlock := startBlock + moduleParams.RemoveStakeDelayWindow
+	epochLength := int64(100)
 
 	// Create a topic and activate it
-	topic := s.mockTopic()
-	topic.Id = topicId
-	topic.EpochLength = 100
-	topic.WorkerSubmissionWindow = 100 // Make sure WorkerSubmissionWindow matches EpochLength to pass validation
-	err = keeper.SetTopic(ctx, topicId, topic)
-	s.Require().NoError(err)
-	err = keeper.ActivateTopic(ctx, topicId)
+	s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength),
+		alloratestutil.WithWorkerSubmissionWindow(epochLength),
+	)
+	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err)
 
 	// Verify the topic is active
-	isActive, err := keeper.IsTopicActive(ctx, topicId)
+	isActive, err := k.IsTopicActive(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().True(isActive, "Topic should be active")
 
 	// Add some stake to the topic
-	err = keeper.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
+	err = k.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Verify the stake was added correctly
-	topicStake, err := keeper.GetTopicStake(ctx, topicId)
+	topicStake, err := k.GetTopicStake(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(stakeAmount, topicStake, "Topic stake should match the added amount")
 
 	// Setup for stake removal
-	err = keeper.SetStakeRemoval(ctx, types.StakeRemovalInfo{
+	err = k.SetStakeRemoval(ctx, types.StakeRemovalInfo{
 		TopicId:               topicId,
 		Reputer:               reputerAddr,
 		Amount:                stakeAmount,
@@ -3653,11 +3412,11 @@ func (s *KeeperTestSuite) TestActiveTopicStakeRemoval() {
 	s.Require().NoError(err)
 
 	// Remove stake
-	err = keeper.RemoveReputerStake(ctx, endBlock, topicId, reputerAddr, stakeAmount)
+	err = k.RemoveReputerStake(ctx, endBlock, topicId, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Check that the stake was removed correctly
-	topicStake, err = keeper.GetTopicStake(ctx, topicId)
+	topicStake, err = k.GetTopicStake(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(cosmosMath.ZeroInt(), topicStake, "Topic stake should be zero after removal")
 }
@@ -3665,43 +3424,42 @@ func (s *KeeperTestSuite) TestActiveTopicStakeRemoval() {
 // TestDelegateStakeRemoval tests that when a delegate stake is removed,
 // it correctly updates the stake
 func (s *KeeperTestSuite) TestDelegateStakeRemoval() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputerAddr := s.addrsStr[1]
-	delegatorAddr := s.addrsStr[0]
+	reputerAddr := s.AddrsStr(1)
+	delegatorAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(500)
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	startBlock := ctx.BlockHeight()
 	endBlock := startBlock + moduleParams.RemoveStakeDelayWindow
+	epochLength := int64(100)
 
 	// Create a topic and activate it
-	topic := s.mockTopic()
-	topic.Id = topicId
-	topic.EpochLength = 100
-	topic.WorkerSubmissionWindow = 100 // Make sure WorkerSubmissionWindow matches EpochLength to pass validation
-	err = keeper.SetTopic(ctx, topicId, topic)
-	s.Require().NoError(err)
-	err = keeper.ActivateTopic(ctx, topicId)
+	s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength),
+		alloratestutil.WithWorkerSubmissionWindow(epochLength),
+	)
+	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err)
 
 	// Verify the topic is active
-	isActive, err := keeper.IsTopicActive(ctx, topicId)
+	isActive, err := k.IsTopicActive(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().True(isActive, "Topic should be active")
 
 	// Add some delegate stake to the topic
-	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, stakeAmount)
+	err = k.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Verify the stake was added correctly
-	topicStake, err := keeper.GetTopicStake(ctx, topicId)
+	topicStake, err := k.GetTopicStake(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(stakeAmount, topicStake, "Topic stake should match the added amount")
 
 	// Setup for delegate stake removal
-	err = keeper.SetDelegateStakeRemoval(ctx, types.DelegateStakeRemovalInfo{
+	err = k.SetDelegateStakeRemoval(ctx, types.DelegateStakeRemovalInfo{
 		TopicId:               topicId,
 		Delegator:             delegatorAddr,
 		Reputer:               reputerAddr,
@@ -3712,11 +3470,11 @@ func (s *KeeperTestSuite) TestDelegateStakeRemoval() {
 	s.Require().NoError(err)
 
 	// Remove delegate stake
-	err = keeper.RemoveDelegateStake(ctx, endBlock, topicId, delegatorAddr, reputerAddr, stakeAmount)
+	err = k.RemoveDelegateStake(ctx, endBlock, topicId, delegatorAddr, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Check that the stake was removed correctly
-	topicStake, err = keeper.GetTopicStake(ctx, topicId)
+	topicStake, err = k.GetTopicStake(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(cosmosMath.ZeroInt(), topicStake, "Topic stake should be zero after removal")
 }
@@ -3724,40 +3482,39 @@ func (s *KeeperTestSuite) TestDelegateStakeRemoval() {
 // TestInactiveTopicStakeRemoval tests that when a stake is removed from an inactive topic,
 // it still correctly updates the stake but does not affect the total weight calculations
 func (s *KeeperTestSuite) TestInactiveTopicStakeRemoval() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputerAddr := s.addrs[0].String()
+	reputerAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(500)
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	startBlock := ctx.BlockHeight()
 	endBlock := startBlock + moduleParams.RemoveStakeDelayWindow
+	epochLength := int64(100)
 
 	// Create a topic but do NOT activate it
-	topic := s.mockTopic()
-	topic.Id = topicId
-	topic.EpochLength = 100
-	topic.WorkerSubmissionWindow = 100 // Make sure WorkerSubmissionWindow matches EpochLength to pass validation
-	err = keeper.SetTopic(ctx, topicId, topic)
-	s.Require().NoError(err)
+	s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength),
+		alloratestutil.WithWorkerSubmissionWindow(epochLength),
+	)
 
 	// Verify the topic is not active
-	isActive, err := keeper.IsTopicActive(ctx, topicId)
+	isActive, err := k.IsTopicActive(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().False(isActive, "Topic should not be active")
 
 	// Add some stake to the topic
-	err = keeper.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
+	err = k.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Verify the stake was added correctly
-	topicStake, err := keeper.GetTopicStake(ctx, topicId)
+	topicStake, err := k.GetTopicStake(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(stakeAmount, topicStake, "Topic stake should match the added amount")
 
 	// Setup for stake removal
-	err = keeper.SetStakeRemoval(ctx, types.StakeRemovalInfo{
+	err = k.SetStakeRemoval(ctx, types.StakeRemovalInfo{
 		TopicId:               topicId,
 		Reputer:               reputerAddr,
 		Amount:                stakeAmount,
@@ -3767,11 +3524,11 @@ func (s *KeeperTestSuite) TestInactiveTopicStakeRemoval() {
 	s.Require().NoError(err)
 
 	// Remove stake first (this should work even for inactive topics)
-	err = keeper.RemoveReputerStake(ctx, endBlock, topicId, reputerAddr, stakeAmount)
+	err = k.RemoveReputerStake(ctx, endBlock, topicId, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
 
 	// Check that the stake was removed correctly
-	topicStake, err = keeper.GetTopicStake(ctx, topicId)
+	topicStake, err = k.GetTopicStake(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(cosmosMath.ZeroInt(), topicStake, "Topic stake should be zero after removal")
 }
@@ -3779,49 +3536,48 @@ func (s *KeeperTestSuite) TestInactiveTopicStakeRemoval() {
 // TestTopicWeightRecalculationAfterStakeRemoval tests that when a stake is removed,
 // the topic weight is recalculated correctly based on the remaining stake
 func (s *KeeperTestSuite) TestTopicWeightRecalculationAfterStakeRemoval() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-	reputerAddr := s.addrs[0].String()
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := uint64(2)
+	reputerAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(1000)
 	feeRevenue := cosmosMath.NewInt(100)
-	moduleParams, err := keeper.GetParams(ctx)
+	moduleParams, err := k.GetParams(ctx)
 	s.Require().NoError(err)
 	startBlock := ctx.BlockHeight()
 	endBlock := startBlock + moduleParams.RemoveStakeDelayWindow
+	epochLength := int64(100)
 
 	// Create and activate topic
-	topic := s.mockTopic()
-	topic.Id = topicId
-	topic.EpochLength = 100
-	topic.WorkerSubmissionWindow = 100
-	err = keeper.SetTopic(ctx, topicId, topic)
-	s.Require().NoError(err)
-	err = keeper.ActivateTopic(ctx, topicId)
+	s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength),
+		alloratestutil.WithWorkerSubmissionWindow(epochLength),
+	)
+	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err)
 
 	// Add stake and fee revenue
-	err = keeper.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
+	err = k.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
-	err = keeper.AddTopicFeeRevenue(ctx, topicId, feeRevenue)
+	err = k.AddTopicFeeRevenue(ctx, topicId, feeRevenue)
 	s.Require().NoError(err)
 
 	// Get initial weight and set it
-	initialWeight, _, err := keeper.GetCurrentTopicWeight(
+	initialWeight, _, err := k.GetCurrentTopicWeight(
 		ctx,
 		topicId,
-		topic.EpochLength,
+		epochLength,
 		moduleParams.TopicRewardAlpha,
 		moduleParams.TopicRewardStakeImportance,
 		moduleParams.TopicRewardFeeRevenueImportance,
 		moduleParams.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
-	err = keeper.SetPreviousTopicWeight(ctx, topicId, initialWeight)
+	err = k.SetPreviousTopicWeight(ctx, topicId, initialWeight)
 	s.Require().NoError(err)
 
 	// Remove half the stake
-	err = keeper.SetStakeRemoval(ctx, types.StakeRemovalInfo{
+	err = k.SetStakeRemoval(ctx, types.StakeRemovalInfo{
 		TopicId:               topicId,
 		Reputer:               reputerAddr,
 		Amount:                stakeAmount.QuoRaw(2),
@@ -3829,16 +3585,16 @@ func (s *KeeperTestSuite) TestTopicWeightRecalculationAfterStakeRemoval() {
 		BlockRemovalCompleted: endBlock,
 	})
 	s.Require().NoError(err)
-	err = keeper.RemoveReputerStake(ctx, endBlock, topicId, reputerAddr, stakeAmount.QuoRaw(2))
+	err = k.RemoveReputerStake(ctx, endBlock, topicId, reputerAddr, stakeAmount.QuoRaw(2))
 	s.Require().NoError(err)
 
 	// Verify weight and stake changes
-	newWeight, noPrior, err := keeper.GetPreviousTopicWeight(ctx, topicId)
+	newWeight, noPrior, err := k.GetPreviousTopicWeight(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().False(noPrior, "Should still have a prior weight")
 	s.Require().True(newWeight.Lt(initialWeight), "New weight should be less than initial weight")
 
-	remainingStake, err := keeper.GetTopicStake(ctx, topicId)
+	remainingStake, err := k.GetTopicStake(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(stakeAmount.QuoRaw(2), remainingStake, "Remaining stake should be half of initial stake")
 }
@@ -3846,16 +3602,16 @@ func (s *KeeperTestSuite) TestTopicWeightRecalculationAfterStakeRemoval() {
 // TestTopicWeightRecalculationWithMultipleTopics tests that when stakes are removed,
 // the weights of multiple topics are recalculated correctly and the total sum is updated
 func (s *KeeperTestSuite) TestTopicWeightRecalculationWithMultipleTopics() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	reputerAddr := s.addrs[0].String()
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	reputerAddr := s.AddrsStr(0)
 
 	// Set up test parameters
 	stakeAmount1 := cosmosMath.NewInt(1000)
 	stakeAmount2 := cosmosMath.NewInt(2000)
+	epochLength := int64(100)
 	feeRevenue1 := cosmosMath.NewInt(100)
 	feeRevenue2 := cosmosMath.NewInt(200)
-	topicId1, topicId2 := uint64(1), uint64(2)
 
 	// Set up params
 	params := types.DefaultParams()
@@ -3864,37 +3620,34 @@ func (s *KeeperTestSuite) TestTopicWeightRecalculationWithMultipleTopics() {
 	params.TopicRewardAlpha = alloraMath.MustNewDecFromString("0.5")
 	params.TopicRewardStakeImportance = alloraMath.OneDec()
 	params.TopicRewardFeeRevenueImportance = alloraMath.OneDec()
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
 	// Create and activate both topics
-	for id, epochLength := range map[uint64]int64{topicId1: 100, topicId2: 100} {
-		topic := s.mockTopic()
-		topic.Id = id
-		topic.EpochLength = epochLength
-		topic.WorkerSubmissionWindow = epochLength
-		err = keeper.SetTopic(ctx, id, topic)
-		s.Require().NoError(err)
-		err = keeper.ActivateTopic(ctx, id)
-		s.Require().NoError(err)
-	}
+	topicId1, topicId2 :=
+		s.CreateTopic(alloratestutil.WithEpochLength(epochLength)),
+		s.CreateTopic(alloratestutil.WithEpochLength(epochLength))
+	err = k.ActivateTopic(ctx, topicId1)
+	s.Require().NoError(err)
+	err = k.ActivateTopic(ctx, topicId2)
+	s.Require().NoError(err)
 
 	// Add stake and fee revenue to both topics
-	err = keeper.AddReputerStake(ctx, topicId1, reputerAddr, stakeAmount1)
+	err = k.AddReputerStake(ctx, topicId1, reputerAddr, stakeAmount1)
 	s.Require().NoError(err)
-	err = keeper.AddReputerStake(ctx, topicId2, reputerAddr, stakeAmount2)
+	err = k.AddReputerStake(ctx, topicId2, reputerAddr, stakeAmount2)
 	s.Require().NoError(err)
-	err = keeper.AddTopicFeeRevenue(ctx, topicId1, feeRevenue1)
+	err = k.AddTopicFeeRevenue(ctx, topicId1, feeRevenue1)
 	s.Require().NoError(err)
-	err = keeper.AddTopicFeeRevenue(ctx, topicId2, feeRevenue2)
+	err = k.AddTopicFeeRevenue(ctx, topicId2, feeRevenue2)
 	s.Require().NoError(err)
 
 	// Calculate and set initial weights for both topics
 	for id := range map[uint64]struct{}{topicId1: {}, topicId2: {}} {
-		weight, _, err := keeper.GetCurrentTopicWeight(
+		weight, _, err := k.GetCurrentTopicWeight(
 			ctx,
 			id,
-			100, // epochLength
+			epochLength, // epochLength
 			params.TopicRewardAlpha,
 			params.TopicRewardStakeImportance,
 			params.TopicRewardFeeRevenueImportance,
@@ -3902,18 +3655,18 @@ func (s *KeeperTestSuite) TestTopicWeightRecalculationWithMultipleTopics() {
 		)
 		s.Require().NoError(err)
 		s.Require().True(weight.Gt(params.MinTopicWeight), "Initial weight should be greater than minimum weight")
-		err = keeper.SetPreviousTopicWeight(ctx, id, weight)
+		err = k.SetPreviousTopicWeight(ctx, id, weight)
 		s.Require().NoError(err)
 	}
 
 	// Get total sum before stake removal
-	totalSumBefore, err := keeper.GetTotalSumPreviousTopicWeights(ctx)
+	totalSumBefore, err := k.GetTotalSumPreviousTopicWeights(ctx)
 	s.Require().NoError(err)
 
 	// Remove stake from first topic
 	startBlock := ctx.BlockHeight()
 	endBlock := startBlock + params.RemoveStakeDelayWindow
-	err = keeper.SetStakeRemoval(ctx, types.StakeRemovalInfo{
+	err = k.SetStakeRemoval(ctx, types.StakeRemovalInfo{
 		TopicId:               topicId1,
 		Reputer:               reputerAddr,
 		Amount:                stakeAmount1,
@@ -3921,19 +3674,19 @@ func (s *KeeperTestSuite) TestTopicWeightRecalculationWithMultipleTopics() {
 		BlockRemovalCompleted: endBlock,
 	})
 	s.Require().NoError(err)
-	err = keeper.RemoveReputerStake(ctx, endBlock, topicId1, reputerAddr, stakeAmount1)
+	err = k.RemoveReputerStake(ctx, endBlock, topicId1, reputerAddr, stakeAmount1)
 	s.Require().NoError(err)
 
 	// Verify total sum was updated correctly
-	totalSumAfter, err := keeper.GetTotalSumPreviousTopicWeights(ctx)
+	totalSumAfter, err := k.GetTotalSumPreviousTopicWeights(ctx)
 	s.Require().NoError(err)
 	s.Require().True(totalSumAfter.Lt(totalSumBefore), "Total sum should decrease after stake removal")
 }
 
 func (s *KeeperTestSuite) TestGetFirstStakeRemovalForReputerAndTopicId() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
-	reputer := s.addrsStr[2]
+	k := s.EmissionsKeeper()
+	ctx := s.Ctx()
+	reputer := s.AddrsStr(2)
 	topicId := uint64(1)
 
 	// Create a stake removal info
@@ -3966,9 +3719,9 @@ func (s *KeeperTestSuite) TestGetFirstStakeRemovalForReputerAndTopicId() {
 }
 
 func (s *KeeperTestSuite) TestGetFirstStakeRemovalForReputerAndTopicIdNotFound() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
-	reputer := s.addrsStr[2]
+	k := s.EmissionsKeeper()
+	ctx := s.Ctx()
+	reputer := s.AddrsStr(2)
 	topicId := uint64(1)
 
 	_, found, err := k.GetStakeRemovalForReputerAndTopicId(ctx, reputer, topicId)
@@ -3977,11 +3730,11 @@ func (s *KeeperTestSuite) TestGetFirstStakeRemovalForReputerAndTopicIdNotFound()
 }
 
 func (s *KeeperTestSuite) TestGetFirstDelegateStakeRemovalForDelegatorReputerAndTopicId() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
-	delegator := s.addrsStr[5]
-	reputer := s.addrsStr[2]
-	reputer2 := s.addrsStr[3]
+	k := s.EmissionsKeeper()
+	ctx := s.Ctx()
+	delegator := s.AddrsStr(5)
+	reputer := s.AddrsStr(2)
+	reputer2 := s.AddrsStr(3)
 	topicId := uint64(1)
 
 	// Create a stake removal info
@@ -4016,10 +3769,10 @@ func (s *KeeperTestSuite) TestGetFirstDelegateStakeRemovalForDelegatorReputerAnd
 }
 
 func (s *KeeperTestSuite) TestGetFirstDelegateStakeRemovalForDelegatorReputerAndTopicIdNotFound() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
+	k := s.EmissionsKeeper()
+	ctx := s.Ctx()
 	delegator := "delegator"
-	reputer := s.addrsStr[2]
+	reputer := s.AddrsStr(2)
 	topicId := uint64(1)
 
 	_, found, err := k.GetDelegateStakeRemovalForDelegatorReputerAndTopicId(ctx, delegator, reputer, topicId)
@@ -4028,10 +3781,10 @@ func (s *KeeperTestSuite) TestGetFirstDelegateStakeRemovalForDelegatorReputerAnd
 }
 
 func (s *KeeperTestSuite) TestAppendInference() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	// Topic IDs
-	topicId := s.CreateOneTopic(10800)
+	topicId := s.CreateTopic()
 	nonce := types.Nonce{BlockHeight: 10}
 	blockHeightInferences := int64(10)
 
@@ -4177,10 +3930,9 @@ func getNewAddress() string {
 }
 
 func (s *KeeperTestSuite) TestAppendInferenceWithResetActiveWorkers() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	// Topic IDs
-	topicId := s.CreateOneTopic(10801)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic(alloratestutil.WithEpochLength(10801), alloratestutil.WithGroundTruthLag(10801))
 	nonce := types.Nonce{BlockHeight: 10}
 	blockHeightInferences := int64(10)
 
@@ -4191,47 +3943,45 @@ func (s *KeeperTestSuite) TestAppendInferenceWithResetActiveWorkers() {
 	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
 
-	worker1 := getNewAddress()
-	worker2 := getNewAddress()
-	worker3 := getNewAddress()
-	worker4 := getNewAddress()
-	worker5 := getNewAddress()
-	worker6 := getNewAddress()
-	// score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker1, Score: alloraMath.NewDecFromInt64(91)}
-	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker2, Score: alloraMath.NewDecFromInt64(92)}
-	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker3, Score: alloraMath.NewDecFromInt64(93)}
-	score4 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker4, Score: alloraMath.NewDecFromInt64(94)}
-	score5 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker5, Score: alloraMath.NewDecFromInt64(95)}
-	score6 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker6, Score: alloraMath.NewDecFromInt64(96)}
-	// err = k.SetInfererScoreEma(ctx, topicId, worker1, score1)
-	// s.Require().NoError(err)
-	err = k.SetInfererScoreEma(ctx, topicId, worker2, score2)
-	s.Require().NoError(err)
-	err = k.SetInfererScoreEma(ctx, topicId, worker3, score3)
-	s.Require().NoError(err)
-	err = k.SetInfererScoreEma(ctx, topicId, worker4, score4)
-	s.Require().NoError(err)
-	err = k.SetInfererScoreEma(ctx, topicId, worker5, score5)
-	s.Require().NoError(err)
-	err = k.SetInfererScoreEma(ctx, topicId, worker6, score6)
-	s.Require().NoError(err)
+	// Create workers
+	workers := make([]string, 6)
+	for i := range workers {
+		workers[i] = getNewAddress()
+	}
 
-	// Ensure that the number of top inferers is capped at the max top inferers to reward
-	// New high-score entrant should replace earlier low-score entrant
+	// Set scores for workers 2-6
+	for i := 1; i < len(workers); i++ {
+		score := types.Score{
+			TopicId:     topicId,
+			BlockHeight: 2,
+			Address:     workers[i],
+			Score:       alloraMath.NewDecFromInt64(int64(91 + i)),
+		}
+		err = k.SetInfererScoreEma(ctx, topicId, workers[i], score)
+		s.Require().NoError(err)
+	}
+
 	params := types.DefaultParams()
 	params.MaxTopInferersToReward = 4
 	err = k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
-	allInferences := types.Inferences{
-		Inferences: []*types.Inference{
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.11")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.12")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.13")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.14")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker5, Value: alloraMath.MustNewDecFromString("0.15")},
-		},
+	formatValue := func(val float64) string {
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", val), "0"), ".")
 	}
+
+	// Create first set of inferences
+	inferences := make([]*types.Inference, 5)
+	for i := range inferences {
+		inferences[i] = &types.Inference{
+			TopicId:     topicId,
+			BlockHeight: blockHeightInferences,
+			Inferer:     workers[i],
+			Value:       alloraMath.MustNewDecFromString(formatValue(0.11 + float64(i)*0.01)),
+		}
+	}
+
+	allInferences := types.Inferences{Inferences: inferences}
 	for _, inference := range allInferences.Inferences {
 		err = k.AppendInference(ctx, topic, nonce.BlockHeight, inference, params.MaxTopInferersToReward)
 		s.Require().NoError(err)
@@ -4244,7 +3994,7 @@ func (s *KeeperTestSuite) TestAppendInferenceWithResetActiveWorkers() {
 	lowestEmaScore, found, err := k.GetLowestInfererScoreEma(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().True(found)
-	s.Require().Equal(lowestEmaScore.Address, worker2)
+	s.Require().Equal(lowestEmaScore.Address, workers[1])
 
 	err = k.ResetActiveWorkersForTopic(ctx, topicId)
 	s.Require().NoError(err)
@@ -4256,18 +4006,21 @@ func (s *KeeperTestSuite) TestAppendInferenceWithResetActiveWorkers() {
 	lowestEmaScore, found, err = k.GetLowestInfererScoreEma(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().True(found)
-	s.Require().Equal(lowestEmaScore.Address, worker2)
+	s.Require().Equal(lowestEmaScore.Address, workers[1])
 
+	// Create second set of inferences
 	blockHeightInferences = blockHeightInferences + topic.EpochLength
-	allInferences = types.Inferences{
-		Inferences: []*types.Inference{
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.22")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.23")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.24")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker5, Value: alloraMath.MustNewDecFromString("0.25")},
-			{TopicId: topicId, BlockHeight: blockHeightInferences, Inferer: worker6, Value: alloraMath.MustNewDecFromString("0.26")},
-		},
+	inferences = make([]*types.Inference, 5)
+	for i := 1; i <= len(inferences); i++ {
+		inferences[i-1] = &types.Inference{
+			TopicId:     topicId,
+			BlockHeight: blockHeightInferences,
+			Inferer:     workers[i],
+			Value:       alloraMath.MustNewDecFromString(formatValue(0.22 + float64(i-1)*0.01)),
+		}
 	}
+
+	allInferences = types.Inferences{Inferences: inferences}
 	nonce.BlockHeight++
 	for _, inference := range allInferences.Inferences {
 		err = k.AppendInference(ctx, topic, nonce.BlockHeight, inference, params.MaxTopInferersToReward)
@@ -4281,7 +4034,7 @@ func (s *KeeperTestSuite) TestAppendInferenceWithResetActiveWorkers() {
 	lowestEmaScore, found, err = k.GetLowestInfererScoreEma(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().True(found)
-	s.Require().Equal(lowestEmaScore.Address, worker3)
+	s.Require().Equal(lowestEmaScore.Address, workers[2])
 }
 
 func mockUninitializedParams() types.Params {
@@ -4344,106 +4097,66 @@ func mockUninitializedParams() types.Params {
 }
 
 func (s *KeeperTestSuite) TestAppendForecast() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
 	nonce := types.Nonce{BlockHeight: 10}
 	blockHeightInferences := int64(10)
 
-	worker1 := s.addrsStr[0]
-	worker2 := s.addrsStr[1]
-	worker3 := s.addrsStr[2]
-	worker4 := s.addrsStr[3]
-	worker5 := s.addrsStr[4]
+	workers := make([]string, 5)
+	for i := range workers {
+		workers[i] = s.AddrsStr(i)
+	}
 
-	score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker1, Score: alloraMath.NewDecFromInt64(95)}
-	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker2, Score: alloraMath.NewDecFromInt64(90)}
-	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker3, Score: alloraMath.NewDecFromInt64(99)}
-	score4 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker4, Score: alloraMath.NewDecFromInt64(91)}
-	score5 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker5, Score: alloraMath.NewDecFromInt64(96)}
-	err := k.SetForecasterScoreEma(ctx, topicId, worker1, score1)
-	s.Require().NoError(err)
-	err = k.SetForecasterScoreEma(ctx, topicId, worker2, score2)
-	s.Require().NoError(err)
-	err = k.SetForecasterScoreEma(ctx, topicId, worker3, score3)
-	s.Require().NoError(err)
-	err = k.SetForecasterScoreEma(ctx, topicId, worker4, score4)
-	s.Require().NoError(err)
-	err = k.SetForecasterScoreEma(ctx, topicId, worker5, score5)
-	s.Require().NoError(err)
+	// Set initial scores
+	scores := []int64{95, 90, 99, 91, 96}
+	for i, worker := range workers {
+		score := types.Score{
+			TopicId:     topicId,
+			BlockHeight: 2,
+			Address:     worker,
+			Score:       alloraMath.NewDecFromInt64(scores[i]),
+		}
+		err := k.SetForecasterScoreEma(ctx, topicId, worker, score)
+		s.Require().NoError(err)
+	}
 
 	params := mockUninitializedParams()
 	params.MaxTopForecastersToReward = 4
-	err = k.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
-	allForecasts := types.Forecasts{
-		Forecasts: []*types.Forecast{
+	//nolint:exhaustruct
+	newForecast := types.Forecast{
+		TopicId:     topicId,
+		BlockHeight: blockHeightInferences,
+		Forecaster:  "",
+		ForecastElements: []*types.ForecastElement{
 			{
-				TopicId:     topicId,
-				BlockHeight: blockHeightInferences,
-				Forecaster:  worker1,
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: worker1,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-					{
-						Inferer: worker2,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-				},
+				Inferer: workers[0],
+				Value:   alloraMath.MustNewDecFromString("0.52"),
 			},
 			{
-				TopicId:     topicId,
-				BlockHeight: blockHeightInferences,
-				Forecaster:  worker2,
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: worker1,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-					{
-						Inferer: worker2,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-				},
-			},
-			{
-				TopicId:     topicId,
-				BlockHeight: blockHeightInferences,
-				Forecaster:  worker3,
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: worker1,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-					{
-						Inferer: worker2,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-				},
-			},
-			{
-				TopicId:     topicId,
-				BlockHeight: blockHeightInferences,
-				Forecaster:  worker4,
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: worker1,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-					{
-						Inferer: worker2,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-				},
+				Inferer: workers[1],
+				Value:   alloraMath.MustNewDecFromString("0.52"),
 			},
 		},
 	}
 
+	// Create forecasts for first 4 workers
+	forecasts := make([]*types.Forecast, 4)
+	for i := range forecasts {
+		forecast := newForecast
+		forecast.Forecaster = workers[i]
+		forecasts[i] = &forecast
+	}
+
+	allForecasts := types.Forecasts{Forecasts: forecasts}
+
 	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
+
+	// Append initial forecasts
 	for _, forecast := range allForecasts.Forecasts {
 		err = k.AppendForecast(ctx, topic, nonce.BlockHeight, forecast, params.MaxTopForecastersToReward)
 		s.Require().NoError(err)
@@ -4453,25 +4166,13 @@ func (s *KeeperTestSuite) TestAppendForecast() {
 	s.Require().NoError(err)
 	s.Require().Equal(params.MaxTopForecastersToReward, uint64(len(activeForecasters)))
 
+	// Try to add forecast for the fifth worker
 	blockHeightInferences = blockHeightInferences + topic.EpochLength
-	newForecast2 := types.Forecast{
-		TopicId:     topicId,
-		BlockHeight: blockHeightInferences,
-		Forecaster:  worker5,
-		ForecastElements: []*types.ForecastElement{
-			{
-				Inferer: worker1,
-				Value:   alloraMath.MustNewDecFromString("0.52"),
-			},
-			{
-				Inferer: worker2,
-				Value:   alloraMath.MustNewDecFromString("0.52"),
-			},
-		},
-		ExtraData: nil,
-	}
-	// MaxTopInferersToReward is 4, so this should not be added
-	err = k.AppendForecast(ctx, topic, nonce.BlockHeight, &newForecast2, params.MaxTopForecastersToReward)
+	newForecast.Forecaster = workers[4]
+	newForecast.BlockHeight = blockHeightInferences
+
+	// MaxTopForecastersToReward is 4, so this should not increase active forecasters
+	err = k.AppendForecast(ctx, topic, nonce.BlockHeight, &newForecast, params.MaxTopForecastersToReward)
 	s.Require().NoError(err)
 
 	activeForecasters, err = k.GetActiveForecastersForTopic(ctx, topicId)
@@ -4480,122 +4181,60 @@ func (s *KeeperTestSuite) TestAppendForecast() {
 }
 
 func (s *KeeperTestSuite) TestAppendForecastWithResetActiveForecasters() {
-
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
 	nonce := types.Nonce{BlockHeight: 10}
 	blockHeightInferences := int64(10)
 
-	worker1 := s.addrsStr[0]
-	worker2 := s.addrsStr[1]
-	worker3 := s.addrsStr[2]
-	worker4 := s.addrsStr[3]
-	worker5 := s.addrsStr[4]
+	// Create workers and set their scores
+	workers := make([]string, 5)
+	scores := []int64{95, 90, 99, 91, 96}
+	for i := range workers {
+		workers[i] = s.AddrsStr(i)
+		score := types.Score{
+			TopicId:     topicId,
+			BlockHeight: 2,
+			Address:     workers[i],
+			Score:       alloraMath.NewDecFromInt64(scores[i]),
+		}
+		err := k.SetForecasterScoreEma(ctx, topicId, workers[i], score)
+		s.Require().NoError(err)
+	}
 
-	score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker1, Score: alloraMath.NewDecFromInt64(95)}
-	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker2, Score: alloraMath.NewDecFromInt64(90)}
-	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker3, Score: alloraMath.NewDecFromInt64(99)}
-	score4 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker4, Score: alloraMath.NewDecFromInt64(91)}
-	score5 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker5, Score: alloraMath.NewDecFromInt64(96)}
-	err := k.SetForecasterScoreEma(ctx, topicId, worker1, score1)
-	s.Require().NoError(err)
-	err = k.SetForecasterScoreEma(ctx, topicId, worker2, score2)
-	s.Require().NoError(err)
-	err = k.SetForecasterScoreEma(ctx, topicId, worker3, score3)
-	s.Require().NoError(err)
-	err = k.SetForecasterScoreEma(ctx, topicId, worker4, score4)
-	s.Require().NoError(err)
-	err = k.SetForecasterScoreEma(ctx, topicId, worker5, score5)
-	s.Require().NoError(err)
-
+	// Set params
 	params := mockUninitializedParams()
 	params.MaxTopForecastersToReward = 4
-	err = k.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
-	allForecasts := types.Forecasts{
-		Forecasts: []*types.Forecast{
-			{
-				TopicId:     topicId,
-				BlockHeight: blockHeightInferences,
-				Forecaster:  worker1,
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: worker1,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-					{
-						Inferer: worker2,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-				},
-			},
-			{
-				TopicId:     topicId,
-				BlockHeight: blockHeightInferences,
-				Forecaster:  worker2,
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: worker1,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-					{
-						Inferer: worker2,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-				},
-			},
-			{
-				TopicId:     topicId,
-				BlockHeight: blockHeightInferences,
-				Forecaster:  worker3,
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: worker1,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-					{
-						Inferer: worker2,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-				},
-			},
-			{
-				TopicId:     topicId,
-				BlockHeight: blockHeightInferences,
-				Forecaster:  worker4,
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: worker1,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-					{
-						Inferer: worker2,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-				},
-			},
-			{
-				TopicId:     topicId,
-				BlockHeight: blockHeightInferences,
-				Forecaster:  worker5,
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: worker1,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-					{
-						Inferer: worker2,
-						Value:   alloraMath.MustNewDecFromString("0.52"),
-					},
-				},
-			},
+	// Create forecast elements template
+	forecastElements := []*types.ForecastElement{
+		{
+			Inferer: workers[0],
+			Value:   alloraMath.MustNewDecFromString("0.52"),
+		},
+		{
+			Inferer: workers[1],
+			Value:   alloraMath.MustNewDecFromString("0.52"),
 		},
 	}
 
+	// Create forecasts for all workers
+	allForecasts := types.Forecasts{Forecasts: make([]*types.Forecast, len(workers))}
+	for i, worker := range workers {
+		allForecasts.Forecasts[i] = &types.Forecast{
+			TopicId:          topicId,
+			BlockHeight:      blockHeightInferences,
+			Forecaster:       worker,
+			ForecastElements: forecastElements,
+		}
+	}
+
+	// Append initial forecasts and verify
 	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
+
 	for _, forecast := range allForecasts.Forecasts {
 		err = k.AppendForecast(ctx, topic, nonce.BlockHeight, forecast, params.MaxTopForecastersToReward)
 		s.Require().NoError(err)
@@ -4605,7 +4244,7 @@ func (s *KeeperTestSuite) TestAppendForecastWithResetActiveForecasters() {
 	s.Require().NoError(err)
 	s.Require().Equal(params.MaxTopForecastersToReward, uint64(len(activeForecasters)))
 
-	// Reset active forecasters
+	// Reset active forecasters and verify
 	err = k.ResetActiveWorkersForTopic(ctx, topicId)
 	s.Require().NoError(err)
 
@@ -4613,6 +4252,7 @@ func (s *KeeperTestSuite) TestAppendForecastWithResetActiveForecasters() {
 	s.Require().NoError(err)
 	s.Require().Empty(activeForecasters)
 
+	// Re-append forecasts and verify again
 	topic, err = k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
 
@@ -4628,166 +4268,74 @@ func (s *KeeperTestSuite) TestAppendForecastWithResetActiveForecasters() {
 }
 
 func (s *KeeperTestSuite) TestAppendReputerLoss() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
 	blockHeight := int64(10)
 	nonce := types.Nonce{BlockHeight: blockHeight}
 	reputerRequestNonce := &types.ReputerRequestNonce{
 		ReputerNonce: &types.Nonce{BlockHeight: blockHeight},
 	}
 
-	reputer1 := s.addrsStr[0]
-	reputer2 := s.addrsStr[1]
-	reputer3 := s.addrsStr[2]
-	reputer4 := s.addrsStr[3]
-	reputer5 := s.addrsStr[4]
+	// Create reputers and set their scores
+	reputers := make([]string, 5)
+	scores := []int64{95, 90, 99, 91, 96}
+	for i := range reputers {
+		reputers[i] = s.AddrsStr(i)
+		score := types.Score{
+			TopicId:     topicId,
+			BlockHeight: 2,
+			Address:     reputers[i],
+			Score:       alloraMath.NewDecFromInt64(scores[i]),
+		}
+		err := k.SetReputerScoreEma(ctx, topicId, reputers[i], score)
+		s.Require().NoError(err)
+	}
 
-	score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer1, Score: alloraMath.NewDecFromInt64(95)}
-	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer2, Score: alloraMath.NewDecFromInt64(90)}
-	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer3, Score: alloraMath.NewDecFromInt64(99)}
-	score4 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer4, Score: alloraMath.NewDecFromInt64(91)}
-	score5 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer5, Score: alloraMath.NewDecFromInt64(96)}
-	err := k.SetReputerScoreEma(ctx, topicId, reputer1, score1)
-	s.Require().NoError(err)
-	err = k.SetReputerScoreEma(ctx, topicId, reputer2, score2)
-	s.Require().NoError(err)
-	err = k.SetReputerScoreEma(ctx, topicId, reputer3, score3)
-	s.Require().NoError(err)
-	err = k.SetReputerScoreEma(ctx, topicId, reputer4, score4)
-	s.Require().NoError(err)
-	err = k.SetReputerScoreEma(ctx, topicId, reputer5, score5)
-	s.Require().NoError(err)
-
+	// Set params
 	params := types.DefaultParams()
 	params.MaxTopReputersToReward = 4
-	err = k.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
-	valueBundleReputer1 := types.ValueBundle{
-		Reputer:                       reputer1,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000117005278862668"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature := s.signValueBundle(&valueBundleReputer1, s.privKeys[0])
-	reputerValueBundle1 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer1,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[0],
-	}
-	valueBundleReputer2 := types.ValueBundle{
-		Reputer:                       reputer2,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".00000962701954026944"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature = s.signValueBundle(&valueBundleReputer2, s.privKeys[1])
-	reputerValueBundle2 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer2,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[1],
-	}
-	valueBundleReputer3 := types.ValueBundle{
-		Reputer:                       reputer3,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature = s.signValueBundle(&valueBundleReputer3, s.privKeys[2])
-	reputerValueBundle3 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer3,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[2],
-	}
-
-	allReputerLosses := types.ReputerValueBundles{
-		ReputerValueBundles: []*types.ReputerValueBundle{
-			&reputerValueBundle1,
-			&reputerValueBundle2,
-			&reputerValueBundle3,
-		},
+	// Create value bundles for all reputers
+	reputerValueBundles := make([]*types.ReputerValueBundle, len(reputers))
+	for i, reputer := range reputers {
+		//nolint:exhaustruct
+		valueBundle := types.ValueBundle{
+			Reputer:             reputer,
+			CombinedValue:       alloraMath.MustNewDecFromString(".0000256948644008351"),
+			ReputerRequestNonce: reputerRequestNonce,
+			TopicId:             topicId,
+			InfererValues:       s.createDefaultInfererValues(),
+			NaiveValue:          alloraMath.MustNewDecFromString("0.0"),
+		}
+		signature := s.SignValueBundle(&valueBundle, s.PrivKeys(i))
+		reputerValueBundles[i] = &types.ReputerValueBundle{
+			ValueBundle: &valueBundle,
+			Signature:   signature,
+			Pubkey:      s.PubKeyHexStr(i),
+		}
 	}
 
 	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
-	for _, reputerValueBundle := range allReputerLosses.ReputerValueBundles {
-		err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, reputerValueBundle)
+
+	// Append first three reputer losses
+	for i := 0; i < 3; i++ {
+		err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, reputerValueBundles[i])
 		s.Require().NoError(err)
 	}
 
-	valueBundleReputer4 := types.ValueBundle{
-		Reputer:                       reputer4,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature = s.signValueBundle(&valueBundleReputer4, s.privKeys[3])
-	reputerValueBundle4 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer4,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[3],
-	}
-
-	err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, &reputerValueBundle4)
+	// Add fourth reputer and verify active reputers count
+	err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, reputerValueBundles[3])
 	s.Require().NoError(err)
 	activeReputers, err := k.GetActiveReputersForTopic(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(params.MaxTopReputersToReward, uint64(len(activeReputers)))
 
-	valueBundleReputer5 := types.ValueBundle{
-		Reputer:                       reputer5,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature = s.signValueBundle(&valueBundleReputer5, s.privKeys[4])
-	reputerValueBundle5 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer5,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[4],
-	}
-	err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, &reputerValueBundle5)
+	// Add fifth reputer and verify active reputers count remains at max
+	err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, reputerValueBundles[4])
 	s.Require().NoError(err)
 	activeReputers, err = k.GetActiveReputersForTopic(ctx, topicId)
 	s.Require().NoError(err)
@@ -4795,164 +4343,75 @@ func (s *KeeperTestSuite) TestAppendReputerLoss() {
 }
 
 func (s *KeeperTestSuite) TestAppendReputerLossWithResetActiveReputers() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
 	blockHeight := int64(10)
 	nonce := types.Nonce{BlockHeight: blockHeight}
 	reputerRequestNonce := &types.ReputerRequestNonce{
 		ReputerNonce: &types.Nonce{BlockHeight: blockHeight},
 	}
 
-	reputer1 := s.addrsStr[0]
-	reputer2 := s.addrsStr[1]
-	reputer3 := s.addrsStr[2]
-	reputer4 := s.addrsStr[3]
-	reputer5 := s.addrsStr[4]
+	// Setup reputers and their scores
+	reputers := make([]string, 5)
+	scores := []int64{95, 90, 99, 91, 96}
+	for i := range reputers {
+		reputers[i] = s.AddrsStr(i)
+		score := types.Score{
+			TopicId:     topicId,
+			BlockHeight: 2,
+			Address:     reputers[i],
+			Score:       alloraMath.NewDecFromInt64(scores[i]),
+		}
+		err := k.SetReputerScoreEma(ctx, topicId, reputers[i], score)
+		s.Require().NoError(err)
+	}
 
-	score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer1, Score: alloraMath.NewDecFromInt64(95)}
-	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer2, Score: alloraMath.NewDecFromInt64(90)}
-	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer3, Score: alloraMath.NewDecFromInt64(99)}
-	score4 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer4, Score: alloraMath.NewDecFromInt64(91)}
-	score5 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer5, Score: alloraMath.NewDecFromInt64(96)}
-	err := k.SetReputerScoreEma(ctx, topicId, reputer1, score1)
-	s.Require().NoError(err)
-	err = k.SetReputerScoreEma(ctx, topicId, reputer2, score2)
-	s.Require().NoError(err)
-	err = k.SetReputerScoreEma(ctx, topicId, reputer3, score3)
-	s.Require().NoError(err)
-	err = k.SetReputerScoreEma(ctx, topicId, reputer4, score4)
-	s.Require().NoError(err)
-	err = k.SetReputerScoreEma(ctx, topicId, reputer5, score5)
-	s.Require().NoError(err)
-
+	// Set params
 	params := types.DefaultParams()
 	params.MaxTopReputersToReward = 4
-	err = k.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
-	valueBundleReputer1 := types.ValueBundle{
-		Reputer:                       reputer1,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000117005278862668"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature := s.signValueBundle(&valueBundleReputer1, s.privKeys[0])
-	reputerValueBundle1 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer1,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[0],
-	}
-	valueBundleReputer2 := types.ValueBundle{
-		Reputer:                       reputer2,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".00000962701954026944"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature = s.signValueBundle(&valueBundleReputer2, s.privKeys[1])
-	reputerValueBundle2 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer2,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[1],
-	}
-	valueBundleReputer3 := types.ValueBundle{
-		Reputer:                       reputer3,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature = s.signValueBundle(&valueBundleReputer3, s.privKeys[2])
-	reputerValueBundle3 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer3,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[2],
-	}
-	valueBundleReputer4 := types.ValueBundle{
-		Reputer:                       reputer4,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature = s.signValueBundle(&valueBundleReputer4, s.privKeys[3])
-	reputerValueBundle4 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer4,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[3],
-	}
-	valueBundleReputer5 := types.ValueBundle{
-		Reputer:                       reputer5,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topicId,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature = s.signValueBundle(&valueBundleReputer5, s.privKeys[4])
-	reputerValueBundle5 := types.ReputerValueBundle{
-		ValueBundle: &valueBundleReputer5,
-		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[4],
+	// Create reputer value bundles
+	reputerValueBundles := make([]*types.ReputerValueBundle, len(reputers))
+	for i, reputer := range reputers {
+		//nolint:exhaustruct
+		valueBundle := types.ValueBundle{
+			Reputer:             reputer,
+			CombinedValue:       alloraMath.MustNewDecFromString(".0000256948644008351"),
+			ReputerRequestNonce: reputerRequestNonce,
+			TopicId:             topicId,
+			InfererValues:       s.createDefaultInfererValues(),
+			NaiveValue:          alloraMath.MustNewDecFromString("0.0"),
+		}
+		signature := s.SignValueBundle(&valueBundle, s.PrivKeys(i))
+		reputerValueBundles[i] = &types.ReputerValueBundle{
+			ValueBundle: &valueBundle,
+			Signature:   signature,
+			Pubkey:      s.PubKeyHexStr(i),
+		}
 	}
 
 	allReputerLosses := types.ReputerValueBundles{
-		ReputerValueBundles: []*types.ReputerValueBundle{
-			&reputerValueBundle1,
-			&reputerValueBundle2,
-			&reputerValueBundle3,
-			&reputerValueBundle4,
-			&reputerValueBundle5,
-		},
+		ReputerValueBundles: reputerValueBundles,
 	}
 
 	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
+
+	// First round: append all reputer losses
 	for _, reputerValueBundle := range allReputerLosses.ReputerValueBundles {
 		err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, reputerValueBundle)
 		s.Require().NoError(err)
 	}
 
+	// Verify active reputers count
 	activeReputers, err := k.GetActiveReputersForTopic(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(params.MaxTopReputersToReward, uint64(len(activeReputers)))
 
+	// Reset active reputers
 	err = k.ResetActiveReputersForTopic(ctx, topicId)
 	s.Require().NoError(err)
 
@@ -4960,12 +4419,14 @@ func (s *KeeperTestSuite) TestAppendReputerLossWithResetActiveReputers() {
 	s.Require().NoError(err)
 	s.Require().Empty(activeReputers)
 
+	// Second round: append all reputer losses again
 	nonce.BlockHeight++
 	for _, reputerValueBundle := range allReputerLosses.ReputerValueBundles {
 		err = k.AppendReputerLoss(ctx, topic, params, nonce.BlockHeight, reputerValueBundle)
 		s.Require().NoError(err)
 	}
 
+	// Verify active reputers count again
 	activeReputers, err = k.GetActiveReputersForTopic(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(params.MaxTopReputersToReward, uint64(len(activeReputers)))
@@ -4973,8 +4434,8 @@ func (s *KeeperTestSuite) TestAppendReputerLossWithResetActiveReputers() {
 
 func (s *KeeperTestSuite) TestDripTopicFeeRevenue() {
 	// Initialize the test environment
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	require := s.Require()
 
 	// Define test data
@@ -4989,9 +4450,11 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenue() {
 	require.NoError(err, "Setting a new topic should not fail")
 
 	// Create and activate a topic
-	topic := s.mockTopic()
+	topic := s.MockTopic()
+	topic.Id = 2
 	topic.EpochLength = 5
 	topic.WorkerSubmissionWindow = 5
+	topic.GroundTruthLag = 5
 	err = k.SetTopic(ctx, topic.Id, topic)
 	require.NoError(err, "Setting a new topic should not fail")
 
@@ -5026,13 +4489,13 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenue() {
 
 func (s *KeeperTestSuite) TestDripTopicFeeRevenueWithTwoTopicsDifferentEpochLengths() {
 	// Initialize the test environment
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	require := s.Require()
 
 	// Define test data
-	topicId1 := uint64(1)
-	topicId2 := uint64(2)
+	topicId1 := uint64(2)
+	topicId2 := uint64(3)
 	block := int64(100)
 	initialRevenue := cosmosMath.NewInt(1000000) // 0.001 in Int representation (assuming 6 decimal places)
 
@@ -5041,79 +4504,62 @@ func (s *KeeperTestSuite) TestDripTopicFeeRevenueWithTwoTopicsDifferentEpochLeng
 	err := k.SetParams(ctx, params)
 	require.NoError(err, "Setting a new topic should not fail")
 
-	// Create and activate topics
-	topic1 := s.mockTopic()
-	topic1.Id = topicId1
-	topic1.EpochLength = 5
-	topic1.WorkerSubmissionWindow = 5
-	err = k.SetTopic(ctx, topicId1, topic1)
-	require.NoError(err, "Setting a new topic should not fail")
+	// Create topics with different epoch lengths
+	topics := []struct {
+		id          uint64
+		epochLength int64
+		expected    cosmosMath.Int
+	}{
+		{topicId1, 5, cosmosMath.NewInt(26)},  // shorter epoch length
+		{topicId2, 10, cosmosMath.NewInt(51)}, // longer epoch length
+	}
 
-	topic2 := s.mockTopic()
-	topic2.Id = topicId2
-	topic2.EpochLength = 10
-	topic2.WorkerSubmissionWindow = 10
-	err = k.SetTopic(ctx, topicId2, topic2)
-	require.NoError(err, "Setting a new topic should not fail")
+	for _, t := range topics {
+		topic := s.MockTopic()
+		topic.Id = t.id
+		topic.EpochLength = t.epochLength
+		topic.WorkerSubmissionWindow = t.epochLength
+		topic.GroundTruthLag = t.epochLength
 
-	// Activate the topics
-	err = k.ActivateTopic(ctx, topic1.Id)
-	require.NoError(err, "Activating the topic should not fail")
+		err = k.SetTopic(ctx, t.id, topic)
+		require.NoError(err, "Setting a new topic should not fail")
 
-	err = k.ActivateTopic(ctx, topic2.Id)
-	require.NoError(err, "Activating the topic should not fail")
+		err = k.ActivateTopic(ctx, topic.Id)
+		require.NoError(err, "Activating the topic should not fail")
 
-	// Set up initial topic fee revenue
-	err = k.AddTopicFeeRevenue(ctx, topic1.Id, initialRevenue)
-	require.NoError(err, "Setting initial topic fee revenue should not fail")
-
-	err = k.AddTopicFeeRevenue(ctx, topic2.Id, initialRevenue)
-	require.NoError(err, "Setting initial topic fee revenue should not fail")
+		err = k.AddTopicFeeRevenue(ctx, topic.Id, initialRevenue)
+		require.NoError(err, "Setting initial topic fee revenue should not fail")
+	}
 
 	// Calculate the blocks per week
 	blocksPerWeek, err := alloraMath.CalculateBlocksPerWeek(params.BlocksPerMonth)
 	require.NoError(err, "error calculating blocks per week")
 
-	// Call the function under test
-	err = k.DripTopicFeeRevenue(ctx, topic1, blocksPerWeek, block)
-	require.NoError(err, "DripTopicFeeRevenue should not return an error")
+	// Process drips and verify results for each topic
+	for _, t := range topics {
+		topic, err := k.GetTopic(ctx, t.id)
+		require.NoError(err)
 
-	err = k.DripTopicFeeRevenue(ctx, topic2, blocksPerWeek, block)
-	require.NoError(err, "DripTopicFeeRevenue should not return an error")
+		err = k.DripTopicFeeRevenue(ctx, topic, blocksPerWeek, block)
+		require.NoError(err, "DripTopicFeeRevenue should not return an error")
 
-	// Retrieve the updated topic fee revenue
-	updatedTopicFeeRevenue1, err := k.GetTopicFeeRevenue(ctx, topic1.Id)
-	require.NoError(err, "Getting topic fee revenue should not fail")
+		updatedRevenue, err := k.GetTopicFeeRevenue(ctx, t.id)
+		require.NoError(err, "Getting topic fee revenue should not fail")
 
-	updatedTopicFeeRevenue2, err := k.GetTopicFeeRevenue(ctx, topic2.Id)
-	require.NoError(err, "Getting topic fee revenue should not fail")
+		require.True(updatedRevenue.LT(initialRevenue),
+			"The topic fee revenue should have decreased after dripping")
 
-	// Assert the expected results
-	require.True(updatedTopicFeeRevenue1.LT(initialRevenue),
-		"The topic fee revenue should have decreased after dripping")
-	require.True(updatedTopicFeeRevenue2.LT(initialRevenue),
-		"The topic fee revenue should have decreased after dripping")
-
-	// Expected revenue should be the initial revenue minus the expected drip
-	// Topic 1 should have a smaller drip because it has a shorter epoch length
-	// Topic 2 should have a larger drip because it has a longer epoch length
-	// The initial expectation of the drip in this case is approximately 25.14 for topic 1 and 50.28 for topic 2 (since epoch length is 5 and 10 respectively)
-	// But because the revenue is truncated to the nearest integer, the actual drip is 26 for topic 1 and 51 for topic 2
-	expectedDripTopic1 := cosmosMath.NewInt(26)
-	expectedDripTopic2 := cosmosMath.NewInt(51)
-	expectedRevenue1 := initialRevenue.Sub(expectedDripTopic1)
-	expectedRevenue2 := initialRevenue.Sub(expectedDripTopic2)
-	require.Equal(expectedRevenue1.String(), updatedTopicFeeRevenue1.String(),
-		"The topic fee revenue for topic 1 should match the expected value after dripping")
-	require.Equal(expectedRevenue2.String(), updatedTopicFeeRevenue2.String(),
-		"The topic fee revenue for topic 2 should match the expected value after dripping")
+		expectedRevenue := initialRevenue.Sub(t.expected)
+		require.Equal(expectedRevenue.String(), updatedRevenue.String(),
+			"The topic fee revenue should match the expected value after dripping")
+	}
 }
 
 func (s *KeeperTestSuite) TestActiveInfererFunctions() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	inferer := s.addrsStr[0]
+	inferer := s.AddrsStr(0)
 
 	err := k.AddActiveInferer(ctx, topicId, inferer)
 	s.Require().NoError(err)
@@ -5129,10 +4575,10 @@ func (s *KeeperTestSuite) TestActiveInfererFunctions() {
 }
 
 func (s *KeeperTestSuite) TestActiveForecasterFunctions() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	forecaster := s.addrsStr[1]
+	forecaster := s.AddrsStr(1)
 
 	err := k.AddActiveForecaster(ctx, topicId, forecaster)
 	s.Require().NoError(err)
@@ -5155,10 +4601,10 @@ func (s *KeeperTestSuite) TestActiveForecasterFunctions() {
 }
 
 func (s *KeeperTestSuite) TestLowestScoreEmaFunctions() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	address := s.addrsStr[2]
+	address := s.AddrsStr(2)
 
 	lowestInfererScore := types.Score{
 		TopicId:     topicId,
@@ -5190,10 +4636,10 @@ func (s *KeeperTestSuite) TestLowestScoreEmaFunctions() {
 }
 
 func (s *KeeperTestSuite) TestActiveReputerFunctions() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputer := s.addrsStr[3]
+	reputer := s.AddrsStr(3)
 
 	err := k.AddActiveReputer(ctx, topicId, reputer)
 	s.Require().NoError(err)
@@ -5216,15 +4662,15 @@ func (s *KeeperTestSuite) TestActiveReputerFunctions() {
 }
 
 func (s *KeeperTestSuite) TestResetFunctions() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 
-	err := k.AddActiveReputer(ctx, topicId, s.addrsStr[0])
+	err := k.AddActiveReputer(ctx, topicId, s.AddrsStr(0))
 	s.Require().NoError(err)
-	err = k.AddActiveInferer(ctx, topicId, s.addrsStr[1])
+	err = k.AddActiveInferer(ctx, topicId, s.AddrsStr(1))
 	s.Require().NoError(err)
-	err = k.AddActiveForecaster(ctx, topicId, s.addrsStr[2])
+	err = k.AddActiveForecaster(ctx, topicId, s.AddrsStr(2))
 	s.Require().NoError(err)
 
 	err = k.ResetActiveReputersForTopic(ctx, topicId)
@@ -5250,10 +4696,10 @@ func (s *KeeperTestSuite) TestResetFunctions() {
 }
 
 func (s *KeeperTestSuite) TestLowestReputerScoreEmaFunctions() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	address := s.addrsStr[4]
+	address := s.AddrsStr(4)
 
 	lowestReputerScore := types.Score{
 		TopicId:     topicId,
@@ -5271,33 +4717,29 @@ func (s *KeeperTestSuite) TestLowestReputerScoreEmaFunctions() {
 }
 
 func (s *KeeperTestSuite) TestRemoveReputerLoss() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
-	reputer := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
+	reputer := s.AddrsStr(0)
 
 	// Create a reputer loss bundle
+	//nolint:exhaustruct
 	valueBundle := &types.ValueBundle{
 		TopicId: topicId,
 		ReputerRequestNonce: &types.ReputerRequestNonce{
 			ReputerNonce: &types.Nonce{BlockHeight: 100},
 		},
-		Reputer:                       reputer,
-		ExtraData:                     []byte("data"),
-		CombinedValue:                 alloraMath.MustNewDecFromString("123"),
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("123"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		Reputer:       reputer,
+		ExtraData:     []byte("data"),
+		CombinedValue: alloraMath.MustNewDecFromString("123"),
+		InfererValues: s.createDefaultInfererValues(),
+		NaiveValue:    alloraMath.MustNewDecFromString("123"),
 	}
-	signature := s.signValueBundle(valueBundle, s.privKeys[0])
+	signature := s.SignValueBundle(valueBundle, s.PrivKeys(0))
 	reputerLossBundle := types.ReputerValueBundle{
 		ValueBundle: valueBundle,
 		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[0],
+		Pubkey:      s.PubKeyHexStr(0),
 	}
 
 	// Insert the reputer loss bundle
@@ -5319,10 +4761,10 @@ func (s *KeeperTestSuite) TestRemoveReputerLoss() {
 }
 
 func (s *KeeperTestSuite) TestRemoveForecast() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
-	forecaster := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
+	forecaster := s.AddrsStr(0)
 
 	// Create a forecast
 	forecast := types.Forecast{
@@ -5361,10 +4803,10 @@ func (s *KeeperTestSuite) TestRemoveForecast() {
 }
 
 func (s *KeeperTestSuite) TestRemoveInference() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
-	inferer := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
+	inferer := s.AddrsStr(0)
 
 	// Create an inference
 	inference := types.Inference{
@@ -5396,14 +4838,14 @@ func (s *KeeperTestSuite) TestRemoveInference() {
 
 func (s *KeeperTestSuite) TestGetCountInfererInclusionsInTopic() {
 	// Initialize the test environment
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	require := s.Require()
 
 	// Define test data
 	topicId := uint64(1)
-	inferer1 := s.addrsStr[0]
-	inferer2 := s.addrsStr[1]
+	inferer1 := s.AddrsStr(0)
+	inferer2 := s.AddrsStr(1)
 	err := k.IncrementCountInfererInclusionsInTopic(ctx, topicId, inferer1)
 	require.NoError(err)
 	err = k.IncrementCountInfererInclusionsInTopic(ctx, topicId, inferer1)
@@ -5422,14 +4864,14 @@ func (s *KeeperTestSuite) TestGetCountInfererInclusionsInTopic() {
 
 func (s *KeeperTestSuite) TestGetCountForecasterInclusionsInTopic() {
 	// Initialize the test environment
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	require := s.Require()
 
 	// Define test data
 	topicId := uint64(1)
-	forecaster1 := s.addrsStr[0]
-	forecaster2 := s.addrsStr[1]
+	forecaster1 := s.AddrsStr(0)
+	forecaster2 := s.AddrsStr(1)
 	err := k.IncrementCountForecasterInclusionsInTopic(ctx, topicId, forecaster1)
 	require.NoError(err)
 	err = k.IncrementCountForecasterInclusionsInTopic(ctx, topicId, forecaster1)
@@ -5447,9 +4889,9 @@ func (s *KeeperTestSuite) TestGetCountForecasterInclusionsInTopic() {
 }
 
 func (s *KeeperTestSuite) TestScoreLimiting() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
-	topicId := s.CreateOneTopic(10800)
+	k := s.EmissionsKeeper()
+	ctx := s.Ctx()
+	topicId := s.CreateTopic()
 	blockHeight := int64(10)
 
 	params := types.DefaultParams()
@@ -5462,7 +4904,7 @@ func (s *KeeperTestSuite) TestScoreLimiting() {
 		score := types.Score{
 			TopicId:     topicId,
 			BlockHeight: blockHeight,
-			Address:     s.addrsStr[i],
+			Address:     s.AddrsStr(i),
 			Score:       alloraMath.NewDecFromInt64(int64(90 + i)),
 		}
 		err := k.InsertWorkerInferenceScore(ctx, topicId, blockHeight, score)
@@ -5474,14 +4916,14 @@ func (s *KeeperTestSuite) TestScoreLimiting() {
 	s.Require().Len(scores.Scores, 6, "Should keep MaxSamplesToScaleScores * MaxTopInferersToReward scores")
 
 	for i, score := range scores.Scores {
-		expectedWorker := s.addrsStr[i+2]
+		expectedWorker := s.AddrsStr(i + 2)
 		s.Require().Equal(expectedWorker, score.Address)
 	}
 }
 
 func (s *KeeperTestSuite) TestUpdateNetworkInferencesOutlierMetrics() {
 	// Create one topic
-	topicId := s.CreateOneTopic(10800)
+	topicId := s.CreateTopic()
 	blockHeight := int64(1)
 
 	// Create specific inferences for testing
@@ -5490,33 +4932,33 @@ func (s *KeeperTestSuite) TestUpdateNetworkInferencesOutlierMetrics() {
 			TopicId:     topicId,
 			BlockHeight: blockHeight,
 			Value:       alloraMath.NewDecFromInt64(10),
-			Inferer:     s.addrsStr[0],
+			Inferer:     s.AddrsStr(0),
 		},
 		{
 			TopicId:     topicId,
 			BlockHeight: blockHeight,
 			Value:       alloraMath.NewDecFromInt64(11),
-			Inferer:     s.addrsStr[1],
+			Inferer:     s.AddrsStr(1),
 		},
 		{
 			TopicId:     topicId,
 			BlockHeight: blockHeight,
 			Value:       alloraMath.NewDecFromInt64(12),
-			Inferer:     s.addrsStr[2],
+			Inferer:     s.AddrsStr(2),
 		},
 	}
 
 	inferencesWrapper := types.Inferences{Inferences: inferences}
-	err := s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, blockHeight, inferencesWrapper)
+	err := s.EmissionsKeeper().InsertActiveInferences(s.Ctx(), topicId, blockHeight, inferencesWrapper)
 	s.Require().NoError(err)
 	// Test the update function
-	err = s.emissionsKeeper.UpdateNetworkInferencesOutlierMetrics(s.ctx, topicId, blockHeight)
+	err = s.EmissionsKeeper().UpdateNetworkInferencesOutlierMetrics(s.Ctx(), topicId, blockHeight)
 	s.Require().NoError(err)
 
 	// Verify results
-	mad, err := s.emissionsKeeper.GetMadInferences(s.ctx, topicId)
+	mad, err := s.EmissionsKeeper().GetMadInferences(s.Ctx(), topicId)
 	s.Require().NoError(err)
-	median, err := s.emissionsKeeper.GetLastMedianInferences(s.ctx, topicId)
+	median, err := s.EmissionsKeeper().GetLastMedianInferences(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	// Verify expected values
 	s.Require().Equal(alloraMath.NewDecFromInt64(1), mad)
@@ -5525,15 +4967,15 @@ func (s *KeeperTestSuite) TestUpdateNetworkInferencesOutlierMetrics() {
 	// Modify a copy of the previous inferences and run it again
 	inferencesWrapper.Inferences[0].Value = alloraMath.NewDecFromInt64(100)
 	inferencesWrapper.Inferences[1].Value = alloraMath.NewDecFromInt64(50)
-	err = s.emissionsKeeper.InsertActiveInferences(s.ctx, topicId, blockHeight, inferencesWrapper)
+	err = s.EmissionsKeeper().InsertActiveInferences(s.Ctx(), topicId, blockHeight, inferencesWrapper)
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.UpdateNetworkInferencesOutlierMetrics(s.ctx, topicId, blockHeight)
+	err = s.EmissionsKeeper().UpdateNetworkInferencesOutlierMetrics(s.Ctx(), topicId, blockHeight)
 	s.Require().NoError(err)
 
-	mad, err = s.emissionsKeeper.GetMadInferences(s.ctx, topicId)
+	mad, err = s.EmissionsKeeper().GetMadInferences(s.Ctx(), topicId)
 	s.Require().NoError(err)
-	median, err = s.emissionsKeeper.GetLastMedianInferences(s.ctx, topicId)
+	median, err = s.EmissionsKeeper().GetLastMedianInferences(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
 	s.Require().Equal(alloraMath.MustNewDecFromString("8.4"), mad)
@@ -5541,14 +4983,14 @@ func (s *KeeperTestSuite) TestUpdateNetworkInferencesOutlierMetrics() {
 }
 
 func (s *KeeperTestSuite) TestFilterOutlierResistantInferences() {
-	topicId := s.CreateOneTopic(10800)
+	topicId := s.CreateTopic()
 
 	// Ensure param is set to 11
 	params := types.DefaultParams()
 	params.InferenceOutlierDetectionThreshold = alloraMath.MustNewDecFromString("11")
 
 	// Set the maximum number of unfulfilled worker nonces via the SetParams method
-	err := s.emissionsKeeper.SetParams(s.ctx, params)
+	err := s.EmissionsKeeper().SetParams(s.Ctx(), params)
 	s.Require().NoError(err, "Error retrieving nonces after addition")
 
 	testCases := []struct {
@@ -5561,9 +5003,9 @@ func (s *KeeperTestSuite) TestFilterOutlierResistantInferences() {
 		{
 			name: "filter with median=10, mad=1",
 			setupMetrics: func() {
-				err := s.emissionsKeeper.SetLastMedianInferences(s.ctx, topicId, alloraMath.NewDecFromInt64(10))
+				err := s.EmissionsKeeper().SetLastMedianInferences(s.Ctx(), topicId, alloraMath.NewDecFromInt64(10))
 				s.Require().NoError(err)
-				err = s.emissionsKeeper.SetMadInferences(s.ctx, topicId, alloraMath.NewDecFromInt64(1))
+				err = s.EmissionsKeeper().SetMadInferences(s.Ctx(), topicId, alloraMath.NewDecFromInt64(1))
 				s.Require().NoError(err)
 			},
 			inferences: types.Inferences{
@@ -5585,9 +5027,9 @@ func (s *KeeperTestSuite) TestFilterOutlierResistantInferences() {
 		{
 			name: "filter with median=100, mad=10",
 			setupMetrics: func() {
-				err := s.emissionsKeeper.SetLastMedianInferences(s.ctx, topicId, alloraMath.NewDecFromInt64(100))
+				err := s.EmissionsKeeper().SetLastMedianInferences(s.Ctx(), topicId, alloraMath.NewDecFromInt64(100))
 				s.Require().NoError(err)
-				err = s.emissionsKeeper.SetMadInferences(s.ctx, topicId, alloraMath.NewDecFromInt64(10))
+				err = s.EmissionsKeeper().SetMadInferences(s.Ctx(), topicId, alloraMath.NewDecFromInt64(10))
 				s.Require().NoError(err)
 			},
 			inferences: types.Inferences{
@@ -5609,9 +5051,9 @@ func (s *KeeperTestSuite) TestFilterOutlierResistantInferences() {
 		{
 			name: "zero mad - should return all inferences",
 			setupMetrics: func() {
-				err := s.emissionsKeeper.SetLastMedianInferences(s.ctx, topicId, alloraMath.NewDecFromInt64(10))
+				err := s.EmissionsKeeper().SetLastMedianInferences(s.Ctx(), topicId, alloraMath.NewDecFromInt64(10))
 				s.Require().NoError(err)
-				err = s.emissionsKeeper.SetMadInferences(s.ctx, topicId, alloraMath.ZeroDec())
+				err = s.EmissionsKeeper().SetMadInferences(s.Ctx(), topicId, alloraMath.ZeroDec())
 				s.Require().NoError(err)
 			},
 			inferences: types.Inferences{
@@ -5629,9 +5071,9 @@ func (s *KeeperTestSuite) TestFilterOutlierResistantInferences() {
 		{
 			name: "zero last_median - should return all inferences",
 			setupMetrics: func() {
-				err := s.emissionsKeeper.SetLastMedianInferences(s.ctx, topicId, alloraMath.ZeroDec())
+				err := s.EmissionsKeeper().SetLastMedianInferences(s.Ctx(), topicId, alloraMath.ZeroDec())
 				s.Require().NoError(err)
-				err = s.emissionsKeeper.SetMadInferences(s.ctx, topicId, alloraMath.NewDecFromInt64(1))
+				err = s.EmissionsKeeper().SetMadInferences(s.Ctx(), topicId, alloraMath.NewDecFromInt64(1))
 				s.Require().NoError(err)
 			},
 			inferences: types.Inferences{
@@ -5654,7 +5096,7 @@ func (s *KeeperTestSuite) TestFilterOutlierResistantInferences() {
 		s.Run(tc.name, func() {
 			tc.setupMetrics()
 
-			filtered, err := s.emissionsKeeper.FilterOutlierResistantInferences(s.ctx, topicId, tc.inferences)
+			filtered, err := s.EmissionsKeeper().FilterOutlierResistantInferences(s.Ctx(), topicId, tc.inferences)
 			s.Require().NoError(err)
 
 			s.Require().Len(filtered.Inferences, tc.expectedCount)
@@ -5667,10 +5109,10 @@ func (s *KeeperTestSuite) TestFilterOutlierResistantInferences() {
 }
 
 func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendInference() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
-	worker := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
+	worker := s.AddrsStr(0)
 	blockHeight := int64(10)
 
 	// Set initial EMA score for the topic
@@ -5679,13 +5121,12 @@ func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendInference() {
 	s.Require().NoError(err)
 
 	// Create and append a new inference
+	//nolint:exhaustruct
 	inference := &types.Inference{
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
 		Value:       alloraMath.MustNewDecFromString("0.52"),
 		Inferer:     worker,
-		ExtraData:   nil,
-		Proof:       "",
 	}
 
 	topic, err := k.GetTopic(ctx, topicId)
@@ -5705,10 +5146,10 @@ func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendInference() {
 }
 
 func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendForecast() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
-	worker := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
+	worker := s.AddrsStr(0)
 	blockHeight := int64(10)
 
 	// Set initial EMA score for the topic
@@ -5723,7 +5164,7 @@ func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendForecast() {
 		Forecaster:  worker,
 		ForecastElements: []*types.ForecastElement{
 			{
-				Inferer: s.addrsStr[1],
+				Inferer: s.AddrsStr(1),
 				Value:   alloraMath.MustNewDecFromString("0.52"),
 			},
 		},
@@ -5747,10 +5188,10 @@ func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendForecast() {
 }
 
 func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendReputer() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
-	reputer := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
+	reputer := s.AddrsStr(0)
 	blockHeight := int64(10)
 
 	// Set initial EMA score for the topic
@@ -5759,27 +5200,22 @@ func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendReputer() {
 	s.Require().NoError(err)
 
 	// Create and append a new reputer value bundle
+	//nolint:exhaustruct
 	valueBundle := &types.ValueBundle{
 		TopicId: topicId,
 		ReputerRequestNonce: &types.ReputerRequestNonce{
 			ReputerNonce: &types.Nonce{BlockHeight: blockHeight},
 		},
-		Reputer:                       reputer,
-		ExtraData:                     nil,
-		CombinedValue:                 alloraMath.MustNewDecFromString("0.52"),
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.52"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		Reputer:       reputer,
+		CombinedValue: alloraMath.MustNewDecFromString("0.52"),
+		InfererValues: s.createDefaultInfererValues(),
+		NaiveValue:    alloraMath.MustNewDecFromString("0.52"),
 	}
-	signature := s.signValueBundle(valueBundle, s.privKeys[0])
+	signature := s.SignValueBundle(valueBundle, s.PrivKeys(0))
 	reputerValueBundle := &types.ReputerValueBundle{
 		ValueBundle: valueBundle,
 		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[0],
+		Pubkey:      s.PubKeyHexStr(0),
 	}
 
 	topic, err := k.GetTopic(ctx, topicId)
@@ -5800,27 +5236,28 @@ func (s *KeeperTestSuite) TestInitialEmaScoreSettingInAppendReputer() {
 }
 
 func (s *KeeperTestSuite) TestFirstSubmissionDoesNotUpdateEMAUsingQuantile() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := s.CreateOneTopic(10800)
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := s.CreateTopic()
 
 	params := types.DefaultParams()
 	params.MaxTopInferersToReward = 4
 	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
-	//nolint: gosec
+	// nolint: gosec
 	for i := int64(0); i < int64(params.MaxTopInferersToReward); i++ {
+		addr := s.AddrsStr(int(i))
 		score := types.Score{
 			TopicId:     topicId,
-			Address:     s.addrsStr[i],
+			Address:     addr,
 			BlockHeight: 1,
 			Score:       alloraMath.NewDecFromInt64(90 + i),
 		}
-		err := k.SetInfererScoreEma(ctx, topicId, s.addrsStr[i], score)
+		err := k.SetInfererScoreEma(ctx, topicId, addr, score)
 		s.Require().NoError(err)
 
-		err = k.AddActiveInferer(ctx, topicId, s.addrsStr[i])
+		err = k.AddActiveInferer(ctx, topicId, addr)
 		s.Require().NoError(err)
 
 		if i == 0 {
@@ -5838,7 +5275,7 @@ func (s *KeeperTestSuite) TestFirstSubmissionDoesNotUpdateEMAUsingQuantile() {
 	inference := &types.Inference{
 		TopicId:     topicId,
 		BlockHeight: 2,
-		Inferer:     s.addrsStr[9], // Using a different address
+		Inferer:     s.AddrsStr(9), // Using a different address
 		Value:       alloraMath.NewDecFromInt64(100),
 		ExtraData:   nil,
 		Proof:       "",
@@ -5853,44 +5290,48 @@ func (s *KeeperTestSuite) TestFirstSubmissionDoesNotUpdateEMAUsingQuantile() {
 	s.Require().NoError(err)
 
 	// Verify score remains at initial value
-	score, err := k.GetInfererScoreEma(ctx, topicId, s.addrsStr[9])
+	score, err := k.GetInfererScoreEma(ctx, topicId, s.AddrsStr(9))
 	s.Require().NoError(err)
 	s.Require().Equal(initialScore, score.Score)
 }
 
 func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendInference() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topic := s.mockTopic()
-	topic.EpochLastEnded = 10000
-	topic.EpochLength = 1000
-	topic.GroundTruthLag = 1000
-	s.Require().NoError(s.emissionsKeeper.SetTopic(ctx, topic.Id, topic))
-	worker := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+
+	epochLength := int64(1000)
+	groundTruthLag := int64(1000)
+
+	topicId := s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength),
+		alloratestutil.WithGroundTruthLag(groundTruthLag),
+		alloratestutil.WithInitialRegret("0.5"),
+		alloratestutil.WithEpochLastEnded(10000),
+	)
+	worker := s.AddrsStr(0)
 	blockHeight := int64(10000)
 
 	// Set initial EMA score for the topic
 	initialScore := alloraMath.MustNewDecFromString("50")
-	s.Require().NoError(k.SetTopicInitialInfererEmaScore(ctx, topic.Id, initialScore))
+	s.Require().NoError(k.SetTopicInitialInfererEmaScore(ctx, topicId, initialScore))
 
-	s.Require().NoError(k.SetInfererScoreEma(ctx, topic.Id, worker, types.Score{
-		TopicId:     topic.Id,
+	s.Require().NoError(k.SetInfererScoreEma(ctx, topicId, worker, types.Score{
+		TopicId:     topicId,
 		BlockHeight: 5000,
 		Address:     worker,
 		Score:       alloraMath.MustNewDecFromString("100"),
 	}))
 
 	// Create and append a new inference
+	//nolint:exhaustruct
 	inference := &types.Inference{
-		TopicId:     topic.Id,
+		TopicId:     topicId,
 		BlockHeight: blockHeight,
 		Value:       alloraMath.MustNewDecFromString("0.52"),
 		Inferer:     worker,
-		ExtraData:   nil,
-		Proof:       "",
 	}
 
-	topic, err := k.GetTopic(ctx, topic.Id)
+	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
 
 	// Append the inference
@@ -5899,33 +5340,37 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendInference() {
 
 	// Verify the worker's EMA score trended toward the topic initial score especially when there is a lapse in their
 	// liveness
-	score, err := k.GetInfererScoreEma(ctx, topic.Id, worker)
+	score, err := k.GetInfererScoreEma(ctx, topicId, worker)
 	s.Require().NoError(err)
 	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("82.805"), score.Score, alloraMath.MustNewDecFromString("0.0001"))
 	s.Require().NoError(err)
 	s.Require().True(inDelta, "expected %s, got %s", "82.805", score.Score.String())
 	s.Require().Equal(blockHeight, score.BlockHeight)
 	s.Require().Equal(worker, score.Address)
-	s.Require().Equal(topic.Id, score.TopicId)
+	s.Require().Equal(topicId, score.TopicId)
 }
 
 func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendForecast() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topic := s.mockTopic()
-	topic.EpochLastEnded = 10000
-	topic.EpochLength = 1000
-	topic.GroundTruthLag = 1000
-	s.Require().NoError(s.emissionsKeeper.SetTopic(ctx, topic.Id, topic))
-	worker := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+
+	epochLength := int64(1000)
+	groundTruthLag := int64(1000)
+
+	topicId := s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength),
+		alloratestutil.WithGroundTruthLag(groundTruthLag),
+		alloratestutil.WithEpochLastEnded(10000),
+	)
+	worker := s.AddrsStr(0)
 	blockHeight := int64(10000)
 
 	// Set initial EMA score for the topic
 	initialScore := alloraMath.MustNewDecFromString("50")
-	s.Require().NoError(k.SetTopicInitialForecasterEmaScore(ctx, topic.Id, initialScore))
+	s.Require().NoError(k.SetTopicInitialForecasterEmaScore(ctx, topicId, initialScore))
 
-	s.Require().NoError(k.SetForecasterScoreEma(ctx, topic.Id, worker, types.Score{
-		TopicId:     topic.Id,
+	s.Require().NoError(k.SetForecasterScoreEma(ctx, topicId, worker, types.Score{
+		TopicId:     topicId,
 		BlockHeight: 5000,
 		Address:     worker,
 		Score:       alloraMath.MustNewDecFromString("100"),
@@ -5933,7 +5378,7 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendForecast() {
 
 	// Create and append a new forecast
 	forecast := &types.Forecast{
-		TopicId:     topic.Id,
+		TopicId:     topicId,
 		BlockHeight: 10000,
 		Forecaster:  worker,
 		ForecastElements: []*types.ForecastElement{
@@ -5945,7 +5390,7 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendForecast() {
 		ExtraData: nil,
 	}
 
-	topic, err := k.GetTopic(ctx, topic.Id)
+	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
 
 	// Append the forecast
@@ -5955,25 +5400,29 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendForecast() {
 
 	// Verify the worker's EMA score trended toward the topic initial score especially when there is a lapse in their
 	// liveness
-	score, err := k.GetForecasterScoreEma(ctx, topic.Id, worker)
+	score, err := k.GetForecasterScoreEma(ctx, topicId, worker)
 	s.Require().NoError(err)
 	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("82.805"), score.Score, alloraMath.MustNewDecFromString("0.0001"))
 	s.Require().NoError(err)
 	s.Require().True(inDelta, "expected %s, got %s", "82.805", score.Score.String())
 	s.Require().Equal(blockHeight, score.BlockHeight)
 	s.Require().Equal(worker, score.Address)
-	s.Require().Equal(topic.Id, score.TopicId)
+	s.Require().Equal(topicId, score.TopicId)
 }
 
 func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendReputerLoss() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topic := s.mockTopic()
-	topic.EpochLastEnded = 10000
-	topic.EpochLength = 1000
-	topic.GroundTruthLag = 1000
-	s.Require().NoError(s.emissionsKeeper.SetTopic(ctx, topic.Id, topic))
-	reputer := s.addrsStr[0]
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+
+	epochLength := int64(1000)
+	groundTruthLag := int64(1000)
+
+	topicId := s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength),
+		alloratestutil.WithGroundTruthLag(groundTruthLag),
+		alloratestutil.WithEpochLastEnded(10000),
+	)
+	reputer := s.AddrsStr(0)
 	blockHeight := int64(10000)
 	reputerRequestNonce := &types.ReputerRequestNonce{
 		ReputerNonce: &types.Nonce{BlockHeight: blockHeight},
@@ -5981,38 +5430,33 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendReputerLoss() {
 
 	// Set initial EMA score for the topic
 	initialScore := alloraMath.MustNewDecFromString("50")
-	s.Require().NoError(k.SetTopicInitialReputerEmaScore(ctx, topic.Id, initialScore))
+	s.Require().NoError(k.SetTopicInitialReputerEmaScore(ctx, topicId, initialScore))
 
-	s.Require().NoError(k.SetReputerScoreEma(ctx, topic.Id, reputer, types.Score{
-		TopicId:     topic.Id,
+	s.Require().NoError(k.SetReputerScoreEma(ctx, topicId, reputer, types.Score{
+		TopicId:     topicId,
 		BlockHeight: 5000,
 		Address:     reputer,
 		Score:       alloraMath.MustNewDecFromString("100"),
 	}))
 
 	// Create and append a new reputer loss
+	//nolint:exhaustruct
 	valueBundleReputer := types.ValueBundle{
-		Reputer:                       reputer,
-		CombinedValue:                 alloraMath.MustNewDecFromString(".0000256948644008351"),
-		ReputerRequestNonce:           reputerRequestNonce,
-		TopicId:                       topic.Id,
-		ExtraData:                     nil,
-		InfererValues:                 s.createDefaultInfererValues(),
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		Reputer:             reputer,
+		CombinedValue:       alloraMath.MustNewDecFromString(".0000256948644008351"),
+		ReputerRequestNonce: reputerRequestNonce,
+		TopicId:             topicId,
+		InfererValues:       s.createDefaultInfererValues(),
+		NaiveValue:          alloraMath.MustNewDecFromString("0.0"),
 	}
-	signature := s.signValueBundle(&valueBundleReputer, s.privKeys[0])
+	signature := s.SignValueBundle(&valueBundleReputer, s.PrivKeys(0))
 	reputerValueBundle := types.ReputerValueBundle{
 		ValueBundle: &valueBundleReputer,
 		Signature:   signature,
-		Pubkey:      s.pubKeyHexStr[0],
+		Pubkey:      s.PubKeyHexStr(0),
 	}
 
-	topic, err := k.GetTopic(ctx, topic.Id)
+	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
 
 	// Append the reputer loss
@@ -6021,21 +5465,21 @@ func (s *KeeperTestSuite) TestLivenessPenaltyAppliedInAppendReputerLoss() {
 
 	// Verify the reputer's EMA score trended toward the topic initial score especially when there is a lapse in their
 	// liveness
-	score, err := k.GetReputerScoreEma(ctx, topic.Id, reputer)
+	score, err := k.GetReputerScoreEma(ctx, topicId, reputer)
 	s.Require().NoError(err)
 	inDelta, err := alloraMath.InDelta(alloraMath.MustNewDecFromString("86.450"), score.Score, alloraMath.MustNewDecFromString("0.0001"))
 	s.Require().NoError(err)
 	s.Require().True(inDelta, "expected %s, got %s", "86.450", score.Score.String())
 	s.Require().Equal(blockHeight, score.BlockHeight)
 	s.Require().Equal(reputer, score.Address)
-	s.Require().Equal(topic.Id, score.TopicId)
+	s.Require().Equal(topicId, score.TopicId)
 }
 
 func (s *KeeperTestSuite) TestLatestForecasterWeightFunctions() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	forecaster := s.addrsStr[0]
+	forecaster := s.AddrsStr(0)
 	weight := alloraMath.NewDecFromInt64(100)
 
 	// Test initial state (should be zero)
@@ -6060,10 +5504,10 @@ func (s *KeeperTestSuite) TestLatestForecasterWeightFunctions() {
 }
 
 func (s *KeeperTestSuite) TestLatestInfererWeightFunctions() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
-	inferer := s.addrsStr[1]
+	inferer := s.AddrsStr(1)
 	weight := alloraMath.NewDecFromInt64(75)
 
 	// Test initial state (should be zero)
@@ -6088,8 +5532,8 @@ func (s *KeeperTestSuite) TestLatestInfererWeightFunctions() {
 }
 
 func (s *KeeperTestSuite) TestLatestRegretStdNormFunctions() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 	topicId := uint64(1)
 	stdNorm := alloraMath.NewDecFromInt64(50)
 
@@ -6122,12 +5566,12 @@ func (s *KeeperTestSuite) TestLatestRegretStdNormFunctions() {
 // This can be used to ensure ValueBundle validation passes when InfererValues cannot be nil
 func (s *KeeperTestSuite) createDefaultInfererValues() []*types.WorkerAttributedValue {
 	// Create an array to hold all worker attributed values
-	infererValues := make([]*types.WorkerAttributedValue, len(s.addrsStr))
+	infererValues := make([]*types.WorkerAttributedValue, s.LenAccounts())
 
 	// Add a WorkerAttributedValue for each address in the test suite
-	for i, addr := range s.addrsStr {
+	for i := range s.LenAccounts() {
 		infererValues[i] = &types.WorkerAttributedValue{
-			Worker: addr,
+			Worker: s.AddrsStr(i),
 			Value:  alloraMath.NewDecFromInt64(int64(i + 1)), // Using different values based on index
 		}
 	}
@@ -6136,8 +5580,8 @@ func (s *KeeperTestSuite) createDefaultInfererValues() []*types.WorkerAttributed
 }
 
 func (s *KeeperTestSuite) TestMonthlyRewards() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
 
 	// Initial state should be zero
 	reputerRewards, err := k.GetMonthlyReputerRewards(ctx)
@@ -6197,10 +5641,9 @@ func (s *KeeperTestSuite) TestMonthlyRewards() {
 // TestRemoveTopicFromPreviousTopicWeights tests that when a topic is removed from previous topic weights,
 // its weight is correctly subtracted from the total sum while preserving the weight itself
 func (s *KeeperTestSuite) TestRemoveTopicFromPreviousTopicWeights() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-	reputerAddr := s.addrs[0].String()
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	reputerAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(1000)
 	feeRevenue := cosmosMath.NewInt(100)
 
@@ -6209,66 +5652,67 @@ func (s *KeeperTestSuite) TestRemoveTopicFromPreviousTopicWeights() {
 	params.TopicRewardAlpha = alloraMath.MustNewDecFromString("0.5")
 	params.TopicRewardStakeImportance = alloraMath.OneDec()
 	params.TopicRewardFeeRevenueImportance = alloraMath.OneDec()
-	err := keeper.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
 	s.Require().NoError(err)
 
+	epochLength := int64(100)
+	workerSubmissionWindow := int64(100)
+
 	// Create and activate topic
-	topic := s.mockTopic()
-	topic.Id = topicId
-	topic.EpochLength = 100
-	topic.WorkerSubmissionWindow = 100
-	err = keeper.SetTopic(ctx, topicId, topic)
-	s.Require().NoError(err)
-	err = keeper.ActivateTopic(ctx, topicId)
+	topicId := s.CreateTopic(
+		alloratestutil.WithEpochLength(epochLength),
+		alloratestutil.WithWorkerSubmissionWindow(workerSubmissionWindow),
+	)
+	err = k.ActivateTopic(ctx, topicId)
 	s.Require().NoError(err)
 
 	// Add stake and fee revenue
-	err = keeper.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
+	err = k.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
 	s.Require().NoError(err)
-	err = keeper.AddTopicFeeRevenue(ctx, topicId, feeRevenue)
+	err = k.AddTopicFeeRevenue(ctx, topicId, feeRevenue)
 	s.Require().NoError(err)
 
 	// Calculate and set initial weight
-	initialWeight, _, err := keeper.GetCurrentTopicWeight(
+	initialWeight, _, err := k.GetCurrentTopicWeight(
 		ctx,
 		topicId,
-		topic.EpochLength,
+		epochLength,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
 		params.TopicRewardFeeRevenueImportance,
 		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
-	err = keeper.SetPreviousTopicWeight(ctx, topicId, initialWeight)
+	err = k.SetPreviousTopicWeight(ctx, topicId, initialWeight)
 	s.Require().NoError(err)
 
 	// Get initial total sum
-	initialTotalSum, err := keeper.GetTotalSumPreviousTopicWeights(ctx)
+	initialTotalSum, err := k.GetTotalSumPreviousTopicWeights(ctx)
 	s.Require().NoError(err)
 	s.Require().True(initialTotalSum.Equal(initialWeight), "Initial total sum should equal initial weight")
 
 	// Remove topic from previous weights
-	err = keeper.RemoveTopicFromPreviousTopicWeights(ctx, topicId)
+	err = k.RemoveTopicFromPreviousTopicWeights(ctx, topicId)
 	s.Require().NoError(err)
 
 	// Verify total sum is updated
-	newTotalSum, err := keeper.GetTotalSumPreviousTopicWeights(ctx)
+	newTotalSum, err := k.GetTotalSumPreviousTopicWeights(ctx)
 	s.Require().NoError(err)
 	s.Require().True(newTotalSum.IsZero(), "Total sum should be zero after removal")
 
 	// Verify the topic's weight is still preserved
-	topicWeight, noPrior, err := keeper.GetPreviousTopicWeight(ctx, topicId)
+	topicWeight, noPrior, err := k.GetPreviousTopicWeight(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().False(noPrior, "Topic weight should still exist")
 	s.Require().True(topicWeight.Equal(initialWeight), "Topic weight should remain unchanged")
 
 	// Test removing a topic that has no prior weight
 	nonExistentTopicId := uint64(999)
-	err = keeper.RemoveTopicFromPreviousTopicWeights(ctx, nonExistentTopicId)
+	err = k.RemoveTopicFromPreviousTopicWeights(ctx, nonExistentTopicId)
 	s.Require().NoError(err, "Removing non-existent topic should not error")
 
 	// Verify total sum remains unchanged after removing non-existent topic
-	finalTotalSum, err := keeper.GetTotalSumPreviousTopicWeights(ctx)
+	finalTotalSum, err := k.GetTotalSumPreviousTopicWeights(ctx)
 	s.Require().NoError(err)
 	s.Require().True(finalTotalSum.Equal(newTotalSum), "Total sum should remain unchanged after removing non-existent topic")
 }

--- a/x/emissions/keeper/msgserver/msg_server_demand_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand_test.go
@@ -2,37 +2,34 @@ package msgserver_test
 
 import (
 	cosmosMath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (s *MsgServerTestSuite) TestFundTopicSimple() {
-	senderAddr := s.addrs[0]
-	sender := s.addrsStr[0]
-	topic := s.CreateOneTopic()
+	senderAddr := s.Addrs(0)
+	topic := uint64(1)
 	// put some stake in the topic
-	err := s.emissionsKeeper.AddReputerStake(s.ctx, topic.Id, s.addrsStr[1], cosmosMath.NewInt(500000))
+	err := s.EmissionsKeeper().AddReputerStake(s.Ctx(), topic, s.AddrsStr(1), cosmosMath.NewInt(500000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.InactivateTopic(s.ctx, topic.Id)
+	err = s.EmissionsKeeper().InactivateTopic(s.Ctx(), topic)
 	s.Require().NoError(err)
 	var initialStake int64 = 1000
 	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake)))
-	err = s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
+	err = s.BankKeeper().MintCoins(s.Ctx(), types.AlloraStakingAccountName, initialStakeCoins)
 	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, senderAddr, initialStakeCoins)
+	err = s.BankKeeper().SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, senderAddr, initialStakeCoins)
 	s.Require().NoError(err)
-	r := types.FundTopicRequest{
-		Sender:  sender,
-		TopicId: topic.Id,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err, "GetParams should not return an error")
-	topicWeightBefore, feeRevBefore, err := s.emissionsKeeper.GetCurrentTopicWeight(
-		s.ctx,
-		r.TopicId,
+	topicWeightBefore, feeRevBefore, err := s.EmissionsKeeper().GetCurrentTopicWeight(
+		s.Ctx(),
+		topic,
 		10800,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
@@ -40,18 +37,16 @@ func (s *MsgServerTestSuite) TestFundTopicSimple() {
 		params.BlocksPerMonth,
 	)
 	s.Require().NoError(err)
-	response, err := s.msgServer.FundTopic(s.ctx, &r)
-	s.Require().NoError(err, "RequestInference should not return an error")
-	s.Require().NotNil(response, "Response should not be nil")
+	s.FundTopic(topic, senderAddr, cosmosMath.NewInt(initialStake))
 
 	// Check if the topic is activated
-	res, err := s.emissionsKeeper.IsTopicActive(s.ctx, r.TopicId)
+	res, err := s.EmissionsKeeper().IsTopicActive(s.Ctx(), topic)
 	s.Require().NoError(err)
 	s.Require().Equal(true, res, "TopicId is not activated")
 	// check that the topic fee revenue has been updated
-	topicWeightAfter, feeRevAfter, err := s.emissionsKeeper.GetCurrentTopicWeight(
-		s.ctx,
-		r.TopicId,
+	topicWeightAfter, feeRevAfter, err := s.EmissionsKeeper().GetCurrentTopicWeight(
+		s.Ctx(),
+		topic,
 		10800,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
@@ -64,56 +59,43 @@ func (s *MsgServerTestSuite) TestFundTopicSimple() {
 }
 
 func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
-	senderAddr := s.addrs[0]
-	sender := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic1 := s.CreateOneTopic()
-	topic2 := s.CreateCustomEpochTopic(10900)
+	senderAddr := s.Addrs(0)
+	reputer := s.AddrsStr(1)
+	topic1 := s.CreateTopic()
+	topic2 := s.CreateTopic(testutil.WithEpochLength(10900), testutil.WithGroundTruthLag(10900))
+
 	// put some stake in the topic
-	err := s.emissionsKeeper.AddReputerStake(s.ctx, topic1.Id, reputer, cosmosMath.NewInt(500000))
+	err := s.EmissionsKeeper().AddReputerStake(s.Ctx(), topic1, reputer, cosmosMath.NewInt(500000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.InactivateTopic(s.ctx, topic1.Id)
+	err = s.EmissionsKeeper().InactivateTopic(s.Ctx(), topic1)
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerStake(s.ctx, topic2.Id, reputer, cosmosMath.NewInt(500000))
+	err = s.EmissionsKeeper().AddReputerStake(s.Ctx(), topic2, reputer, cosmosMath.NewInt(500000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.InactivateTopic(s.ctx, topic2.Id)
+	err = s.EmissionsKeeper().InactivateTopic(s.Ctx(), topic2)
 	s.Require().NoError(err)
 	var initialStake int64 = 1000
 	var initialStake2 int64 = 10000
 	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake+initialStake2)))
-	err = s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
+	err = s.BankKeeper().MintCoins(s.Ctx(), types.AlloraStakingAccountName, initialStakeCoins)
 	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, senderAddr, initialStakeCoins)
+	err = s.BankKeeper().SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, senderAddr, initialStakeCoins)
 	s.Require().NoError(err)
-	r := types.FundTopicRequest{
-		Sender:  sender,
-		TopicId: topic1.Id,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	r2 := types.FundTopicRequest{
-		Sender:  sender,
-		TopicId: topic2.Id,
-		Amount:  cosmosMath.NewInt(initialStake2),
-	}
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
-	s.Require().NoError(err, "GetParams should not return an error")
 
-	response, err := s.msgServer.FundTopic(s.ctx, &r)
-	s.Require().NoError(err, "RequestInference should not return an error")
-	s.Require().NotNil(response, "Response should not be nil")
-
-	response2, err := s.msgServer.FundTopic(s.ctx, &r2)
-	s.Require().NoError(err, "RequestInference should not return an error")
-	s.Require().NotNil(response2, "Response should not be nil")
+	s.FundTopic(topic1, senderAddr, cosmosMath.NewInt(initialStake))
+	s.FundTopic(topic2, senderAddr, cosmosMath.NewInt(initialStake2))
 
 	// Check if the topic is activated
-	res, err := s.emissionsKeeper.IsTopicActive(s.ctx, r.TopicId)
+	res, err := s.EmissionsKeeper().IsTopicActive(s.Ctx(), topic1)
 	s.Require().NoError(err)
 	s.Require().Equal(true, res, "TopicId is not activated")
+
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
+	s.Require().NoError(err, "GetParams should not return an error")
+
 	// check that the topic fee revenue has been updated
-	topicWeight, _, err := s.emissionsKeeper.GetCurrentTopicWeight(
-		s.ctx,
-		r.TopicId,
+	topicWeight, _, err := s.EmissionsKeeper().GetCurrentTopicWeight(
+		s.Ctx(),
+		topic1,
 		10800,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
@@ -122,9 +104,9 @@ func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
 	)
 	s.Require().NoError(err)
 
-	topic2Weight, _, err := s.emissionsKeeper.GetCurrentTopicWeight(
-		s.ctx,
-		r2.TopicId,
+	topic2Weight, _, err := s.EmissionsKeeper().GetCurrentTopicWeight(
+		s.Ctx(),
+		topic2,
 		10800,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
@@ -137,74 +119,56 @@ func (s *MsgServerTestSuite) TestHighWeightForHighFundedTopic() {
 }
 
 func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengths() {
-	senderAddr := s.addrs[0]
-	sender := s.addrsStr[0]
-	reputer := s.addrsStr[1]
+	senderAddr := s.Addrs(0)
+	reputer := s.AddrsStr(1)
 
 	// Create two topics with different epoch lengths
 	epochLength1 := int64(125)
 	epochLength2 := int64(50)
-	topic1 := s.CreateCustomEpochTopic(epochLength1) // Longer epoch
-	topic2 := s.CreateCustomEpochTopic(epochLength2) // Shorter epoch
+	topic1 := s.CreateTopic(testutil.WithEpochLength(epochLength1)) // Longer epoch
+	topic2 := s.CreateTopic(testutil.WithEpochLength(epochLength2)) // Shorter epoch
 
 	// Put same stake in both topics
-	err := s.emissionsKeeper.AddReputerStake(s.ctx, topic1.Id, reputer, cosmosMath.NewInt(500000))
+	err := s.EmissionsKeeper().AddReputerStake(s.Ctx(), topic1, reputer, cosmosMath.NewInt(500000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.InactivateTopic(s.ctx, topic1.Id)
+	err = s.EmissionsKeeper().InactivateTopic(s.Ctx(), topic1)
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.AddReputerStake(s.ctx, topic2.Id, reputer, cosmosMath.NewInt(500000))
+	err = s.EmissionsKeeper().AddReputerStake(s.Ctx(), topic2, reputer, cosmosMath.NewInt(500000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.InactivateTopic(s.ctx, topic2.Id)
+	err = s.EmissionsKeeper().InactivateTopic(s.Ctx(), topic2)
 	s.Require().NoError(err)
 
 	// Set up funding amounts
 	var initialStake int64 = 10000
 	var initialStake2 int64 = 10000
 	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake+initialStake2)))
-	err = s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
+	err = s.BankKeeper().MintCoins(s.Ctx(), types.AlloraStakingAccountName, initialStakeCoins)
 	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, senderAddr, initialStakeCoins)
+	err = s.BankKeeper().SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, senderAddr, initialStakeCoins)
 	s.Require().NoError(err)
-
-	// Create funding requests
-	r := types.FundTopicRequest{
-		Sender:  sender,
-		TopicId: topic1.Id,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	r2 := types.FundTopicRequest{
-		Sender:  sender,
-		TopicId: topic2.Id,
-		Amount:  cosmosMath.NewInt(initialStake2),
-	}
-
-	// Get params for weight calculation
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
-	s.Require().NoError(err, "GetParams should not return an error")
 
 	// Fund both topics
-	response, err := s.msgServer.FundTopic(s.ctx, &r)
-	s.Require().NoError(err, "FundTopic should not return an error")
-	s.Require().NotNil(response, "Response should not be nil")
-
-	response2, err := s.msgServer.FundTopic(s.ctx, &r2)
-	s.Require().NoError(err, "FundTopic should not return an error")
-	s.Require().NotNil(response2, "Response should not be nil")
+	s.FundTopic(topic1, senderAddr, cosmosMath.NewInt(initialStake))
+	s.FundTopic(topic2, senderAddr, cosmosMath.NewInt(initialStake2))
 
 	// Check if both topics are activated
-	res, err := s.emissionsKeeper.IsTopicActive(s.ctx, r.TopicId)
+	res, err := s.EmissionsKeeper().IsTopicActive(s.Ctx(), topic1)
 	s.Require().NoError(err)
 	s.Require().Equal(true, res, "Topic1 is not activated")
 
-	res2, err := s.emissionsKeeper.IsTopicActive(s.ctx, r2.TopicId)
+	res2, err := s.EmissionsKeeper().IsTopicActive(s.Ctx(), topic2)
 	s.Require().NoError(err)
 	s.Require().Equal(true, res2, "Topic2 is not activated")
 
+	// Get params for weight calculation
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
+	s.Require().NoError(err, "GetParams should not return an error")
+
 	// Get weights for both topics
-	topicWeight1, _, err := s.emissionsKeeper.GetCurrentTopicWeight(
-		s.ctx,
-		r.TopicId,
+	topicWeight1, _, err := s.EmissionsKeeper().GetCurrentTopicWeight(
+		s.Ctx(),
+		topic1,
 		epochLength1,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
@@ -213,9 +177,9 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 	)
 	s.Require().NoError(err)
 
-	topicWeight2, _, err := s.emissionsKeeper.GetCurrentTopicWeight(
-		s.ctx,
-		r2.TopicId,
+	topicWeight2, _, err := s.EmissionsKeeper().GetCurrentTopicWeight(
+		s.Ctx(),
+		topic2,
 		epochLength2,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
@@ -227,15 +191,15 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 	s.Require().Equal(topicWeight2.Equal(topicWeight1), true, "Topic2 weight should be equal to Topic1 weight if no previous topic weight is set")
 
 	// Setting previous topic weights
-	err = s.emissionsKeeper.SetPreviousTopicWeight(s.ctx, r.TopicId, alloraMath.MustNewDecFromString("100"))
+	err = s.EmissionsKeeper().SetPreviousTopicWeight(s.Ctx(), topic1, alloraMath.MustNewDecFromString("100"))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.SetPreviousTopicWeight(s.ctx, r2.TopicId, alloraMath.MustNewDecFromString("100"))
+	err = s.EmissionsKeeper().SetPreviousTopicWeight(s.Ctx(), topic2, alloraMath.MustNewDecFromString("100"))
 	s.Require().NoError(err)
 
 	// Recalculate having set previous topic weights
-	topicWeight1, _, err = s.emissionsKeeper.GetCurrentTopicWeight(
-		s.ctx,
-		r.TopicId,
+	topicWeight1, _, err = s.EmissionsKeeper().GetCurrentTopicWeight(
+		s.Ctx(),
+		topic1,
 		epochLength1,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,
@@ -244,9 +208,9 @@ func (s *MsgServerTestSuite) TestTopicWeightDoesNotChangeWithDifferentEpochLengt
 	)
 	s.Require().NoError(err)
 
-	topicWeight2, _, err = s.emissionsKeeper.GetCurrentTopicWeight(
-		s.ctx,
-		r2.TopicId,
+	topicWeight2, _, err = s.EmissionsKeeper().GetCurrentTopicWeight(
+		s.Ctx(),
+		topic2,
 		epochLength2,
 		params.TopicRewardAlpha,
 		params.TopicRewardStakeImportance,

--- a/x/emissions/keeper/msgserver/msg_server_demand_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_demand_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/keeper/msgserver/msg_server_params_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_params_test.go
@@ -2,15 +2,16 @@ package msgserver_test
 
 import (
 	cosmosMath "cosmossdk.io/math"
-	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 func (s *MsgServerTestSuite) TestUpdateAllParams() {
-	ctx, msgServer := s.ctx, s.msgServer
-	keeper := s.emissionsKeeper
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
+	keeper := s.EmissionsKeeper()
 	require := s.Require()
 
 	adminPrivateKey := secp256k1.GenPrivKey()
@@ -19,7 +20,7 @@ func (s *MsgServerTestSuite) TestUpdateAllParams() {
 	err := keeper.AddWhitelistAdmin(ctx, adminAddr.String())
 	require.NoError(err)
 
-	newParams := &types.OptionalParams{
+	newParams := &types.OptionalParams{ //nolint:exhaustruct
 		Version:                             []string{"1234"},
 		MinTopicWeight:                      []alloraMath.Dec{alloraMath.NewDecFromInt64(1234)},
 		RequiredMinimumStake:                []cosmosMath.Int{cosmosMath.NewInt(1234)},
@@ -145,7 +146,7 @@ func (s *MsgServerTestSuite) TestUpdateAllParams() {
 }
 
 func (s *MsgServerTestSuite) TestUpdateParamsNonWhitelistedUser() {
-	ctx, msgServer := s.ctx, s.msgServer
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
 	require := s.Require()
 
 	// Setup a non-whitelisted sender address
@@ -153,62 +154,9 @@ func (s *MsgServerTestSuite) TestUpdateParamsNonWhitelistedUser() {
 	nonAdminAddr := sdk.AccAddress(nonAdminPrivateKey.PubKey().Address())
 
 	// Define new parameters to update
-	newParams := &types.OptionalParams{
+	newParams := &types.OptionalParams{ //nolint:exhaustruct
 		Version: []string{"2.0"}, // example of changing the version
-		// don't update the following params
-		MaxSerializedMsgLength:              nil,
-		MinTopicWeight:                      nil,
-		RequiredMinimumStake:                nil,
-		RemoveStakeDelayWindow:              nil,
-		MinEpochLength:                      nil,
-		BetaEntropy:                         nil,
-		LearningRate:                        nil,
-		MaxGradientThreshold:                nil,
-		MinStakeFraction:                    nil,
-		MaxUnfulfilledWorkerRequests:        nil,
-		MaxUnfulfilledReputerRequests:       nil,
-		TopicRewardStakeImportance:          nil,
-		TopicRewardFeeRevenueImportance:     nil,
-		TopicRewardAlpha:                    nil,
-		TaskRewardAlpha:                     nil,
-		ValidatorsVsAlloraPercentReward:     nil,
-		MaxSamplesToScaleScores:             nil,
-		MaxTopInferersToReward:              nil,
-		MaxTopForecastersToReward:           nil,
-		MaxTopReputersToReward:              nil,
-		CreateTopicFee:                      nil,
-		GradientDescentMaxIters:             nil,
-		RegistrationFee:                     nil,
-		DefaultPageLimit:                    nil,
-		MaxPageLimit:                        nil,
-		MinEpochLengthRecordLimit:           nil,
-		BlocksPerMonth:                      nil,
-		PRewardInference:                    nil,
-		PRewardForecast:                     nil,
-		PRewardReputer:                      nil,
-		CRewardInference:                    nil,
-		CRewardForecast:                     nil,
-		CNorm:                               nil,
-		EpsilonReputer:                      nil,
-		HalfMaxProcessStakeRemovalsEndBlock: nil,
-		DataSendingFee:                      nil,
-		EpsilonSafeDiv:                      nil,
-		MaxElementsPerForecast:              nil,
-		MaxActiveTopicsPerBlock:             nil,
-		MaxStringLength:                     nil,
-		InitialRegretQuantile:               nil,
-		PNormSafeDiv:                        nil,
-		GlobalWhitelistEnabled:              nil,
-		TopicCreatorWhitelistEnabled:        nil,
-		MinExperiencedWorkerRegrets:         nil,
-		InferenceOutlierDetectionThreshold:  nil,
-		InferenceOutlierDetectionAlpha:      nil,
-		LambdaInitialScore:                  nil,
-		GlobalWorkerWhitelistEnabled:        nil,
-		GlobalReputerWhitelistEnabled:       nil,
-		GlobalAdminWhitelistAppended:        nil,
-		MaxWhitelistInputArrayLength:        nil,
-		MinWeightThresholdForStdnorm:        nil,
+		// don't update the other params
 	}
 
 	// Creating the UpdateParamsRequest message with a non-whitelisted user

--- a/x/emissions/keeper/msgserver/msg_server_registrations_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations_test.go
@@ -8,7 +8,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
@@ -202,14 +201,13 @@ func (s *MsgServerTestSuite) TestRegistrationErrors() {
 				err := s.EmissionsKeeper().ActivateTopic(ctx, topicId)
 				s.Require().NoError(err)
 
-				_, _, _, accs := alloratestutil.GenerateTestAccounts(1)
-				blockedReputer := accs[0]
+				blockedReputer := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
 
 				return &types.RegisterRequest{
-					Sender:    blockedReputer,
+					Sender:    blockedReputer.String(),
 					TopicId:   topicId,
 					IsReputer: true,
-					Owner:     blockedReputer,
+					Owner:     blockedReputer.String(),
 				}
 			},
 			expectedError: sdkerrors.ErrInsufficientFunds,

--- a/x/emissions/keeper/msgserver/msg_server_registrations_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations_test.go
@@ -1,369 +1,226 @@
 package msgserver_test
 
 import (
-	"cosmossdk.io/log"
+	"context"
+
 	cosmosMath "cosmossdk.io/math"
-	"github.com/allora-network/allora-chain/app/params"
-	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	"github.com/allora-network/allora-chain/x/emissions/types"
-	minttypes "github.com/allora-network/allora-chain/x/mint/types"
+	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (s *MsgServerTestSuite) TestMsgRegisterReputer() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
+func (s *MsgServerTestSuite) TestRegistration() {
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
+	topicId := uint64(1)
 
-	// Mock setup for addresses
-	reputerAddr := s.addrs[0]
-	topic1 := s.CreateOneTopic()
+	// Setup topic once
+	err := s.EmissionsKeeper().ActivateTopic(ctx, topicId)
+	s.Require().NoError(err)
 
-	// Topic register
-	err := s.emissionsKeeper.SetTopic(ctx, topic1.Id, topic1)
-	require.NoError(err, "SetTopic should not return an error")
-	err = s.emissionsKeeper.ActivateTopic(ctx, topic1.Id)
-	require.NoError(err, "ActivateTopic should not return an error")
-	// Reputer register
-	registerMsg := &types.RegisterRequest{
-		Sender:    reputerAddr.String(),
-		TopicId:   topic1.Id,
-		IsReputer: true,
-		Owner:     reputerAddr.String(),
-	}
-
-	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-
-	mintAmount := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, moduleParams.RegistrationFee))
-	err = s.bankKeeper.MintCoins(ctx, minttypes.ModuleName, mintAmount)
-	require.NoError(err, "MintCoins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(
-		ctx,
-		minttypes.ModuleName,
-		reputerAddr,
-		mintAmount,
-	)
-	require.NoError(err, "SendCoinsFromModuleToAccount should not return an error")
-
-	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topic1.Id, reputerAddr.String())
-	require.NoError(err)
-	require.False(isReputerRegistered, "Reputer should not be registered in topic")
-
-	_, err = msgServer.Register(ctx, registerMsg)
-	require.NoError(err, "Registering reputer should not return an error")
-
-	isReputerRegistered, err = s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topic1.Id, reputerAddr.String())
-	require.NoError(err)
-	require.True(isReputerRegistered, "Reputer should be registered in topic")
-}
-
-func (s *MsgServerTestSuite) TestMsgRemoveRegistration() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	// Mock setup for addresses
-	reputerAddr := s.addrs[0]
-	topic1 := s.CreateOneTopic()
-
-	// Topic register
-	err := s.emissionsKeeper.SetTopic(ctx, topic1.Id, topic1)
-	require.NoError(err)
-	err = s.emissionsKeeper.ActivateTopic(ctx, topic1.Id)
-	require.NoError(err)
-	// Reputer register
-	registerMsg := &types.RegisterRequest{
-		Sender:    reputerAddr.String(),
-		TopicId:   topic1.Id,
-		IsReputer: true,
-		Owner:     reputerAddr.String(),
-	}
-
-	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	mintAmount := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, moduleParams.RegistrationFee))
-	err = s.bankKeeper.MintCoins(ctx, minttypes.ModuleName, mintAmount)
-	require.NoError(err, "MintCoins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(
-		ctx,
-		minttypes.ModuleName,
-		reputerAddr,
-		mintAmount,
-	)
-	require.NoError(err, "SendCoinsFromModuleToAccount should not return an error")
-
-	_, err = msgServer.Register(ctx, registerMsg)
-	require.NoError(err, "Registering reputer should not return an error")
-
-	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topic1.Id, reputerAddr.String())
-	require.NoError(err)
-	require.True(isReputerRegistered, "Reputer should be registered in topic")
-
-	unregisterMsg := &types.RemoveRegistrationRequest{
-		Sender:    reputerAddr.String(),
-		TopicId:   topic1.Id,
-		IsReputer: true,
-	}
-
-	_, err = msgServer.RemoveRegistration(ctx, unregisterMsg)
-	require.NoError(err, "Registering reputer should not return an error")
-
-	isReputerRegistered, err = s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topic1.Id, reputerAddr.String())
-	require.NoError(err)
-	require.False(isReputerRegistered, "Reputer should be registered in topic")
-}
-
-func (s *MsgServerTestSuite) TestMsgRegisterWorker() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	// Mock setup for addresses
-	workerAddr := s.addrs[0]
-	topic1 := s.CreateOneTopic()
-
-	// Topic register
-	err := s.emissionsKeeper.SetTopic(ctx, topic1.Id, topic1)
-	require.NoError(err)
-	err = s.emissionsKeeper.ActivateTopic(ctx, topic1.Id)
-	require.NoError(err)
-	// Reputer register
-	registerMsg := &types.RegisterRequest{
-		Sender:    workerAddr.String(),
-		TopicId:   topic1.Id,
-		IsReputer: false,
-		Owner:     workerAddr.String(),
-	}
-
-	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	mintAmount := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, moduleParams.RegistrationFee))
-	err = s.bankKeeper.MintCoins(ctx, minttypes.ModuleName, mintAmount)
-	require.NoError(err, "MintCoins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(
-		ctx,
-		minttypes.ModuleName,
-		workerAddr,
-		mintAmount,
-	)
-	require.NoError(err, "SendCoinsFromModuleToAccount should not return an error")
-
-	isWorkerRegistered, err := s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topic1.Id, workerAddr.String())
-	require.NoError(err)
-	require.False(isWorkerRegistered, "Worker should not be registered in topic")
-
-	isReputerRegistered, err := s.emissionsKeeper.IsReputerRegisteredInTopic(ctx, topic1.Id, workerAddr.String())
-	require.NoError(err)
-	require.False(isReputerRegistered, "Reputer should not be registered in topic")
-
-	_, err = msgServer.Register(ctx, registerMsg)
-	require.NoError(err, "Registering worker should not return an error")
-
-	isWorkerRegistered, err = s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topic1.Id, workerAddr.String())
-	require.NoError(err)
-	require.True(isWorkerRegistered, "Worker should be registered in topic")
-}
-
-func (s *MsgServerTestSuite) TestMsgRemoveRegistrationWorker() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	// Mock setup for addresses
-	workerAddr := s.addrs[0]
-	topic1 := s.CreateOneTopic()
-
-	// Topic register
-	err := s.emissionsKeeper.SetTopic(ctx, topic1.Id, topic1)
-	require.NoError(err)
-	err = s.emissionsKeeper.ActivateTopic(ctx, topic1.Id)
-	require.NoError(err)
-	// Reputer register
-	registerMsg := &types.RegisterRequest{
-		Sender:    workerAddr.String(),
-		TopicId:   topic1.Id,
-		IsReputer: false,
-		Owner:     workerAddr.String(),
-	}
-
-	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	mintAmount := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, moduleParams.RegistrationFee))
-	err = s.bankKeeper.MintCoins(ctx, minttypes.ModuleName, mintAmount)
-	require.NoError(err, "MintCoins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(
-		ctx,
-		minttypes.ModuleName,
-		workerAddr,
-		mintAmount,
-	)
-	require.NoError(err, "SendCoinsFromModuleToAccount should not return an error")
-
-	_, err = msgServer.Register(ctx, registerMsg)
-	require.NoError(err, "Registering worker should not return an error")
-
-	isWorkerRegistered, err := s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topic1.Id, workerAddr.String())
-	require.NoError(err)
-	require.True(isWorkerRegistered, "Worker should be registered in topic")
-
-	unregisterMsg := &types.RemoveRegistrationRequest{
-		Sender:    workerAddr.String(),
-		TopicId:   topic1.Id,
-		IsReputer: false,
-	}
-
-	_, err = msgServer.RemoveRegistration(ctx, unregisterMsg)
-	require.NoError(err, "Unregistering worker should not return an error")
-
-	isWorkerRegistered, err = s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topic1.Id, workerAddr.String())
-	require.NoError(err)
-	require.False(isWorkerRegistered, "Worker should be registered in topic")
-}
-
-func (s *MsgServerTestSuite) TestMsgRegisterReputerInsufficientBalance() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	// Mock setup for addresses
-	reputerAddr := s.addrs[0]
-	topic1 := s.CreateOneTopic()
-	err := s.emissionsKeeper.SetTopic(ctx, topic1.Id, topic1)
-	require.NoError(err)
-	err = s.emissionsKeeper.ActivateTopic(ctx, topic1.Id)
-	require.NoError(err)
-	// Zero initial stake
-
-	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1))
-	// Topic does not exist
-	registerMsg := &types.RegisterRequest{
-		Sender:    reputerAddr.String(),
-		Owner:     reputerAddr.String(),
-		TopicId:   topic1.Id,
-		IsReputer: true,
-	}
-	_, err = msgServer.Register(ctx, registerMsg)
-	require.Error(err)
-}
-
-func (s *MsgServerTestSuite) TestMsgRegisterReputerInsufficientDenom() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-	topic1 := s.CreateOneTopic()
-
-	// Mock setup for addresses
-	reputerAddr := s.addrs[0]
-	registrationInitialStake := cosmosMath.NewInt(100)
-
-	// Register Reputer
-	reputerRegMsg := &types.RegisterRequest{
-		Sender:    reputerAddr.String(),
-		TopicId:   topic1.Id,
-		IsReputer: true,
-		Owner:     reputerAddr.String(),
-	}
-
-	err := s.emissionsKeeper.AddReputerStake(ctx, topic1.Id, reputerAddr.String(), registrationInitialStake.QuoRaw(2))
-	require.NoError(err)
-
-	// Try to register without any funds to pay fees
-	_, err = msgServer.Register(ctx, reputerRegMsg)
-	require.ErrorIs(err, sdkerrors.ErrInsufficientFunds, "Register should return an error")
-}
-
-func (s *MsgServerTestSuite) TestBlocklistedAddressUnableToRegister() {
-	// Reputer Addresses
-	reputer := s.addrs[2]
-	// Worker Addresses
-	worker := s.addrs[3]
-	cosmosOneE18, ok := cosmosMath.NewIntFromString("1000000000000000000")
-	s.Require().True(ok)
-
-	s.bankKeeper = bankkeeper.NewBaseKeeper(
-		s.codec,
-		s.storeService,
-		s.accountKeeper,
-		map[string]bool{
-			s.addrsStr[0]: true,
+	testCases := []struct {
+		name      string
+		isReputer bool
+		checkReg  func(context.Context, uint64, string) (bool, error)
+	}{
+		{
+			name:      "Register reputer",
+			isReputer: true,
+			checkReg:  s.EmissionsKeeper().IsReputerRegisteredInTopic,
 		},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		log.NewNopLogger(),
-	)
-	s.emissionsKeeper = keeper.NewKeeper(
-		s.codec,
-		s.addressCodec,
-		s.storeService,
-		s.accountKeeper,
-		s.bankKeeper,
-		authtypes.FeeCollectorName,
-	)
-
-	blockHeight := int64(600)
-	s.ctx = s.ctx.WithBlockHeight(blockHeight)
-	epochLength := int64(10800)
-
-	s.MintTokensToAddress(worker, cosmosMath.NewInt(10).Mul(cosmosOneE18))
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  worker.String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              epochLength,
-		GroundTruthLag:           epochLength,
-		WorkerSubmissionWindow:   10,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
+		{
+			name:      "Register worker",
+			isReputer: false,
+			checkReg:  s.EmissionsKeeper().IsWorkerRegisteredInTopic,
+		},
 	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	// Get Topic Id
-	topicId := res.TopicId
 
-	// Register 1 worker
-	workerRegMsg := &types.RegisterRequest{
-		Sender:    worker.String(),
-		TopicId:   topicId,
-		IsReputer: false,
-		Owner:     worker.String(),
-	}
-	_, err = s.msgServer.Register(s.ctx, workerRegMsg)
-	s.Require().NoError(err)
+	for i, tc := range testCases {
+		s.Run(tc.name, func() {
+			addr := s.Addrs(i)
 
-	reputerRegMsg := &types.RegisterRequest{
-		Sender:    reputer.String(),
-		TopicId:   topicId,
-		IsReputer: true,
-		Owner:     reputer.String(),
+			// Fund the account
+			moduleParams, _ := s.EmissionsKeeper().GetParams(ctx)
+			s.FundAccount(moduleParams.RegistrationFee.Int64(), addr)
+
+			// Check not registered
+			isRegistered, err := tc.checkReg(ctx, topicId, addr.String())
+			s.Require().NoError(err)
+			s.Require().False(isRegistered)
+
+			// Register
+			registerMsg := &types.RegisterRequest{
+				Sender:    addr.String(),
+				TopicId:   topicId,
+				IsReputer: tc.isReputer,
+				Owner:     addr.String(),
+			}
+			_, err = msgServer.Register(ctx, registerMsg)
+			s.Require().NoError(err)
+
+			// Check registered
+			isRegistered, err = tc.checkReg(ctx, topicId, addr.String())
+			s.Require().NoError(err)
+			s.Require().True(isRegistered)
+		})
 	}
-	_, err = s.msgServer.Register(s.ctx, reputerRegMsg)
-	s.Require().ErrorIs(err, sdkerrors.ErrInsufficientFunds, "Register should return an error")
 }
 
-func (s *MsgServerTestSuite) TestMsgRegisterReputerInvalidTopicNotExist() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
+func (s *MsgServerTestSuite) TestRemoveRegistration() {
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
+	topicId := uint64(1)
 
-	topicId := uint64(0)
+	// Setup topic once
+	err := s.EmissionsKeeper().ActivateTopic(ctx, topicId)
+	s.Require().NoError(err)
 
-	// Mock setup for addresses
-	reputerAddr := s.addrs[3]
-
-	// Topic does not exist
-	registerMsg := &types.RegisterRequest{
-		Sender:    reputerAddr.String(),
-		Owner:     reputerAddr.String(),
-		TopicId:   topicId,
-		IsReputer: true,
+	testCases := []struct {
+		name      string
+		isReputer bool
+		checkReg  func(context.Context, uint64, string) (bool, error)
+	}{
+		{
+			name:      "Remove reputer registration",
+			isReputer: true,
+			checkReg:  s.EmissionsKeeper().IsReputerRegisteredInTopic,
+		},
+		{
+			name:      "Remove worker registration",
+			isReputer: false,
+			checkReg:  s.EmissionsKeeper().IsWorkerRegisteredInTopic,
+		},
 	}
-	_, err := msgServer.Register(ctx, registerMsg)
-	require.ErrorIs(err, types.ErrTopicDoesNotExist, "Register should return an error")
+
+	for i, tc := range testCases {
+		s.Run(tc.name, func() {
+			addr := s.Addrs(i)
+
+			// Setup: Register first
+			moduleParams, _ := s.EmissionsKeeper().GetParams(ctx)
+			s.FundAccount(moduleParams.RegistrationFee.Int64(), addr)
+
+			registerMsg := &types.RegisterRequest{
+				Sender:    addr.String(),
+				TopicId:   topicId,
+				IsReputer: tc.isReputer,
+				Owner:     addr.String(),
+			}
+			_, err = msgServer.Register(ctx, registerMsg)
+			s.Require().NoError(err)
+
+			// Verify registered
+			isRegistered, err := tc.checkReg(ctx, topicId, addr.String())
+			s.Require().NoError(err)
+			s.Require().True(isRegistered)
+
+			// Remove registration
+			unregisterMsg := &types.RemoveRegistrationRequest{
+				Sender:    addr.String(),
+				TopicId:   topicId,
+				IsReputer: tc.isReputer,
+			}
+			_, err = msgServer.RemoveRegistration(ctx, unregisterMsg)
+			s.Require().NoError(err)
+
+			// Verify unregistered
+			isRegistered, err = tc.checkReg(ctx, topicId, addr.String())
+			s.Require().NoError(err)
+			s.Require().False(isRegistered)
+		})
+	}
+}
+
+func (s *MsgServerTestSuite) TestRegistrationErrors() {
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
+
+	testCases := []struct {
+		name          string
+		setup         func() *types.RegisterRequest
+		expectedError error
+	}{
+		{
+			name: "Topic does not exist",
+			setup: func() *types.RegisterRequest {
+				addr := s.Addrs(0)
+				return &types.RegisterRequest{
+					Sender:    addr.String(),
+					Owner:     addr.String(),
+					TopicId:   uint64(999), // non-existent topic
+					IsReputer: true,
+				}
+			},
+			expectedError: types.ErrTopicDoesNotExist,
+		},
+		{
+			name: "Insufficient balance for registration fee",
+			setup: func() *types.RegisterRequest {
+				topicId := uint64(1)
+				err := s.EmissionsKeeper().ActivateTopic(ctx, topicId)
+				s.Require().NoError(err)
+
+				addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+				s.MintTokensToAddress(addr, cosmosMath.NewInt(1)) // Not enough for registration fee
+
+				return &types.RegisterRequest{
+					Sender:    addr.String(),
+					Owner:     addr.String(),
+					TopicId:   topicId,
+					IsReputer: true,
+				}
+			},
+			expectedError: sdkerrors.ErrInsufficientFunds,
+		},
+		{
+			name: "Insufficient funds with partial stake",
+			setup: func() *types.RegisterRequest {
+				topicId := uint64(1)
+				err := s.EmissionsKeeper().ActivateTopic(ctx, topicId)
+				s.Require().NoError(err)
+
+				addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+				registrationInitialStake := cosmosMath.NewInt(100)
+
+				// Add some stake but no funds to pay fees
+				err = s.EmissionsKeeper().AddReputerStake(ctx, topicId, addr.String(), registrationInitialStake.QuoRaw(2))
+				s.Require().NoError(err)
+
+				return &types.RegisterRequest{
+					Sender:    addr.String(),
+					TopicId:   topicId,
+					IsReputer: true,
+					Owner:     addr.String(),
+				}
+			},
+			expectedError: sdkerrors.ErrInsufficientFunds,
+		},
+		{
+			name: "Blacklisted address cannot register",
+			setup: func() *types.RegisterRequest {
+				topicId := uint64(1)
+				err := s.EmissionsKeeper().ActivateTopic(ctx, topicId)
+				s.Require().NoError(err)
+
+				_, _, _, accs := alloratestutil.GenerateTestAccounts(1)
+				blockedReputer := accs[0]
+
+				return &types.RegisterRequest{
+					Sender:    blockedReputer,
+					TopicId:   topicId,
+					IsReputer: true,
+					Owner:     blockedReputer,
+				}
+			},
+			expectedError: sdkerrors.ErrInsufficientFunds,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			msg := tc.setup()
+			_, err := msgServer.Register(ctx, msg)
+			s.Require().ErrorIs(err, tc.expectedError)
+		})
+	}
 }

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
@@ -71,6 +71,7 @@ func (s *MsgServerTestSuite) TestMsgInsertReputerPayloadReputerNotMatchSignature
 	topicId := uint64(1)
 
 	unauthReputer := s.AddrsStr(3)
+	//nolint:exhaustruct
 	inputValueBundle := &types.InputValueBundle{
 		TopicId:             topicId,
 		ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: 1}},

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
@@ -3,7 +3,7 @@ package msgserver_test
 import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload_test.go
@@ -1,264 +1,94 @@
 package msgserver_test
 
 import (
-	alloraMath "github.com/allora-network/allora-chain/math"
-	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
-	"github.com/allora-network/allora-chain/x/emissions/types"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-const block = types.BlockHeight(1)
-
-func (s *MsgServerTestSuite) setUpMsgReputerPayload(
-	reputer string,
-	reputerAddr sdk.AccAddress,
-	worker string,
-	workerAddr sdk.AccAddress,
-) (
-	reputerValueBundle types.InputValueBundle,
-	expectedInferences types.Inferences,
-	expectedForecasts types.Forecasts,
-	topicId uint64,
-) {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-	keeper := s.emissionsKeeper
-
-	params, err := keeper.GetParams(ctx)
-	require.NoError(err)
-
-	minStakeScaled := params.RequiredMinimumStake.Mul(inferencesynthesis.CosmosIntOneE18())
-
-	topicId = s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, minStakeScaled)
-	s.MintTokensToAddress(reputerAddr, params.RequiredMinimumStake)
-
-	addStakeMsg := &types.AddStakeRequest{
-		Sender:  reputerAddr.String(),
-		TopicId: topicId,
-		Amount:  minStakeScaled,
-	}
-
-	_, err = msgServer.AddStake(ctx, addStakeMsg)
-	s.Require().NoError(err)
-
-	workerNonce := types.Nonce{
-		BlockHeight: block,
-	}
-
-	err = keeper.AddWorkerNonce(ctx, topicId, &workerNonce)
-	require.NoError(err)
-	_, err = keeper.FulfillWorkerNonce(ctx, topicId, &workerNonce)
-	require.NoError(err)
-	err = keeper.AddReputerNonce(ctx, topicId, &workerNonce)
-	require.NoError(err)
-
-	// add in inference and forecast data
-	expectedInferences = types.Inferences{
-		Inferences: []*types.Inference{
-			{
-				TopicId:     topicId,
-				BlockHeight: block,
-				Value:       alloraMath.NewDecFromInt64(1), // Assuming NewDecFromInt64 exists and is appropriate
-				Inferer:     workerAddr.String(),
-			},
-		},
-	}
-
-	expectedForecasts = types.Forecasts{
-		Forecasts: []*types.Forecast{
-			{
-				TopicId:     topicId,
-				BlockHeight: block,
-				Forecaster:  workerAddr.String(),
-				ForecastElements: []*types.ForecastElement{
-					{
-						Inferer: workerAddr.String(),
-						Value:   alloraMath.NewDecFromInt64(1),
-					},
-				},
-			},
-		},
-	}
-
-	reputerValueBundle = types.InputValueBundle{
-		TopicId:             topicId,
-		ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &workerNonce},
-		Reputer:             reputerAddr.String(),
-		ExtraData:           nil,
-		CombinedValue:       alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-		InfererValues: []*types.InputWorkerAttributedValue{
-			{
-				Worker: workerAddr.String(),
-				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-			},
-		},
-		ForecasterValues: []*types.InputWorkerAttributedValue{
-			{
-				Worker: workerAddr.String(),
-				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-			},
-		},
-		NaiveValue:          alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-		OneOutInfererValues: []*types.InputWithheldWorkerAttributedValue{},
-		OneOutForecasterValues: []*types.InputWithheldWorkerAttributedValue{
-			{
-				Worker: workerAddr.String(),
-				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-			},
-		},
-		OneInForecasterValues: []*types.InputWorkerAttributedValue{
-			{
-				Worker: workerAddr.String(),
-				Value:  alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-			},
-		},
-		OneOutInfererForecasterValues: nil,
-	}
-
-	return reputerValueBundle, expectedInferences, expectedForecasts, topicId
-}
-
-func (s *MsgServerTestSuite) signInputValueBundle(InputReputerValueBundle *types.InputValueBundle, privateKey secp256k1.PrivKey) []byte {
-	require := s.Require()
-	reputerValueBundle, err := types.NewValueBundleFromInput(InputReputerValueBundle)
-	require.NoError(err, "Convert should not return an error")
-	return s.signValueBundle(reputerValueBundle, privateKey)
-}
-
-func (s *MsgServerTestSuite) signValueBundle(reputerValueBundle *types.ValueBundle, privateKey secp256k1.PrivKey) []byte {
-	require := s.Require()
-	src := make([]byte, 0)
-	src, err := reputerValueBundle.XXX_Marshal(src, true)
-	require.NoError(err, "Marshall reputer value bundle should not return an error")
-
-	valueBundleSignature, err := privateKey.Sign(src)
-	require.NoError(err, "Sign should not return an error")
-
-	return valueBundleSignature
-}
-
-func (s *MsgServerTestSuite) constructAndInsertReputerPayload(
-	reputerAddr sdk.AccAddress,
-	reputerPrivateKey secp256k1.PrivKey,
-	reputerPublicKeyHex string,
-	reputerValueBundle *types.InputValueBundle,
-) error {
-	ctx, msgServer := s.ctx, s.msgServer
-	valueBundleSignature := s.signInputValueBundle(reputerValueBundle, reputerPrivateKey)
-
-	// Create a InsertReputerPayloadRequest message
-	lossesMsg := &types.InsertReputerPayloadRequest{
-		Sender: reputerAddr.String(),
-		ReputerValueBundle: &types.InputReputerValueBundle{
-			ValueBundle: reputerValueBundle,
-			Signature:   valueBundleSignature,
-			Pubkey:      reputerPublicKeyHex,
-		},
-	}
-
-	_, err := msgServer.InsertReputerPayload(ctx, lossesMsg)
-	return err
-}
-
 func (s *MsgServerTestSuite) TestMsgInsertReputerPayloadFailsEarlyWindowAndWhitelistCheck() {
-	ctx := s.ctx
-	require := s.Require()
-	keeper := s.emissionsKeeper
+	reputerIndexes := testutil.ReturnIndexes(0, 1)
+	workerIndexes := testutil.ReturnIndexes(1, 1)
+	reputerAddr := s.Addrs(reputerIndexes[0])
+	reputerValues := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.1")
 
-	reputerPrivateKey := s.privKeys[0]
-	reputerPublicKeyHex := s.pubKeyHexStr[0]
-	reputerAddr := s.addrs[0]
-	reputer := s.addrsStr[0]
+	topic := s.FullTopicSetup(workerIndexes, reputerIndexes)
 
-	workerAddr := s.addrs[1]
-	worker := s.addrsStr[1]
+	nonce, _, _ := s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), topic.Id)
+	s.WithBlockHeight(nonce)
+	s.EndBlock()
 
-	reputerValueBundle, expectedInferences, expectedForecasts, topicId := s.setUpMsgReputerPayload(reputer, reputerAddr, worker, workerAddr)
-
-	err := keeper.InsertActiveForecasts(ctx, topicId, block, expectedForecasts)
-	require.NoError(err)
-
-	err = keeper.InsertActiveInferences(ctx, topicId, block, expectedInferences)
-	require.NoError(err)
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
+	s.SetupInferences(topic.Id, nonce, workerIndexes)
+	newBlockheight := nonce + topic.WorkerSubmissionWindow
+	s.WithBlockHeight(newBlockheight)
+	s.CloseWorkerNonce(topic, types.Nonce{BlockHeight: nonce})
 
 	// Prior to the ground truth lag, should not allow reputer payload
-	newBlockheight := block + topic.GroundTruthLag - 1
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
+	newBlockheight = nonce + topic.GroundTruthLag - 1
+	s.WithBlockHeight(newBlockheight)
 
-	err = s.constructAndInsertReputerPayload(reputerAddr, reputerPrivateKey, reputerPublicKeyHex, &reputerValueBundle)
-	require.ErrorIs(err, types.ErrReputerNonceWindowNotAvailable)
+	err := s.InsertReputerLossBundle(
+		topic.GetId(),
+		nonce,
+		reputerIndexes,
+		testutil.WithReputerValues(reputerValues),
+		testutil.WithSkipNetworkInferences(),
+	)
+	s.Require().ErrorIs(err, types.ErrReputerNonceWindowNotAvailable)
 
 	// Valid reputer nonce window, end
-	newBlockheight = block + topic.GroundTruthLag*2 + 1
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-	err = s.constructAndInsertReputerPayload(reputerAddr, reputerPrivateKey, reputerPublicKeyHex, &reputerValueBundle)
-	require.ErrorIs(err, types.ErrReputerNonceWindowNotAvailable)
+	newBlockheight = nonce + topic.GroundTruthLag*2 + 1
+	s.WithBlockHeight(newBlockheight)
+	err = s.InsertReputerLossBundle(topic.GetId(), nonce, reputerIndexes)
+	s.Require().ErrorIs(err, types.ErrReputerNonceWindowNotAvailable)
 
 	// Remove reputer from whitelist
-	err = keeper.RemoveFromGlobalWhitelist(ctx, reputerAddr.String())
-	require.NoError(err)
-	err = keeper.RemoveFromTopicReputerWhitelist(ctx, topicId, reputerAddr.String())
-	require.NoError(err)
+	err = s.EmissionsKeeper().RemoveFromGlobalWhitelist(s.Ctx(), reputerAddr.String())
+	s.Require().NoError(err)
+	err = s.EmissionsKeeper().RemoveFromTopicReputerWhitelist(s.Ctx(), topic.Id, reputerAddr.String())
+	s.Require().NoError(err)
 
-	newBlockheight = block + topic.GroundTruthLag*2
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-	err = s.constructAndInsertReputerPayload(reputerAddr, reputerPrivateKey, reputerPublicKeyHex, &reputerValueBundle)
-	require.ErrorIs(err, types.ErrNotPermittedToSubmitReputerPayload)
+	newBlockheight = nonce + topic.GroundTruthLag*2
+	s.WithBlockHeight(newBlockheight)
+	err = s.InsertReputerLossBundle(topic.GetId(), nonce, reputerIndexes)
+	s.Require().ErrorIs(err, types.ErrNotPermittedToSubmitReputerPayload)
 
 	// Add reputer to whitelist so they could submit payload again
-	err = keeper.AddToTopicReputerWhitelist(ctx, topicId, reputerAddr.String())
-	require.NoError(err)
+	err = s.EmissionsKeeper().AddToTopicReputerWhitelist(s.Ctx(), topic.Id, reputerAddr.String())
+	s.Require().NoError(err)
 
 	// Valid reputer nonce window, end
-	err = s.constructAndInsertReputerPayload(reputerAddr, reputerPrivateKey, reputerPublicKeyHex, &reputerValueBundle)
-	require.NoError(err)
+	err = s.InsertReputerLossBundle(topic.GetId(), nonce, reputerIndexes)
+	s.Require().NoError(err)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertReputerPayloadReputerNotMatchSignature() {
-	ctx := s.ctx
-	require := s.Require()
-	keeper := s.emissionsKeeper
+	reputerIndexes := testutil.ReturnIndexes(0, 1)
+	reputerAddr := s.Addrs(reputerIndexes[0])
+	reputerPrivateKey := s.PrivKeys(0)
+	reputerPublicKeyHex := s.PubKeyHexStr(0)
+	topicId := uint64(1)
 
-	reputerPrivateKey := s.privKeys[0]
-	reputerAddr := s.addrs[0]
-	reputer := s.addrsStr[0]
-	reputerPublicKeyHex := s.pubKeyHexStr[0]
-	workerAddr := s.addrs[1]
-	worker := s.addrsStr[1]
-
-	reputerValueBundle, expectedInferences, expectedForecasts, topicId := s.setUpMsgReputerPayload(reputer, reputerAddr, worker, workerAddr)
-
-	err := keeper.InsertActiveForecasts(ctx, topicId, block, expectedForecasts)
-	require.NoError(err)
-
-	err = keeper.InsertActiveInferences(ctx, topicId, block, expectedInferences)
-	require.NoError(err)
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	// Prior to the ground truth lag, should not allow reputer payload
-	newBlockheight := block + topic.GroundTruthLag - 1
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-
-	reputerValueBundle.Reputer = s.addrsStr[3]
-	valueBundleSignature := s.signInputValueBundle(&reputerValueBundle, reputerPrivateKey)
+	unauthReputer := s.AddrsStr(3)
+	inputValueBundle := &types.InputValueBundle{
+		TopicId:             topicId,
+		ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: 1}},
+		Reputer:             unauthReputer,
+		InfererValues:       []*types.InputWorkerAttributedValue{{Worker: s.AddrsStr(0)}},
+	}
+	valueBundleSignature := s.SignInputValueBundle(inputValueBundle, reputerPrivateKey)
 
 	// Create a InsertReputerPayloadRequest message
 	lossesMsg := &types.InsertReputerPayloadRequest{
 		Sender: reputerAddr.String(),
 		ReputerValueBundle: &types.InputReputerValueBundle{
-			ValueBundle: &reputerValueBundle,
+			ValueBundle: inputValueBundle,
 			Signature:   valueBundleSignature,
 			Pubkey:      reputerPublicKeyHex,
 		},
 	}
 
-	_, err = s.msgServer.InsertReputerPayload(ctx, lossesMsg)
-	require.ErrorIs(err, sdkerrors.ErrUnauthorized)
+	_, err := s.EmissionsMsgServer().InsertReputerPayload(s.Ctx(), lossesMsg)
+	s.Require().ErrorIs(err, sdkerrors.ErrUnauthorized)
 }

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -8,107 +8,26 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	cosmosMath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/utils/ptr"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (s *MsgServerTestSuite) commonStakingSetup(
-	ctx sdk.Context,
-	reputer string,
-	reputerAddr sdk.AccAddress,
-	worker string,
-	workerAddr sdk.AccAddress,
-	reputerInitialBalanceUint cosmosMath.Int,
-) uint64 {
-	msgServer := s.msgServer
-	require := s.Require()
-
-	// Create Topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  reputer,
-		Metadata:                 "Some metadata for the new topic",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-
-	reputerInitialBalance := types.DefaultParams().CreateTopicFee.Add(reputerInitialBalanceUint)
-
-	reputerInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, reputerInitialBalance))
-
-	err := s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, reputer)
-	require.NoError(err)
-
-	err = s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, reputerInitialBalanceCoins)
-	require.NoError(err, "Minting coins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, reputerAddr, reputerInitialBalanceCoins)
-	require.NoError(err, "Sending coins should not return an error")
-
-	response, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.NoError(err, "CreateTopic fails on creation")
-	topicId := response.TopicId
-
-	// Register Reputer
-	reputerRegMsg := &types.RegisterRequest{
-		Sender:    reputer,
-		Owner:     reputer,
-		TopicId:   topicId,
-		IsReputer: true,
-	}
-	_, err = msgServer.Register(ctx, reputerRegMsg)
-	require.NoError(err, "Registering reputer should not return an error")
-
-	workerInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(11000)))
-
-	err = s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, workerInitialBalanceCoins)
-	require.NoError(err, "Minting coins should not return an error")
-	err = s.bankKeeper.MintCoins(ctx, types.AlloraRewardsAccountName, workerInitialBalanceCoins)
-	require.NoError(err, "Minting coins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, workerAddr, workerInitialBalanceCoins)
-	require.NoError(err, "Sending coins should not return an error")
-
-	// Register Worker
-	workerRegMsg := &types.RegisterRequest{
-		Sender:    worker,
-		Owner:     worker,
-		TopicId:   topicId,
-		IsReputer: false,
-	}
-	_, err = msgServer.Register(ctx, workerRegMsg)
-	require.NoError(err, "Registering worker should not return an error")
-
-	return topicId
-}
-
 func (s *MsgServerTestSuite) TestMsgAddStakeWithWhitelistCheck() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 
-	reputer := s.addrsStr[0]
-	reputerAddr := s.addrs[0]
-	worker := s.addrsStr[1]
-	workerAddr := s.addrs[1]
+	reputerIndexes := testutil.ReturnIndexes(0, 1)
+	workerIndexes := testutil.ReturnIndexes(1, 1)
+	reputer := s.AddrsStr(reputerIndexes[0])
 	stakeAmount := cosmosMath.NewInt(10)
-	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	registrationInitialBalance := moduleParams.RegistrationFee.Add(stakeAmount)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.FullTopicSetup(workerIndexes, reputerIndexes, testutil.WithReputerStake(ptr.To(cosmosMath.ZeroInt()))).Id
 
 	addStakeMsg := &types.AddStakeRequest{
 		Sender:  reputer,
@@ -116,83 +35,72 @@ func (s *MsgServerTestSuite) TestMsgAddStakeWithWhitelistCheck() {
 		Amount:  stakeAmount,
 	}
 
-	reputerStake, err := s.emissionsKeeper.GetStakeReputerAuthority(ctx, topicId, reputer)
+	reputerStake, err := s.EmissionsKeeper().GetStakeReputerAuthority(ctx, topicId, reputer)
 	require.NoError(err)
 	require.Equal(cosmosMath.ZeroInt(), reputerStake, "Stake amount mismatch")
 
-	topicStake, err := s.emissionsKeeper.GetTopicStake(ctx, topicId)
+	topicStake, err := s.EmissionsKeeper().GetTopicStake(ctx, topicId)
 	require.NoError(err)
 	require.Equal(cosmosMath.ZeroInt(), topicStake, "Stake amount mismatch")
 
 	// Remove sender from whitelist
-	err = s.emissionsKeeper.RemoveFromTopicReputerWhitelist(ctx, topicId, reputer)
+	err = s.EmissionsKeeper().RemoveFromTopicReputerWhitelist(ctx, topicId, reputer)
 	require.NoError(err)
-	err = s.emissionsKeeper.RemoveFromGlobalWhitelist(ctx, reputer)
+	err = s.EmissionsKeeper().RemoveFromGlobalWhitelist(ctx, reputer)
 	require.NoError(err)
 
 	// Should now fail
-	response, err := s.msgServer.AddStake(ctx, addStakeMsg)
+	response, err := s.EmissionsMsgServer().AddStake(ctx, addStakeMsg)
 	require.ErrorIs(err, types.ErrNotPermittedToAddStake)
 	require.Nil(response)
 
 	// Add sender back to whitelist
-	err = s.emissionsKeeper.AddToTopicReputerWhitelist(ctx, topicId, reputer)
+	err = s.EmissionsKeeper().AddToTopicReputerWhitelist(ctx, topicId, reputer)
 	require.NoError(err)
 
 	// Should now succeed
-	response, err = s.msgServer.AddStake(ctx, addStakeMsg)
+	response, err = s.EmissionsMsgServer().AddStake(ctx, addStakeMsg)
 	require.NoError(err, "AddStake should not return an error")
 	require.NotNil(response)
 
-	reputerStake, err = s.emissionsKeeper.GetStakeReputerAuthority(ctx, topicId, reputer)
+	reputerStake, err = s.EmissionsKeeper().GetStakeReputerAuthority(ctx, topicId, reputer)
 	require.NoError(err)
 	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
 
-	topicStake, err = s.emissionsKeeper.GetTopicStake(ctx, topicId)
+	topicStake, err = s.EmissionsKeeper().GetTopicStake(ctx, topicId)
 	require.NoError(err)
 	require.Equal(stakeAmount, topicStake, "Stake amount mismatch")
 }
 
 func (s *MsgServerTestSuite) TestMsgAddStakeNil() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 
-	reputer := s.addrsStr[0]
-	reputerAddr := s.addrs[0]
-	worker := s.addrsStr[1]
-	workerAddr := s.addrs[1]
-	stakeAmount := cosmosMath.NewInt(10)
-	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	registrationInitialBalance := moduleParams.RegistrationFee.Add(stakeAmount)
-
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
-
 	addStakeMsg := &types.AddStakeRequest{
-		Sender:  reputer,
-		TopicId: topicId,
+		Sender:  s.AddrsStr(0),
+		TopicId: uint64(1),
 		Amount:  cosmosMath.Int{},
 	}
 
-	_, err = s.msgServer.AddStake(ctx, addStakeMsg)
+	_, err := s.EmissionsMsgServer().AddStake(ctx, addStakeMsg)
 	require.ErrorIs(err, sdkerrors.ErrInvalidCoins)
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	senderAddr := s.addrs[0]
-	sender := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
+	senderAddr := s.Addrs(0)
+	sender := s.AddrsStr(0)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 
 	s.MintTokensToAddress(senderAddr, cosmosMath.NewInt(1000))
 
 	// Assuming you have methods to directly manipulate the state
 	// Simulate that sender has already staked the required amount
-	err := s.emissionsKeeper.AddReputerStake(ctx, topicId, sender, stakeAmount)
+	err := s.EmissionsKeeper().AddReputerStake(ctx, topicId, sender, stakeAmount)
 	require.NoError(err)
 
 	msg := &types.RemoveStakeRequest{
@@ -201,7 +109,7 @@ func (s *MsgServerTestSuite) TestStartRemoveStake() {
 		Amount:  stakeAmount,
 	}
 
-	response, err := s.msgServer.RemoveStake(ctx, msg)
+	response, err := s.EmissionsMsgServer().RemoveStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(response)
 
@@ -226,11 +134,11 @@ func (s *MsgServerTestSuite) TestStartRemoveStake() {
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveStakeInsufficientStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 
-	sender := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
+	sender := s.AddrsStr(0)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 
 	msg := &types.RemoveStakeRequest{
@@ -239,37 +147,35 @@ func (s *MsgServerTestSuite) TestStartRemoveStakeInsufficientStake() {
 		Amount:  stakeAmount,
 	}
 
-	_, err := s.msgServer.RemoveStake(ctx, msg)
+	_, err := s.EmissionsMsgServer().RemoveStake(ctx, msg)
 	require.ErrorIs(err, types.ErrInsufficientStakeToRemove)
 
-	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
+	moduleParams, err := s.EmissionsKeeper().GetParams(ctx)
 	require.NoError(err)
 	expectedUnstake := ctx.BlockHeight() + moduleParams.RemoveStakeDelayWindow
-	retrievedInfo, limitHit, err := s.emissionsKeeper.GetStakeRemovalsUpUntilBlock(ctx, expectedUnstake, 100)
+	retrievedInfo, limitHit, err := s.EmissionsKeeper().GetStakeRemovalsUpUntilBlock(ctx, expectedUnstake, 100)
 	require.NoError(err)
 	require.Len(retrievedInfo, 0)
 	require.False(limitHit)
 }
 
 func (s *MsgServerTestSuite) TestConfirmRemoveStake() {
-	ctx := s.ctx
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	senderAddr := s.addrs[0]
-	sender := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
+	senderAddr := s.Addrs(0)
+	sender := s.AddrsStr(0)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	startBlock := sdkCtx.BlockHeight()
+	startBlock := s.Ctx().BlockHeight()
 
-	params, err := keeper.GetParams(ctx)
+	params, err := keeper.GetParams(s.Ctx())
 	require.NoError(err)
 	removalDelay := params.RemoveStakeDelayWindow
 
 	s.MintTokensToAddress(senderAddr, cosmosMath.NewInt(1000))
 	s.MintTokensToModule(types.AlloraStakingAccountName, cosmosMath.NewInt(1000))
-	err = s.emissionsKeeper.AddReputerStake(ctx, topicId, sender, stakeAmount)
+	err = s.EmissionsKeeper().AddReputerStake(s.Ctx(), topicId, sender, stakeAmount)
 	require.NoError(err)
 	blockEnd := startBlock + removalDelay
 
@@ -283,36 +189,35 @@ func (s *MsgServerTestSuite) TestConfirmRemoveStake() {
 	}
 
 	// Manually setting the removal in state (this part would normally involve interacting with the keeper to set up state).
-	err = keeper.SetStakeRemoval(ctx, placement) // This assumes such a method exists.
+	err = keeper.SetStakeRemoval(s.Ctx(), placement) // This assumes such a method exists.
 	require.NoError(err)
 
-	ctx = ctx.WithBlockHeight(blockEnd)
+	s.WithBlockHeight(blockEnd)
 
 	// Perform the stake confirmation
-	err = s.appModule.EndBlock(ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	require.NoError(err)
 
-	finalStake, err := keeper.GetStakeReputerAuthority(ctx, topicId, senderAddr.String())
+	finalStake, err := keeper.GetStakeReputerAuthority(s.Ctx(), topicId, senderAddr.String())
 	require.NoError(err)
 	require.True(finalStake.IsZero(), "Stake amount should be zero after removal is confirmed")
 
 	// Check that the stake removal has been removed from the state
-	removals, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(ctx, blockEnd, 100)
+	removals, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(s.Ctx(), blockEnd, 100)
 	require.NoError(err)
 	require.Len(removals, 0)
 	require.False(limitHit)
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveStakeTwiceInSameBlock() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	sender := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
+	sender := s.AddrsStr(0)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	startBlock := sdkCtx.BlockHeight()
+	startBlock := s.Ctx().BlockHeight()
 
 	// Fetch the delay window for removing stake
 	params, err := keeper.GetParams(ctx)
@@ -321,10 +226,10 @@ func (s *MsgServerTestSuite) TestStartRemoveStakeTwiceInSameBlock() {
 	removeBlock := startBlock + removalDelay
 
 	// Simulate that sender has already staked the required amount
-	err = s.emissionsKeeper.AddReputerStake(ctx, topicId, sender, stakeAmount)
+	err = s.EmissionsKeeper().AddReputerStake(ctx, topicId, sender, stakeAmount)
 	require.NoError(err)
 
-	_, err = s.msgServer.RemoveStake(ctx, &types.RemoveStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveStake(ctx, &types.RemoveStakeRequest{
 		Sender:  sender,
 		TopicId: topicId,
 		Amount:  stakeAmount,
@@ -346,7 +251,7 @@ func (s *MsgServerTestSuite) TestStartRemoveStakeTwiceInSameBlock() {
 	require.Equal(expected, stakePlacements[0])
 
 	newStake := stakeAmount.SubRaw(10)
-	_, err = s.msgServer.RemoveStake(ctx, &types.RemoveStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveStake(ctx, &types.RemoveStakeRequest{
 		Sender:  sender,
 		TopicId: topicId,
 		Amount:  newStake,
@@ -368,34 +273,32 @@ func (s *MsgServerTestSuite) TestStartRemoveStakeTwiceInSameBlock() {
 }
 
 func (s *MsgServerTestSuite) TestRemoveStakeTwiceInDifferentBlocks() {
-	ctx := s.ctx
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	sender := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
+	sender := s.AddrsStr(0)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	startBlock := sdkCtx.BlockHeight()
+	startBlock := s.Ctx().BlockHeight()
 
 	// Fetch the delay window for removing stake
-	params, err := keeper.GetParams(ctx)
+	params, err := keeper.GetParams(s.Ctx())
 	require.NoError(err)
 	removalDelay := params.RemoveStakeDelayWindow
 	removeBlock := startBlock + removalDelay
 
 	// Simulate that sender has already staked the required amount
-	err = s.emissionsKeeper.AddReputerStake(ctx, topicId, sender, stakeAmount)
+	err = s.EmissionsKeeper().AddReputerStake(s.Ctx(), topicId, sender, stakeAmount)
 	require.NoError(err)
 
-	_, err = s.msgServer.RemoveStake(ctx, &types.RemoveStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveStake(s.Ctx(), &types.RemoveStakeRequest{
 		Sender:  sender,
 		TopicId: topicId,
 		Amount:  stakeAmount,
 	})
 	s.Require().NoError(err)
 
-	stakePlacements, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(ctx, removeBlock, 100)
+	stakePlacements, limitHit, err := keeper.GetStakeRemovalsUpUntilBlock(s.Ctx(), removeBlock, 100)
 	require.NoError(err)
 	require.Len(stakePlacements, 1)
 	require.False(limitHit)
@@ -412,19 +315,19 @@ func (s *MsgServerTestSuite) TestRemoveStakeTwiceInDifferentBlocks() {
 	newStartBlock := startBlock + 5
 	newRemoveBlock := newStartBlock + removalDelay
 	newStake := stakeAmount.SubRaw(10)
-	ctx = ctx.WithBlockHeight(newStartBlock)
-	_, err = s.msgServer.RemoveStake(ctx, &types.RemoveStakeRequest{
+	s.WithBlockHeight(newStartBlock)
+	_, err = s.EmissionsMsgServer().RemoveStake(s.Ctx(), &types.RemoveStakeRequest{
 		Sender:  sender,
 		TopicId: topicId,
 		Amount:  newStake,
 	})
 	s.Require().NoError(err)
 
-	stakePlacements, limitHit, err = keeper.GetStakeRemovalsUpUntilBlock(ctx, removeBlock, 100)
+	stakePlacements, limitHit, err = keeper.GetStakeRemovalsUpUntilBlock(s.Ctx(), removeBlock, 100)
 	require.NoError(err)
 	require.Len(stakePlacements, 0)
 	require.False(limitHit)
-	stakePlacements, limitHit, err = keeper.GetStakeRemovalsUpUntilBlock(ctx, newRemoveBlock, 100)
+	stakePlacements, limitHit, err = keeper.GetStakeRemovalsUpUntilBlock(s.Ctx(), newRemoveBlock, 100)
 	require.NoError(err)
 	require.Len(stakePlacements, 1)
 	require.False(limitHit)
@@ -435,27 +338,26 @@ func (s *MsgServerTestSuite) TestRemoveStakeTwiceInDifferentBlocks() {
 }
 
 func (s *MsgServerTestSuite) TestRemoveMultipleReputersSameBlock() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
-	senderAddr1 := s.addrs[0]
-	senderAddr2 := s.addrs[1]
-	topic := s.CreateOneTopic()
+	keeper := s.EmissionsKeeper()
+	senderAddr1 := s.Addrs(0)
+	senderAddr2 := s.Addrs(1)
+	topicId := uint64(1)
 	stakeAmount1 := cosmosMath.NewInt(50)
 	stakeAmount2 := cosmosMath.NewInt(30)
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	startBlock := sdkCtx.BlockHeight()
+	startBlock := s.Ctx().BlockHeight()
 	// Fetch the delay window for removing stake
 	params, err := keeper.GetParams(ctx)
 	require.NoError(err)
 	removalDelay := params.RemoveStakeDelayWindow
 	removeBlock := startBlock + removalDelay
 	// Simulate that sender1 has already staked the required amount
-	err = s.emissionsKeeper.AddReputerStake(ctx, topic.Id, senderAddr1.String(), stakeAmount1)
+	err = s.EmissionsKeeper().AddReputerStake(ctx, topicId, senderAddr1.String(), stakeAmount1)
 	require.NoError(err)
-	_, err = s.msgServer.RemoveStake(ctx, &types.RemoveStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveStake(ctx, &types.RemoveStakeRequest{
 		Sender:  senderAddr1.String(),
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount1,
 	})
 	s.Require().NoError(err)
@@ -464,7 +366,7 @@ func (s *MsgServerTestSuite) TestRemoveMultipleReputersSameBlock() {
 	require.Len(stakePlacements1, 1)
 	require.False(limitHit)
 	expected1 := types.StakeRemovalInfo{
-		TopicId:               topic.Id,
+		TopicId:               topicId,
 		Reputer:               senderAddr1.String(),
 		Amount:                stakeAmount1,
 		BlockRemovalStarted:   startBlock,
@@ -472,11 +374,11 @@ func (s *MsgServerTestSuite) TestRemoveMultipleReputersSameBlock() {
 	}
 	require.Equal(expected1, stakePlacements1[0])
 	// Simulate that sender2 has already staked the required amount
-	err = s.emissionsKeeper.AddReputerStake(ctx, topic.Id, senderAddr2.String(), stakeAmount2)
+	err = s.EmissionsKeeper().AddReputerStake(ctx, topicId, senderAddr2.String(), stakeAmount2)
 	require.NoError(err)
-	_, err = s.msgServer.RemoveStake(ctx, &types.RemoveStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveStake(ctx, &types.RemoveStakeRequest{
 		Sender:  senderAddr2.String(),
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount2,
 	})
 	s.Require().NoError(err)
@@ -485,7 +387,7 @@ func (s *MsgServerTestSuite) TestRemoveMultipleReputersSameBlock() {
 	require.Len(stakePlacements2, 2)
 	require.False(limitHit)
 	expected2 := types.StakeRemovalInfo{
-		TopicId:               topic.Id,
+		TopicId:               topicId,
 		Reputer:               senderAddr2.String(),
 		Amount:                stakeAmount2,
 		BlockRemovalStarted:   startBlock,
@@ -496,9 +398,9 @@ func (s *MsgServerTestSuite) TestRemoveMultipleReputersSameBlock() {
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveStakeNegative() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	senderAddr := s.addrs[0]
+	senderAddr := s.Addrs(0)
 
 	msg := &types.RemoveStakeRequest{
 		Sender:  senderAddr.String(),
@@ -506,14 +408,14 @@ func (s *MsgServerTestSuite) TestStartRemoveStakeNegative() {
 		Amount:  cosmosMath.NewInt(-1),
 	}
 
-	_, err := s.msgServer.RemoveStake(ctx, msg)
+	_, err := s.EmissionsMsgServer().RemoveStake(ctx, msg)
 	require.ErrorIs(err, sdkerrors.ErrInvalidCoins)
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveStakeNil() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	senderAddr := s.addrs[0]
+	senderAddr := s.Addrs(0)
 
 	msg := &types.RemoveStakeRequest{
 		Sender:  senderAddr.String(),
@@ -521,55 +423,55 @@ func (s *MsgServerTestSuite) TestStartRemoveStakeNil() {
 		Amount:  cosmosMath.Int{},
 	}
 
-	_, err := s.msgServer.RemoveStake(ctx, msg)
+	_, err := s.EmissionsMsgServer().RemoveStake(ctx, msg)
 	require.ErrorIs(err, sdkerrors.ErrInvalidCoins)
 }
 
 func (s *MsgServerTestSuite) TestDelegateStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[7],
+		Owner:       s.AddrsStr(7),
 		NodeAddress: reputer,
 	}
 
-	err := keeper.InsertReputer(ctx, topic.Id, reputer, reputerInfo)
+	err := keeper.InsertReputer(ctx, topicId, reputer, reputerInfo)
 	require.NoError(err)
 
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Reputer: reputer,
 		Amount:  stakeAmount,
 	}
 
-	reputerStake, err := s.emissionsKeeper.GetStakeReputerAuthority(ctx, topic.Id, reputer)
+	reputerStake, err := s.EmissionsKeeper().GetStakeReputerAuthority(ctx, topicId, reputer)
 	require.NoError(err)
 	require.Equal(cosmosMath.ZeroInt(), reputerStake, "Stake amount mismatch")
 
-	amount0, err := keeper.GetDelegateStakePlacement(ctx, topic.Id, delegator, reputer)
+	amount0, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegator, reputer)
 	require.NoError(err)
 	require.Equal(alloraMath.NewDecFromInt64(0), amount0.Amount)
 
 	// Perform the stake delegation
-	response, err := s.msgServer.DelegateStake(ctx, msg)
+	response, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil after successful delegation")
 
-	reputerStake, err = s.emissionsKeeper.GetStakeReputerAuthority(ctx, topic.Id, reputer)
+	reputerStake, err = s.EmissionsKeeper().GetStakeReputerAuthority(ctx, topicId, reputer)
 	require.NoError(err)
 	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
 
-	amount1, err := keeper.GetDelegateStakePlacement(ctx, topic.Id, delegator, reputer)
+	amount1, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegator, reputer)
 	require.NoError(err)
 	amountInt, err := amount1.Amount.SdkIntTrim()
 	require.NoError(err)
@@ -577,48 +479,48 @@ func (s *MsgServerTestSuite) TestDelegateStake() {
 }
 
 func (s *MsgServerTestSuite) TestDelegateStakeNil() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[7],
+		Owner:       s.AddrsStr(7),
 		NodeAddress: reputer,
 	}
 
-	err := keeper.InsertReputer(ctx, topic.Id, reputer, reputerInfo)
+	err := keeper.InsertReputer(ctx, topicId, reputer, reputerInfo)
 	require.NoError(err)
 
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Reputer: reputer,
 		Amount:  cosmosMath.Int{},
 	}
-	_, err = s.msgServer.DelegateStake(ctx, msg)
+	_, err = s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.ErrorIs(err, sdkerrors.ErrInvalidCoins)
 }
 
 func (s *MsgServerTestSuite) TestReputerCantSelfDelegateStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
+	delegatorAddr := s.Addrs(0)
 	reputerAddr := delegatorAddr
-	topicId := s.CreateOneTopic().Id
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[0],
-		NodeAddress: s.addrsStr[0],
+		Owner:       s.AddrsStr(0),
+		NodeAddress: s.AddrsStr(0),
 	}
 
 	err := keeper.InsertReputer(ctx, topicId, reputerAddr.String(), reputerInfo)
@@ -632,47 +534,47 @@ func (s *MsgServerTestSuite) TestReputerCantSelfDelegateStake() {
 	}
 
 	// Perform the stake delegation
-	_, err = s.msgServer.DelegateStake(ctx, msg)
+	_, err = s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.ErrorIs(err, sdkerrors.ErrInvalidRequest)
 }
 
 func (s *MsgServerTestSuite) TestDelegateeCantWithdrawDelegatedStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputerAddr := s.addrs[1]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputerAddr := s.Addrs(1)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[0],
-		NodeAddress: s.addrsStr[0],
+		Owner:       s.AddrsStr(0),
+		NodeAddress: s.AddrsStr(0),
 	}
 
-	err := keeper.InsertReputer(ctx, topic.Id, reputerAddr.String(), reputerInfo)
+	err := keeper.InsertReputer(ctx, topicId, reputerAddr.String(), reputerInfo)
 	require.NoError(err)
 
 	delegateStakeMsg := &types.DelegateStakeRequest{
 		Sender:  delegator,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Reputer: reputer,
 		Amount:  stakeAmount,
 	}
 
-	response, err := s.msgServer.DelegateStake(ctx, delegateStakeMsg)
+	response, err := s.EmissionsMsgServer().DelegateStake(ctx, delegateStakeMsg)
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil after successful delegation")
 
-	reputerStake, err := s.emissionsKeeper.GetStakeReputerAuthority(ctx, topic.Id, reputer)
+	reputerStake, err := s.EmissionsKeeper().GetStakeReputerAuthority(ctx, topicId, reputer)
 	require.NoError(err)
 	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
 
-	amount1, err := keeper.GetDelegateStakePlacement(ctx, topic.Id, delegator, reputer)
+	amount1, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegator, reputer)
 	require.NoError(err)
 	amountInt, err := amount1.Amount.SdkIntTrim()
 	require.NoError(err)
@@ -681,21 +583,21 @@ func (s *MsgServerTestSuite) TestDelegateeCantWithdrawDelegatedStake() {
 	// Attempt to withdraw the delegated stake
 	removeMsg := &types.RemoveStakeRequest{
 		Sender:  reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount,
 	}
 
-	_, err = s.msgServer.RemoveStake(ctx, removeMsg)
+	_, err = s.EmissionsMsgServer().RemoveStake(ctx, removeMsg)
 	require.Error(err)
 }
 
 func (s *MsgServerTestSuite) TestDelegateStakeUnregisteredReputer() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 
-	sender := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topicId := s.CreateOneTopic().Id
+	sender := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 
 	// Do not register the reputer to simulate failure case
@@ -708,45 +610,45 @@ func (s *MsgServerTestSuite) TestDelegateStakeUnregisteredReputer() {
 	}
 
 	// Attempt to perform the stake delegation
-	response, err := s.msgServer.DelegateStake(ctx, msg)
+	response, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.Error(err)
 	require.Nil(response, "Response should be nil when delegation fails due to unregistered reputer")
 	require.True(errors.Is(err, types.ErrAddressIsNotRegisteredInThisTopic), "Error should indicate that the reputer is not registered in the topic")
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveDelegateStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 	moduleParams, err := keeper.GetParams(ctx)
 	require.NoError(err)
 	removalDelay := moduleParams.RemoveStakeDelayWindow
 
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[0],
+		Owner:       s.AddrsStr(0),
 		NodeAddress: reputer,
 	}
 
-	err = keeper.InsertReputer(ctx, topic.Id, reputer, reputerInfo)
+	err = keeper.InsertReputer(ctx, topicId, reputer, reputerInfo)
 	require.NoError(err)
 
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Reputer: reputer,
 		Amount:  stakeAmount,
 	}
 
 	// Perform the stake delegation
-	response, err := s.msgServer.DelegateStake(ctx, msg)
+	response, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil after successful delegation")
 
@@ -754,10 +656,10 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStake() {
 	msg2 := &types.RemoveDelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount,
 	}
-	response2, err := s.msgServer.RemoveDelegateStake(ctx, msg2)
+	response2, err := s.EmissionsMsgServer().RemoveDelegateStake(ctx, msg2)
 	require.NoError(err)
 	require.NotNil(response2, "Response should not be nil after successful stake removal initiation")
 
@@ -771,52 +673,52 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStake() {
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeOnUnregisteredReputer() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 	moduleParams, err := keeper.GetParams(ctx)
 	require.NoError(err)
 	removalDelay := moduleParams.RemoveStakeDelayWindow
 
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[0],
+		Owner:       s.AddrsStr(0),
 		NodeAddress: reputer,
 	}
 
-	err = keeper.InsertReputer(ctx, topic.Id, reputer, reputerInfo)
+	err = keeper.InsertReputer(ctx, topicId, reputer, reputerInfo)
 	require.NoError(err)
 
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Reputer: reputer,
 		Amount:  stakeAmount,
 	}
 
 	// Perform the stake delegation
-	response, err := s.msgServer.DelegateStake(ctx, msg)
+	response, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil after successful delegation")
 
-	err = keeper.RemoveReputer(ctx, topic.Id, reputer)
+	err = keeper.RemoveReputer(ctx, topicId, reputer)
 	require.NoError(err)
 
 	// Perform the stake removal initiation
 	msg2 := &types.RemoveDelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount,
 	}
-	response2, err := s.msgServer.RemoveDelegateStake(ctx, msg2)
+	response2, err := s.EmissionsMsgServer().RemoveDelegateStake(ctx, msg2)
 	require.NoError(err)
 	require.NotNil(response2, "Response should not be nil after successful stake removal initiation")
 
@@ -830,22 +732,22 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeOnUnregisteredReputer()
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeError() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[0],
-		NodeAddress: s.addrsStr[0],
+		Owner:       s.AddrsStr(0),
+		NodeAddress: s.AddrsStr(0),
 	}
 
-	err := keeper.InsertReputer(ctx, topic.Id, reputer, reputerInfo)
+	err := keeper.InsertReputer(ctx, topicId, reputer, reputerInfo)
 	require.NoError(err)
 
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
@@ -853,42 +755,39 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeError() {
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount,
 	}
 
 	// Perform the stake delegation
-	response, err := s.msgServer.DelegateStake(ctx, msg)
+	response, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil after successful delegation")
 
 	msg2 := &types.RemoveDelegateStakeRequest{
 		Sender:  delegatorAddr.String(),
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount.Mul(cosmosMath.NewInt(2)),
 	}
 
 	// Perform the stake removal initiation
-	_, err = s.msgServer.RemoveDelegateStake(ctx, msg2)
+	_, err = s.EmissionsMsgServer().RemoveDelegateStake(ctx, msg2)
 	require.ErrorIs(err, types.ErrInsufficientDelegateStakeToRemove)
 }
 
 func (s *MsgServerTestSuite) TestConfirmRemoveDelegateStake() {
-	ctx := s.ctx
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
+	startBlock := s.Ctx().BlockHeight()
 
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	startBlock := sdkCtx.BlockHeight()
-
-	params, err := keeper.GetParams(ctx)
+	params, err := keeper.GetParams(s.Ctx())
 	require.NoError(err)
 	removalDelay := params.RemoveStakeDelayWindow
 	endBlock := startBlock + removalDelay
@@ -896,43 +795,43 @@ func (s *MsgServerTestSuite) TestConfirmRemoveDelegateStake() {
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 
 	// Simulate adding a reputer and delegating stake to them
-	err = keeper.InsertReputer(ctx, topic.Id, reputer, types.OffchainNode{
-		Owner:       s.addrsStr[0],
+	err = keeper.InsertReputer(s.Ctx(), topicId, reputer, types.OffchainNode{
+		Owner:       s.AddrsStr(0),
 		NodeAddress: reputer,
 	})
 	require.NoError(err)
 
-	_, err = s.msgServer.DelegateStake(ctx, &types.DelegateStakeRequest{
+	_, err = s.EmissionsMsgServer().DelegateStake(s.Ctx(), &types.DelegateStakeRequest{
 		Sender:  delegator,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Reputer: reputer,
 		Amount:  stakeAmount,
 	})
 	require.NoError(err)
 
 	// Start removing the delegated stake
-	_, err = s.msgServer.RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveDelegateStake(s.Ctx(), &types.RemoveDelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount,
 	})
 	require.NoError(err)
 
 	// Simulate passing of time to surpass the withdrawal delay
-	ctx = ctx.WithBlockHeight(endBlock)
+	s.WithBlockHeight(endBlock)
 
 	// Try to confirm removal after delay window
-	err = s.appModule.EndBlock(ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	require.NoError(err)
 
 	// Check that the stake was actually removed
-	delegateStakePlaced, err := keeper.GetDelegateStakePlacement(ctx, topic.Id, delegator, reputer)
+	delegateStakePlaced, err := keeper.GetDelegateStakePlacement(s.Ctx(), topicId, delegator, reputer)
 	require.NoError(err)
 	require.True(delegateStakePlaced.Amount.IsZero(), "Delegate stake should be zero after successful removal")
 
 	// Check that the stake removal has been removed from the state
-	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock, 100)
+	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock, 100)
 	require.NoError(err)
 	require.False(limitHit)
 	require.Len(removals, 0)
@@ -941,18 +840,16 @@ func (s *MsgServerTestSuite) TestConfirmRemoveDelegateStake() {
 // test you are able to restart the stake withdrawal
 // if your stake expires or whatever other reason you may want
 func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeTwiceSameBlock() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
-
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	startBlock := sdkCtx.BlockHeight()
+	startBlock := s.Ctx().BlockHeight()
 
 	params, err := keeper.GetParams(ctx)
 	require.NoError(err)
@@ -962,30 +859,30 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeTwiceSameBlock() {
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 
 	// Simulate adding a reputer and delegating stake to them
-	err = keeper.InsertReputer(ctx, topic.Id, reputer, types.OffchainNode{
-		Owner:       s.addrsStr[0],
+	err = keeper.InsertReputer(ctx, topicId, reputer, types.OffchainNode{
+		Owner:       s.AddrsStr(0),
 		NodeAddress: reputer,
 	})
 	require.NoError(err)
-	_, err = s.msgServer.DelegateStake(ctx, &types.DelegateStakeRequest{
+	_, err = s.EmissionsMsgServer().DelegateStake(ctx, &types.DelegateStakeRequest{
 		Sender:  delegator,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Reputer: reputer,
 		Amount:  stakeAmount,
 	})
 	require.NoError(err)
 
 	// Start removing the delegated stake
-	_, err = s.msgServer.RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount,
 	})
 	require.NoError(err)
 
 	expected := types.DelegateStakeRemovalInfo{
-		TopicId:               topic.Id,
+		TopicId:               topicId,
 		Delegator:             delegator,
 		Reputer:               reputer,
 		Amount:                stakeAmount,
@@ -1001,10 +898,10 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeTwiceSameBlock() {
 
 	// Start removing the delegated stake again
 	newStakeAmount := stakeAmount.SubRaw(10)
-	_, err = s.msgServer.RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
 		Sender:  delegatorAddr.String(),
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  newStakeAmount,
 	})
 	require.NoError(err)
@@ -1018,20 +915,17 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeTwiceSameBlock() {
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeTwice() {
-	ctx := s.ctx
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
+	startBlock := s.Ctx().BlockHeight()
 
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	startBlock := sdkCtx.BlockHeight()
-
-	params, err := keeper.GetParams(ctx)
+	params, err := keeper.GetParams(s.Ctx())
 	require.NoError(err)
 	removalDelay := params.RemoveStakeDelayWindow
 	endBlock := startBlock + removalDelay
@@ -1039,30 +933,30 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeTwice() {
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 
 	// Simulate adding a reputer and delegating stake to them
-	err = keeper.InsertReputer(ctx, topic.Id, reputer, types.OffchainNode{
-		Owner:       s.addrsStr[0],
+	err = keeper.InsertReputer(s.Ctx(), topicId, reputer, types.OffchainNode{
+		Owner:       s.AddrsStr(0),
 		NodeAddress: reputer,
 	})
 	require.NoError(err)
-	_, err = s.msgServer.DelegateStake(ctx, &types.DelegateStakeRequest{
+	_, err = s.EmissionsMsgServer().DelegateStake(s.Ctx(), &types.DelegateStakeRequest{
 		Sender:  delegator,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Reputer: reputer,
 		Amount:  stakeAmount,
 	})
 	require.NoError(err)
 
 	// Start removing the delegated stake
-	_, err = s.msgServer.RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveDelegateStake(s.Ctx(), &types.RemoveDelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount,
 	})
 	require.NoError(err)
 
 	expected := types.DelegateStakeRemovalInfo{
-		TopicId:               topic.Id,
+		TopicId:               topicId,
 		Delegator:             delegator,
 		Reputer:               reputer,
 		Amount:                stakeAmount,
@@ -1070,32 +964,32 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeTwice() {
 		BlockRemovalCompleted: endBlock,
 	}
 
-	stakePlacements, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock, 100)
+	stakePlacements, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock, 100)
 	require.NoError(err)
 	require.False(limitHit)
 	require.Len(stakePlacements, 1)
 	require.Equal(expected, stakePlacements[0])
 
 	// Now wait 5 blocks
-	newStartBlock := ctx.BlockHeight() + 5
+	newStartBlock := s.Ctx().BlockHeight() + 5
 	newEndBlock := endBlock + 5
-	ctx = ctx.WithBlockHeight(newStartBlock)
+	s.WithBlockHeight(newStartBlock)
 	// Start removing the delegated stake again
 	newStakeAmount := stakeAmount.SubRaw(10)
-	_, err = s.msgServer.RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
+	_, err = s.EmissionsMsgServer().RemoveDelegateStake(s.Ctx(), &types.RemoveDelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  newStakeAmount,
 	})
 	require.NoError(err)
 
-	stakePlacements, limitHit, err = keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock, 100)
+	stakePlacements, limitHit, err = keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock, 100)
 	require.NoError(err)
 	require.False(limitHit)
 	require.Len(stakePlacements, 0)
 
-	stakePlacements, limitHit, err = keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, newEndBlock, 100)
+	stakePlacements, limitHit, err = keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), newEndBlock, 100)
 	require.NoError(err)
 	require.False(limitHit)
 	require.Len(stakePlacements, 1)
@@ -1107,22 +1001,22 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeTwice() {
 }
 
 func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeNegative() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	topic := s.CreateOneTopic()
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[7],
+		Owner:       s.AddrsStr(7),
 		NodeAddress: reputer,
 	}
 
-	err := keeper.InsertReputer(ctx, topic.Id, reputer, reputerInfo)
+	err := keeper.InsertReputer(ctx, topicId, reputer, reputerInfo)
 	require.NoError(err)
 
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
@@ -1130,68 +1024,66 @@ func (s *MsgServerTestSuite) TestStartRemoveDelegateStakeNegative() {
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  stakeAmount,
 	}
 
 	// Perform the stake delegation
-	response, err := s.msgServer.DelegateStake(ctx, msg)
+	response, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil after successful delegation")
 
 	msg2 := &types.RemoveDelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  cosmosMath.NewInt(-1),
 	}
 
 	// Perform the stake removal initiation
-	_, err = s.msgServer.RemoveDelegateStake(ctx, msg2)
+	_, err = s.EmissionsMsgServer().RemoveDelegateStake(ctx, msg2)
 	require.ErrorIs(err, sdkerrors.ErrInvalidCoins)
 
 	msg2 = &types.RemoveDelegateStakeRequest{
 		Sender:  delegator,
 		Reputer: reputer,
-		TopicId: topic.Id,
+		TopicId: topicId,
 		Amount:  cosmosMath.Int{},
 	}
 
 	// Perform the stake removal initiation
-	_, err = s.msgServer.RemoveDelegateStake(ctx, msg2)
+	_, err = s.EmissionsMsgServer().RemoveDelegateStake(ctx, msg2)
 	require.ErrorIs(err, sdkerrors.ErrInvalidCoins)
 }
 
 func (s *MsgServerTestSuite) TestRemoveDelegateStakeMultipleReputersSameDelegator() {
-	ctx := s.ctx
 	require := s.Require()
-	keeper := s.emissionsKeeper
-	delegatorAddr := s.addrs[0]
-	topic := s.CreateOneTopic()
+	keeper := s.EmissionsKeeper()
+	delegatorAddr := s.Addrs(0)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	startBlock := sdkCtx.BlockHeight()
-	params, err := keeper.GetParams(ctx)
+	startBlock := s.Ctx().BlockHeight()
+	params, err := keeper.GetParams(s.Ctx())
 	require.NoError(err)
 	removalDelay := params.RemoveStakeDelayWindow
 	endBlock := startBlock + removalDelay
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 	// Simulate adding multiple reputers and delegating stake to them
 	reputers := []sdk.AccAddress{
-		s.addrs[1],
-		s.addrs[2],
-		s.addrs[3],
+		s.Addrs(1),
+		s.Addrs(2),
+		s.Addrs(3),
 	}
 	for _, reputer := range reputers {
 		reputerAddr := reputer.String()
-		err := keeper.InsertReputer(ctx, topic.Id, reputerAddr, types.OffchainNode{
-			Owner:       s.addrsStr[0],
+		err := keeper.InsertReputer(s.Ctx(), topicId, reputerAddr, types.OffchainNode{
+			Owner:       s.AddrsStr(0),
 			NodeAddress: reputerAddr,
 		})
 		require.NoError(err)
-		_, err = s.msgServer.DelegateStake(ctx, &types.DelegateStakeRequest{
+		_, err = s.EmissionsMsgServer().DelegateStake(s.Ctx(), &types.DelegateStakeRequest{
 			Sender:  delegatorAddr.String(),
-			TopicId: topic.Id,
+			TopicId: topicId,
 			Reputer: reputerAddr,
 			Amount:  stakeAmount,
 		})
@@ -1199,63 +1091,61 @@ func (s *MsgServerTestSuite) TestRemoveDelegateStakeMultipleReputersSameDelegato
 	}
 	// Start removing the delegated stake for each reputer
 	for _, reputer := range reputers {
-		_, err = s.msgServer.RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
+		_, err = s.EmissionsMsgServer().RemoveDelegateStake(s.Ctx(), &types.RemoveDelegateStakeRequest{
 			Sender:  delegatorAddr.String(),
 			Reputer: reputer.String(),
-			TopicId: topic.Id,
+			TopicId: topicId,
 			Amount:  stakeAmount,
 		})
 		require.NoError(err)
 	}
 	// Call ctx.WithBlockHeight to simulate passing time
-	ctx = ctx.WithBlockHeight(endBlock)
+	s.WithBlockHeight(endBlock)
 	// Call EndBlock to trigger stake removal
-	err = s.appModule.EndBlock(ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	require.NoError(err)
 	// Check that the stake was actually removed for each reputer
 	for _, reputer := range reputers {
-		delegateStakePlaced, err := keeper.GetDelegateStakePlacement(ctx, topic.Id, delegatorAddr.String(), reputer.String())
+		delegateStakePlaced, err := keeper.GetDelegateStakePlacement(s.Ctx(), topicId, delegatorAddr.String(), reputer.String())
 		require.NoError(err)
 		require.True(delegateStakePlaced.Amount.IsZero(), "Delegate stake should be zero after successful removal")
 	}
 	// Check that the stake removals have been removed from the state
-	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock, 100)
+	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock, 100)
 	require.NoError(err)
 	require.False(limitHit)
 	require.Len(removals, 0)
 }
 
 func (s *MsgServerTestSuite) TestRemoveOneDelegateMultipleTargetsDifferentBlocks() {
-	ctx := s.ctx
 	require := s.Require()
-	keeper := s.emissionsKeeper
-	delegator := s.addrsStr[0]
-	delegatorAddr := s.addrs[0]
-	topic := s.CreateOneTopic()
+	keeper := s.EmissionsKeeper()
+	delegator := s.AddrsStr(0)
+	delegatorAddr := s.Addrs(0)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	params, err := keeper.GetParams(ctx)
+	params, err := keeper.GetParams(s.Ctx())
 	require.NoError(err)
 	removalDelay := params.RemoveStakeDelayWindow
-	startBlock := sdkCtx.BlockHeight()
+	startBlock := s.Ctx().BlockHeight()
 	endBlock := startBlock + removalDelay
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000))
 	// Simulate adding multiple reputers and delegating stake to them
 	reputers := []sdk.AccAddress{
-		s.addrs[1],
-		s.addrs[2],
-		s.addrs[3],
+		s.Addrs(1),
+		s.Addrs(2),
+		s.Addrs(3),
 	}
 	for _, reputer := range reputers {
 		reputerStr := reputer.String()
-		err := keeper.InsertReputer(ctx, topic.Id, reputerStr, types.OffchainNode{
-			Owner:       s.addrsStr[0],
+		err := keeper.InsertReputer(s.Ctx(), topicId, reputerStr, types.OffchainNode{
+			Owner:       s.AddrsStr(0),
 			NodeAddress: reputerStr,
 		})
 		require.NoError(err)
-		_, err = s.msgServer.DelegateStake(ctx, &types.DelegateStakeRequest{
+		_, err = s.EmissionsMsgServer().DelegateStake(s.Ctx(), &types.DelegateStakeRequest{
 			Sender:  delegator,
-			TopicId: topic.Id,
+			TopicId: topicId,
 			Reputer: reputerStr,
 			Amount:  stakeAmount,
 		})
@@ -1263,41 +1153,41 @@ func (s *MsgServerTestSuite) TestRemoveOneDelegateMultipleTargetsDifferentBlocks
 	}
 	// Start removing the delegated stake for each reputer
 	for _, reputer := range reputers {
-		_, err = s.msgServer.RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
+		_, err = s.EmissionsMsgServer().RemoveDelegateStake(s.Ctx(), &types.RemoveDelegateStakeRequest{
 			Sender:  delegator,
 			Reputer: reputer.String(),
-			TopicId: topic.Id,
+			TopicId: topicId,
 			Amount:  stakeAmount,
 		})
 		require.NoError(err)
-		ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+		s.WithBlockHeight(s.Ctx().BlockHeight() + 1)
 	}
 
 	// verify the removals are put in correctly
-	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock+int64(len(reputers)), 100)
+	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock+int64(len(reputers)), 100)
 	require.NoError(err)
 	require.False(limitHit)
 	require.Len(removals, len(reputers))
 
 	// Call ctx.WithBlockHeight to simulate passing time
-	ctx = ctx.WithBlockHeight(endBlock)
+	s.WithBlockHeight(endBlock)
 	for i := 0; i < len(reputers); i++ {
 		// Call EndBlock to trigger stake removal
-		err = s.appModule.EndBlock(ctx)
+		err = s.EmissionsAppModule().EndBlock(s.Ctx())
 		require.NoError(err)
 
 		// Check that the stake removals have been removed from the state
-		removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock, 100)
+		removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock, 100)
 		require.NoError(err)
 		require.False(limitHit)
 		require.Len(removals, 0)
-		ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+		s.WithBlockHeight(s.Ctx().BlockHeight() + 1)
 	}
 	// Check that the stake was actually removed for each reputer
 	for _, reputer := range reputers {
 		delegateStakePlaced, err := keeper.GetDelegateStakePlacement(
-			ctx,
-			topic.Id,
+			s.Ctx(),
+			topicId,
 			delegator,
 			reputer.String(),
 		)
@@ -1312,36 +1202,34 @@ func (s *MsgServerTestSuite) TestRemoveOneDelegateMultipleTargetsDifferentBlocks
 }
 
 func (s *MsgServerTestSuite) TestRemoveMultipleDelegatesSameTargetSameBlock() {
-	ctx := s.ctx
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 	delegators := []sdk.AccAddress{
-		s.addrs[0],
-		s.addrs[1],
-		s.addrs[2],
+		s.Addrs(0),
+		s.Addrs(1),
+		s.Addrs(2),
 	}
-	topic := s.CreateOneTopic()
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	params, err := keeper.GetParams(ctx)
+	params, err := keeper.GetParams(s.Ctx())
 	require.NoError(err)
 	removalDelay := params.RemoveStakeDelayWindow
-	startBlock := sdkCtx.BlockHeight()
+	startBlock := s.Ctx().BlockHeight()
 	endBlock := startBlock + removalDelay
 	for _, delegator := range delegators {
 		s.MintTokensToAddress(delegator, cosmosMath.NewInt(1000))
 	}
 	// Simulate adding multiple reputers and delegating stake to them
-	reputer := s.addrs[3]
-	err = keeper.InsertReputer(ctx, topic.Id, reputer.String(), types.OffchainNode{
-		Owner:       s.addrsStr[0],
+	reputer := s.Addrs(3)
+	err = keeper.InsertReputer(s.Ctx(), topicId, reputer.String(), types.OffchainNode{
+		Owner:       s.AddrsStr(0),
 		NodeAddress: reputer.String(),
 	})
 	require.NoError(err)
 	for _, delegator := range delegators {
-		_, err = s.msgServer.DelegateStake(ctx, &types.DelegateStakeRequest{
+		_, err = s.EmissionsMsgServer().DelegateStake(s.Ctx(), &types.DelegateStakeRequest{
 			Sender:  delegator.String(),
-			TopicId: topic.Id,
+			TopicId: topicId,
 			Reputer: reputer.String(),
 			Amount:  stakeAmount,
 		})
@@ -1349,30 +1237,30 @@ func (s *MsgServerTestSuite) TestRemoveMultipleDelegatesSameTargetSameBlock() {
 	}
 	// Start removing the delegated stake for each reputer
 	for _, delegator := range delegators {
-		_, err = s.msgServer.RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
+		_, err = s.EmissionsMsgServer().RemoveDelegateStake(s.Ctx(), &types.RemoveDelegateStakeRequest{
 			Sender:  delegator.String(),
 			Reputer: reputer.String(),
-			TopicId: topic.Id,
+			TopicId: topicId,
 			Amount:  stakeAmount,
 		})
 		require.NoError(err)
 	}
 
 	// verify the removals are put in correctly
-	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock, 100)
+	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock, 100)
 	require.NoError(err)
 	require.False(limitHit)
 	require.Len(removals, len(delegators))
 
 	// Call ctx.WithBlockHeight to simulate passing time
-	ctx = ctx.WithBlockHeight(endBlock)
+	s.WithBlockHeight(endBlock)
 	for i := 0; i < len(delegators); i++ {
 		// Call EndBlock to trigger stake removal
-		err = s.appModule.EndBlock(ctx)
+		err = s.EmissionsAppModule().EndBlock(s.Ctx())
 		require.NoError(err)
 
 		// Check that the stake removals have been removed from the state
-		removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock, 100)
+		removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock, 100)
 		require.NoError(err)
 		require.False(limitHit)
 		require.Len(removals, 0)
@@ -1380,8 +1268,8 @@ func (s *MsgServerTestSuite) TestRemoveMultipleDelegatesSameTargetSameBlock() {
 	// Check that the stake was actually removed for each reputer
 	for _, delegator := range delegators {
 		delegateStakePlaced, err := keeper.GetDelegateStakePlacement(
-			ctx,
-			topic.Id,
+			s.Ctx(),
+			topicId,
 			delegator.String(),
 			reputer.String(),
 		)
@@ -1396,39 +1284,37 @@ func (s *MsgServerTestSuite) TestRemoveMultipleDelegatesSameTargetSameBlock() {
 }
 
 func (s *MsgServerTestSuite) TestRemoveMultipleDelegatesDifferentTargetsSameBlock() {
-	ctx := s.ctx
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 	delegators := []sdk.AccAddress{
-		s.addrs[0],
-		s.addrs[1],
+		s.Addrs(0),
+		s.Addrs(1),
 	}
-	topic := s.CreateOneTopic()
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	params, err := keeper.GetParams(ctx)
+	params, err := keeper.GetParams(s.Ctx())
 	require.NoError(err)
 	removalDelay := params.RemoveStakeDelayWindow
-	startBlock := sdkCtx.BlockHeight()
+	startBlock := s.Ctx().BlockHeight()
 	endBlock := startBlock + removalDelay
 	s.MintTokensToAddress(delegators[0], cosmosMath.NewInt(1000))
 	s.MintTokensToAddress(delegators[1], cosmosMath.NewInt(1000))
 	// Simulate adding multiple reputers and delegating stake to them
 	reputers := []sdk.AccAddress{
-		s.addrs[2],
-		s.addrs[3],
+		s.Addrs(2),
+		s.Addrs(3),
 	}
 	for i := 0; i < len(delegators); i++ {
 		reputerAddr := reputers[i].String()
 		delegatorAddr := delegators[i].String()
-		err := keeper.InsertReputer(ctx, topic.Id, reputerAddr, types.OffchainNode{
-			Owner:       s.addrsStr[0],
+		err := keeper.InsertReputer(s.Ctx(), topicId, reputerAddr, types.OffchainNode{
+			Owner:       s.AddrsStr(0),
 			NodeAddress: reputerAddr,
 		})
 		require.NoError(err)
-		_, err = s.msgServer.DelegateStake(ctx, &types.DelegateStakeRequest{
+		_, err = s.EmissionsMsgServer().DelegateStake(s.Ctx(), &types.DelegateStakeRequest{
 			Sender:  delegatorAddr,
-			TopicId: topic.Id,
+			TopicId: topicId,
 			Reputer: reputerAddr,
 			Amount:  stakeAmount,
 		})
@@ -1436,30 +1322,30 @@ func (s *MsgServerTestSuite) TestRemoveMultipleDelegatesDifferentTargetsSameBloc
 	}
 	// Start removing the delegated stake for each reputer
 	for i := 0; i < len(delegators); i++ {
-		_, err = s.msgServer.RemoveDelegateStake(ctx, &types.RemoveDelegateStakeRequest{
+		_, err = s.EmissionsMsgServer().RemoveDelegateStake(s.Ctx(), &types.RemoveDelegateStakeRequest{
 			Sender:  delegators[i].String(),
 			Reputer: reputers[i].String(),
-			TopicId: topic.Id,
+			TopicId: topicId,
 			Amount:  stakeAmount,
 		})
 		require.NoError(err)
 	}
 
 	// verify the removals are put in correctly
-	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock, 100)
+	removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock, 100)
 	require.NoError(err)
 	require.False(limitHit)
 	require.Len(removals, len(delegators))
 
 	// Call ctx.WithBlockHeight to simulate passing time
-	ctx = ctx.WithBlockHeight(endBlock)
+	s.WithBlockHeight(endBlock)
 	for i := 0; i < len(reputers); i++ {
 		// Call EndBlock to trigger stake removal
-		err = s.appModule.EndBlock(ctx)
+		err = s.EmissionsAppModule().EndBlock(s.Ctx())
 		require.NoError(err)
 
 		// Check that the stake removals have been removed from the state
-		removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(ctx, endBlock, 100)
+		removals, limitHit, err := keeper.GetDelegateStakeRemovalsUpUntilBlock(s.Ctx(), endBlock, 100)
 		require.NoError(err)
 		require.False(limitHit)
 		require.Len(removals, 0)
@@ -1467,8 +1353,8 @@ func (s *MsgServerTestSuite) TestRemoveMultipleDelegatesDifferentTargetsSameBloc
 	// Check that the stake was actually removed for each reputer
 	for i := 0; i < len(reputers); i++ {
 		delegateStakePlaced, err := keeper.GetDelegateStakePlacement(
-			ctx,
-			topic.Id,
+			s.Ctx(),
+			topicId,
 			delegators[i].String(),
 			reputers[i].String(),
 		)
@@ -1483,70 +1369,69 @@ func (s *MsgServerTestSuite) TestRemoveMultipleDelegatesDifferentTargetsSameBloc
 }
 
 func (s *MsgServerTestSuite) TestRewardDelegateStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
+
 	block := int64(1003)
 	newBlock := int64(1004)
 	score := alloraMath.MustNewDecFromString("17.53436")
 
-	delegator := s.addrsStr[0]
-	delegatorAddr := s.addrs[0]
-	reputer := s.addrsStr[1]
-	reputerAddr := s.addrs[1]
-	worker := s.addrsStr[2]
-	workerAddr := s.addrs[2]
-	delegator2 := s.addrsStr[3]
-	delegator2Addr := s.addrs[3]
+	delegator := s.AddrsStr(0)
+	delegatorAddr := s.Addrs(0)
+	reputerIndexes := testutil.ReturnIndexes(1, 1)
+	workerIndexes := testutil.ReturnIndexes(2, 1)
+	reputerAddr := s.Addrs(reputerIndexes[0])
+	delegator2 := s.AddrsStr(3)
+	delegator2Addr := s.Addrs(3)
 	stakeAmount := cosmosMath.NewInt(500000)
-	registrationInitialBalance := cosmosMath.NewInt(1000)
 	delegatorStakeAmount := cosmosMath.NewInt(500)
 	delegatorStakeAmount2 := cosmosMath.NewInt(500)
 	delegator2StakeAmount := cosmosMath.NewInt(5000)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.FullTopicSetup(workerIndexes, reputerIndexes, testutil.WithReputerStake(ptr.To(cosmosMath.ZeroInt()))).Id
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegator2Addr, cosmosMath.NewInt(1000000))
 
 	addStakeMsg := &types.AddStakeRequest{
-		Sender:  reputer,
+		Sender:  reputerAddr.String(),
 		TopicId: topicId,
 		Amount:  stakeAmount,
 	}
 
-	response, err := s.msgServer.AddStake(ctx, addStakeMsg)
+	response, err := s.EmissionsMsgServer().AddStake(ctx, addStakeMsg)
 	require.NoError(err, "AddStake should not return an error")
 	require.NotNil(response)
 
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 		Amount:  delegatorStakeAmount,
 	}
 
 	msg2 := &types.DelegateStakeRequest{
 		Sender:  delegator2,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 		Amount:  delegator2StakeAmount,
 	}
 
-	reputerStake, err := s.emissionsKeeper.GetStakeReputerAuthority(ctx, topicId, reputer)
+	reputerStake, err := s.EmissionsKeeper().GetStakeReputerAuthority(ctx, topicId, reputerAddr.String())
 	require.NoError(err)
 	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
 
-	amount0, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegator, reputer)
+	amount0, err := keeper.GetDelegateStakePlacement(ctx, topicId, delegator, reputerAddr.String())
 	require.NoError(err)
 	require.Equal(alloraMath.NewDecFromInt64(0), amount0.Amount)
 
 	// Perform the stake delegation
-	responseDelegator, err := s.msgServer.DelegateStake(ctx, msg)
+	responseDelegator, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(responseDelegator, "Response should not be nil after successful delegation")
 
-	responseDelegator2, err := s.msgServer.DelegateStake(ctx, msg2)
+	responseDelegator2, err := s.EmissionsMsgServer().DelegateStake(ctx, msg2)
 	require.NoError(err)
 	require.NotNil(responseDelegator2, "Response should not be nil after successful delegation")
 
@@ -1554,55 +1439,43 @@ func (s *MsgServerTestSuite) TestRewardDelegateStake() {
 	scoreToAdd := types.Score{
 		TopicId:     topicId,
 		BlockHeight: block,
-		Address:     reputer,
+		Address:     reputerAddr.String(),
 		Score:       score,
 	}
-	err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, block, scoreToAdd)
+	err = s.EmissionsKeeper().InsertReputerScore(s.Ctx(), topicId, block, scoreToAdd)
 	s.Require().NoError(err)
 
+	//nolint:exhaustruct
 	reputerValueBundle := &types.ReputerValueBundle{
-		Pubkey: s.pubKeyHexStr[1],
+		Pubkey: s.PubKeyHexStr(1),
 		ValueBundle: &types.ValueBundle{
 			TopicId:             topicId,
 			ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
-			Reputer:             reputer,
-			ExtraData:           nil,
-			CombinedValue:       alloraMath.MustNewDecFromString("1500.0"),
-			InfererValues: []*types.WorkerAttributedValue{
-				{
-					Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
-					Value:  alloraMath.MustNewDecFromString("1"),
-				},
-			},
-			ForecasterValues:              nil,
-			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
-			OneOutInfererValues:           nil,
-			OneOutForecasterValues:        nil,
-			OneInForecasterValues:         nil,
-			OneOutInfererForecasterValues: nil,
+			Reputer:             reputerAddr.String(),
+			InfererValues:       []*types.WorkerAttributedValue{{Worker: s.AddrsStr(workerIndexes[0])}},
 		},
 		Signature: []byte{},
 	}
 	reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, reputerValueBundle)
-	err = s.emissionsKeeper.InsertActiveReputerLosses(s.ctx, topicId, block, reputerValueBundles)
+	err = s.EmissionsKeeper().InsertActiveReputerLosses(s.Ctx(), topicId, block, reputerValueBundles)
 	s.Require().NoError(err)
 
 	// Calculate and Set the reputer scores
-	scores, err := rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err := rewards.GenerateReputerScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block, reputerValueBundles)
 	s.Require().NoError(err)
 
 	// Generate rewards
 	reputers, reputersRewardFractions, err := rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		scores,
 	)
 	s.Require().NoError(err)
 	reputerRewards, err := rewards.GetRewardPerReputer(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.MustNewDecFromString("1017.5559072418691"),
 		reputers,
@@ -1614,67 +1487,45 @@ func (s *MsgServerTestSuite) TestRewardDelegateStake() {
 	msg3 := &types.DelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 		Amount:  delegatorStakeAmount2,
 	}
 
-	responseDelegator3, err := s.msgServer.DelegateStake(ctx, msg3)
+	responseDelegator3, err := s.EmissionsMsgServer().DelegateStake(ctx, msg3)
 	require.NoError(err)
 	require.NotNil(responseDelegator3, "Response should not be nil after successful delegation")
 
 	var newReputerValueBundles types.ReputerValueBundles
-	newScoreToAdd := types.Score{
-		TopicId:     topicId,
-		BlockHeight: newBlock,
-		Address:     reputer,
-		Score:       score,
-	}
-	err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, newBlock, newScoreToAdd)
+	newScoreToAdd := scoreToAdd
+	newScoreToAdd.BlockHeight = newBlock
+
+	err = s.EmissionsKeeper().InsertReputerScore(s.Ctx(), topicId, newBlock, newScoreToAdd)
 	s.Require().NoError(err)
 
-	newReputerValueBundle := &types.ReputerValueBundle{
-		ValueBundle: &types.ValueBundle{
-			TopicId:             topicId,
-			ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: newBlock}},
-			Reputer:             reputer,
-			ExtraData:           nil,
-			CombinedValue:       alloraMath.MustNewDecFromString("1500.0"),
-			InfererValues: []*types.WorkerAttributedValue{
-				{
-					Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
-					Value:  alloraMath.MustNewDecFromString("1"),
-				},
-			},
-			ForecasterValues:              nil,
-			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
-			OneOutInfererValues:           nil,
-			OneOutForecasterValues:        nil,
-			OneInForecasterValues:         nil,
-			OneOutInfererForecasterValues: nil,
-		},
-		Signature: []byte{},
-		Pubkey:    s.pubKeyHexStr[1],
-	}
+	newReputerValueBundle := reputerValueBundle
+	newReputerValueBundle.ValueBundle.ReputerRequestNonce.ReputerNonce.BlockHeight = newBlock
+	newReputerValueBundle.Pubkey = s.PubKeyHexStr(1)
+
 	newReputerValueBundles.ReputerValueBundles = append(newReputerValueBundles.ReputerValueBundles, newReputerValueBundle)
-	err = s.emissionsKeeper.InsertActiveReputerLosses(s.ctx, topicId, newBlock, newReputerValueBundles)
+	err = s.EmissionsKeeper().InsertActiveReputerLosses(s.Ctx(), topicId, newBlock, newReputerValueBundles)
 	s.Require().NoError(err)
 
 	// Calculate and Set the reputer scores
-	scores, err = rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err = rewards.GenerateReputerScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block, reputerValueBundles)
 	s.Require().NoError(err)
 
 	// Generate new rewards
 	reputers, reputersRewardFractions, err = rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		scores,
 	)
 	s.Require().NoError(err)
 	newReputerRewards, err := rewards.GetRewardPerReputer(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.MustNewDecFromString("1020.5559072418691"),
 		reputers,
@@ -1683,68 +1534,68 @@ func (s *MsgServerTestSuite) TestRewardDelegateStake() {
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(newReputerRewards))
 
-	beforeBalance := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	beforeBalance := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	rewardMsg := &types.RewardDelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 	}
-	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
-	afterBalance := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, rewardMsg)
+	afterBalance := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	s.Require().NoError(err)
 	s.Require().Greater(afterBalance.Amount.Uint64(), beforeBalance.Amount.Uint64(), "Balance must be increased")
 
-	beforeBalance2 := s.bankKeeper.GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
+	beforeBalance2 := s.BankKeeper().GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
 	rewardMsg2 := &types.RewardDelegateStakeRequest{
 		Sender:  delegator2,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 	}
-	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg2)
-	afterBalance2 := s.bankKeeper.GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, rewardMsg2)
+	afterBalance2 := s.BankKeeper().GetBalance(ctx, delegator2Addr, params.DefaultBondDenom)
 	s.Require().NoError(err)
 	s.Require().Greater(afterBalance2.Amount.Uint64(), beforeBalance2.Amount.Uint64(), "Balance must be increased")
 }
 
 func (s *MsgServerTestSuite) TestRewardDelegateStakeOnUnregisteredReputer() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
+
 	block := int64(1003)
 	score := alloraMath.MustNewDecFromString("17.53436")
 
-	delegator := s.addrsStr[0]
-	delegatorAddr := s.addrs[0]
-	reputer := s.addrsStr[1]
-	reputerAddr := s.addrs[1]
-	worker := s.addrsStr[2]
-	workerAddr := s.addrs[2]
+	delegator := s.AddrsStr(0)
+	delegatorAddr := s.Addrs(0)
+	reputerIndexes := testutil.ReturnIndexes(1, 1)
+	workerIndexes := testutil.ReturnIndexes(2, 1)
+	reputerAddr := s.Addrs(reputerIndexes[0])
+
 	stakeAmount := cosmosMath.NewInt(500000)
-	registrationInitialBalance := cosmosMath.NewInt(1000)
 	delegatorStakeAmount := cosmosMath.NewInt(500)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.FullTopicSetup(workerIndexes, reputerIndexes, testutil.WithReputerStake(ptr.To(cosmosMath.ZeroInt()))).Id
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
 
 	addStakeMsg := &types.AddStakeRequest{
-		Sender:  reputer,
+		Sender:  reputerAddr.String(),
 		TopicId: topicId,
 		Amount:  stakeAmount,
 	}
 
-	response, err := s.msgServer.AddStake(ctx, addStakeMsg)
+	response, err := s.EmissionsMsgServer().AddStake(ctx, addStakeMsg)
 	require.NoError(err, "AddStake should not return an error")
 	require.NotNil(response)
 
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 		Amount:  delegatorStakeAmount,
 	}
 
 	// Perform the stake delegation
-	responseDelegator, err := s.msgServer.DelegateStake(ctx, msg)
+	responseDelegator, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(responseDelegator, "Response should not be nil after successful delegation")
 
@@ -1752,55 +1603,43 @@ func (s *MsgServerTestSuite) TestRewardDelegateStakeOnUnregisteredReputer() {
 	scoreToAdd := types.Score{
 		TopicId:     topicId,
 		BlockHeight: block,
-		Address:     reputer,
+		Address:     reputerAddr.String(),
 		Score:       score,
 	}
-	err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, block, scoreToAdd)
+	err = s.EmissionsKeeper().InsertReputerScore(s.Ctx(), topicId, block, scoreToAdd)
 	s.Require().NoError(err)
 
+	//nolint:exhaustruct
 	reputerValueBundle := &types.ReputerValueBundle{
-		Pubkey: s.pubKeyHexStr[1],
+		Pubkey: s.PubKeyHexStr(1),
 		ValueBundle: &types.ValueBundle{
 			TopicId:             topicId,
 			ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
-			Reputer:             reputer,
-			ExtraData:           nil,
-			CombinedValue:       alloraMath.MustNewDecFromString("1500.0"),
-			InfererValues: []*types.WorkerAttributedValue{
-				{
-					Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
-					Value:  alloraMath.MustNewDecFromString("1"),
-				},
-			},
-			ForecasterValues:              nil,
-			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
-			OneOutInfererValues:           nil,
-			OneOutForecasterValues:        nil,
-			OneInForecasterValues:         nil,
-			OneOutInfererForecasterValues: nil,
+			Reputer:             reputerAddr.String(),
+			InfererValues:       []*types.WorkerAttributedValue{{Worker: s.AddrsStr(workerIndexes[0])}},
 		},
 		Signature: []byte{},
 	}
 	reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, reputerValueBundle)
-	err = s.emissionsKeeper.InsertActiveReputerLosses(s.ctx, topicId, block, reputerValueBundles)
+	err = s.EmissionsKeeper().InsertActiveReputerLosses(s.Ctx(), topicId, block, reputerValueBundles)
 	s.Require().NoError(err)
 
 	// Calculate and Set the reputer scores
-	scores, err := rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err := rewards.GenerateReputerScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block, reputerValueBundles)
 	s.Require().NoError(err)
 
 	// Generate rewards
 	reputers, reputersRewardFractions, err := rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		scores,
 	)
 	s.Require().NoError(err)
 	reputerRewards, err := rewards.GetRewardPerReputer(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.MustNewDecFromString("1017.5559072418691"),
 		reputers,
@@ -1809,16 +1648,16 @@ func (s *MsgServerTestSuite) TestRewardDelegateStakeOnUnregisteredReputer() {
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(reputerRewards))
 
-	beforeBalance := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
-	s.Require().NoError(s.emissionsKeeper.RemoveReputer(ctx, topicId, reputer))
+	beforeBalance := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	s.Require().NoError(s.EmissionsKeeper().RemoveReputer(ctx, topicId, reputerAddr.String()))
 
 	rewardMsg := &types.RewardDelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 	}
-	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
-	afterBalance := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, rewardMsg)
+	afterBalance := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	s.Require().NoError(err)
 	s.Require().Greater(afterBalance.Amount.Uint64(), beforeBalance.Amount.Uint64(), "Balance must be increased")
 }
@@ -1831,7 +1670,7 @@ func (s *MsgServerTestSuite) insertValueBundlesAndGetRewards(
 	block int64,
 	score alloraMath.Dec,
 ) []types.TaskReward {
-	keeper := s.emissionsKeeper
+	keeper := *s.EmissionsKeeper()
 	var reputerValueBundles types.ReputerValueBundles
 	scoreToAdd := types.Score{
 		TopicId:     topicId,
@@ -1839,44 +1678,32 @@ func (s *MsgServerTestSuite) insertValueBundlesAndGetRewards(
 		Address:     reputer,
 		Score:       score,
 	}
-	err := keeper.InsertReputerScore(s.ctx, topicId, block, scoreToAdd)
+	err := keeper.InsertReputerScore(s.Ctx(), topicId, block, scoreToAdd)
 	s.Require().NoError(err)
+	//nolint:exhaustruct
 	valueBundle := &types.ValueBundle{
 		TopicId:             topicId,
 		ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
 		Reputer:             reputer,
-		ExtraData:           nil,
-		CombinedValue:       alloraMath.MustNewDecFromString("1500.0"),
-		InfererValues: []*types.WorkerAttributedValue{
-			{
-				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
-				Value:  alloraMath.MustNewDecFromString("1"),
-			},
-		},
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		InfererValues:       []*types.WorkerAttributedValue{{Worker: s.AddrsStr(0)}},
 	}
-	signature := s.signValueBundle(valueBundle, reputerPrivKey)
+	signature := s.SignValueBundle(valueBundle, reputerPrivKey)
 	reputerValueBundle := &types.ReputerValueBundle{
 		ValueBundle: valueBundle,
 		Signature:   signature,
 		Pubkey:      reputerPubKeyHex,
 	}
 	reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, reputerValueBundle)
-	err = keeper.InsertActiveReputerLosses(s.ctx, topicId, block, reputerValueBundles)
+	err = keeper.InsertActiveReputerLosses(s.Ctx(), topicId, block, reputerValueBundles)
 	s.Require().NoError(err)
 
 	// Calculate and Set the reputer scores
-	scores, err := rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err := rewards.GenerateReputerScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block, reputerValueBundles)
 	s.Require().NoError(err)
 
 	// Generate rewards
 	reputers, reputersRewardFractions, err := rewards.GetReputersRewardFractions(
-		s.ctx,
+		s.Ctx(),
 		keeper,
 		topicId,
 		alloraMath.OneDec(),
@@ -1884,7 +1711,7 @@ func (s *MsgServerTestSuite) insertValueBundlesAndGetRewards(
 	)
 	s.Require().NoError(err)
 	reputerRewards, err := rewards.GetRewardPerReputer(
-		s.ctx,
+		s.Ctx(),
 		keeper,
 		topicId,
 		alloraMath.MustNewDecFromString("1017.5559072418691"),
@@ -1942,67 +1769,63 @@ func (s *MsgServerTestSuite) TestRewardConversionsZeroIntWithDecimals() {
 }
 
 func (s *MsgServerTestSuite) TestEqualStakeRewardsToDelegatorAndReputer() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
+
 	block := int64(1003)
-	// newBlock := int64(1004)
 	score := alloraMath.MustNewDecFromString("17.53436")
-
-	delegator := s.addrsStr[0]
-	delegatorAddr := s.addrs[0]
-	reputer := s.addrsStr[1]
-	reputerAddr := s.addrs[1]
-	reputerPubKeyHex := s.pubKeyHexStr[1]
-	reputerPrivKey := s.privKeys[1]
-	worker := s.addrsStr[2]
-	workerAddr := s.addrs[2]
-
-	registrationInitialBalance := cosmosMath.NewInt(1000)
 	stakeAmount := cosmosMath.NewInt(500000)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	delegator := s.AddrsStr(0)
+	delegatorAddr := s.Addrs(0)
+	reputerIndexes := testutil.ReturnIndexes(1, 1)
+	workerIndexes := testutil.ReturnIndexes(2, 1)
+	reputerAddr := s.Addrs(reputerIndexes[0])
+	reputerPubKeyHex := s.PubKeyHexStr(reputerIndexes[0])
+	reputerPrivKey := s.PrivKeys(reputerIndexes[0])
+
+	topicId := s.FullTopicSetup(workerIndexes, reputerIndexes, testutil.WithReputerStake(ptr.To(cosmosMath.ZeroInt()))).Id
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
 
 	addStakeMsg := &types.AddStakeRequest{
-		Sender:  reputer,
+		Sender:  reputerAddr.String(),
 		TopicId: topicId,
 		Amount:  stakeAmount,
 	}
 
-	response, err := s.msgServer.AddStake(ctx, addStakeMsg)
+	response, err := s.EmissionsMsgServer().AddStake(ctx, addStakeMsg)
 	require.NoError(err, "AddStake should not return an error")
 	require.NotNil(response)
 
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 		Amount:  stakeAmount,
 	}
 
-	//
-	reputerStake, err := s.emissionsKeeper.GetStakeReputerAuthority(ctx, topicId, reputer)
+	reputerStake, err := s.EmissionsKeeper().GetStakeReputerAuthority(ctx, topicId, reputerAddr.String())
 	require.NoError(err)
 	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
 
 	// Perform the stake delegation
-	responseDelegator, err := s.msgServer.DelegateStake(ctx, msg)
+	responseDelegator, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(responseDelegator, "Response should not be nil after successful delegation")
 
-	reputerRewards := s.insertValueBundlesAndGetRewards(reputerPrivKey, reputer, reputerPubKeyHex, topicId, block, score)
+	reputerRewards := s.insertValueBundlesAndGetRewards(reputerPrivKey, reputerAddr.String(), reputerPubKeyHex, topicId, block, score)
 
-	delegatorBal0 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	delegatorBal0 := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	rewardMsg := &types.RewardDelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 	}
-	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, rewardMsg)
 	s.Require().NoError(err)
 
-	delegatorBal1 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	delegatorBal1 := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	s.Require().NoError(err)
 
 	s.Require().Greater(delegatorBal1.Amount.Uint64(), delegatorBal0.Amount.Uint64(), "Balance must be increased")
@@ -2021,81 +1844,77 @@ func (s *MsgServerTestSuite) TestEqualStakeRewardsToDelegatorAndReputer() {
 			delegatorReward0.String(), reputerReward.String()),
 	)
 
-	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, rewardMsg)
 	s.Require().NoError(err)
-	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, rewardMsg)
 	s.Require().NoError(err)
-	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, rewardMsg)
 	s.Require().NoError(err)
 
-	delegatorBal2 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
-
+	delegatorBal2 := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	delegatorReward1 := delegatorBal2.Amount.Sub(delegatorBal1.Amount)
 
 	s.Require().True(delegatorReward1.Equal(cosmosMath.NewInt(0)), "Delegator cant double claim rewards")
 }
 
 func (s *MsgServerTestSuite) Test1000xDelegatorStakeVsReputerStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	block := int64(1003)
-	// newBlock := int64(1004)
 	score := alloraMath.MustNewDecFromString("17.53436")
 
-	delegatorAddr := s.addrs[0]
-	delegator := s.addrsStr[0]
-	reputerAddr := s.addrs[1]
-	reputerPubKeyHex := s.pubKeyHexStr[1]
-	reputerPrivKey := s.privKeys[1]
-	reputer := s.addrsStr[1]
-	workerAddr := s.addrs[2]
-	worker := s.addrsStr[2]
+	delegatorAddr := s.Addrs(0)
+	delegator := s.AddrsStr(0)
+	reputerIndexes := testutil.ReturnIndexes(1, 1)
+	workerIndexes := testutil.ReturnIndexes(2, 1)
+	reputerAddr := s.Addrs(reputerIndexes[0])
+	reputerPubKeyHex := s.PubKeyHexStr(reputerIndexes[0])
+	reputerPrivKey := s.PrivKeys(reputerIndexes[0])
 
-	registrationInitialBalance := cosmosMath.NewInt(10000)
 	reputerStakeAmount := cosmosMath.NewInt(1e2)
 	delegatorRatio := cosmosMath.NewInt(1e3)
 	delegatorStakeAmount := reputerStakeAmount.Mul(delegatorRatio)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.FullTopicSetup(workerIndexes, reputerIndexes, testutil.WithReputerStake(ptr.To(cosmosMath.ZeroInt()))).Id
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
-	err := s.bankKeeper.MintCoins(ctx, types.AlloraRewardsAccountName,
+	err := s.BankKeeper().MintCoins(ctx, types.AlloraRewardsAccountName,
 		sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(1000000))))
 	require.NoError(err)
 
 	addStakeMsg := &types.AddStakeRequest{
-		Sender:  reputer,
+		Sender:  reputerAddr.String(),
 		TopicId: topicId,
 		Amount:  reputerStakeAmount,
 	}
 
-	response, err := s.msgServer.AddStake(ctx, addStakeMsg)
+	response, err := s.EmissionsMsgServer().AddStake(ctx, addStakeMsg)
 	require.NoError(err, "AddStake should not return an error")
 	require.NotNil(response)
 
 	msg := &types.DelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 		Amount:  delegatorStakeAmount,
 	}
 
 	// Perform the stake delegation
-	delegateResponse, err := s.msgServer.DelegateStake(ctx, msg)
+	delegateResponse, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(delegateResponse, "Response should not be nil after successful delegation")
 
-	reputerRewards := s.insertValueBundlesAndGetRewards(reputerPrivKey, reputer, reputerPubKeyHex, topicId, block, score)
+	reputerRewards := s.insertValueBundlesAndGetRewards(reputerPrivKey, reputerAddr.String(), reputerPubKeyHex, topicId, block, score)
 
-	delegatorBal0 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	delegatorBal0 := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	rewardMsg := &types.RewardDelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 	}
-	_, err = s.msgServer.RewardDelegateStake(ctx, rewardMsg)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, rewardMsg)
 
-	delegatorBal1 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	delegatorBal1 := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 	s.Require().NoError(err)
 
 	delegatorRewardRaw := delegatorBal1.Amount.Sub(delegatorBal0.Amount)
@@ -2110,72 +1929,78 @@ func (s *MsgServerTestSuite) Test1000xDelegatorStakeVsReputerStake() {
 }
 
 func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	block := int64(1000)
 	score := alloraMath.MustNewDecFromString("17.53436")
 
-	reputerPrivKey := s.privKeys[0]
-	reputerPubKeyHex := s.pubKeyHexStr[0]
-	reputerAddr := s.addrs[0]
-	reputer := s.addrsStr[0]
-	delegatorAddr := s.addrs[1]
-	delegator := s.addrsStr[1]
-	largeDelegatorAddr := s.addrs[2]
-	largeDelegator := s.addrsStr[2]
-	workerAddr := s.addrs[3]
-	worker := s.addrsStr[3]
+	reputerIndexes := testutil.ReturnIndexes(0, 1)
+	reputerAddr := s.Addrs(reputerIndexes[0])
+	reputerPubKeyHex := s.PubKeyHexStr(reputerIndexes[0])
+	reputerPrivKey := s.PrivKeys(reputerIndexes[0])
+	delegatorAddr := s.Addrs(1)
+	delegator := s.AddrsStr(1)
+	largeDelegatorAddr := s.Addrs(2)
+	largeDelegator := s.AddrsStr(2)
+	workerIndexes := testutil.ReturnIndexes(3, 1)
 
-	registrationInitialBalance := cosmosMath.NewInt(10000)
 	reputerStakeAmount := cosmosMath.NewInt(1e2)
 	largeDelegatorRatio := cosmosMath.NewInt(1e3)
 	largeDelegatorStakeAmount := reputerStakeAmount.Mul(largeDelegatorRatio)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	zero := cosmosMath.ZeroInt()
+	topic := s.FullTopicSetup(
+		workerIndexes,
+		reputerIndexes,
+		testutil.WithInitialTopicStake(zero),
+		testutil.WithReputerStake(&zero),
+	)
+	topicId := topic.GetId()
+
 	s.MintTokensToAddress(reputerAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(delegatorAddr, cosmosMath.NewInt(1000000))
 	s.MintTokensToAddress(largeDelegatorAddr, cosmosMath.NewInt(1000000))
-	err := s.bankKeeper.MintCoins(ctx, types.AlloraRewardsAccountName, sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(1000000))))
+	err := s.BankKeeper().MintCoins(ctx, types.AlloraRewardsAccountName, sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(1000000))))
 	require.NoError(err)
 
 	// STEP 1 stake equal amount for reputer and delegator
 	addStakeMsg := &types.AddStakeRequest{
-		Sender:  reputer,
+		Sender:  reputerAddr.String(),
 		TopicId: topicId,
 		Amount:  reputerStakeAmount,
 	}
 
-	response, err := s.msgServer.AddStake(ctx, addStakeMsg)
+	response, err := s.EmissionsMsgServer().AddStake(ctx, addStakeMsg)
 	require.NoError(err, "AddStake should not return an error")
 	require.NotNil(response)
 
 	addDelegateStakeMsg := &types.DelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 		Amount:  reputerStakeAmount,
 	}
 
-	delegateStakeResponse, err := s.msgServer.DelegateStake(ctx, addDelegateStakeMsg)
+	delegateStakeResponse, err := s.EmissionsMsgServer().DelegateStake(ctx, addDelegateStakeMsg)
 	require.NoError(err)
 	require.NotNil(delegateStakeResponse, "Response should not be nil after successful delegation")
 
 	// STEP 2 Calculate rewards for the first round
 	reputerReward0, err := s.insertValueBundlesAndGetRewards(
-		reputerPrivKey, reputer, reputerPubKeyHex, topicId, block, score)[0].Reward.SdkIntTrim()
+		reputerPrivKey, reputerAddr.String(), reputerPubKeyHex, topicId, block, score)[0].Reward.SdkIntTrim()
 	require.NoError(err)
 
-	delegatorBal0 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	delegatorBal0 := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 
 	delegateRewardsMsg := &types.RewardDelegateStakeRequest{
 		Sender:  delegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 	}
-	_, err = s.msgServer.RewardDelegateStake(ctx, delegateRewardsMsg)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, delegateRewardsMsg)
 	require.NoError(err)
 
-	delegatorBal1 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	delegatorBal1 := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 
 	delegatorReward0 := delegatorBal1.Amount.Sub(delegatorBal0.Amount)
 
@@ -2183,13 +2008,13 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 	block++
 
 	reputerReward1, err := s.insertValueBundlesAndGetRewards(
-		reputerPrivKey, reputer, reputerPubKeyHex, topicId, block, score)[0].Reward.SdkIntTrim()
+		reputerPrivKey, reputerAddr.String(), reputerPubKeyHex, topicId, block, score)[0].Reward.SdkIntTrim()
 	require.NoError(err)
 
-	_, err = s.msgServer.RewardDelegateStake(ctx, delegateRewardsMsg)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, delegateRewardsMsg)
 	require.NoError(err)
 
-	delegatorBal2 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	delegatorBal2 := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
 
 	delegatorReward1 := delegatorBal2.Amount.Sub(delegatorBal1.Amount)
 
@@ -2197,35 +2022,35 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 	addLargeDelegateStakeMsg := &types.DelegateStakeRequest{
 		Sender:  largeDelegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 		Amount:  largeDelegatorStakeAmount,
 	}
 
-	largeDelegateStakeResponse, err := s.msgServer.DelegateStake(ctx, addLargeDelegateStakeMsg)
+	largeDelegateStakeResponse, err := s.EmissionsMsgServer().DelegateStake(ctx, addLargeDelegateStakeMsg)
 	require.NoError(err)
 	require.NotNil(largeDelegateStakeResponse, "Response should not be nil after successful delegation")
 
-	largeDelegatorBal2 := s.bankKeeper.GetBalance(ctx, largeDelegatorAddr, params.DefaultBondDenom)
+	largeDelegatorBal2 := s.BankKeeper().GetBalance(ctx, largeDelegatorAddr, params.DefaultBondDenom)
 
 	// STEP 4 Calculate rewards for the third round
 	block++
 	reputerReward2, err := s.insertValueBundlesAndGetRewards(
-		reputerPrivKey, reputer, reputerPubKeyHex, topicId, block, score)[0].Reward.SdkIntTrim()
+		reputerPrivKey, reputerAddr.String(), reputerPubKeyHex, topicId, block, score)[0].Reward.SdkIntTrim()
 	require.NoError(err)
 
-	_, err = s.msgServer.RewardDelegateStake(ctx, delegateRewardsMsg)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, delegateRewardsMsg)
 	require.NoError(err)
 
 	largeDelegateRewardsMsg := &types.RewardDelegateStakeRequest{
 		Sender:  largeDelegator,
 		TopicId: topicId,
-		Reputer: reputer,
+		Reputer: reputerAddr.String(),
 	}
-	_, err = s.msgServer.RewardDelegateStake(ctx, largeDelegateRewardsMsg)
+	_, err = s.EmissionsMsgServer().RewardDelegateStake(ctx, largeDelegateRewardsMsg)
 	require.NoError(err)
 
-	delegatorBal3 := s.bankKeeper.GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
-	largeDelegatorBal3 := s.bankKeeper.GetBalance(ctx, largeDelegatorAddr, params.DefaultBondDenom)
+	delegatorBal3 := s.BankKeeper().GetBalance(ctx, delegatorAddr, params.DefaultBondDenom)
+	largeDelegatorBal3 := s.BankKeeper().GetBalance(ctx, largeDelegatorAddr, params.DefaultBondDenom)
 
 	delegatorReward2 := delegatorBal3.Amount.Sub(delegatorBal2.Amount)
 	largeDelegatorReward2 := largeDelegatorBal3.Amount.Sub(largeDelegatorBal2.Amount)
@@ -2260,12 +2085,12 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 }
 
 func (s *MsgServerTestSuite) TestCancelRemoveStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 
 	// Set up test data
-	reputer := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
+	reputer := s.AddrsStr(0)
+	topicId := uint64(1)
 	amount := cosmosMath.NewInt(50)
 
 	// Add a delegate stake removal
@@ -2276,7 +2101,7 @@ func (s *MsgServerTestSuite) TestCancelRemoveStake() {
 		Amount:                amount,
 		BlockRemovalCompleted: 20,
 	}
-	err := s.emissionsKeeper.SetStakeRemoval(ctx, stakeToRemove)
+	err := s.EmissionsKeeper().SetStakeRemoval(ctx, stakeToRemove)
 	require.NoError(err)
 
 	// Call CancelRemoveDelegateStake
@@ -2284,46 +2109,51 @@ func (s *MsgServerTestSuite) TestCancelRemoveStake() {
 		Sender:  reputer,
 		TopicId: topicId,
 	}
-	_, err = s.msgServer.CancelRemoveStake(ctx, msg)
+	_, err = s.EmissionsMsgServer().CancelRemoveStake(ctx, msg)
 	require.NoError(err)
 
 	// Verify that the stake removal is deleted
-	_, found, err := s.emissionsKeeper.
+	_, found, err := s.EmissionsKeeper().
 		GetStakeRemovalForReputerAndTopicId(ctx, reputer, topicId)
 	require.NoError(err)
 	require.False(found, "Stake removal should be deleted")
 }
 
 func (s *MsgServerTestSuite) TestCancelRemoveStakeNotExist() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	// Set up test data
-	reputer := s.addrsStr[0]
-	topicID := s.CreateOneTopic().Id
+	reputer := s.AddrsStr(0)
+	topicId := uint64(1)
 
 	// Call CancelRemoveDelegateStake
 	msg := &types.CancelRemoveStakeRequest{
 		Sender:  reputer,
-		TopicId: topicID,
+		TopicId: topicId,
 	}
-	_, err := s.msgServer.CancelRemoveStake(ctx, msg)
+	_, err := s.EmissionsMsgServer().CancelRemoveStake(ctx, msg)
 	require.Error(err)
 	require.True(errors.Is(err, types.ErrStakeRemovalNotFound), "Expected stake removal not found error")
 }
 
 func (s *MsgServerTestSuite) TestCancelRemoveDelegateStake() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	// Set up test data
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	reputerAddr := s.addrs[1]
-	worker := s.addrsStr[2]
-	workerAddr := s.addrs[2]
-	registrationInitialBalance := cosmosMath.NewInt(10000)
+	delegator := s.AddrsStr(0)
+	reputerIndexes := testutil.ReturnIndexes(1, 1)
+	workerIndexes := testutil.ReturnIndexes(2, 1)
+	reputer := s.AddrsStr(reputerIndexes[0])
 	amount := cosmosMath.NewInt(50)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	zero := cosmosMath.ZeroInt()
+	topic := s.FullTopicSetup(
+		workerIndexes,
+		reputerIndexes,
+		testutil.WithInitialTopicStake(zero),
+		testutil.WithReputerStake(&zero),
+	)
+	topicId := topic.GetId()
 
 	// Add a delegate stake removal
 	stakeToRemove := types.DelegateStakeRemovalInfo{
@@ -2334,7 +2164,7 @@ func (s *MsgServerTestSuite) TestCancelRemoveDelegateStake() {
 		Amount:                amount,
 		BlockRemovalCompleted: 20,
 	}
-	err := s.emissionsKeeper.SetDelegateStakeRemoval(ctx, stakeToRemove)
+	err := s.EmissionsKeeper().SetDelegateStakeRemoval(ctx, stakeToRemove)
 	require.NoError(err)
 
 	// Call CancelRemoveDelegateStake
@@ -2344,29 +2174,27 @@ func (s *MsgServerTestSuite) TestCancelRemoveDelegateStake() {
 		TopicId:   topicId,
 		Delegator: delegator,
 	}
-	_, err = s.msgServer.CancelRemoveDelegateStake(ctx, msg)
+	_, err = s.EmissionsMsgServer().CancelRemoveDelegateStake(ctx, msg)
 	require.NoError(err)
 
 	// Verify that the stake removal is deleted
-	_, found, err := s.emissionsKeeper.
+	_, found, err := s.EmissionsKeeper().
 		GetDelegateStakeRemovalForDelegatorReputerAndTopicId(ctx, delegator, reputer, topicId)
 	require.NoError(err)
 	require.False(found, "Stake removal should be deleted")
 }
 
 func (s *MsgServerTestSuite) TestCancelRemoveDelegateStakeOnUnregisteredReputer() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	// Set up test data
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	reputerAddr := s.addrs[1]
-	worker := s.addrsStr[2]
-	workerAddr := s.addrs[2]
-	registrationInitialBalance := cosmosMath.NewInt(10000)
+	delegator := s.AddrsStr(0)
+	reputerIndexes := testutil.ReturnIndexes(1, 1)
+	reputer := s.AddrsStr(reputerIndexes[0])
+	workerIndexes := testutil.ReturnIndexes(2, 1)
 	amount := cosmosMath.NewInt(50)
 
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	topicId := s.FullTopicSetup(workerIndexes, reputerIndexes).Id
 
 	// Add a delegate stake removal
 	stakeToRemove := types.DelegateStakeRemovalInfo{
@@ -2377,10 +2205,10 @@ func (s *MsgServerTestSuite) TestCancelRemoveDelegateStakeOnUnregisteredReputer(
 		Amount:                amount,
 		BlockRemovalCompleted: 20,
 	}
-	err := s.emissionsKeeper.SetDelegateStakeRemoval(ctx, stakeToRemove)
+	err := s.EmissionsKeeper().SetDelegateStakeRemoval(ctx, stakeToRemove)
 	require.NoError(err)
 
-	s.Require().NoError(s.emissionsKeeper.RemoveReputer(ctx, topicId, reputer))
+	s.Require().NoError(s.EmissionsKeeper().RemoveReputer(ctx, topicId, reputer))
 
 	// Call CancelRemoveDelegateStake
 	msg := &types.CancelRemoveDelegateStakeRequest{
@@ -2389,28 +2217,23 @@ func (s *MsgServerTestSuite) TestCancelRemoveDelegateStakeOnUnregisteredReputer(
 		TopicId:   topicId,
 		Delegator: delegator,
 	}
-	_, err = s.msgServer.CancelRemoveDelegateStake(ctx, msg)
+	_, err = s.EmissionsMsgServer().CancelRemoveDelegateStake(ctx, msg)
 	require.NoError(err)
 
 	// Verify that the stake removal is deleted
-	_, found, err := s.emissionsKeeper.
+	_, found, err := s.EmissionsKeeper().
 		GetDelegateStakeRemovalForDelegatorReputerAndTopicId(ctx, delegator, reputer, topicId)
 	require.NoError(err)
 	require.False(found, "Stake removal should be deleted")
 }
 
 func (s *MsgServerTestSuite) TestCancelRemoveDelegateStakeNotExist() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	// Set up test data
-	delegator := s.addrsStr[0]
-	reputer := s.addrsStr[1]
-	reputerAddr := s.addrs[1]
-	worker := s.addrsStr[2]
-	workerAddr := s.addrs[2]
-	registrationInitialBalance := cosmosMath.NewInt(10000)
-
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, registrationInitialBalance)
+	delegator := s.AddrsStr(0)
+	reputer := s.AddrsStr(1)
+	topicId := uint64(1)
 
 	// Call CancelRemoveDelegateStake
 	msg := &types.CancelRemoveDelegateStakeRequest{
@@ -2419,7 +2242,7 @@ func (s *MsgServerTestSuite) TestCancelRemoveDelegateStakeNotExist() {
 		TopicId:   topicId,
 		Delegator: delegator,
 	}
-	_, err := s.msgServer.CancelRemoveDelegateStake(ctx, msg)
+	_, err := s.EmissionsMsgServer().CancelRemoveDelegateStake(ctx, msg)
 	require.Error(err)
 	require.True(errors.Is(err, types.ErrStakeRemovalNotFound), "Expected delegate stake removal not found error")
 }

--- a/x/emissions/keeper/msgserver/msg_server_stake_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_stake_test.go
@@ -12,9 +12,10 @@ import (
 
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
+	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/utils/ptr"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
@@ -2081,7 +2082,7 @@ func (s *MsgServerTestSuite) TestMultiRoundReputerStakeVs1000xDelegatorStake() {
 	totalRewardsSecondRound := reputerReward1.Add(delegatorReward1)
 	totalRewardsThirdRound := reputerReward2.Add(delegatorReward2).Add(largeDelegatorReward2)
 
-	testutil.InEpsilon3(s.T(), alloraMath.MustNewDecFromString(totalRewardsSecondRound.String()), totalRewardsThirdRound.String())
+	alloratestutil.InEpsilon3(s.T(), alloraMath.MustNewDecFromString(totalRewardsSecondRound.String()), totalRewardsThirdRound.String())
 }
 
 func (s *MsgServerTestSuite) TestCancelRemoveStake() {

--- a/x/emissions/keeper/msgserver/msg_server_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_test.go
@@ -9,18 +9,19 @@ import (
 
 	"github.com/allora-network/allora-chain/app/params"
 	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 var _, _, nonAdminAccounts, _ = alloratestutil.GenerateTestAccounts(4)
 
 type MsgServerTestSuite struct {
-	alloratestutil.TestSuite
+	testutil.TestSuite
 }
 
 func TestMsgServerTestSuite(t *testing.T) {
 	suite.Run(t, &MsgServerTestSuite{
-		alloratestutil.NewTestSuite("emissions_msg_server"),
+		testutil.NewTestSuite("emissions_msg_server"),
 	})
 }
 

--- a/x/emissions/keeper/msgserver/msg_server_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_test.go
@@ -1,291 +1,56 @@
 package msgserver_test
 
 import (
-	"crypto/ed25519"
 	"testing"
-	"time"
 
-	cosmosAddress "cosmossdk.io/core/address"
-	"cosmossdk.io/core/header"
-
-	"cosmossdk.io/core/store"
-	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
-	storetypes "cosmossdk.io/store/types"
-	"github.com/allora-network/allora-chain/app/params"
-	alloraMath "github.com/allora-network/allora-chain/math"
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
-	"github.com/allora-network/allora-chain/x/emissions/module"
-	"github.com/allora-network/allora-chain/x/emissions/types"
-	minttypes "github.com/allora-network/allora-chain/x/mint/types"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/codec/address"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/stretchr/testify/suite"
-)
 
-const (
-	multiPerm  = "multiple permissions account"
-	randomPerm = "random permission"
+	"github.com/allora-network/allora-chain/app/params"
+	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
-
-type ChainKey struct {
-	pubKey ed25519.PublicKey
-	priKey ed25519.PrivateKey
-}
 
 var _, _, nonAdminAccounts, _ = alloratestutil.GenerateTestAccounts(4)
 
 type MsgServerTestSuite struct {
-	suite.Suite
-
-	ctx             sdk.Context
-	codec           codec.Codec
-	addressCodec    cosmosAddress.Codec
-	storeService    store.KVStoreService
-	accountKeeper   authkeeper.AccountKeeper
-	bankKeeper      bankkeeper.BaseKeeper
-	emissionsKeeper keeper.Keeper
-	appModule       module.AppModule
-	msgServer       types.MsgServiceServer
-	key             *storetypes.KVStoreKey
-	privKeys        []secp256k1.PrivKey
-	pubKeyHexStr    []string
-	addrs           []sdk.AccAddress
-	addrsStr        []string
+	alloratestutil.TestSuite
 }
 
 func TestMsgServerTestSuite(t *testing.T) {
-	suite.Run(t, new(MsgServerTestSuite))
-}
-
-func (s *MsgServerTestSuite) SetupTest() {
-	key := storetypes.NewKVStoreKey("emissions")
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()}) // nolint: exhaustruct // dependency code
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
-	s.codec = encCfg.Codec
-	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
-	s.addressCodec = addressCodec
-
-	maccPerms := map[string][]string{
-		"fee_collector":                {"minter"},
-		"mint":                         {"minter"},
-		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName: {"minter"},
-		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
-		minttypes.EcosystemModuleName:                    nil,
-		"bonded_tokens_pool":                             {"burner", "staking"},
-		"not_bonded_tokens_pool":                         {"burner", "staking"},
-		multiPerm:                                        {"burner", "minter", "staking"},
-		randomPerm:                                       {"random"},
-	}
-
-	accountKeeper := authkeeper.NewAccountKeeper(
-		encCfg.Codec,
-		storeService,
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
-		params.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress("gov").String(),
-	)
-
-	s.privKeys, s.pubKeyHexStr, s.addrs, s.addrsStr = alloratestutil.GenerateTestAccounts(12)
-
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		log.NewNopLogger(),
-	)
-
-	s.ctx = ctx
-	s.accountKeeper = accountKeeper
-	s.bankKeeper = bankKeeper
-	s.emissionsKeeper = keeper.NewKeeper(
-		encCfg.Codec,
-		addressCodec,
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-	s.key = key
-	appModule := module.NewAppModule(encCfg.Codec, s.emissionsKeeper)
-	defaultGenesis := appModule.DefaultGenesis(encCfg.Codec)
-	appModule.InitGenesis(ctx, encCfg.Codec, defaultGenesis)
-	s.msgServer = msgserver.NewMsgServerImpl(s.emissionsKeeper)
-
-	s.appModule = appModule
-
-	// Add all tests addresses in whitelists
-	for _, addr := range s.addrsStr {
-		err := s.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToGlobalWhitelist(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, addr)
-		s.Require().NoError(err)
-	}
-}
-
-func GeneratePrivateKeys(numKeys int) []ChainKey {
-	testAddrs := make([]ChainKey, numKeys)
-	for i := 0; i < numKeys; i++ {
-		pk, prk, _ := ed25519.GenerateKey(nil)
-		testAddrs[i] = ChainKey{
-			pubKey: pk,
-			priKey: prk,
-		}
-	}
-
-	return testAddrs
-}
-
-func (s *MsgServerTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
-	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
-
-	err := s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
-}
-
-func (s *MsgServerTestSuite) MintTokensToModule(moduleName string, amount cosmosMath.Int) {
-	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
-	err := s.bankKeeper.MintCoins(s.ctx, moduleName, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
-}
-
-func (s *MsgServerTestSuite) CreateOneTopic() types.Topic {
-	result := s.CreateCustomEpochTopic(10800)
-	return result
-}
-
-func (s *MsgServerTestSuite) CreateCustomEpochTopic(epochLen int64) types.Topic {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	// Create a topic first
-	metadata := "Some metadata for the new topic"
-	creator := 9
-	// Create a CreateNewTopicRequest message
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[creator],
-		Metadata:                 metadata,
-		LossMethod:               "mse",
-		EpochLength:              epochLen,
-		GroundTruthLag:           epochLen,
-		AllowNegative:            false,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-
-	s.MintTokensToAddress(s.addrs[creator], types.DefaultParams().CreateTopicFee)
-
-	result, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.NoError(err, "CreateTopic fails on first creation")
-
-	return types.Topic{
-		Id:                       result.TopicId,
-		Creator:                  newTopicMsg.Creator,
-		Metadata:                 newTopicMsg.Metadata,
-		LossMethod:               newTopicMsg.LossMethod,
-		EpochLength:              newTopicMsg.EpochLength,
-		EpochLastEnded:           0,
-		InitialRegret:            alloraMath.ZeroDec(),
-		GroundTruthLag:           newTopicMsg.GroundTruthLag,
-		WorkerSubmissionWindow:   newTopicMsg.WorkerSubmissionWindow,
-		AlphaRegret:              newTopicMsg.AlphaRegret,
-		AllowNegative:            newTopicMsg.AllowNegative,
-		PNorm:                    newTopicMsg.PNorm,
-		Epsilon:                  newTopicMsg.Epsilon,
-		MeritSortitionAlpha:      newTopicMsg.MeritSortitionAlpha,
-		ActiveInfererQuantile:    newTopicMsg.ActiveInfererQuantile,
-		ActiveForecasterQuantile: newTopicMsg.ActiveForecasterQuantile,
-		ActiveReputerQuantile:    newTopicMsg.ActiveReputerQuantile,
-	}
+	suite.Run(t, &MsgServerTestSuite{
+		alloratestutil.NewTestSuite("emissions_msg_server"),
+	})
 }
 
 func (s *MsgServerTestSuite) TestCreateSeveralTopics() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-	// Mock setup for metadata and validation steps
-	metadata := "Some metadata for the new topic"
-	// Create a CreateNewTopicRequest message
-	creator := s.addrs[0]
-
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  creator.String(),
-		Metadata:                 metadata,
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
+	creator := s.Addrs(0)
 
 	creatorInitialBalance := types.DefaultParams().CreateTopicFee.Mul(cosmosMath.NewInt(3))
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, creatorInitialBalance))
 
-	err := s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
+	err := s.BankKeeper().MintCoins(s.Ctx(), types.AlloraStakingAccountName, creatorInitialBalanceCoins)
 	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, creator, creatorInitialBalanceCoins)
+	err = s.BankKeeper().SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, creator, creatorInitialBalanceCoins)
 	s.Require().NoError(err)
 
-	initialTopicId, err := s.emissionsKeeper.GetNextTopicId(s.ctx)
+	initialTopicId, err := s.EmissionsKeeper().GetNextTopicId(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().NotNil(initialTopicId)
 
-	_, err = msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.NoError(err, "CreateTopic fails on first creation")
+	// Create first topic
+	s.CreateTopic()
 
-	result, err := s.emissionsKeeper.GetNextTopicId(s.ctx)
+	result, err := s.EmissionsKeeper().GetNextTopicId(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(initialTopicId+1, result)
 
 	// Create second topic
-	_, err = msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.NoError(err, "CreateTopic fails on second topic")
+	s.CreateTopic()
 
-	result, err = s.emissionsKeeper.GetNextTopicId(s.ctx)
+	result, err = s.EmissionsKeeper().GetNextTopicId(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(initialTopicId+2, result)

--- a/x/emissions/keeper/msgserver/msg_server_topics_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Topics tests
-
+//nolint:exhaustruct
 func (s *MsgServerTestSuite) TestCreateNewTopic() {
 	ctx := s.Ctx()
 	msgServer := s.EmissionsMsgServer()

--- a/x/emissions/keeper/msgserver/msg_server_topics_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 // Topics tests
+//
+//nolint:exhaustr
 //nolint:exhaustruct
 func (s *MsgServerTestSuite) TestCreateNewTopic() {
 	ctx := s.Ctx()

--- a/x/emissions/keeper/msgserver/msg_server_topics_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics_test.go
@@ -7,192 +7,148 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-/// Topics tests
+// Topics tests
 
-func (s *MsgServerTestSuite) TestMsgCreateNewTopicAndWhitelistCheck() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
+func (s *MsgServerTestSuite) TestCreateNewTopic() {
+	ctx := s.Ctx()
+	msgServer := s.EmissionsMsgServer()
+	keeper := s.EmissionsKeeper()
+	senderAddr := s.Addrs(0)
 
-	senderAddr := s.addrs[0]
-	sender := s.addrsStr[0]
+	testCases := []struct {
+		name          string
+		setup         func() *types.CreateNewTopicRequest
+		postCheck     func(topicId uint64)
+		expectedError string
+		expectSuccess bool
+	}{
+		{
+			name: "Fails when sender not whitelisted",
+			setup: func() *types.CreateNewTopicRequest {
+				// Ensure sender is not whitelisted
+				err := keeper.RemoveFromTopicCreatorWhitelist(ctx, senderAddr.String())
+				s.Require().NoError(err)
+				err = keeper.RemoveFromGlobalWhitelist(ctx, senderAddr.String())
+				s.Require().NoError(err)
 
-	// Create a CreateNewTopicRequest message
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  sender,
-		Metadata:                 "Some metadata for the new topic",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
+				return s.MockTopicMsg()
+			},
+			expectedError: types.ErrNotPermittedToCreateTopic.Error(),
+			expectSuccess: false,
+		},
+		{
+			name: "Success when sender is whitelisted",
+			setup: func() *types.CreateNewTopicRequest {
+				// Add sender to whitelist
+				err := keeper.AddToTopicCreatorWhitelist(ctx, senderAddr.String())
+				s.Require().NoError(err)
+
+				return s.MockTopicMsg()
+			},
+			postCheck: func(topicId uint64) {
+				// Check topic is not in active topics yet
+				activeTopics, err := keeper.GetActiveTopicIdsAtBlock(ctx, 10800)
+				s.Require().NoError(err)
+				found := false
+				for _, id := range activeTopics.TopicIds {
+					if id == topicId {
+						found = true
+						break
+					}
+				}
+				s.Require().False(found, "Added topic found in active topics")
+
+				// Check worker whitelist is enabled
+				enabled, err := keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
+				s.Require().NoError(err)
+				s.Require().True(enabled, "Topic worker whitelist should be enabled")
+
+				// Check reputer whitelist is enabled
+				enabled, err = keeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
+				s.Require().NoError(err)
+				s.Require().True(enabled, "Topic reputer whitelist should be enabled")
+			},
+			expectSuccess: true,
+		},
+		{
+			name: "Fails with epsilon zero",
+			setup: func() *types.CreateNewTopicRequest {
+				// Add to whitelist to avoid that error
+				err := keeper.AddToTopicCreatorWhitelist(ctx, senderAddr.String())
+				s.Require().NoError(err)
+
+				msg := s.MockTopicMsg()
+				msg.Epsilon = alloraMath.MustNewDecFromString("0")
+				return msg
+			},
+			expectedError: "epsilon must be greater than",
+			expectSuccess: false,
+		},
+		{
+			name: "Fails with too long metadata",
+			setup: func() *types.CreateNewTopicRequest {
+				// Add to whitelist
+				err := keeper.AddToTopicCreatorWhitelist(ctx, senderAddr.String())
+				s.Require().NoError(err)
+
+				msg := s.MockTopicMsg()
+				msg.Metadata = strings.Repeat("a", 257)
+				return msg
+			},
+			expectedError: "metadata invalid",
+			expectSuccess: false,
+		},
+		{
+			name: "Fails with too long loss method",
+			setup: func() *types.CreateNewTopicRequest {
+				// Add to whitelist
+				err := keeper.AddToTopicCreatorWhitelist(ctx, senderAddr.String())
+				s.Require().NoError(err)
+
+				msg := s.MockTopicMsg()
+				msg.LossMethod = strings.Repeat("a", 257)
+				return msg
+			},
+			expectedError: "loss method invalid",
+			expectSuccess: false,
+		},
 	}
 
-	s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
+			msg := tc.setup()
 
-	// Should fail if sender is not whitelisted
-	err := s.emissionsKeeper.RemoveFromTopicCreatorWhitelist(ctx, sender)
-	require.NoError(err)
-	err = s.emissionsKeeper.RemoveFromGlobalWhitelist(ctx, sender)
-	require.NoError(err)
+			result, err := msgServer.CreateNewTopic(ctx, msg)
 
-	result, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.ErrorIs(err, types.ErrNotPermittedToCreateTopic)
-	require.Nil(result)
-
-	// Add sender to whitelist
-	err = s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, sender)
-	require.NoError(err)
-
-	// Should now succeed
-	result, err = msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.NoError(err)
-	require.NotNil(result)
-
-	activeTopics, err := s.emissionsKeeper.GetActiveTopicIdsAtBlock(s.ctx, 10800)
-	require.NoError(err)
-	found := false
-	for _, topicId := range activeTopics.TopicIds {
-		if topicId == result.TopicId {
-			found = true
-			break
-		}
+			if tc.expectSuccess {
+				s.Require().NoError(err)
+				s.Require().NotNil(result)
+				if tc.postCheck != nil {
+					tc.postCheck(result.TopicId)
+				}
+			} else {
+				s.Require().Error(err)
+				s.Require().Nil(result)
+				if tc.expectedError != "" {
+					s.Require().ErrorContains(err, tc.expectedError)
+				}
+			}
+		})
 	}
-	require.False(found, "Added topic found in active topics")
-
-	enabled, err := s.emissionsKeeper.IsTopicWorkerWhitelistEnabled(s.ctx, result.TopicId)
-	require.NoError(err)
-	require.True(enabled, "Topic worker whitelist should be enabled")
-
-	enabled, err = s.emissionsKeeper.IsTopicReputerWhitelistEnabled(s.ctx, result.TopicId)
-	require.NoError(err)
-	require.True(enabled, "Topic reputer whitelist should be enabled")
-}
-
-func (s *MsgServerTestSuite) TestMsgCreateNewTopicWithEpsilonZeroFails() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	senderAddr := s.addrs[0]
-	sender := s.addrsStr[0]
-
-	// Create a CreateNewTopicRequest message
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  sender,
-		Metadata:                 "Some metadata for the new topic",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-
-	s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
-
-	result, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.Error(err)
-	require.True(strings.Contains(err.Error(), "epsilon must be greater than"))
-	s.Require().Nil(result)
 }
 
 func (s *MsgServerTestSuite) TestUpdateTopicEpochLastEnded() {
-	ctx := s.ctx
-	require := s.Require()
-	topicPrev := s.CreateOneTopic()
-
-	// Mock setup for topic
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	topicId := uint64(1)
 	inferenceTs := int64(20)
 
-	err := s.emissionsKeeper.UpdateTopicEpochLastEnded(ctx, topicPrev.Id, inferenceTs)
-	require.NoError(err, "UpdateTopicEpochLastEnded should not return an error")
+	err := keeper.UpdateTopicEpochLastEnded(ctx, topicId, inferenceTs)
+	s.Require().NoError(err, "UpdateTopicEpochLastEnded should not return an error")
 
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicPrev.Id)
+	topic, err := keeper.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().NotNil(topic)
-	s.Require().Equal(topic.EpochLastEnded, inferenceTs)
-}
-
-func (s *MsgServerTestSuite) TestMsgCreateNewTopicTooLongMetadataFails() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	senderAddr := s.addrs[0]
-	sender := s.addrsStr[0]
-
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  sender,
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		Metadata:                 strings.Repeat("a", 257),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-
-	s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
-
-	result, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.Error(err)
-	require.Nil(result)
-	require.ErrorContains(err, "metadata invalid")
-}
-
-func (s *MsgServerTestSuite) TestMsgCreateNewTopicTooLongLossMethodFails() {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	senderAddr := s.addrs[0]
-	sender := s.addrsStr[0]
-
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  sender,
-		Metadata:                 "Some metadata for the new topic",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		LossMethod:               strings.Repeat("a", 257),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-
-	s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
-
-	result, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.Error(err)
-	require.Nil(result)
-	require.ErrorContains(err, "loss method invalid")
+	s.Require().Equal(inferenceTs, topic.EpochLastEnded)
 }

--- a/x/emissions/keeper/msgserver/msg_server_topics_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics_test.go
@@ -9,7 +9,6 @@ import (
 
 // Topics tests
 //
-//nolint:exhaustr
 //nolint:exhaustruct
 func (s *MsgServerTestSuite) TestCreateNewTopic() {
 	ctx := s.Ctx()

--- a/x/emissions/keeper/msgserver/msg_server_whitelist_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_whitelist_test.go
@@ -1,1178 +1,997 @@
 package msgserver_test
 
 import (
+	"context"
+
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (s *MsgServerTestSuite) TestAddWhitelistAdmin() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
+func (s *MsgServerTestSuite) TestWhitelistAdminOperations() {
+	ctx := s.Ctx()
+	msgServer := s.EmissionsMsgServer()
+	keeper := s.EmissionsKeeper()
 
-	adminAddr := s.addrsStr[0]
-	newAdminAddr := nonAdminAccounts[0].String()
+	adminAddr := s.AddrsStr(0)
+	targetAddr := s.AddrsStr(1)
+	nonAdminAddr := nonAdminAccounts[0].String()
 
-	// Verify that newAdminAddr is not a whitelist admin
-	isWhitelistAdmin, err := s.emissionsKeeper.IsWhitelistAdmin(ctx, newAdminAddr)
-	require.NoError(err, "IsWhitelistAdmin should not return an error")
-	require.False(isWhitelistAdmin, "newAdminAddr should not be a whitelist admin")
-
-	// Attempt to add newAdminAddr to whitelist by adminAddr
-	msg := &types.AddToWhitelistAdminRequest{
-		Sender:  adminAddr,
-		Address: newAdminAddr,
+	testCases := []struct {
+		name          string
+		execute       func() error
+		verifyResult  func()
+		expectedError error
+	}{
+		// Whitelist Admin Operations
+		{
+			name: "Add whitelist admin - unauthorized",
+			execute: func() error {
+				msg := &types.AddToWhitelistAdminRequest{
+					Sender:  nonAdminAddr,
+					Address: targetAddr,
+				}
+				_, err := msgServer.AddToWhitelistAdmin(ctx, msg)
+				return err
+			},
+			expectedError: types.ErrNotPermittedToUpdateWhitelistAdmins,
+		},
+		{
+			name: "Remove whitelist admin - unauthorized",
+			execute: func() error {
+				msg := &types.RemoveFromWhitelistAdminRequest{
+					Sender:  nonAdminAddr,
+					Address: adminAddr,
+				}
+				_, err := msgServer.RemoveFromWhitelistAdmin(ctx, msg)
+				return err
+			},
+			expectedError: types.ErrNotPermittedToUpdateWhitelistAdmins,
+		},
+		{
+			name: "Add whitelist admin - success",
+			execute: func() error {
+				msg := &types.AddToWhitelistAdminRequest{
+					Sender:  adminAddr,
+					Address: nonAdminAddr,
+				}
+				_, err := msgServer.AddToWhitelistAdmin(ctx, msg)
+				return err
+			},
+			verifyResult: func() {
+				isAdmin, err := keeper.IsWhitelistAdmin(ctx, nonAdminAddr)
+				s.Require().NoError(err)
+				s.Require().True(isAdmin)
+			},
+		},
+		{
+			name: "Remove whitelist admin - success",
+			execute: func() error {
+				msg := &types.RemoveFromWhitelistAdminRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+				_, err := msgServer.RemoveFromWhitelistAdmin(ctx, msg)
+				return err
+			},
+			verifyResult: func() {
+				isAdmin, err := keeper.IsWhitelistAdmin(ctx, targetAddr)
+				s.Require().NoError(err)
+				s.Require().False(isAdmin)
+			},
+		},
 	}
 
-	_, err = msgServer.AddToWhitelistAdmin(ctx, msg)
-	require.NoError(err, "Adding to whitelist admin should succeed")
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			err := tc.execute()
 
-	// Verify that newAdminAddr is now a whitelist admin
-	isWhitelistAdmin, err = s.emissionsKeeper.IsWhitelistAdmin(ctx, newAdminAddr)
-	require.NoError(err, "IsWhitelistAdmin should not return an error")
-	require.True(isWhitelistAdmin, "newAdminAddr should be a whitelist admin")
+			if tc.expectedError != nil {
+				s.Require().ErrorIs(err, tc.expectedError)
+			} else {
+				s.Require().NoError(err)
+				if tc.verifyResult != nil {
+					tc.verifyResult()
+				}
+			}
+		})
+	}
 }
 
-func (s *MsgServerTestSuite) TestAddWhitelistAdminInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
+func (s *MsgServerTestSuite) TestGlobalWhitelistOperations() {
+	ctx := s.Ctx()
+	msgServer := s.EmissionsMsgServer()
+	keeper := s.EmissionsKeeper()
 
-	nonAdminAddr := nonAdminAccounts[0]
-	targetAddr := s.addrsStr[1]
+	adminAddr := s.AddrsStr(0)
+	targetAddr := s.AddrsStr(1)
+	nonAdminAddr := nonAdminAccounts[0].String()
 
-	// Attempt to add targetAddr to whitelist by nonAdminAddr
-	msg := &types.AddToWhitelistAdminRequest{
-		Sender:  nonAdminAddr.String(),
-		Address: targetAddr,
+	testCases := []struct {
+		name          string
+		whitelistType string // "global", "worker", "reputer", "admin"
+		operation     string // "add" or "remove"
+		setupMsg      func() any
+		execute       func(any) error
+		verify        func(context.Context, string) (bool, error)
+		expectedError error
+	}{
+		// Global Whitelist
+		{
+			name:          "Add to global whitelist - success",
+			whitelistType: "global",
+			operation:     "add",
+			setupMsg: func() any {
+				return &types.AddToGlobalWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.AddToGlobalWhitelist(ctx, msg.(*types.AddToGlobalWhitelistRequest))
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalActor,
+		},
+		{
+			name:          "Add to global whitelist - unauthorized",
+			whitelistType: "global",
+			operation:     "add",
+			setupMsg: func() any {
+				return &types.AddToGlobalWhitelistRequest{
+					Sender:  nonAdminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.AddToGlobalWhitelist(ctx, msg.(*types.AddToGlobalWhitelistRequest))
+				return err
+			},
+			expectedError: types.ErrNotPermittedToUpdateGlobalWhitelist,
+		},
+		{
+			name:          "Remove from global whitelist - success",
+			whitelistType: "global",
+			operation:     "remove",
+			setupMsg: func() any {
+				// First add to whitelist
+				addMsg := &types.AddToGlobalWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+				_, err := msgServer.AddToGlobalWhitelist(ctx, addMsg)
+				s.Require().NoError(err)
+
+				return &types.RemoveFromGlobalWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.RemoveFromGlobalWhitelist(ctx, msg.(*types.RemoveFromGlobalWhitelistRequest))
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalActor,
+		},
+		{
+			name:          "Remove from global whitelist - unauthorized",
+			whitelistType: "global",
+			operation:     "remove",
+			setupMsg: func() any {
+				return &types.RemoveFromGlobalWhitelistRequest{
+					Sender:  nonAdminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.RemoveFromGlobalWhitelist(ctx, msg.(*types.RemoveFromGlobalWhitelistRequest))
+				return err
+			},
+			expectedError: types.ErrNotPermittedToUpdateGlobalWhitelist,
+		},
+
+		// Global Worker Whitelist
+		{
+			name:          "Add to global worker whitelist - success",
+			whitelistType: "worker",
+			operation:     "add",
+			setupMsg: func() any {
+				return &types.AddToGlobalWorkerWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.AddToGlobalWorkerWhitelist(ctx, msg.(*types.AddToGlobalWorkerWhitelistRequest))
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalWorker,
+		},
+		{
+			name:          "Add to global worker whitelist - unauthorized",
+			whitelistType: "worker",
+			operation:     "add",
+			setupMsg: func() any {
+				return &types.AddToGlobalWorkerWhitelistRequest{
+					Sender:  nonAdminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.AddToGlobalWorkerWhitelist(ctx, msg.(*types.AddToGlobalWorkerWhitelistRequest))
+				return err
+			},
+			expectedError: types.ErrNotPermittedToUpdateGlobalWhitelist,
+		},
+		{
+			name:          "Remove from global worker whitelist - success",
+			whitelistType: "worker",
+			operation:     "remove",
+			setupMsg: func() any {
+				// First add to whitelist
+				addMsg := &types.AddToGlobalWorkerWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+				_, err := msgServer.AddToGlobalWorkerWhitelist(ctx, addMsg)
+				s.Require().NoError(err)
+
+				return &types.RemoveFromGlobalWorkerWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.RemoveFromGlobalWorkerWhitelist(ctx, msg.(*types.RemoveFromGlobalWorkerWhitelistRequest))
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalWorker,
+		},
+
+		// Global Reputer Whitelist
+		{
+			name:          "Add to global reputer whitelist - success",
+			whitelistType: "reputer",
+			operation:     "add",
+			setupMsg: func() any {
+				return &types.AddToGlobalReputerWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.AddToGlobalReputerWhitelist(ctx, msg.(*types.AddToGlobalReputerWhitelistRequest))
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalReputer,
+		},
+		{
+			name:          "Remove from global reputer whitelist - success",
+			whitelistType: "reputer",
+			operation:     "remove",
+			setupMsg: func() any {
+				// First add to whitelist
+				addMsg := &types.AddToGlobalReputerWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+				_, err := msgServer.AddToGlobalReputerWhitelist(ctx, addMsg)
+				s.Require().NoError(err)
+
+				return &types.RemoveFromGlobalReputerWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.RemoveFromGlobalReputerWhitelist(ctx, msg.(*types.RemoveFromGlobalReputerWhitelistRequest))
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalReputer,
+		},
+
+		// Global Admin Whitelist
+		{
+			name:          "Add to global admin whitelist - success",
+			whitelistType: "admin",
+			operation:     "add",
+			setupMsg: func() any {
+				return &types.AddToGlobalAdminWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.AddToGlobalAdminWhitelist(ctx, msg.(*types.AddToGlobalAdminWhitelistRequest))
+				return err
+			},
+			verify: keeper.CanUpdateAllGlobalWhitelists,
+		},
+		{
+			name:          "Remove from global admin whitelist - success",
+			whitelistType: "admin",
+			operation:     "remove",
+			setupMsg: func() any {
+				// First add to whitelist
+				addMsg := &types.AddToGlobalAdminWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+				_, err := msgServer.AddToGlobalAdminWhitelist(ctx, addMsg)
+				s.Require().NoError(err)
+
+				return &types.RemoveFromGlobalAdminWhitelistRequest{
+					Sender:  adminAddr,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.RemoveFromGlobalAdminWhitelist(ctx, msg.(*types.RemoveFromGlobalAdminWhitelistRequest))
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalAdmin,
+		},
 	}
 
-	_, err := s.msgServer.AddToWhitelistAdmin(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateWhitelistAdmins, "Should fail due to unauthorized access")
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			msg := tc.setupMsg()
+			err := tc.execute(msg)
+
+			if tc.expectedError != nil {
+				s.Require().ErrorIs(err, tc.expectedError)
+			} else {
+				s.Require().NoError(err)
+				if tc.verify != nil {
+					isWhitelisted, err := tc.verify(ctx, targetAddr)
+					s.Require().NoError(err)
+					if tc.operation == "add" {
+						s.Require().True(isWhitelisted)
+					} else {
+						s.Require().False(isWhitelisted)
+					}
+				}
+			}
+		})
+	}
 }
 
-func (s *MsgServerTestSuite) TestRemoveWhitelistAdmin() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
+func (s *MsgServerTestSuite) TestBulkWhitelistOperations() {
+	ctx := s.Ctx()
+	msgServer := s.EmissionsMsgServer()
+	keeper := s.EmissionsKeeper()
+	adminAddr := s.AddrsStr(0)
 
-	adminAddr := s.addrsStr[0]
-	adminToRemove := s.addrsStr[1]
-
-	// Attempt to remove adminToRemove from the whitelist by adminAddr
-	removeMsg := &types.RemoveFromWhitelistAdminRequest{
-		Sender:  adminAddr,
-		Address: adminToRemove,
-	}
-	_, err := msgServer.RemoveFromWhitelistAdmin(ctx, removeMsg)
-	require.NoError(err, "Removing from whitelist admin should succeed")
-
-	// Verify that adminToRemove is no longer a whitelist admin
-	isWhitelistAdmin, err := s.emissionsKeeper.IsWhitelistAdmin(ctx, adminToRemove)
-	require.NoError(err, "IsWhitelistAdmin check should not return an error")
-	require.False(isWhitelistAdmin, "adminToRemove should not be a whitelist admin anymore")
-}
-
-func (s *MsgServerTestSuite) TestRemoveWhitelistAdminInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-
-	nonAdminAddr := nonAdminAccounts[0]
-
-	// Attempt to remove an admin from whitelist by nonAdminAddr
-	msg := &types.RemoveFromWhitelistAdminRequest{
-		Sender:  nonAdminAddr.String(),
-		Address: s.addrsStr[0],
-	}
-
-	_, err := s.msgServer.RemoveFromWhitelistAdmin(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateWhitelistAdmins, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestAddToGlobalWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-
-	adminAddr := s.addrsStr[0]
-	targetAddr := s.addrsStr[1]
-
-	// Add targetAddr to global whitelist by adminAddr
-	msg := &types.AddToGlobalWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err := msgServer.AddToGlobalWhitelist(ctx, msg)
-	require.NoError(err, "Adding to global whitelist should succeed")
-
-	// Verify targetAddr is now in global whitelist
-	isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalActor(ctx, targetAddr)
-	require.NoError(err, "IsWhitelistedGlobalActor check should not return an error")
-	require.True(isWhitelisted, "targetAddr should be in global whitelist")
-}
-
-func (s *MsgServerTestSuite) TestAddToGlobalWhitelistInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-
-	nonAdminAddr := nonAdminAccounts[0]
-	targetAddr := s.addrsStr[1]
-
-	// Attempt to add targetAddr to global whitelist by nonAdminAddr
-	msg := &types.AddToGlobalWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		Address: targetAddr,
-	}
-
-	_, err := s.msgServer.AddToGlobalWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateGlobalWhitelist, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestRemoveFromGlobalWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-
-	adminAddr := s.addrsStr[0]
-	targetAddr := s.addrsStr[1]
-
-	// First add targetAddr to global whitelist
-	addMsg := &types.AddToGlobalWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err := msgServer.AddToGlobalWhitelist(ctx, addMsg)
-	require.NoError(err, "Adding to global whitelist should succeed")
-
-	// Remove targetAddr from global whitelist
-	removeMsg := &types.RemoveFromGlobalWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err = msgServer.RemoveFromGlobalWhitelist(ctx, removeMsg)
-	require.NoError(err, "Removing from global whitelist should succeed")
-
-	// Verify targetAddr is no longer in global whitelist
-	isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalActor(ctx, targetAddr)
-	require.NoError(err, "IsWhitelistedGlobalActor check should not return an error")
-	require.False(isWhitelisted, "targetAddr should not be in global whitelist")
-}
-
-func (s *MsgServerTestSuite) TestRemoveFromGlobalWhitelistInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-
-	nonAdminAddr := nonAdminAccounts[0]
-	targetAddr := s.addrsStr[1]
-
-	// Attempt to remove targetAddr from global whitelist by nonAdminAddr
-	msg := &types.RemoveFromGlobalWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		Address: targetAddr,
-	}
-
-	_, err := s.msgServer.RemoveFromGlobalWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateGlobalWhitelist, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestAddToGlobalWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-
-	adminAddr := s.addrsStr[0]
-	targetAddr := s.addrsStr[1]
-
-	// Add targetAddr to global worker whitelist
-	msg := &types.AddToGlobalWorkerWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err := msgServer.AddToGlobalWorkerWhitelist(ctx, msg)
-	require.NoError(err, "Adding to global worker whitelist should succeed")
-
-	// Verify targetAddr is in global worker whitelist
-	isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalWorker(ctx, targetAddr)
-	require.NoError(err, "IsWhitelistedGlobalWorker check should not return an error")
-	require.True(isWhitelisted, "targetAddr should be in global worker whitelist")
-}
-
-func (s *MsgServerTestSuite) TestAddToGlobalWorkerWhitelistInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-
-	nonAdminAddr := nonAdminAccounts[0]
-	targetAddr := s.addrsStr[1]
-
-	// Attempt to add targetAddr to global worker whitelist by nonAdminAddr
-	msg := &types.AddToGlobalWorkerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		Address: targetAddr,
-	}
-
-	_, err := s.msgServer.AddToGlobalWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateGlobalWhitelist, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestRemoveFromGlobalWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-
-	adminAddr := s.addrsStr[0]
-	targetAddr := s.addrsStr[1]
-
-	// First add targetAddr to global worker whitelist
-	addMsg := &types.AddToGlobalWorkerWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err := msgServer.AddToGlobalWorkerWhitelist(ctx, addMsg)
-	require.NoError(err, "Adding to global worker whitelist should succeed")
-
-	// Remove targetAddr from global worker whitelist
-	removeMsg := &types.RemoveFromGlobalWorkerWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err = msgServer.RemoveFromGlobalWorkerWhitelist(ctx, removeMsg)
-	require.NoError(err, "Removing from global worker whitelist should succeed")
-
-	// Verify targetAddr is no longer in global worker whitelist
-	isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalWorker(ctx, targetAddr)
-	require.NoError(err, "IsWhitelistedGlobalWorker check should not return an error")
-	require.False(isWhitelisted, "targetAddr should not be in global worker whitelist")
-}
-
-func (s *MsgServerTestSuite) TestAddToGlobalReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-
-	adminAddr := s.addrsStr[0]
-	targetAddr := s.addrsStr[1]
-
-	// Add targetAddr to global reputer whitelist
-	msg := &types.AddToGlobalReputerWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err := msgServer.AddToGlobalReputerWhitelist(ctx, msg)
-	require.NoError(err, "Adding to global reputer whitelist should succeed")
-
-	// Verify targetAddr is in global reputer whitelist
-	isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalReputer(ctx, targetAddr)
-	require.NoError(err, "IsWhitelistedGlobalReputer check should not return an error")
-	require.True(isWhitelisted, "targetAddr should be in global reputer whitelist")
-}
-
-func (s *MsgServerTestSuite) TestRemoveFromGlobalReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-
-	adminAddr := s.addrsStr[0]
-	targetAddr := s.addrsStr[1]
-
-	// First add targetAddr to global reputer whitelist
-	addMsg := &types.AddToGlobalReputerWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err := msgServer.AddToGlobalReputerWhitelist(ctx, addMsg)
-	require.NoError(err, "Adding to global reputer whitelist should succeed")
-
-	// Remove targetAddr from global reputer whitelist
-	removeMsg := &types.RemoveFromGlobalReputerWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err = msgServer.RemoveFromGlobalReputerWhitelist(ctx, removeMsg)
-	require.NoError(err, "Removing from global reputer whitelist should succeed")
-
-	// Verify targetAddr is no longer in global reputer whitelist
-	isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalReputer(ctx, targetAddr)
-	require.NoError(err, "IsWhitelistedGlobalReputer check should not return an error")
-	require.False(isWhitelisted, "targetAddr should not be in global reputer whitelist")
-}
-
-func (s *MsgServerTestSuite) TestAddToGlobalAdminWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-
-	adminAddr := s.addrsStr[0]
-	targetAddr := s.addrsStr[1]
-
-	// Add targetAddr to global admin whitelist
-	msg := &types.AddToGlobalAdminWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err := msgServer.AddToGlobalAdminWhitelist(ctx, msg)
-	require.NoError(err, "Adding to global admin whitelist should succeed")
-
-	// Verify targetAddr is in global admin whitelist
-	canUpdate, err := s.emissionsKeeper.CanUpdateAllGlobalWhitelists(ctx, targetAddr)
-	require.NoError(err, "CanUpdateAllGlobalWhitelists check should not return an error")
-	require.True(canUpdate, "targetAddr should be in global admin whitelist")
-}
-
-func (s *MsgServerTestSuite) TestRemoveFromGlobalAdminWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-
-	adminAddr := s.addrsStr[0]
-	targetAddr := s.addrsStr[1]
-
-	// First add targetAddr to global admin whitelist
-	addMsg := &types.AddToGlobalAdminWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err := msgServer.AddToGlobalAdminWhitelist(ctx, addMsg)
-	require.NoError(err, "Adding to global admin whitelist should succeed")
-
-	// Verify targetAddr is in global admin whitelist before removal
-	isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalAdmin(ctx, targetAddr)
-	require.NoError(err, "IsWhitelistedGlobalAdmin check should not return an error")
-	require.True(isWhitelisted, "targetAddr should be in global admin whitelist before removal")
-
-	// Remove targetAddr from global admin whitelist
-	removeMsg := &types.RemoveFromGlobalAdminWhitelistRequest{
-		Sender:  adminAddr,
-		Address: targetAddr,
-	}
-	_, err = msgServer.RemoveFromGlobalAdminWhitelist(ctx, removeMsg)
-	require.NoError(err, "Removing from global admin whitelist should succeed")
-
-	// Verify targetAddr is no longer in global admin whitelist
-	isWhitelisted, err = s.emissionsKeeper.IsWhitelistedGlobalAdmin(ctx, targetAddr)
-	require.NoError(err, "IsWhitelistedGlobalAdmin check should not return an error")
-	require.False(isWhitelisted, "targetAddr should not be in global admin whitelist")
-}
-
-func (s *MsgServerTestSuite) TestBulkAddToGlobalWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-
-	// First add some addresses
 	addresses := []string{
 		nonAdminAccounts[0].String(),
 		nonAdminAccounts[1].String(),
 		nonAdminAccounts[2].String(),
 	}
 
-	// Add addresses to whitelist
-	msg := &types.BulkAddToGlobalWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-	}
-	_, err := msgServer.BulkAddToGlobalWorkerWhitelist(ctx, msg)
-	require.NoError(err, "Bulk adding to global worker whitelist should succeed")
-
-	// Verify all addresses were added
-	for _, addr := range addresses {
-		isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalWorker(ctx, addr)
-		require.NoError(err)
-		require.True(isWhitelisted, "Address should be whitelisted")
-	}
-
-	// Set max length parameter
-	params, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
+	// Set max array length for testing
+	params, err := keeper.GetParams(ctx)
+	s.Require().NoError(err)
 	params.MaxWhitelistInputArrayLength = 3
-	err = s.emissionsKeeper.SetParams(ctx, params)
-	require.NoError(err)
+	err = keeper.SetParams(ctx, params)
+	s.Require().NoError(err)
 
-	// Try adding more than max length
 	tooManyAddresses := make([]string, params.MaxWhitelistInputArrayLength+1)
 	for i := range tooManyAddresses {
 		tooManyAddresses[i] = nonAdminAccounts[i].String()
 	}
 
-	msg = &types.BulkAddToGlobalWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: tooManyAddresses,
+	testCases := []struct {
+		name          string
+		whitelistType string // "worker", "reputer"
+		isGlobal      bool
+		operation     string // "add" or "remove"
+		addresses     []string
+		topicId       uint64
+		execute       func() error
+		verify        func(context.Context, string) (bool, error)
+		expectedError error
+	}{
+		// Global Worker Bulk Operations
+		{
+			name:          "Bulk add to global worker whitelist - success",
+			whitelistType: "worker",
+			isGlobal:      true,
+			operation:     "add",
+			addresses:     addresses,
+			execute: func() error {
+				msg := &types.BulkAddToGlobalWorkerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+				}
+				_, err := msgServer.BulkAddToGlobalWorkerWhitelist(ctx, msg)
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalWorker,
+		},
+		{
+			name:          "Bulk add to global worker whitelist - too many addresses",
+			whitelistType: "worker",
+			isGlobal:      true,
+			operation:     "add",
+			addresses:     tooManyAddresses,
+			execute: func() error {
+				msg := &types.BulkAddToGlobalWorkerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: tooManyAddresses,
+				}
+				_, err := msgServer.BulkAddToGlobalWorkerWhitelist(ctx, msg)
+				return err
+			},
+			expectedError: types.ErrMaxWhitelistInputArrayLengthExceeded,
+		},
+		{
+			name:          "Bulk remove from global worker whitelist - success",
+			whitelistType: "worker",
+			isGlobal:      true,
+			operation:     "remove",
+			addresses:     addresses,
+			execute: func() error {
+				// First add addresses
+				addMsg := &types.BulkAddToGlobalWorkerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+				}
+				_, err = msgServer.BulkAddToGlobalWorkerWhitelist(ctx, addMsg)
+				s.Require().NoError(err)
+
+				// Then remove
+				msg := &types.BulkRemoveFromGlobalWorkerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+				}
+				_, err = msgServer.BulkRemoveFromGlobalWorkerWhitelist(ctx, msg)
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalWorker,
+		},
+
+		// Global Reputer Bulk Operations
+		{
+			name:          "Bulk add to global reputer whitelist - success",
+			whitelistType: "reputer",
+			isGlobal:      true,
+			operation:     "add",
+			addresses:     addresses,
+			execute: func() error {
+				msg := &types.BulkAddToGlobalReputerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+				}
+				_, err := msgServer.BulkAddToGlobalReputerWhitelist(ctx, msg)
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalReputer,
+		},
+		{
+			name:          "Bulk remove from global reputer whitelist - success",
+			whitelistType: "reputer",
+			isGlobal:      true,
+			operation:     "remove",
+			addresses:     addresses,
+			execute: func() error {
+				// First add addresses
+				addMsg := &types.BulkAddToGlobalReputerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+				}
+				_, err = msgServer.BulkAddToGlobalReputerWhitelist(ctx, addMsg)
+				s.Require().NoError(err)
+
+				// Then remove
+				msg := &types.BulkRemoveFromGlobalReputerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+				}
+				_, err = msgServer.BulkRemoveFromGlobalReputerWhitelist(ctx, msg)
+				return err
+			},
+			verify: keeper.IsWhitelistedGlobalReputer,
+		},
 	}
-	_, err = msgServer.BulkAddToGlobalWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrMaxWhitelistInputArrayLengthExceeded)
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			err := tc.execute()
+
+			if tc.expectedError != nil {
+				s.Require().ErrorIs(err, tc.expectedError)
+			} else {
+				s.Require().NoError(err)
+				if tc.verify != nil {
+					for _, addr := range tc.addresses {
+						isWhitelisted, err := tc.verify(ctx, addr)
+						s.Require().NoError(err)
+						if tc.operation == "add" {
+							s.Require().True(isWhitelisted)
+						} else {
+							s.Require().False(isWhitelisted)
+						}
+					}
+				}
+			}
+		})
+	}
 }
 
-func (s *MsgServerTestSuite) TestBulkRemoveFromGlobalWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
+func (s *MsgServerTestSuite) TestTopicWhitelistOperations() {
+	ctx := s.Ctx()
+	msgServer := s.EmissionsMsgServer()
+	keeper := s.EmissionsKeeper()
 
-	// First add some addresses
+	adminAddr := s.AddrsStr(0)
+	targetAddr := s.AddrsStr(1)
+	nonAdminAddr := nonAdminAccounts[0].String()
+	topicId := s.CreateTopic()
+	nonExistentTopicId := uint64(1000)
+
+	testCases := []struct {
+		name          string
+		whitelistType string // "worker" or "reputer"
+		operation     string // "enable", "disable", "add", "remove"
+		topicId       uint64
+		setupMsg      func() any
+		execute       func(any) error
+		verify        func() (bool, error)
+		expectedError error
+	}{
+		// Topic Worker Whitelist Operations
+		{
+			name:          "Enable topic worker whitelist - success",
+			whitelistType: "worker",
+			operation:     "enable",
+			topicId:       topicId,
+			setupMsg: func() any {
+				return &types.EnableTopicWorkerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.EnableTopicWorkerWhitelist(ctx, msg.(*types.EnableTopicWorkerWhitelistRequest))
+				return err
+			},
+			verify: func() (bool, error) {
+				return keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
+			},
+		},
+		{
+			name:          "Enable topic worker whitelist - unauthorized",
+			whitelistType: "worker",
+			operation:     "enable",
+			topicId:       topicId,
+			setupMsg: func() any {
+				return &types.EnableTopicWorkerWhitelistRequest{
+					Sender:  nonAdminAddr,
+					TopicId: topicId,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.EnableTopicWorkerWhitelist(ctx, msg.(*types.EnableTopicWorkerWhitelistRequest))
+				return err
+			},
+			expectedError: types.ErrNotPermittedToUpdateTopicWhitelist,
+		},
+		{
+			name:          "Enable topic worker whitelist - topic does not exist",
+			whitelistType: "worker",
+			operation:     "enable",
+			topicId:       nonExistentTopicId,
+			setupMsg: func() any {
+				return &types.EnableTopicWorkerWhitelistRequest{
+					Sender:  nonAdminAddr,
+					TopicId: nonExistentTopicId,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.EnableTopicWorkerWhitelist(ctx, msg.(*types.EnableTopicWorkerWhitelistRequest))
+				return err
+			},
+			expectedError: types.ErrTopicDoesNotExist,
+		},
+		{
+			name:          "Disable topic worker whitelist - success",
+			whitelistType: "worker",
+			operation:     "disable",
+			topicId:       topicId,
+			setupMsg: func() any {
+				// First enable
+				enableMsg := &types.EnableTopicWorkerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+				}
+				_, err := msgServer.EnableTopicWorkerWhitelist(ctx, enableMsg)
+				s.Require().NoError(err)
+
+				return &types.DisableTopicWorkerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.DisableTopicWorkerWhitelist(ctx, msg.(*types.DisableTopicWorkerWhitelistRequest))
+				return err
+			},
+			verify: func() (bool, error) {
+				return keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
+			},
+		},
+		{
+			name:          "Add to topic worker whitelist - success",
+			whitelistType: "worker",
+			operation:     "add",
+			topicId:       topicId,
+			setupMsg: func() any {
+				return &types.AddToTopicWorkerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.AddToTopicWorkerWhitelist(ctx, msg.(*types.AddToTopicWorkerWhitelistRequest))
+				return err
+			},
+		},
+		{
+			name:          "Add to topic worker whitelist - unauthorized",
+			whitelistType: "worker",
+			operation:     "add",
+			topicId:       topicId,
+			setupMsg: func() any {
+				return &types.AddToTopicWorkerWhitelistRequest{
+					Sender:  nonAdminAddr,
+					TopicId: topicId,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.AddToTopicWorkerWhitelist(ctx, msg.(*types.AddToTopicWorkerWhitelistRequest))
+				return err
+			},
+			expectedError: types.ErrNotPermittedToUpdateTopicWorkerWhitelist,
+		},
+		{
+			name:          "Remove from topic worker whitelist - success",
+			whitelistType: "worker",
+			operation:     "remove",
+			topicId:       topicId,
+			setupMsg: func() any {
+				return &types.RemoveFromTopicWorkerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.RemoveFromTopicWorkerWhitelist(ctx, msg.(*types.RemoveFromTopicWorkerWhitelistRequest))
+				return err
+			},
+		},
+
+		// Topic Reputer Whitelist Operations (similar pattern)
+		{
+			name:          "Enable topic reputer whitelist - success",
+			whitelistType: "reputer",
+			operation:     "enable",
+			topicId:       topicId,
+			setupMsg: func() any {
+				return &types.EnableTopicReputerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.EnableTopicReputerWhitelist(ctx, msg.(*types.EnableTopicReputerWhitelistRequest))
+				return err
+			},
+			verify: func() (bool, error) {
+				return keeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
+			},
+		},
+		{
+			name:          "Disable topic reputer whitelist - success",
+			whitelistType: "reputer",
+			operation:     "disable",
+			topicId:       topicId,
+			setupMsg: func() any {
+				// First enable
+				enableMsg := &types.EnableTopicReputerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+				}
+				_, err := msgServer.EnableTopicReputerWhitelist(ctx, enableMsg)
+				s.Require().NoError(err)
+
+				return &types.DisableTopicReputerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.DisableTopicReputerWhitelist(ctx, msg.(*types.DisableTopicReputerWhitelistRequest))
+				return err
+			},
+			verify: func() (bool, error) {
+				return keeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
+			},
+		},
+		{
+			name:          "Add to topic reputer whitelist - success",
+			whitelistType: "reputer",
+			operation:     "add",
+			topicId:       topicId,
+			setupMsg: func() any {
+				return &types.AddToTopicReputerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.AddToTopicReputerWhitelist(ctx, msg.(*types.AddToTopicReputerWhitelistRequest))
+				return err
+			},
+		},
+		{
+			name:          "Remove from topic reputer whitelist - success",
+			whitelistType: "reputer",
+			operation:     "remove",
+			topicId:       topicId,
+			setupMsg: func() any {
+				return &types.RemoveFromTopicReputerWhitelistRequest{
+					Sender:  adminAddr,
+					TopicId: topicId,
+					Address: targetAddr,
+				}
+			},
+			execute: func(msg any) error {
+				_, err := msgServer.RemoveFromTopicReputerWhitelist(ctx, msg.(*types.RemoveFromTopicReputerWhitelistRequest))
+				return err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			msg := tc.setupMsg()
+			err := tc.execute(msg)
+
+			if tc.expectedError != nil {
+				s.Require().ErrorIs(err, tc.expectedError)
+			} else {
+				s.Require().NoError(err)
+				if tc.verify != nil {
+					result, err := tc.verify()
+					s.Require().NoError(err)
+					if tc.operation == "enable" {
+						s.Require().True(result)
+					} else if tc.operation == "disable" {
+						s.Require().False(result)
+					}
+				}
+			}
+		})
+	}
+}
+
+func (s *MsgServerTestSuite) TestBulkTopicWhitelistOperations() {
+	ctx := s.Ctx()
+	msgServer := s.EmissionsMsgServer()
+	keeper := s.EmissionsKeeper()
+	adminAddr := s.AddrsStr(0)
+	topicId := s.CreateTopic()
+
 	addresses := []string{
 		nonAdminAccounts[0].String(),
 		nonAdminAccounts[1].String(),
 		nonAdminAccounts[2].String(),
 	}
 
-	addMsg := &types.BulkAddToGlobalWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-	}
-	_, err := msgServer.BulkAddToGlobalWorkerWhitelist(ctx, addMsg)
-	require.NoError(err)
-
-	// Remove addresses
-	removeMsg := &types.BulkRemoveFromGlobalWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-	}
-	_, err = msgServer.BulkRemoveFromGlobalWorkerWhitelist(ctx, removeMsg)
-	require.NoError(err, "Bulk removing from global worker whitelist should succeed")
-
-	// Verify addresses were removed
-	for _, addr := range addresses {
-		isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalWorker(ctx, addr)
-		require.NoError(err)
-		require.False(isWhitelisted, "Address should not be whitelisted")
-	}
-
-	// Set max length parameter
-	params, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
+	// Set max array length for testing
+	params, err := keeper.GetParams(ctx)
+	s.Require().NoError(err)
 	params.MaxWhitelistInputArrayLength = 3
-	err = s.emissionsKeeper.SetParams(ctx, params)
-	require.NoError(err)
+	err = keeper.SetParams(ctx, params)
+	s.Require().NoError(err)
 
-	// Try adding more than max length
 	tooManyAddresses := make([]string, params.MaxWhitelistInputArrayLength+1)
 	for i := range tooManyAddresses {
 		tooManyAddresses[i] = nonAdminAccounts[i].String()
 	}
 
-	msg := &types.BulkAddToGlobalWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: tooManyAddresses,
-	}
-	_, err = msgServer.BulkAddToGlobalWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrMaxWhitelistInputArrayLengthExceeded)
-}
+	testCases := []struct {
+		name          string
+		whitelistType string // "worker" or "reputer"
+		operation     string // "add" or "remove"
+		addresses     []string
+		execute       func() error
+		verify        func(string) (bool, error)
+		expectedError error
+	}{
+		// Topic Worker Bulk Operations
+		{
+			name:          "Bulk add to topic worker whitelist - success",
+			whitelistType: "worker",
+			operation:     "add",
+			addresses:     addresses,
+			execute: func() error {
+				msg := &types.BulkAddToTopicWorkerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+					TopicId:   topicId,
+				}
+				_, err = msgServer.BulkAddToTopicWorkerWhitelist(ctx, msg)
+				return err
+			},
+			verify: func(addr string) (bool, error) {
+				return keeper.IsWhitelistedTopicWorker(ctx, topicId, addr)
+			},
+		},
+		{
+			name:          "Bulk add to topic worker whitelist - too many addresses",
+			whitelistType: "worker",
+			operation:     "add",
+			addresses:     tooManyAddresses,
+			execute: func() error {
+				msg := &types.BulkAddToTopicWorkerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: tooManyAddresses,
+					TopicId:   topicId,
+				}
+				_, err = msgServer.BulkAddToTopicWorkerWhitelist(ctx, msg)
+				return err
+			},
+			expectedError: types.ErrMaxWhitelistInputArrayLengthExceeded,
+		},
+		{
+			name:          "Bulk remove from topic worker whitelist - success",
+			whitelistType: "worker",
+			operation:     "remove",
+			addresses:     addresses,
+			execute: func() error {
+				// First add addresses
+				addMsg := &types.BulkAddToTopicWorkerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+					TopicId:   topicId,
+				}
+				_, err = msgServer.BulkAddToTopicWorkerWhitelist(ctx, addMsg)
+				s.Require().NoError(err)
 
-func (s *MsgServerTestSuite) TestBulkAddToGlobalReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
+				// Then remove
+				msg := &types.BulkRemoveFromTopicWorkerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+					TopicId:   topicId,
+				}
+				_, err = msgServer.BulkRemoveFromTopicWorkerWhitelist(ctx, msg)
+				return err
+			},
+			verify: func(addr string) (bool, error) {
+				return keeper.IsWhitelistedTopicWorker(ctx, topicId, addr)
+			},
+		},
+		{
+			name:          "Bulk remove from topic worker whitelist - too many addresses",
+			whitelistType: "worker",
+			operation:     "remove",
+			addresses:     tooManyAddresses,
+			execute: func() error {
+				msg := &types.BulkRemoveFromTopicWorkerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: tooManyAddresses,
+					TopicId:   topicId,
+				}
+				_, err = msgServer.BulkRemoveFromTopicWorkerWhitelist(ctx, msg)
+				return err
+			},
+			expectedError: types.ErrMaxWhitelistInputArrayLengthExceeded,
+		},
 
-	// First add some addresses
-	addresses := []string{
-		nonAdminAccounts[0].String(),
-		nonAdminAccounts[1].String(),
-		nonAdminAccounts[2].String(),
-	}
+		// Topic Reputer Bulk Operations
+		{
+			name:          "Bulk add to topic reputer whitelist - success",
+			whitelistType: "reputer",
+			operation:     "add",
+			addresses:     addresses,
+			execute: func() error {
+				msg := &types.BulkAddToTopicReputerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+					TopicId:   topicId,
+				}
+				_, err := msgServer.BulkAddToTopicReputerWhitelist(ctx, msg)
+				return err
+			},
+			verify: func(addr string) (bool, error) {
+				return keeper.IsWhitelistedTopicReputer(ctx, topicId, addr)
+			},
+		},
+		{
+			name:          "Bulk add to topic reputer whitelist - too many addresses",
+			whitelistType: "reputer",
+			operation:     "add",
+			addresses:     tooManyAddresses,
+			execute: func() error {
+				msg := &types.BulkAddToTopicReputerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: tooManyAddresses,
+					TopicId:   topicId,
+				}
+				_, err = msgServer.BulkAddToTopicReputerWhitelist(ctx, msg)
+				return err
+			},
+			expectedError: types.ErrMaxWhitelistInputArrayLengthExceeded,
+		},
+		{
+			name:          "Bulk remove from topic reputer whitelist - success",
+			whitelistType: "reputer",
+			operation:     "remove",
+			addresses:     addresses,
+			execute: func() error {
+				// First add addresses
+				addMsg := &types.BulkAddToTopicReputerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+					TopicId:   topicId,
+				}
+				_, err = msgServer.BulkAddToTopicReputerWhitelist(ctx, addMsg)
+				s.Require().NoError(err)
 
-	// Add addresses to whitelist
-	msg := &types.BulkAddToGlobalReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-	}
-	_, err := msgServer.BulkAddToGlobalReputerWhitelist(ctx, msg)
-	require.NoError(err, "Bulk adding to global reputer whitelist should succeed")
-
-	// Verify all addresses were added
-	for _, addr := range addresses {
-		isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalReputer(ctx, addr)
-		require.NoError(err)
-		require.True(isWhitelisted, "Address should be whitelisted")
-	}
-
-	// Set max length parameter
-	params, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	params.MaxWhitelistInputArrayLength = 3
-	err = s.emissionsKeeper.SetParams(ctx, params)
-	require.NoError(err)
-
-	// Try adding more than max length
-	tooManyAddresses := make([]string, params.MaxWhitelistInputArrayLength+1)
-	for i := range tooManyAddresses {
-		tooManyAddresses[i] = nonAdminAccounts[i].String()
-	}
-
-	msg = &types.BulkAddToGlobalReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: tooManyAddresses,
-	}
-	_, err = msgServer.BulkAddToGlobalReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrMaxWhitelistInputArrayLengthExceeded)
-}
-
-func (s *MsgServerTestSuite) TestBulkRemoveFromGlobalReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-
-	// First add some addresses
-	addresses := []string{
-		nonAdminAccounts[0].String(),
-		nonAdminAccounts[1].String(),
-		nonAdminAccounts[2].String(),
-	}
-
-	addMsg := &types.BulkAddToGlobalReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-	}
-	_, err := msgServer.BulkAddToGlobalReputerWhitelist(ctx, addMsg)
-	require.NoError(err)
-
-	// Remove addresses
-	removeMsg := &types.BulkRemoveFromGlobalReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-	}
-	_, err = msgServer.BulkRemoveFromGlobalReputerWhitelist(ctx, removeMsg)
-	require.NoError(err, "Bulk removing from global reputer whitelist should succeed")
-
-	// Verify addresses were removed
-	for _, addr := range addresses {
-		isWhitelisted, err := s.emissionsKeeper.IsWhitelistedGlobalReputer(ctx, addr)
-		require.NoError(err)
-		require.False(isWhitelisted, "Address should not be whitelisted")
-	}
-
-	// Set max length parameter
-	params, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	params.MaxWhitelistInputArrayLength = 3
-	err = s.emissionsKeeper.SetParams(ctx, params)
-	require.NoError(err)
-
-	// Try adding more than max length
-	tooManyAddresses := make([]string, params.MaxWhitelistInputArrayLength+1)
-	for i := range tooManyAddresses {
-		tooManyAddresses[i] = nonAdminAccounts[i].String()
-	}
-
-	msg := &types.BulkAddToGlobalReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: tooManyAddresses,
-	}
-	_, err = msgServer.BulkAddToGlobalReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrMaxWhitelistInputArrayLengthExceeded)
-}
-
-func (s *MsgServerTestSuite) TestBulkAddToTopicWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-
-	// First add some addresses
-	addresses := []string{
-		nonAdminAccounts[0].String(),
-		nonAdminAccounts[1].String(),
-		nonAdminAccounts[2].String(),
-	}
-
-	addMsg := &types.BulkAddToTopicWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-		TopicId:   topicId,
-	}
-	_, err := msgServer.BulkAddToTopicWorkerWhitelist(ctx, addMsg)
-	require.NoError(err)
-
-	// Verify addresses were added
-	for _, addr := range addresses {
-		isWhitelisted, err := s.emissionsKeeper.IsWhitelistedTopicWorker(ctx, topicId, addr)
-		require.NoError(err)
-		require.True(isWhitelisted, "Address should be whitelisted")
-	}
-
-	// Set max length parameter
-	params, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	params.MaxWhitelistInputArrayLength = 3
-	err = s.emissionsKeeper.SetParams(ctx, params)
-	require.NoError(err)
-
-	// Try adding more than max length
-	tooManyAddresses := make([]string, params.MaxWhitelistInputArrayLength+1)
-	for i := range tooManyAddresses {
-		tooManyAddresses[i] = nonAdminAccounts[i].String()
-	}
-
-	msg := &types.BulkAddToTopicWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: tooManyAddresses,
-		TopicId:   topicId,
-	}
-	_, err = msgServer.BulkAddToTopicWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrMaxWhitelistInputArrayLengthExceeded)
-}
-
-func (s *MsgServerTestSuite) TestBulkRemoveFromTopicWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-
-	// First add some addresses
-	addresses := []string{
-		nonAdminAccounts[0].String(),
-		nonAdminAccounts[1].String(),
-		nonAdminAccounts[2].String(),
+				// Then remove
+				msg := &types.BulkRemoveFromTopicReputerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: addresses,
+					TopicId:   topicId,
+				}
+				_, err = msgServer.BulkRemoveFromTopicReputerWhitelist(ctx, msg)
+				return err
+			},
+			verify: func(addr string) (bool, error) {
+				return keeper.IsWhitelistedTopicReputer(ctx, topicId, addr)
+			},
+		},
+		{
+			name:          "Bulk remove from topic reputer whitelist - too many addresses",
+			whitelistType: "reputer",
+			operation:     "remove",
+			addresses:     tooManyAddresses,
+			execute: func() error {
+				msg := &types.BulkRemoveFromTopicReputerWhitelistRequest{
+					Sender:    adminAddr,
+					Addresses: tooManyAddresses,
+					TopicId:   topicId,
+				}
+				_, err = msgServer.BulkRemoveFromTopicReputerWhitelist(ctx, msg)
+				return err
+			},
+			expectedError: types.ErrMaxWhitelistInputArrayLengthExceeded,
+		},
 	}
 
-	addMsg := &types.BulkAddToTopicWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-		TopicId:   topicId,
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			err := tc.execute()
+
+			if tc.expectedError != nil {
+				s.Require().ErrorIs(err, tc.expectedError)
+			} else {
+				s.Require().NoError(err)
+				if tc.verify != nil {
+					for _, addr := range tc.addresses {
+						isWhitelisted, err := tc.verify(addr)
+						s.Require().NoError(err)
+						if tc.operation == "add" {
+							s.Require().True(isWhitelisted)
+						} else {
+							s.Require().False(isWhitelisted)
+						}
+					}
+				}
+			}
+		})
 	}
-	_, err := msgServer.BulkAddToTopicWorkerWhitelist(ctx, addMsg)
-	require.NoError(err)
-
-	// Remove addresses
-	removeMsg := &types.BulkRemoveFromTopicWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-		TopicId:   topicId,
-	}
-	_, err = msgServer.BulkRemoveFromTopicWorkerWhitelist(ctx, removeMsg)
-	require.NoError(err, "Bulk removing from topic worker whitelist should succeed")
-
-	// Verify addresses were removed
-	for _, addr := range addresses {
-		isWhitelisted, err := s.emissionsKeeper.IsWhitelistedTopicWorker(ctx, topicId, addr)
-		require.NoError(err)
-		require.False(isWhitelisted, "Address should not be whitelisted")
-	}
-
-	// Set max length parameter
-	params, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	params.MaxWhitelistInputArrayLength = 3
-	err = s.emissionsKeeper.SetParams(ctx, params)
-	require.NoError(err)
-
-	// Try adding more than max length
-	tooManyAddresses := make([]string, params.MaxWhitelistInputArrayLength+1)
-	for i := range tooManyAddresses {
-		tooManyAddresses[i] = nonAdminAccounts[i].String()
-	}
-
-	msg := &types.BulkRemoveFromTopicWorkerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: tooManyAddresses,
-		TopicId:   topicId,
-	}
-	_, err = msgServer.BulkRemoveFromTopicWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrMaxWhitelistInputArrayLengthExceeded)
-}
-
-func (s *MsgServerTestSuite) TestBulkAddToTopicReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-
-	// First add some addresses
-	addresses := []string{
-		nonAdminAccounts[0].String(),
-		nonAdminAccounts[1].String(),
-		nonAdminAccounts[2].String(),
-	}
-
-	addMsg := &types.BulkAddToTopicReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-		TopicId:   topicId,
-	}
-	_, err := msgServer.BulkAddToTopicReputerWhitelist(ctx, addMsg)
-	require.NoError(err)
-
-	// Verify addresses were added
-	for _, addr := range addresses {
-		isWhitelisted, err := s.emissionsKeeper.IsWhitelistedTopicReputer(ctx, topicId, addr)
-		require.NoError(err)
-		require.True(isWhitelisted, "Address should be whitelisted")
-	}
-
-	// Set max length parameter
-	params, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	params.MaxWhitelistInputArrayLength = 3
-	err = s.emissionsKeeper.SetParams(ctx, params)
-	require.NoError(err)
-
-	// Try adding more than max length
-	tooManyAddresses := make([]string, params.MaxWhitelistInputArrayLength+1)
-	for i := range tooManyAddresses {
-		tooManyAddresses[i] = nonAdminAccounts[i].String()
-	}
-
-	msg := &types.BulkAddToTopicReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: tooManyAddresses,
-		TopicId:   topicId,
-	}
-	_, err = msgServer.BulkAddToTopicReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrMaxWhitelistInputArrayLengthExceeded)
-}
-
-func (s *MsgServerTestSuite) TestBulkRemoveFromTopicReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-
-	// First add some addresses
-	addresses := []string{
-		nonAdminAccounts[0].String(),
-		nonAdminAccounts[1].String(),
-		nonAdminAccounts[2].String(),
-	}
-
-	addMsg := &types.BulkAddToTopicReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-		TopicId:   topicId,
-	}
-	_, err := msgServer.BulkAddToTopicReputerWhitelist(ctx, addMsg)
-	require.NoError(err)
-
-	// Remove addresses
-	removeMsg := &types.BulkRemoveFromTopicReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: addresses,
-		TopicId:   topicId,
-	}
-	_, err = msgServer.BulkRemoveFromTopicReputerWhitelist(ctx, removeMsg)
-	require.NoError(err, "Bulk removing from topic reputer whitelist should succeed")
-
-	// Verify addresses were removed
-	for _, addr := range addresses {
-		isWhitelisted, err := s.emissionsKeeper.IsWhitelistedTopicReputer(ctx, topicId, addr)
-		require.NoError(err)
-		require.False(isWhitelisted, "Address should not be whitelisted")
-	}
-
-	// Set max length parameter
-	params, err := s.emissionsKeeper.GetParams(ctx)
-	require.NoError(err)
-	params.MaxWhitelistInputArrayLength = 3
-	err = s.emissionsKeeper.SetParams(ctx, params)
-	require.NoError(err)
-
-	// Try adding more than max length
-	tooManyAddresses := make([]string, params.MaxWhitelistInputArrayLength+1)
-	for i := range tooManyAddresses {
-		tooManyAddresses[i] = nonAdminAccounts[i].String()
-	}
-
-	msg := &types.BulkRemoveFromTopicReputerWhitelistRequest{
-		Sender:    adminAddr,
-		Addresses: tooManyAddresses,
-		TopicId:   topicId,
-	}
-	_, err = msgServer.BulkRemoveFromTopicReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrMaxWhitelistInputArrayLengthExceeded)
-}
-
-func (s *MsgServerTestSuite) TestEnableTopicWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-
-	// Enable whitelist for topic
-	msg := &types.EnableTopicWorkerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-	}
-	_, err := msgServer.EnableTopicWorkerWhitelist(ctx, msg)
-	require.NoError(err, "Enabling topic whitelist should succeed")
-
-	// Verify topic whitelist is enabled
-	isEnabled, err := s.emissionsKeeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
-	require.NoError(err, "IsTopicWorkerWhitelistEnabled check should not return an error")
-	require.True(isEnabled, "Topic worker whitelist should be enabled")
-}
-
-func (s *MsgServerTestSuite) TestEnableTopicWorkerWhitelistInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := s.CreateOneTopic().Id
-
-	// Attempt to enable whitelist for topic by nonAdminAddr
-	msg := &types.EnableTopicWorkerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-	}
-
-	_, err := s.msgServer.EnableTopicWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateTopicWhitelist, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestEnableTopicWorkerWhitelistTopicDoesNotExist() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := uint64(1000)
-
-	// Attempt to enable whitelist for topic by nonAdminAddr
-	msg := &types.EnableTopicWorkerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-	}
-
-	_, err := s.msgServer.EnableTopicWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrTopicDoesNotExist, "Should fail due to topic not existing")
-}
-
-func (s *MsgServerTestSuite) TestEnableTopicReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-
-	// Enable whitelist for topic
-	msg := &types.EnableTopicReputerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-	}
-	_, err := msgServer.EnableTopicReputerWhitelist(ctx, msg)
-	require.NoError(err, "Enabling topic whitelist should succeed")
-
-	// Verify topic whitelist is enabled
-	isEnabled, err := s.emissionsKeeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
-	require.NoError(err, "IsTopicReputerWhitelistEnabled check should not return an error")
-	require.True(isEnabled, "Topic reputer whitelist should be enabled")
-}
-
-func (s *MsgServerTestSuite) TestEnableTopicReputerWhitelistInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := s.CreateOneTopic().Id
-
-	// Attempt to enable whitelist for topic by nonAdminAddr
-	msg := &types.EnableTopicReputerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-	}
-
-	_, err := s.msgServer.EnableTopicReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateTopicWhitelist, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestEnableTopicReputerWhitelistTopicDoesNotExist() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := uint64(1000)
-
-	// Attempt to enable whitelist for topic by nonAdminAddr
-	msg := &types.EnableTopicReputerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-	}
-
-	_, err := s.msgServer.EnableTopicReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrTopicDoesNotExist, "Should fail due to topic not existing")
-}
-
-func (s *MsgServerTestSuite) TestDisableTopicWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-
-	// First enable whitelist for topic
-	enableMsg := &types.EnableTopicWorkerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-	}
-	_, err := msgServer.EnableTopicWorkerWhitelist(ctx, enableMsg)
-	require.NoError(err, "Enabling topic whitelist should succeed")
-
-	// Disable whitelist for topic
-	disableMsg := &types.DisableTopicWorkerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-	}
-	_, err = msgServer.DisableTopicWorkerWhitelist(ctx, disableMsg)
-	require.NoError(err, "Disabling topic whitelist should succeed")
-
-	// Verify topic whitelist is disabled
-	isEnabled, err := s.emissionsKeeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
-	require.NoError(err, "IsTopicWorkerWhitelistEnabled check should not return an error")
-	require.False(isEnabled, "Topic whitelist should be disabled")
-}
-
-func (s *MsgServerTestSuite) TestDisableTopicWorkerWhitelistInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := s.CreateOneTopic().Id
-
-	// Attempt to disable whitelist for topic by nonAdminAddr
-	msg := &types.DisableTopicWorkerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-	}
-
-	_, err := s.msgServer.DisableTopicWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateTopicWhitelist, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestDisableTopicWorkerWhitelistTopicDoesNotExist() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := uint64(1000)
-
-	// Attempt to disable whitelist for topic by nonAdminAddr
-	msg := &types.DisableTopicWorkerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-	}
-
-	_, err := s.msgServer.DisableTopicWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrTopicDoesNotExist, "Should fail due to topic not existing")
-}
-
-func (s *MsgServerTestSuite) TestDisableTopicReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	msgServer := s.msgServer
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-
-	// First enable whitelist for topic
-	enableMsg := &types.EnableTopicReputerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-	}
-	_, err := msgServer.EnableTopicReputerWhitelist(ctx, enableMsg)
-	require.NoError(err, "Enabling topic whitelist should succeed")
-
-	// Disable whitelist for topic
-	disableMsg := &types.DisableTopicReputerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-	}
-	_, err = msgServer.DisableTopicReputerWhitelist(ctx, disableMsg)
-	require.NoError(err, "Disabling topic whitelist should succeed")
-
-	// Verify topic whitelist is disabled
-	isEnabled, err := s.emissionsKeeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
-	require.NoError(err, "IsTopicReputerWhitelistEnabled check should not return an error")
-	require.False(isEnabled, "Topic reputer whitelist should be disabled")
-}
-
-func (s *MsgServerTestSuite) TestDisableTopicReputerWhitelistInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := s.CreateOneTopic().Id
-
-	// Attempt to disable whitelist for topic by nonAdminAddr
-	msg := &types.DisableTopicReputerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-	}
-
-	_, err := s.msgServer.DisableTopicReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateTopicWhitelist, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestDisableTopicReputerWhitelistTopicDoesNotExist() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := uint64(1000)
-
-	// Attempt to disable whitelist for topic by nonAdminAddr
-	msg := &types.DisableTopicReputerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-	}
-
-	_, err := s.msgServer.DisableTopicReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrTopicDoesNotExist, "Should fail due to topic not existing")
-}
-
-func (s *MsgServerTestSuite) TestAddToTopicWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.AddToTopicWorkerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-	_, err := s.msgServer.AddToTopicWorkerWhitelist(ctx, msg)
-	require.NoError(err, "Adding to topic worker whitelist should succeed")
-}
-
-func (s *MsgServerTestSuite) TestAddToTopicWorkerWhitelistInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := s.CreateOneTopic().Id
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.AddToTopicWorkerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-
-	_, err := s.msgServer.AddToTopicWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateTopicWorkerWhitelist, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestAddToTopicWorkerWhitelistTopicDoesNotExist() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := uint64(1000)
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.AddToTopicWorkerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-
-	_, err := s.msgServer.AddToTopicWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrTopicDoesNotExist, "Should fail due to topic not existing")
-}
-
-func (s *MsgServerTestSuite) TestRemoveFromTopicWorkerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.RemoveFromTopicWorkerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-	_, err := s.msgServer.RemoveFromTopicWorkerWhitelist(ctx, msg)
-	require.NoError(err, "Removing from topic worker whitelist should succeed")
-}
-
-func (s *MsgServerTestSuite) TestRemoveFromTopicWorkerWhitelistTopicDoesNotExist() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := uint64(1000)
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.RemoveFromTopicWorkerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-
-	_, err := s.msgServer.RemoveFromTopicWorkerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrTopicDoesNotExist, "Should fail due to topic not existing")
-}
-
-func (s *MsgServerTestSuite) TestAddToTopicReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.AddToTopicReputerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-	_, err := s.msgServer.AddToTopicReputerWhitelist(ctx, msg)
-	require.NoError(err, "Adding to topic reputer whitelist should succeed")
-}
-
-func (s *MsgServerTestSuite) TestAddToTopicReputerWhitelistInvalidUnauthorized() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := s.CreateOneTopic().Id
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.AddToTopicReputerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-
-	_, err := s.msgServer.AddToTopicReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrNotPermittedToUpdateTopicReputerWhitelist, "Should fail due to unauthorized access")
-}
-
-func (s *MsgServerTestSuite) TestAddToTopicReputerWhitelistTopicDoesNotExist() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := uint64(1000)
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.AddToTopicReputerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-
-	_, err := s.msgServer.AddToTopicReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrTopicDoesNotExist, "Should fail due to topic not existing")
-}
-
-func (s *MsgServerTestSuite) TestRemoveFromTopicReputerWhitelist() {
-	ctx := s.ctx
-	require := s.Require()
-	adminAddr := s.addrsStr[0]
-	topicId := s.CreateOneTopic().Id
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.RemoveFromTopicReputerWhitelistRequest{
-		Sender:  adminAddr,
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-	_, err := s.msgServer.RemoveFromTopicReputerWhitelist(ctx, msg)
-	require.NoError(err, "Removing from topic reputer whitelist should succeed")
-}
-
-func (s *MsgServerTestSuite) TestRemoveFromTopicReputerWhitelistTopicDoesNotExist() {
-	ctx := s.ctx
-	require := s.Require()
-	nonAdminAddr := nonAdminAccounts[0]
-	topicId := uint64(1000)
-	targetAddr := s.addrsStr[1]
-
-	msg := &types.RemoveFromTopicReputerWhitelistRequest{
-		Sender:  nonAdminAddr.String(),
-		TopicId: topicId,
-		Address: targetAddr,
-	}
-
-	_, err := s.msgServer.RemoveFromTopicReputerWhitelist(ctx, msg)
-	require.ErrorIs(err, types.ErrTopicDoesNotExist, "Should fail due to topic not existing")
 }

--- a/x/emissions/keeper/msgserver/msg_server_whitelist_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_whitelist_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
+//nolint:exhaustruct
 func (s *MsgServerTestSuite) TestWhitelistAdminOperations() {
 	ctx := s.Ctx()
 	msgServer := s.EmissionsMsgServer()
@@ -96,6 +97,7 @@ func (s *MsgServerTestSuite) TestWhitelistAdminOperations() {
 	}
 }
 
+//nolint:exhaustruct
 func (s *MsgServerTestSuite) TestGlobalWhitelistOperations() {
 	ctx := s.Ctx()
 	msgServer := s.EmissionsMsgServer()
@@ -354,6 +356,7 @@ func (s *MsgServerTestSuite) TestGlobalWhitelistOperations() {
 	}
 }
 
+//nolint:exhaustruct
 func (s *MsgServerTestSuite) TestBulkWhitelistOperations() {
 	ctx := s.Ctx()
 	msgServer := s.EmissionsMsgServer()
@@ -384,7 +387,6 @@ func (s *MsgServerTestSuite) TestBulkWhitelistOperations() {
 		isGlobal      bool
 		operation     string // "add" or "remove"
 		addresses     []string
-		topicId       uint64
 		execute       func() error
 		verify        func(context.Context, string) (bool, error)
 		expectedError error
@@ -516,6 +518,7 @@ func (s *MsgServerTestSuite) TestBulkWhitelistOperations() {
 	}
 }
 
+//nolint:exhaustruct
 func (s *MsgServerTestSuite) TestTopicWhitelistOperations() {
 	ctx := s.Ctx()
 	msgServer := s.EmissionsMsgServer()
@@ -777,6 +780,7 @@ func (s *MsgServerTestSuite) TestTopicWhitelistOperations() {
 	}
 }
 
+//nolint:exhaustruct
 func (s *MsgServerTestSuite) TestBulkTopicWhitelistOperations() {
 	ctx := s.Ctx()
 	msgServer := s.EmissionsMsgServer()

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
@@ -3,39 +3,38 @@ package msgserver_test
 import (
 	"encoding/hex"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/x/emissions/types"
+	cosmosMath "cosmossdk.io/math"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
 
-func getNewAddress() (sdk.AccAddress, string) {
-	addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
-	return addr, addr.String()
-}
+	"github.com/allora-network/allora-chain/app/params"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+)
 
 func (s *MsgServerTestSuite) setUpMsgInsertWorkerPayload(
 	workerPrivateKey secp256k1.PrivKey,
 ) (types.InsertWorkerPayloadRequest, uint64) {
 	return s.setUpMsgInsertWorkerPayloadWithBlockHeight(workerPrivateKey, 1)
 }
+
 func (s *MsgServerTestSuite) setUpMsgInsertWorkerPayloadWithBlockHeight(
 	workerPrivateKey secp256k1.PrivKey,
 	blockHeight int64,
 ) (types.InsertWorkerPayloadRequest, uint64) {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	nonce := types.Nonce{BlockHeight: blockHeight}
-	topic := s.CreateOneTopic()
+	topic := uint64(1)
 
 	// Mock setup for addresses
-	reputerAddr, reputer := getNewAddress()
 	workerAddr := sdk.AccAddress(workerPrivateKey.PubKey().Address())
 	worker := workerAddr.String()
-	_, Inferer2 := getNewAddress()
-	_, Inferer3 := getNewAddress()
-	_, Inferer4 := getNewAddress()
+
+	reputerIndexes := testutil.ReturnIndexes(0, 1)
+	workerIndexes := testutil.ReturnIndexes(1, 3)
 
 	// Define sample OffchainNode information for a worker
 	workerInfo := types.OffchainNode{
@@ -43,40 +42,39 @@ func (s *MsgServerTestSuite) setUpMsgInsertWorkerPayloadWithBlockHeight(
 		NodeAddress: worker,
 	}
 
-	moduleParams, err := keeper.GetParams(ctx)
+	// Create topic 0 and register reputer in it
+	s.FullTopicSetup(workerIndexes, reputerIndexes)
+	workerInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(11000)))
+	err := s.BankKeeper().SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, workerAddr, workerInitialBalanceCoins)
+	s.Require().NoError(err, "Sending coins should not return an error")
+
+	err = keeper.AddWorkerNonce(ctx, topic, &nonce)
+	s.Require().NoError(err)
+	err = keeper.InsertWorker(ctx, topic, worker, workerInfo)
 	s.Require().NoError(err)
 
-	// Create topic 0 and register reputer in it
-	s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, moduleParams.RegistrationFee)
-	err = keeper.AddWorkerNonce(ctx, topic.Id, &nonce)
-	s.Require().NoError(err)
-	err = keeper.InsertWorker(ctx, topic.Id, worker, workerInfo)
-	s.Require().NoError(err)
-	err = keeper.InsertWorker(ctx, topic.Id, Inferer2, workerInfo)
-	s.Require().NoError(err)
-	err = keeper.InsertWorker(ctx, topic.Id, Inferer3, workerInfo)
-	s.Require().NoError(err)
-	err = keeper.InsertWorker(ctx, topic.Id, Inferer4, workerInfo)
-	s.Require().NoError(err)
+	for _, idx := range workerIndexes {
+		err = keeper.InsertWorker(ctx, topic, s.AddrsStr(idx), workerInfo)
+		s.Require().NoError(err)
+	}
 
 	// Create a InsertWorkerPayloadRequest message
+	//nolint:exhaustruct
 	workerMsg := types.InsertWorkerPayloadRequest{
 		Sender: worker,
 		WorkerDataBundle: &types.InputWorkerDataBundle{
 			Worker:  worker,
 			Nonce:   &nonce,
-			TopicId: topic.Id,
+			TopicId: topic,
 			InferenceForecastsBundle: &types.InputInferenceForecastBundle{
 				Inference: &types.InputInference{
-					TopicId:     topic.Id,
+					TopicId:     topic,
 					BlockHeight: nonce.BlockHeight,
 					Inferer:     worker,
 					Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-					ExtraData:   nil,
-					Proof:       "",
 				},
 				Forecast: &types.InputForecast{
-					TopicId:     topic.Id,
+					TopicId:     topic,
 					BlockHeight: nonce.BlockHeight,
 					Forecaster:  worker,
 					ForecastElements: []*types.InputForecastElement{
@@ -85,27 +83,25 @@ func (s *MsgServerTestSuite) setUpMsgInsertWorkerPayloadWithBlockHeight(
 							Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
 						},
 						{
-							Inferer: Inferer2,
+							Inferer: s.AddrsStr(workerIndexes[0]),
 							Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(101)),
 						},
 						{
-							Inferer: Inferer3,
+							Inferer: s.AddrsStr(workerIndexes[1]),
 							Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(102)),
 						},
 						{
-							Inferer: Inferer4,
+							Inferer: s.AddrsStr(workerIndexes[2]),
 							Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(103)),
 						},
 					},
-					ExtraData: nil,
 				},
 			},
 			InferencesForecastsBundleSignature: []byte{},
-			Pubkey:                             "",
 		},
 	}
 
-	return workerMsg, topic.Id
+	return workerMsg, topic
 }
 func (s *MsgServerTestSuite) signMsgInsertWorkerPayload(workerMsg types.InsertWorkerPayloadRequest, workerPrivateKey secp256k1.PrivKey) types.InsertWorkerPayloadRequest {
 	require := s.Require()
@@ -125,94 +121,84 @@ func (s *MsgServerTestSuite) signMsgInsertWorkerPayload(workerMsg types.InsertWo
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayload() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, topicId := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
-
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
-
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
 
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, topicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), topicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.NoError(err, "InsertWorkerPayload should not return an error")
 
-	inference, err := s.emissionsKeeper.GetWorkerLatestInferenceByTopicId(ctx, topicId, workerMsg.WorkerDataBundle.Worker)
+	inference, err := s.EmissionsKeeper().GetWorkerLatestInferenceByTopicId(s.Ctx(), topicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 	require.NotNil(inference)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadNotFailsWithNilInference() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, topicId := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
 
 	workerMsg.WorkerDataBundle.InferenceForecastsBundle.Inference = nil
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
-	_, err := msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err := s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.ErrorIs(err, types.ErrNotPermittedToSubmitWorkerPayload)
 
 	// Add worker to topic whitelist
-	err = s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err = s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err, "InsertWorkerPayload should not return an error after adding worker to whitelist")
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.NoError(err)
 
-	forecasts, err := s.emissionsKeeper.GetWorkerLatestForecastByTopicId(ctx, topicId, workerMsg.WorkerDataBundle.Worker)
+	forecasts, err := s.EmissionsKeeper().GetWorkerLatestForecastByTopicId(s.Ctx(), topicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 	require.Equal(len(forecasts.ForecastElements), 4)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadNotFailsWithNilForecast() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, topicId := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
 
 	workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast = nil
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Inference.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
 	// Add worker to topic whitelist
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.NoError(err)
 
-	inferences, err := s.emissionsKeeper.GetWorkerLatestInferenceByTopicId(ctx, topicId, workerMsg.WorkerDataBundle.Worker)
+	inferences, err := s.EmissionsKeeper().GetWorkerLatestInferenceByTopicId(s.Ctx(), topicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 	require.NotNil(inferences)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithNilInferenceAndForecast() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, _ := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 	// BEGIN MODIFICATION
 	workerMsg.WorkerDataBundle.InferenceForecastsBundle.Inference = nil
 	workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast = nil
@@ -220,19 +206,18 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithNilInferenceAndF
 	// END MODIFICATION
 
 	// Add worker to topic whitelist
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.ErrorIs(err, sdkerrors.ErrInvalidRequest)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithoutSignature() {
-	ctx, msgServer := s.ctx, s.msgServer
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, _ := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
 
 	// BEGIN MODIFICATION
@@ -240,7 +225,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithoutSignature() {
 	// END MODIFICATION
 
 	// Add worker to topic whitelist
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
@@ -248,18 +233,16 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithoutSignature() {
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithMismatchedTopicId() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
+
 	topicId := uint64(123)
-
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, _ := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
 
 	// Add worker to topic whitelist
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, topicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), topicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
-	err = s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err = s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	// BEGIN MODIFICATION
@@ -267,19 +250,17 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithMismatchedTopicI
 	// END MODIFICATION
 
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Inference.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.ErrorIs(err, sdkerrors.ErrInvalidRequest)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithUnregisteredInferer() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, topicId := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
 
 	// BEGIN MODIFICATION
@@ -291,87 +272,33 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithUnregisteredInfe
 		IsReputer: false,
 	}
 
-	_, err := msgServer.RemoveRegistration(ctx, unregisterMsg)
+	_, err := s.EmissionsMsgServer().RemoveRegistration(s.Ctx(), unregisterMsg)
 	require.NoError(err)
 	// END MODIFICATION
 
 	// Add worker to topic whitelist
-	err = s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err = s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Inference.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.ErrorIs(err, types.ErrAddressNotRegistered)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadWithFewTopElementsPerForecast() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
 	adminPrivateKey := secp256k1.GenPrivKey()
 	adminAddr := sdk.AccAddress(adminPrivateKey.PubKey().Address())
-	_ = s.emissionsKeeper.AddWhitelistAdmin(s.ctx, adminAddr.String())
+	_ = s.EmissionsKeeper().AddWhitelistAdmin(s.Ctx(), adminAddr.String())
 
-	newParams := &types.OptionalParams{
+	newParams := &types.OptionalParams{ //nolint:exhaustruct
 		MaxElementsPerForecast: []uint64{3},
-		// not updated
-		Version:                             nil,
-		MaxSerializedMsgLength:              nil,
-		MinTopicWeight:                      nil,
-		RequiredMinimumStake:                nil,
-		RemoveStakeDelayWindow:              nil,
-		MinEpochLength:                      nil,
-		BetaEntropy:                         nil,
-		LearningRate:                        nil,
-		MaxGradientThreshold:                nil,
-		MinStakeFraction:                    nil,
-		MaxUnfulfilledWorkerRequests:        nil,
-		MaxUnfulfilledReputerRequests:       nil,
-		TopicRewardStakeImportance:          nil,
-		TopicRewardFeeRevenueImportance:     nil,
-		TopicRewardAlpha:                    nil,
-		TaskRewardAlpha:                     nil,
-		ValidatorsVsAlloraPercentReward:     nil,
-		MaxSamplesToScaleScores:             nil,
-		MaxTopInferersToReward:              nil,
-		MaxTopForecastersToReward:           nil,
-		MaxTopReputersToReward:              nil,
-		CreateTopicFee:                      nil,
-		GradientDescentMaxIters:             nil,
-		RegistrationFee:                     nil,
-		DefaultPageLimit:                    nil,
-		MaxPageLimit:                        nil,
-		MinEpochLengthRecordLimit:           nil,
-		BlocksPerMonth:                      nil,
-		PRewardInference:                    nil,
-		PRewardForecast:                     nil,
-		PRewardReputer:                      nil,
-		CRewardInference:                    nil,
-		CRewardForecast:                     nil,
-		CNorm:                               nil,
-		EpsilonReputer:                      nil,
-		HalfMaxProcessStakeRemovalsEndBlock: nil,
-		DataSendingFee:                      nil,
-		EpsilonSafeDiv:                      nil,
-		MaxActiveTopicsPerBlock:             nil,
-		MaxStringLength:                     nil,
-		InitialRegretQuantile:               nil,
-		PNormSafeDiv:                        nil,
-		GlobalWhitelistEnabled:              nil,
-		TopicCreatorWhitelistEnabled:        nil,
-		MinExperiencedWorkerRegrets:         nil,
-		InferenceOutlierDetectionThreshold:  nil,
-		InferenceOutlierDetectionAlpha:      nil,
-		LambdaInitialScore:                  nil,
-		GlobalWorkerWhitelistEnabled:        nil,
-		GlobalReputerWhitelistEnabled:       nil,
-		GlobalAdminWhitelistAppended:        nil,
-		MaxWhitelistInputArrayLength:        nil,
-		MinWeightThresholdForStdnorm:        nil,
+		// rest not updated
 	}
 
 	updateMsg := &types.UpdateParamsRequest{
@@ -379,7 +306,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadWithFewTopElementsPerFore
 		Params: newParams,
 	}
 
-	_, err := s.msgServer.UpdateParams(s.ctx, updateMsg)
+	_, err := s.EmissionsMsgServer().UpdateParams(s.Ctx(), updateMsg)
 	require.NoError(err, "UpdateParams should not return an error")
 
 	blockHeight := int64(1)
@@ -396,25 +323,23 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadWithFewTopElementsPerFore
 	score3 := types.Score{TopicId: topicId, BlockHeight: blockHeight, Address: inferer3, Score: alloraMath.NewDecFromInt64(80)}
 	score4 := types.Score{TopicId: topicId, BlockHeight: blockHeight, Address: inferer4, Score: alloraMath.NewDecFromInt64(99)}
 
-	_ = s.emissionsKeeper.SetInfererScoreEma(ctx, topicId, inferer1, score1)
-	_ = s.emissionsKeeper.SetInfererScoreEma(ctx, topicId, inferer2, score2)
-	_ = s.emissionsKeeper.SetInfererScoreEma(ctx, topicId, inferer3, score3)
-	_ = s.emissionsKeeper.SetInfererScoreEma(ctx, topicId, inferer4, score4)
+	_ = s.EmissionsKeeper().SetInfererScoreEma(s.Ctx(), topicId, inferer1, score1)
+	_ = s.EmissionsKeeper().SetInfererScoreEma(s.Ctx(), topicId, inferer2, score2)
+	_ = s.EmissionsKeeper().SetInfererScoreEma(s.Ctx(), topicId, inferer3, score3)
+	_ = s.EmissionsKeeper().SetInfererScoreEma(s.Ctx(), topicId, inferer4, score4)
 
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
-
-	param, _ := s.emissionsKeeper.GetParams(ctx)
-
-	ctx = ctx.WithBlockHeight(workerBlockHeight)
+	param, _ := s.EmissionsKeeper().GetParams(s.Ctx())
+	s.WithBlockHeight(workerBlockHeight)
 
 	// Add worker to topic whitelist
-	err = s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err = s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.NoError(err, "InsertWorkerPayload should not return an error")
 
-	forecasts, err := s.emissionsKeeper.GetWorkerLatestForecastByTopicId(ctx, topicId, workerMsg.WorkerDataBundle.Worker)
+	forecasts, err := s.EmissionsKeeper().GetWorkerLatestForecastByTopicId(s.Ctx(), topicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	require.Equal(uint64(len(forecasts.ForecastElements)), param.MaxElementsPerForecast)
@@ -424,9 +349,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadWithFewTopElementsPerFore
 }
 
 func (s *MsgServerTestSuite) getCountForecastsAtBlock(topicId uint64, blockHeight int64) int {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	forecastsAtBlock, err := keeper.GetForecastsAtBlock(ctx, topicId, blockHeight)
+	forecastsAtBlock, err := s.EmissionsKeeper().GetForecastsAtBlock(s.Ctx(), topicId, blockHeight)
 	if err != nil {
 		return 0
 	}
@@ -434,11 +357,9 @@ func (s *MsgServerTestSuite) getCountForecastsAtBlock(topicId uint64, blockHeigh
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithMismatchedForecastTopicId() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, _ := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
 
 	// BEGIN MODIFICATION
@@ -448,20 +369,18 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithMismatchedForeca
 	// END MODIFICATION
 
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
-
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
-
 	forecastsCount0 := s.getCountForecastsAtBlock(originalTopicId, blockHeight)
 	require.Equal(forecastsCount0, 0)
 
 	// Enable topic whitelists
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, originalTopicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), originalTopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
-	err = s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, newTopicId, workerMsg.WorkerDataBundle.Worker)
+	err = s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), newTopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
-	ctx = ctx.WithBlockHeight(blockHeight)
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	s.WithBlockHeight(blockHeight)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.ErrorIs(err, sdkerrors.ErrInvalidRequest)
 
 	forecastsCount1 := s.getCountForecastsAtBlock(originalTopicId, blockHeight)
@@ -473,11 +392,9 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithMismatchedForeca
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithUnregisteredForecaster() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, topicId := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
 
 	// BEGIN MODIFICATION
@@ -489,7 +406,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithUnregisteredFore
 		IsReputer: false,
 	}
 
-	_, err := msgServer.RemoveRegistration(ctx, unregisterMsg)
+	_, err := s.EmissionsMsgServer().RemoveRegistration(s.Ctx(), unregisterMsg)
 	require.NoError(err)
 
 	// END MODIFICATION
@@ -497,7 +414,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithUnregisteredFore
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
 
 	// Add worker to topic whitelist
-	err = s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err = s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	forecastsCount0 := s.getCountForecastsAtBlock(topicId, blockHeight)
@@ -505,8 +422,8 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithUnregisteredFore
 
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 
-	ctx = ctx.WithBlockHeight(blockHeight)
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	s.WithBlockHeight(blockHeight)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.ErrorIs(err, types.ErrAddressNotRegistered)
 
 	forecastsCount1 := s.getCountForecastsAtBlock(topicId, blockHeight)
@@ -514,7 +431,6 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFailsWithUnregisteredFore
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFiltersDuplicateForecastElements() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
@@ -531,17 +447,17 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFiltersDuplicateForecastE
 	// END MODIFICATION
 
 	// Add worker to topic whitelist
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 
 	blockHeight := forecast.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	s.WithBlockHeight(blockHeight)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.NoError(err, "InsertWorkerPayload should not return an error")
 
-	storedForecasts, err := s.emissionsKeeper.GetWorkerLatestForecastByTopicId(ctx, topicId, workerMsg.WorkerDataBundle.Worker)
+	storedForecasts, err := s.EmissionsKeeper().GetWorkerLatestForecastByTopicId(s.Ctx(), topicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err, "GetForecastsAtBlock should not return an error")
 	require.NotZero(len(storedForecasts.ForecastElements), "ForecastElements should not be empty")
 
@@ -554,79 +470,53 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadFiltersDuplicateForecastE
 }
 
 func (s *MsgServerTestSuite) TestInsertingHugeBundleWorkerPayloadFails() {
-	ctx, msgServer := s.ctx, s.msgServer
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+
 	nonce := types.Nonce{BlockHeight: 1}
-
+	topicId := uint64(1)
 	// Mock setup for addresses
-	reputer := s.addrsStr[0]
-	reputerAddr := s.addrs[0]
-	worker := s.addrsStr[1]
-	workerPrivateKey := s.privKeys[1]
-	workerPubKeyBytes := s.pubKeyHexStr[1]
-	workerAddr := s.addrs[1]
-	InfererAddr := s.addrsStr[1]
-	ForecasterAddr := s.addrsStr[1]
-
-	// Define sample OffchainNode information for a worker
-	workerInfo := types.OffchainNode{
-		Owner:       worker,
-		NodeAddress: worker,
-	}
-
-	moduleParams, err := keeper.GetParams(ctx)
-	require.NoError(err)
-
-	// Create topic 0 and register reputer in it
-	topicId := s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, moduleParams.RegistrationFee)
-	err = keeper.AddWorkerNonce(ctx, topicId, &nonce)
-	require.NoError(err)
-	err = keeper.InsertWorker(ctx, topicId, InfererAddr, workerInfo)
-	require.NoError(err)
-	err = keeper.InsertWorker(ctx, topicId, ForecasterAddr, workerInfo)
-	require.NoError(err)
-	s.CreateOneTopic()
+	workerIndexes := testutil.ReturnIndexes(1, 1)
+	worker := s.AddrsStr(workerIndexes[0])
+	workerPrivateKey := s.PrivKeys(workerIndexes[0])
+	workerPubKeyBytes := s.PubKeyHexStr(workerIndexes[0])
 
 	forecastElements := []*types.InputForecastElement{}
 	for i := 0; i < 1000000; i++ {
 		forecastElements = append(forecastElements, &types.InputForecastElement{
-			Inferer: InfererAddr,
+			Inferer: worker,
 			Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
 		})
 	}
 
 	// Create a InsertWorkerPayloadRequest message
+	//nolint:exhaustruct
 	workerMsg := &types.InsertWorkerPayloadRequest{
 		Sender: worker,
 		WorkerDataBundle: &types.InputWorkerDataBundle{
 			TopicId: topicId,
-			Worker:  InfererAddr,
+			Worker:  worker,
 			Nonce:   &nonce,
 			InferenceForecastsBundle: &types.InputInferenceForecastBundle{
 				Inference: &types.InputInference{
 					TopicId:     topicId,
 					BlockHeight: nonce.BlockHeight,
-					Inferer:     InfererAddr,
+					Inferer:     worker,
 					Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-					ExtraData:   nil,
-					Proof:       "",
 				},
 				Forecast: &types.InputForecast{
 					TopicId:          topicId,
 					BlockHeight:      nonce.BlockHeight,
-					Forecaster:       ForecasterAddr,
+					Forecaster:       worker,
 					ForecastElements: forecastElements,
-					ExtraData:        nil,
 				},
 			},
-			InferencesForecastsBundleSignature: []byte(""),
-			Pubkey:                             "",
+			InferencesForecastsBundleSignature: []byte{},
 		},
 	}
 
 	src := make([]byte, 0)
-	src, err = workerMsg.WorkerDataBundle.InferenceForecastsBundle.XXX_Marshal(src, true)
+	src, err := workerMsg.WorkerDataBundle.InferenceForecastsBundle.XXX_Marshal(src, true)
 	require.NoError(err, "Marshall reputer value bundle should not return an error")
 
 	sig, err := workerPrivateKey.Sign(src)
@@ -638,148 +528,68 @@ func (s *MsgServerTestSuite) TestInsertingHugeBundleWorkerPayloadFails() {
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadVerifyFailed() {
-	ctx, msgServer := s.ctx, s.msgServer
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
 	require := s.Require()
-	keeper := s.emissionsKeeper
 	topicId := uint64(1)
 	nonce := types.Nonce{BlockHeight: 1}
 
 	// Mock setup for addresses
-	reputer := s.addrsStr[0]
-	reputerAddr := s.addrs[0]
-	worker := s.addrsStr[1]
-	workerAddr := s.addrs[1]
-	Inferer := s.addrsStr[2]
-	Forecaster := s.addrsStr[3]
-	Inferer2 := s.addrsStr[4]
-
-	// Define sample OffchainNode information for a worker
-	workerInfo := types.OffchainNode{
-		Owner:       worker,
-		NodeAddress: worker,
-	}
-
-	moduleParams, err := keeper.GetParams(ctx)
-	require.NoError(err)
-
-	// Create topic 0 and register reputer in it
-	s.commonStakingSetup(ctx, reputer, reputerAddr, worker, workerAddr, moduleParams.RegistrationFee)
-	err = keeper.AddWorkerNonce(ctx, topicId, &nonce)
-	require.NoError(err)
-	err = keeper.InsertWorker(ctx, topicId, Inferer, workerInfo)
-	require.NoError(err)
-	err = keeper.InsertWorker(ctx, topicId, Forecaster, workerInfo)
-	require.NoError(err)
-	s.CreateOneTopic()
+	worker := s.AddrsStr(1)
+	inferer := s.AddrsStr(2)
+	forecaster := s.AddrsStr(3)
+	inferer2 := s.AddrsStr(4)
 
 	// Create a InsertWorkerPayloadRequest message
+	//nolint:exhaustruct
 	workerMsg := &types.InsertWorkerPayloadRequest{
 		Sender: worker,
 		WorkerDataBundle: &types.InputWorkerDataBundle{
-			Worker:  Inferer,
+			Worker:  inferer,
 			TopicId: topicId,
 			Nonce:   &nonce,
 			InferenceForecastsBundle: &types.InputInferenceForecastBundle{
 				Inference: &types.InputInference{
 					TopicId:     topicId,
 					BlockHeight: nonce.BlockHeight,
-					Inferer:     Inferer,
+					Inferer:     inferer,
 					Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
-					ExtraData:   nil,
-					Proof:       "",
 				},
 				Forecast: &types.InputForecast{
 					TopicId:     topicId,
 					BlockHeight: nonce.BlockHeight,
-					Forecaster:  Forecaster,
+					Forecaster:  forecaster,
 					ForecastElements: []*types.InputForecastElement{
 						{
-							Inferer: Inferer,
+							Inferer: inferer,
 							Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
 						},
 						{
-							Inferer: Inferer2,
+							Inferer: inferer2,
 							Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(100)),
 						},
 					},
-					ExtraData: nil,
 				},
 			},
-			InferencesForecastsBundleSignature: []byte(""),
-			Pubkey:                             "",
+			InferencesForecastsBundleSignature: []byte{},
 		},
 	}
 
-	_, err = msgServer.InsertWorkerPayload(ctx, workerMsg)
+	_, err := msgServer.InsertWorkerPayload(ctx, workerMsg)
 	require.ErrorIs(err, sdkerrors.ErrInvalidRequest)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadWithLowScoreForecastsAreRejected() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
 	adminPrivateKey := secp256k1.GenPrivKey()
 	adminAddr := sdk.AccAddress(adminPrivateKey.PubKey().Address())
-	_ = keeper.AddWhitelistAdmin(s.ctx, adminAddr.String())
+	_ = keeper.AddWhitelistAdmin(s.Ctx(), adminAddr.String())
 
-	newParams := &types.OptionalParams{
+	newParams := &types.OptionalParams{ //nolint:exhaustruct
 		MaxElementsPerForecast: []uint64{3},
-		// not updated
-		Version:                             nil,
-		MaxSerializedMsgLength:              nil,
-		MinTopicWeight:                      nil,
-		RequiredMinimumStake:                nil,
-		RemoveStakeDelayWindow:              nil,
-		MinEpochLength:                      nil,
-		BetaEntropy:                         nil,
-		LearningRate:                        nil,
-		MaxGradientThreshold:                nil,
-		MinStakeFraction:                    nil,
-		MaxUnfulfilledWorkerRequests:        nil,
-		MaxUnfulfilledReputerRequests:       nil,
-		TopicRewardStakeImportance:          nil,
-		TopicRewardFeeRevenueImportance:     nil,
-		TopicRewardAlpha:                    nil,
-		TaskRewardAlpha:                     nil,
-		ValidatorsVsAlloraPercentReward:     nil,
-		MaxSamplesToScaleScores:             nil,
-		MaxTopInferersToReward:              nil,
-		MaxTopForecastersToReward:           nil,
-		MaxTopReputersToReward:              nil,
-		CreateTopicFee:                      nil,
-		GradientDescentMaxIters:             nil,
-		RegistrationFee:                     nil,
-		DefaultPageLimit:                    nil,
-		MaxPageLimit:                        nil,
-		MinEpochLengthRecordLimit:           nil,
-		BlocksPerMonth:                      nil,
-		PRewardInference:                    nil,
-		PRewardForecast:                     nil,
-		PRewardReputer:                      nil,
-		CRewardInference:                    nil,
-		CRewardForecast:                     nil,
-		CNorm:                               nil,
-		EpsilonReputer:                      nil,
-		HalfMaxProcessStakeRemovalsEndBlock: nil,
-		DataSendingFee:                      nil,
-		EpsilonSafeDiv:                      nil,
-		MaxActiveTopicsPerBlock:             nil,
-		MaxStringLength:                     nil,
-		InitialRegretQuantile:               nil,
-		PNormSafeDiv:                        nil,
-		GlobalWhitelistEnabled:              nil,
-		TopicCreatorWhitelistEnabled:        nil,
-		MinExperiencedWorkerRegrets:         nil,
-		InferenceOutlierDetectionThreshold:  nil,
-		InferenceOutlierDetectionAlpha:      nil,
-		LambdaInitialScore:                  nil,
-		GlobalWorkerWhitelistEnabled:        nil,
-		GlobalReputerWhitelistEnabled:       nil,
-		GlobalAdminWhitelistAppended:        nil,
-		MaxWhitelistInputArrayLength:        nil,
-		MinWeightThresholdForStdnorm:        nil,
+		// rest not updated
 	}
 
 	updateMsg := &types.UpdateParamsRequest{
@@ -787,7 +597,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadWithLowScoreForecastsAreR
 		Params: newParams,
 	}
 
-	_, err := s.msgServer.UpdateParams(s.ctx, updateMsg)
+	_, err := s.EmissionsMsgServer().UpdateParams(s.Ctx(), updateMsg)
 	require.NoError(err, "UpdateParams should not return an error")
 
 	blockHeight := int64(1)
@@ -795,115 +605,111 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadWithLowScoreForecastsAreR
 	workerMsg, topicId := s.setUpMsgInsertWorkerPayloadWithBlockHeight(workerPrivateKey, inferenceBlockHeight)
 
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
-	ctx = ctx.WithBlockHeight(blockHeight)
-	inferer1 := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.ForecastElements[0].Inferer
-	inferer2 := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.ForecastElements[1].Inferer
-	inferer3 := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.ForecastElements[2].Inferer
-	inferer4 := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.ForecastElements[3].Inferer
+	s.WithBlockHeight(blockHeight)
 
-	score1 := types.Score{TopicId: topicId, BlockHeight: blockHeight, Address: inferer1, Score: alloraMath.NewDecFromInt64(95)}
-	score2 := types.Score{TopicId: topicId, BlockHeight: blockHeight, Address: inferer2, Score: alloraMath.NewDecFromInt64(90)}
-	score3 := types.Score{TopicId: topicId, BlockHeight: blockHeight, Address: inferer3, Score: alloraMath.NewDecFromInt64(80)}
-	score4 := types.Score{TopicId: topicId, BlockHeight: blockHeight, Address: inferer4, Score: alloraMath.NewDecFromInt64(50)}
+	inferers := make([]string, 4)
+	scores := make([]types.Score, 4)
+	scoreValues := []int64{95, 90, 80, 50}
 
-	_ = keeper.SetInfererScoreEma(ctx, topicId, inferer1, score1)
-	_ = keeper.SetInfererScoreEma(ctx, topicId, inferer2, score2)
-	_ = keeper.SetInfererScoreEma(ctx, topicId, inferer3, score3)
-	_ = keeper.SetInfererScoreEma(ctx, topicId, inferer4, score4)
+	for i := range inferers {
+		inferers[i] = workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.ForecastElements[i].Inferer
+		scores[i] = types.Score{
+			TopicId:     topicId,
+			BlockHeight: blockHeight,
+			Address:     inferers[i],
+			Score:       alloraMath.NewDecFromInt64(scoreValues[i]),
+		}
+		_ = keeper.SetInfererScoreEma(s.Ctx(), topicId, inferers[i], scores[i])
+	}
 
 	blockHeight = blockHeight + workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
 	// Add worker to topic whitelist
-	err = s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err = s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.NoError(err, "InsertWorkerPayload should not return an error even if the forecast elements are below the threshold")
 
-	forecastsAtBlock, err := keeper.GetWorkerLatestForecastByTopicId(ctx, topicId, workerMsg.WorkerDataBundle.Worker)
+	forecastsAtBlock, err := keeper.GetWorkerLatestForecastByTopicId(s.Ctx(), topicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 	require.Equal(len(forecastsAtBlock.ForecastElements), 3)
-	require.Equal(forecastsAtBlock.ForecastElements[0].Inferer, inferer1)
-	require.Equal(forecastsAtBlock.ForecastElements[1].Inferer, inferer2)
-	require.Equal(forecastsAtBlock.ForecastElements[2].Inferer, inferer3)
+
+	for i, forecastElement := range forecastsAtBlock.ForecastElements {
+		require.Equal(forecastElement.Inferer, inferers[i])
+	}
 }
 
 // test that the inferer address inside the bundle matches the signature on the payload message
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadInfererNotMatchSignature() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, _ := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
-	workerMsg.WorkerDataBundle.InferenceForecastsBundle.Inference.Inferer = s.addrsStr[3]
+	workerMsg.WorkerDataBundle.InferenceForecastsBundle.Inference.Inferer = s.AddrsStr(3)
 
 	// Add worker to topic whitelist
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	s.WithBlockHeight(blockHeight)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.ErrorIs(err, sdkerrors.ErrUnauthorized)
 }
 
 // test that the forecaster address inside the bundle matches the signature on the payload message
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadForecasterNotMatchSignature() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
-
 	workerMsg, _ := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
-	workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.Forecaster = s.addrsStr[3]
+	workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.Forecaster = s.AddrsStr(3)
 
 	// Add worker to topic whitelist
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	s.WithBlockHeight(blockHeight)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.ErrorIs(err, sdkerrors.ErrUnauthorized)
 }
 
 // test that the worker field on the bundle matches the signature on the payload message
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadWorkerNotMatchSignature() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
 
 	workerMsg, _ := s.setUpMsgInsertWorkerPayload(workerPrivateKey)
-	workerMsg.WorkerDataBundle.Worker = s.addrsStr[3]
+	workerMsg.WorkerDataBundle.Worker = s.AddrsStr(3)
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
 	// Add worker to topic whitelist
-	err := s.emissionsKeeper.AddToGlobalWhitelist(ctx, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToGlobalWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.ErrorIs(err, sdkerrors.ErrUnauthorized)
 }
 
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadForecastIncludesSelf() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
 	adminPrivateKey := secp256k1.GenPrivKey()
 	adminAddr := sdk.AccAddress(adminPrivateKey.PubKey().Address())
-	_ = keeper.AddWhitelistAdmin(s.ctx, adminAddr.String())
+	_ = keeper.AddWhitelistAdmin(s.Ctx(), adminAddr.String())
 
 	// Set up params similar to other tests
-	newParams := &types.OptionalParams{ //nolint: exhaustruct
+	newParams := &types.OptionalParams{ //nolint:exhaustruct
 		MaxElementsPerForecast: []uint64{3},
 		// not updated params remain nil
 	}
@@ -913,7 +719,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadForecastIncludesSelf() {
 		Params: newParams,
 	}
 
-	_, err := s.msgServer.UpdateParams(s.ctx, updateMsg)
+	_, err := s.EmissionsMsgServer().UpdateParams(s.Ctx(), updateMsg)
 	require.NoError(err, "UpdateParams should not return an error")
 
 	blockHeight := int64(1)
@@ -936,35 +742,34 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadForecastIncludesSelf() {
 	}
 
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
 	// Set up scores for both inferers
 	score1 := types.Score{TopicId: topicId, BlockHeight: blockHeight, Address: workerAddr, Score: alloraMath.NewDecFromInt64(95)}
 	score2 := types.Score{TopicId: topicId, BlockHeight: blockHeight, Address: otherInferer, Score: alloraMath.NewDecFromInt64(90)}
 
-	_ = keeper.SetInfererScoreEma(ctx, topicId, workerAddr, score1)
-	_ = keeper.SetInfererScoreEma(ctx, topicId, otherInferer, score2)
+	_ = keeper.SetInfererScoreEma(s.Ctx(), topicId, workerAddr, score1)
+	_ = keeper.SetInfererScoreEma(s.Ctx(), topicId, otherInferer, score2)
 
 	blockHeight = blockHeight + workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
 	// Add worker to topic whitelist
-	err = s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err = s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	// Submit and verify the payload
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.NoError(err, "InsertWorkerPayload should succeed when forecaster includes self in forecast")
 
 	// Verify the stored forecast
-	forecastsAtBlock, err := keeper.GetWorkerLatestForecastByTopicId(ctx, topicId, workerMsg.WorkerDataBundle.Worker)
+	forecastsAtBlock, err := keeper.GetWorkerLatestForecastByTopicId(s.Ctx(), topicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 	require.Equal(2, len(forecastsAtBlock.ForecastElements))
 	require.Equal(workerAddr, forecastsAtBlock.ForecastElements[0].Inferer)
 	require.Equal(otherInferer, forecastsAtBlock.ForecastElements[1].Inferer)
 }
 func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadSucceedsWithUnregisteredForecastedInferer() {
-	ctx, msgServer := s.ctx, s.msgServer
 	require := s.Require()
 
 	workerPrivateKey := secp256k1.GenPrivKey()
@@ -982,7 +787,7 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadSucceedsWithUnregisteredF
 	blockHeight := workerMsg.WorkerDataBundle.InferenceForecastsBundle.Forecast.BlockHeight
 
 	// Whitelist the worker for the topic so they can submit forecasts
-	err := s.emissionsKeeper.AddToTopicWorkerWhitelist(ctx, workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
+	err := s.EmissionsKeeper().AddToTopicWorkerWhitelist(s.Ctx(), workerMsg.WorkerDataBundle.TopicId, workerMsg.WorkerDataBundle.Worker)
 	require.NoError(err)
 
 	// Unregister the inferer
@@ -991,11 +796,11 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadSucceedsWithUnregisteredF
 		TopicId:   topicId,
 		IsReputer: false,
 	}
-	_, err = msgServer.RemoveRegistration(ctx, unregisterMsg)
+	_, err = s.EmissionsMsgServer().RemoveRegistration(s.Ctx(), unregisterMsg)
 	require.NoError(err)
 
 	// Verify that the inferer was successfully unregistered from the topic
-	isRegistered, err := s.emissionsKeeper.IsWorkerRegisteredInTopic(ctx, topicId, infererToUnregister)
+	isRegistered, err := s.EmissionsKeeper().IsWorkerRegisteredInTopic(s.Ctx(), topicId, infererToUnregister)
 	require.NoError(err)
 	require.False(isRegistered, "Inferer should be unregistered")
 
@@ -1007,8 +812,8 @@ func (s *MsgServerTestSuite) TestMsgInsertWorkerPayloadSucceedsWithUnregisteredF
 	workerMsg = s.signMsgInsertWorkerPayload(workerMsg, workerPrivateKey)
 
 	// Set the block height context so that we're within the worker submission window
-	ctx = ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
-	_, err = msgServer.InsertWorkerPayload(ctx, &workerMsg)
+	_, err = s.EmissionsMsgServer().InsertWorkerPayload(s.Ctx(), &workerMsg)
 	require.NoError(err, "InsertWorkerPayload should succeed with an unregistered inferer")
 }

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/keeper/queryserver/query_server_forecasts_test.go
+++ b/x/emissions/keeper/queryserver/query_server_forecasts_test.go
@@ -6,21 +6,20 @@ import (
 )
 
 func (s *QueryServerTestSuite) TestGetForecastsAtBlock() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryserver := s.queryServer
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	queryserver := s.EmissionsQueryServer()
 	topicId := uint64(1)
 	blockHeight := types.BlockHeight(100)
 	expectedForecasts := types.Forecasts{
 		Forecasts: []*types.Forecast{
 			{
 				TopicId:     topicId,
-				Forecaster:  s.addrsStr[6],
+				Forecaster:  s.AddrsStr(6),
 				BlockHeight: blockHeight,
 				ForecastElements: []*types.ForecastElement{
 					{
-						Inferer: s.addrsStr[4],
+						Inferer: s.AddrsStr(4),
 						Value:   alloraMath.MustNewDecFromString("0.5"),
 					},
 				},
@@ -28,11 +27,11 @@ func (s *QueryServerTestSuite) TestGetForecastsAtBlock() {
 			},
 			{
 				TopicId:     topicId,
-				Forecaster:  s.addrsStr[7],
+				Forecaster:  s.AddrsStr(7),
 				BlockHeight: blockHeight,
 				ForecastElements: []*types.ForecastElement{
 					{
-						Inferer: s.addrsStr[4],
+						Inferer: s.AddrsStr(4),
 						Value:   alloraMath.MustNewDecFromString("0.5"),
 					},
 				},
@@ -59,17 +58,16 @@ func (s *QueryServerTestSuite) TestGetForecastsAtBlock() {
 }
 
 func (s *QueryServerTestSuite) TestGetActiveForecastersForTopic() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryServer := s.queryServer
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	queryServer := s.EmissionsQueryServer()
 	topicId := uint64(1)
 
 	// Add some active forecasters
 	activeForecasters := []string{
-		s.addrsStr[0],
-		s.addrsStr[1],
-		s.addrsStr[2],
+		s.AddrsStr(0),
+		s.AddrsStr(1),
+		s.AddrsStr(2),
 	}
 
 	for _, forecaster := range activeForecasters {
@@ -106,7 +104,7 @@ func (s *QueryServerTestSuite) TestGetActiveForecastersForTopic() {
 	s.Require().Contains(err.Error(), "not found")
 
 	// Test with no active forecasters
-	emptyTopicId := s.CreateOneTopic()
+	emptyTopicId := s.CreateTopic()
 	emptyResponse, err := queryServer.GetActiveForecastersForTopic(
 		ctx,
 		&types.GetActiveForecastersForTopicRequest{

--- a/x/emissions/keeper/queryserver/query_server_inclusions_test.go
+++ b/x/emissions/keeper/queryserver/query_server_inclusions_test.go
@@ -5,11 +5,10 @@ import (
 )
 
 func (s *QueryServerTestSuite) TestGetCountInfererInclusionsInTopic() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryserver := s.queryServer
+	ctx := s.Ctx()
+	queryserver := s.EmissionsQueryServer()
 	topicId := uint64(1)
-	inferer := s.addrsStr[0]
+	inferer := s.AddrsStr(0)
 
 	results, err := queryserver.GetCountInfererInclusionsInTopic(ctx, &types.GetCountInfererInclusionsInTopicRequest{
 		TopicId: topicId,
@@ -18,7 +17,7 @@ func (s *QueryServerTestSuite) TestGetCountInfererInclusionsInTopic() {
 	s.Require().NoError(err)
 	s.Equal(results.Count, uint64(0))
 
-	err = s.emissionsKeeper.IncrementCountInfererInclusionsInTopic(s.ctx, topicId, inferer)
+	err = s.EmissionsKeeper().IncrementCountInfererInclusionsInTopic(s.Ctx(), topicId, inferer)
 	s.Require().NoError(err)
 	results, err = queryserver.GetCountInfererInclusionsInTopic(ctx, &types.GetCountInfererInclusionsInTopicRequest{
 		TopicId: topicId,
@@ -29,11 +28,10 @@ func (s *QueryServerTestSuite) TestGetCountInfererInclusionsInTopic() {
 }
 
 func (s *QueryServerTestSuite) TestGetCountForecasterInclusionsInTopic() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryserver := s.queryServer
+	ctx := s.Ctx()
+	queryserver := s.EmissionsQueryServer()
 	topicId := uint64(1)
-	forecaster := s.addrsStr[0]
+	forecaster := s.AddrsStr(0)
 
 	results, err := queryserver.GetCountForecasterInclusionsInTopic(ctx, &types.GetCountForecasterInclusionsInTopicRequest{
 		TopicId:    topicId,
@@ -42,7 +40,7 @@ func (s *QueryServerTestSuite) TestGetCountForecasterInclusionsInTopic() {
 	s.Require().NoError(err)
 	s.Equal(results.Count, uint64(0))
 
-	err = s.emissionsKeeper.IncrementCountForecasterInclusionsInTopic(s.ctx, topicId, forecaster)
+	err = s.EmissionsKeeper().IncrementCountForecasterInclusionsInTopic(s.Ctx(), topicId, forecaster)
 	s.Require().NoError(err)
 	results, err = queryserver.GetCountForecasterInclusionsInTopic(ctx, &types.GetCountForecasterInclusionsInTopicRequest{
 		TopicId:    topicId,

--- a/x/emissions/keeper/queryserver/query_server_inferences_test.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences_test.go
@@ -305,8 +305,8 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferences() {
 	}
 
 	// Set inferences and forecasts
-	inferernces := getInferencesForBlockHeight(workers, inferenceBlockHeight, topicId)
-	err = keeper.InsertActiveInferences(s.Ctx(), topicId, inferenceNonce.BlockHeight, inferernces)
+	inferences := getInferencesForBlockHeight(workers, inferenceBlockHeight, topicId)
+	err = keeper.InsertActiveInferences(s.Ctx(), topicId, inferenceNonce.BlockHeight, inferences)
 	require.NoError(err)
 
 	forecasts := getForecastsForBlockHeight(workers, forecasters, inferenceBlockHeight, topicId)
@@ -323,7 +323,7 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferences() {
 		keeper,
 		topicId,
 		&inferenceNonce.BlockHeight,
-		ptr.To(inferernces),
+		ptr.To(inferences),
 		ptr.To(forecasts),
 		false,
 	)
@@ -578,6 +578,7 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferencesWithMissingInferenc
 	s.WithBlockHeight(blockHeights["loss"])
 
 	// Set Loss bundles
+	//nolint:exhaustruct
 	lossBundle := types.ValueBundle{
 		CombinedValue:       alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
 		ReputerRequestNonce: reputerLossRequestNonce,
@@ -659,6 +660,7 @@ func getInferencesForBlockHeight(workers []string, blockHeight int64, topicId ui
 	}
 
 	for i, worker := range workers {
+		//nolint:exhaustruct
 		inferences = append(inferences, &types.Inference{
 			Inferer:     worker,
 			Value:       alloraMath.MustNewDecFromString(inferenceValues[i]),
@@ -687,6 +689,7 @@ func getForecastsForBlockHeight(workers []string, forecasters []string, blockHei
 				Value:   alloraMath.MustNewDecFromString(forecastValues[i][j]),
 			})
 		}
+		//nolint:exhaustruct
 		forecasts = append(forecasts, &types.Forecast{
 			Forecaster:       forecaster,
 			ForecastElements: elements,

--- a/x/emissions/keeper/queryserver/query_server_inferences_test.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences_test.go
@@ -1,18 +1,22 @@
 package queryserver_test
 
 import (
+	"fmt"
+
 	cosmosMath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/utils/ptr"
 	synth "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (s *QueryServerTestSuite) TestGetInferencesAtBlock() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryServer := s.queryServer
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	queryServer := s.EmissionsQueryServer()
 	topicId := uint64(1)
 	blockHeight := types.BlockHeight(100)
 	expectedInferences := types.Inferences{
@@ -49,11 +53,11 @@ func (s *QueryServerTestSuite) TestGetInferencesAtBlock() {
 }
 
 func (s *QueryServerTestSuite) TestGetWorkerLatestInferenceByTopicId() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryServer := s.queryServer
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	queryServer := s.EmissionsQueryServer()
 
-	topicId := s.CreateOneTopic()
+	topicId := uint64(1)
 	workerAddress := "allo1xy0pf5hq85j873glav6aajkvtennmg3fpu3cec"
 	wrongWorkerAddress := "invalidAddress"
 
@@ -106,249 +110,164 @@ func (s *QueryServerTestSuite) TestGetWorkerLatestInferenceByTopicId() {
 	s.Require().Equal(&inference, response.LatestInference, "The latest inference should match the expected data")
 }
 
+//nolint:exhaustruct
 func (s *QueryServerTestSuite) TestGetNetworkInferencesAtBlock() {
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
-
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 	require := s.Require()
-	topicId := s.CreateOneTopic()
 
-	reputer0 := s.addrsStr[5]
-	reputer1 := s.addrsStr[6]
-	reputer2 := s.addrsStr[7]
-	reputer3 := s.addrsStr[8]
-	reputer4 := s.addrsStr[9]
-
+	topicId := uint64(1)
 	blockHeight := int64(10)
+
+	// Set up test data
+	reputers := make([]string, 5)
+	reputerIndexes := testutil.ReturnIndexes(5, 5)
+	for i, idx := range reputerIndexes {
+		reputers[i] = s.AddrsStr(idx)
+	}
 
 	simpleNonce := types.Nonce{BlockHeight: blockHeight}
 	reputerRequestNonce := &types.ReputerRequestNonce{
 		ReputerNonce: &types.Nonce{BlockHeight: blockHeight},
 	}
 
-	// Set Loss bundles
+	// Create and set value bundles
+	valueBundleData := []struct {
+		reputer       string
+		combinedValue string
+	}{
+		{reputers[0], ".0000117005278862668"},
+		{reputers[1], ".00000962701954026944"},
+		{reputers[2], ".0000256948644008351"},
+		{reputers[3], ".0000123986052417188"},
+		{reputers[4], ".0000115363240547692"},
+	}
 
-	valueBundle1 := types.ValueBundle{
-		TopicId:             topicId,
-		Reputer:             reputer0,
-		ExtraData:           nil,
-		ReputerRequestNonce: reputerRequestNonce,
-		CombinedValue:       alloraMath.MustNewDecFromString(".0000117005278862668"),
-		InfererValues: []*types.WorkerAttributedValue{
-			{
-				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
-				Value:  alloraMath.MustNewDecFromString("1"),
+	var reputerValueBundles []*types.ReputerValueBundle
+	for i, data := range valueBundleData {
+		valueBundle := types.ValueBundle{
+			TopicId:             topicId,
+			Reputer:             data.reputer,
+			ReputerRequestNonce: reputerRequestNonce,
+			CombinedValue:       alloraMath.MustNewDecFromString(data.combinedValue),
+			InfererValues: []*types.WorkerAttributedValue{
+				{
+					Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+					Value:  alloraMath.MustNewDecFromString("1"),
+				},
 			},
-		},
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString(".0000117005278862668"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+			NaiveValue: alloraMath.MustNewDecFromString(data.combinedValue),
+		}
+		signature := s.SignValueBundle(&valueBundle, s.PrivKeys(i+5))
+		reputerValueBundles = append(reputerValueBundles, &types.ReputerValueBundle{
+			ValueBundle: &valueBundle,
+			Signature:   signature,
+			Pubkey:      s.PubKeyHexStr(i + 5),
+		})
 	}
-	signature1 := s.signValueBundle(&valueBundle1, s.privKeys[5])
 
-	valueBundle2 := types.ValueBundle{
-		TopicId:             topicId,
-		Reputer:             reputer1,
-		ExtraData:           nil,
-		CombinedValue:       alloraMath.MustNewDecFromString(".00000962701954026944"),
-		ReputerRequestNonce: reputerRequestNonce,
-		InfererValues: []*types.WorkerAttributedValue{
-			{
-				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
-				Value:  alloraMath.MustNewDecFromString("1"),
-			},
-		},
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString(".00000962701954026944"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature2 := s.signValueBundle(&valueBundle2, s.privKeys[6])
-	valueBundle3 := types.ValueBundle{
-		Reputer:             reputer2,
-		ExtraData:           nil,
-		CombinedValue:       alloraMath.MustNewDecFromString(".0000256948644008351"),
-		ReputerRequestNonce: reputerRequestNonce,
-		TopicId:             topicId,
-		InfererValues: []*types.WorkerAttributedValue{
-			{
-				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
-				Value:  alloraMath.MustNewDecFromString("1"),
-			},
-		},
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString(".0000256948644008351"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature3 := s.signValueBundle(&valueBundle3, s.privKeys[7])
-	valueBundle4 := types.ValueBundle{
-		Reputer:             reputer3,
-		ExtraData:           nil,
-		CombinedValue:       alloraMath.MustNewDecFromString(".0000123986052417188"),
-		ReputerRequestNonce: reputerRequestNonce,
-		TopicId:             topicId,
-		InfererValues: []*types.WorkerAttributedValue{
-			{
-				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
-				Value:  alloraMath.MustNewDecFromString("1"),
-			},
-		},
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString(".0000123986052417188"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature4 := s.signValueBundle(&valueBundle4, s.privKeys[8])
-	valueBundle5 := types.ValueBundle{
-		Reputer:             reputer4,
-		ExtraData:           nil,
-		CombinedValue:       alloraMath.MustNewDecFromString(".0000115363240547692"),
-		ReputerRequestNonce: reputerRequestNonce,
-		TopicId:             topicId,
-		InfererValues: []*types.WorkerAttributedValue{
-			{
-				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
-				Value:  alloraMath.MustNewDecFromString("1"),
-			},
-		},
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString(".0000115363240547692"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
-	}
-	signature5 := s.signValueBundle(&valueBundle5, s.privKeys[9])
 	reputerLossBundles := types.ReputerValueBundles{
-		ReputerValueBundles: []*types.ReputerValueBundle{
-			{ValueBundle: &valueBundle1, Signature: signature1, Pubkey: s.pubKeyHexStr[5]},
-			{ValueBundle: &valueBundle2, Signature: signature2, Pubkey: s.pubKeyHexStr[6]},
-			{ValueBundle: &valueBundle3, Signature: signature3, Pubkey: s.pubKeyHexStr[7]},
-			{ValueBundle: &valueBundle4, Signature: signature4, Pubkey: s.pubKeyHexStr[8]},
-			{ValueBundle: &valueBundle5, Signature: signature5, Pubkey: s.pubKeyHexStr[9]},
-		},
+		ReputerValueBundles: reputerValueBundles,
 	}
 
-	err := keeper.InsertActiveReputerLosses(s.ctx, topicId, blockHeight, reputerLossBundles)
+	err := keeper.InsertActiveReputerLosses(s.Ctx(), topicId, blockHeight, reputerLossBundles)
 	require.NoError(err)
 
-	// Set Stake
-	stake0, ok := cosmosMath.NewIntFromString("210535101370326000000000")
-	s.Require().True(ok)
-	stake1, ok := cosmosMath.NewIntFromString("216697093951021000000000")
-	s.Require().True(ok)
-	stake2, ok := cosmosMath.NewIntFromString("161740241803855000000000")
-	s.Require().True(ok)
-	stake3, ok := cosmosMath.NewIntFromString("394848305052250000000000")
-	s.Require().True(ok)
-	stake4, ok := cosmosMath.NewIntFromString("206169717590569000000000")
-	s.Require().True(ok)
-	err = keeper.AddReputerStake(s.ctx, topicId, reputer0, stake0)
-	require.NoError(err)
-	err = keeper.AddReputerStake(s.ctx, topicId, reputer1, stake1)
-	require.NoError(err)
-	err = keeper.AddReputerStake(s.ctx, topicId, reputer2, stake2)
-	require.NoError(err)
-	err = keeper.AddReputerStake(s.ctx, topicId, reputer3, stake3)
-	require.NoError(err)
-	err = keeper.AddReputerStake(s.ctx, topicId, reputer4, stake4)
-	require.NoError(err)
-
-	// Set Inferences
-
-	inferences := types.Inferences{
-		Inferences: []*types.Inference{
-			{
-				Inferer:     reputer0,
-				Value:       alloraMath.MustNewDecFromString("-0.035995138925040600"),
-				TopicId:     topicId,
-				BlockHeight: blockHeight,
-			},
-			{
-				Inferer:     reputer1,
-				Value:       alloraMath.MustNewDecFromString("-0.07333303938740420"),
-				TopicId:     topicId,
-				BlockHeight: blockHeight,
-			},
-			{
-				Inferer:     reputer2,
-				Value:       alloraMath.MustNewDecFromString("-0.1495482917094790"),
-				TopicId:     topicId,
-				BlockHeight: blockHeight,
-			},
-			{
-				Inferer:     reputer3,
-				Value:       alloraMath.MustNewDecFromString("-0.12952123274063800"),
-				TopicId:     topicId,
-				BlockHeight: blockHeight,
-			},
-			{
-				Inferer:     reputer4,
-				Value:       alloraMath.MustNewDecFromString("-0.0703055329498285"),
-				TopicId:     topicId,
-				BlockHeight: blockHeight,
-			},
-		},
+	// Set stakes
+	stakeValues := []string{
+		"210535101370326000000000",
+		"216697093951021000000000",
+		"161740241803855000000000",
+		"394848305052250000000000",
+		"206169717590569000000000",
 	}
 
-	err = keeper.InsertActiveInferences(s.ctx, topicId, simpleNonce.BlockHeight, inferences)
-	s.Require().NoError(err)
+	for i, stakeValue := range stakeValues {
+		stake, ok := cosmosMath.NewIntFromString(stakeValue)
+		require.True(ok)
+		err = keeper.AddReputerStake(s.Ctx(), topicId, reputers[i], stake)
+		require.NoError(err)
+	}
 
-	// Set actual block
-	s.ctx = s.ctx.WithBlockHeight(blockHeight + 10)
+	// Set inferences
+	inferenceValues := []string{
+		"-0.035995138925040600",
+		"-0.07333303938740420",
+		"-0.1495482917094790",
+		"-0.12952123274063800",
+		"-0.0703055329498285",
+	}
 
-	// Update epoch topic epoch last ended
-	err = keeper.UpdateTopicEpochLastEnded(s.ctx, topicId, blockHeight+10)
+	var infs []*types.Inference
+	for i, value := range inferenceValues {
+		infs = append(infs, &types.Inference{
+			Inferer:     reputers[i],
+			Value:       alloraMath.MustNewDecFromString(value),
+			TopicId:     topicId,
+			BlockHeight: blockHeight,
+		})
+	}
+
+	inferences := types.Inferences{Inferences: infs}
+	err = keeper.InsertActiveInferences(s.Ctx(), topicId, simpleNonce.BlockHeight, inferences)
 	require.NoError(err)
 
-	// Test querying the server
+	// Set block height and update epoch
+	s.WithBlockHeight(blockHeight + 10)
+	err = keeper.UpdateTopicEpochLastEnded(s.Ctx(), topicId, blockHeight+10)
+	require.NoError(err)
+
+	// Test query
 	req := &types.GetNetworkInferencesAtBlockRequest{
 		TopicId:                  topicId,
 		BlockHeightLastInference: blockHeight,
 	}
-	response, err := queryServer.GetNetworkInferencesAtBlock(s.ctx, req)
+	response, err := queryServer.GetNetworkInferencesAtBlock(s.Ctx(), req)
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil")
 }
 
+//nolint:exhaustruct
 func (s *QueryServerTestSuite) TestGetLatestNetworkInferences() {
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
-
+	queryServer := s.EmissionsQueryServer()
+	keeper := *s.EmissionsKeeper()
 	require := s.Require()
-	topicId := s.CreateOneTopic()
-	topic, err := keeper.GetTopic(s.ctx, topicId)
+
+	// Setup test data
+	topicId := uint64(1)
+	topic, err := keeper.GetTopic(s.Ctx(), topicId)
 	require.NoError(err)
 
 	epochLength := topic.EpochLength
-	epochLastEnded := int64(1) // topic.EpochLastEnded , but 0 is not a valid nonce
-
+	epochLastEnded := int64(1)
 	lossBlockHeight := epochLastEnded
 	inferenceBlockHeight := epochLastEnded + epochLength
 
 	lossNonce := types.Nonce{BlockHeight: lossBlockHeight}
 	inferenceNonce := types.Nonce{BlockHeight: inferenceBlockHeight}
-
 	reputerLossRequestNonce := &types.ReputerRequestNonce{ReputerNonce: &lossNonce}
 
-	s.ctx = s.ctx.WithBlockHeight(lossBlockHeight)
+	// Setup workers and forecasters
+	workers := []string{
+		"allo1s8sar766d54wzlmqhwpwdv0unzjfusjydg3l3j",
+		"allo1rp9026g0ppp9nwdtzvxpqqhl43yqplrj7pmnhq",
+		"allo1cmdyvyqgzudlf0ep2nht333a057wg9vwfek7tq",
+		"allo1cr5usf94ph9w2lpeqfjkv3eyuspv47c0zx3nye",
+		"allo19dvpcsqqer4xy7cdh4s3gtm460z6xpe2hzlf5s",
+	}
 
-	// Set Loss bundles
-	err = keeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, lossBlockHeight, types.ValueBundle{
+	forecasters := []string{
+		"allo13hh468ghmmyfjrdwqn567j29wq8sh6pnwff0cn",
+		"allo1nxqgvyt6ggu3dz7uwe8p22sac6v2v8sayhwqvz",
+		"allo1a0sc83cls78g4j5qey5er9zzpjpva4x935aajk",
+	}
+
+	// Set loss bundle
+	s.WithBlockHeight(lossBlockHeight)
+	err = keeper.InsertNetworkLossBundleAtBlock(s.Ctx(), topicId, lossBlockHeight, types.ValueBundle{
 		TopicId:             topicId,
 		ReputerRequestNonce: reputerLossRequestNonce,
-		ExtraData:           nil,
-		Reputer:             s.addrsStr[8],
+		Reputer:             s.AddrsStr(8),
 		CombinedValue:       alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
 		InfererValues: []*types.WorkerAttributedValue{
 			{
@@ -356,21 +275,15 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferences() {
 				Value:  alloraMath.MustNewDecFromString("1"),
 			},
 		},
-		ForecasterValues:              nil,
-		NaiveValue:                    alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
+		NaiveValue: alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
 	})
 	require.NoError(err)
 
-	// Set Latest Worker commit
-	err = keeper.SetWorkerTopicLastCommit(s.ctx, topicId, inferenceBlockHeight, &inferenceNonce)
+	// Set worker commits and regrets
+	err = keeper.SetWorkerTopicLastCommit(s.Ctx(), topicId, inferenceBlockHeight, &inferenceNonce)
 	require.NoError(err)
 
-	// Set Inferences
-	s.ctx = s.ctx.WithBlockHeight(inferenceBlockHeight)
+	s.WithBlockHeight(inferenceBlockHeight)
 
 	getWorkerRegretValue := func(value string) types.TimestampedValue {
 		return types.TimestampedValue{
@@ -379,149 +292,59 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferences() {
 		}
 	}
 
-	worker0 := "allo1s8sar766d54wzlmqhwpwdv0unzjfusjydg3l3j"
-	worker1 := "allo1rp9026g0ppp9nwdtzvxpqqhl43yqplrj7pmnhq"
-	worker2 := "allo1cmdyvyqgzudlf0ep2nht333a057wg9vwfek7tq"
-	worker3 := "allo1cr5usf94ph9w2lpeqfjkv3eyuspv47c0zx3nye"
-	worker4 := "allo19dvpcsqqer4xy7cdh4s3gtm460z6xpe2hzlf5s"
-
-	forecaster0 := "allo13hh468ghmmyfjrdwqn567j29wq8sh6pnwff0cn"
-	forecaster1 := "allo1nxqgvyt6ggu3dz7uwe8p22sac6v2v8sayhwqvz"
-	forecaster2 := "allo1a0sc83cls78g4j5qey5er9zzpjpva4x935aajk"
-
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker0, getWorkerRegretValue("0.1"))
-	require.NoError(err)
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker1, getWorkerRegretValue("0.2"))
-	require.NoError(err)
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker2, getWorkerRegretValue("0.3"))
-	require.NoError(err)
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker3, getWorkerRegretValue("0.4"))
-	require.NoError(err)
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker4, getWorkerRegretValue("0.5"))
-	require.NoError(err)
-
-	err = keeper.SetForecasterNetworkRegret(s.ctx, topicId, forecaster0, getWorkerRegretValue("0.1"))
-	require.NoError(err)
-	err = keeper.SetForecasterNetworkRegret(s.ctx, topicId, forecaster1, getWorkerRegretValue("0.2"))
-	require.NoError(err)
-	err = keeper.SetForecasterNetworkRegret(s.ctx, topicId, forecaster2, getWorkerRegretValue("0.3"))
-	require.NoError(err)
-
-	inferences := types.Inferences{
-		Inferences: []*types.Inference{
-			{
-				Inferer:     worker0,
-				Value:       alloraMath.MustNewDecFromString("-0.035995138925040600"),
-				TopicId:     topicId,
-				BlockHeight: inferenceBlockHeight,
-			},
-			{
-				Inferer:     worker1,
-				Value:       alloraMath.MustNewDecFromString("-0.07333303938740420"),
-				TopicId:     topicId,
-				BlockHeight: inferenceBlockHeight,
-			},
-			{
-				Inferer:     worker2,
-				Value:       alloraMath.MustNewDecFromString("-0.1495482917094790"),
-				TopicId:     topicId,
-				BlockHeight: inferenceBlockHeight,
-			},
-			{
-				Inferer:     worker3,
-				Value:       alloraMath.MustNewDecFromString("-0.12952123274063800"),
-				TopicId:     topicId,
-				BlockHeight: inferenceBlockHeight,
-			},
-			{
-				Inferer:     worker4,
-				Value:       alloraMath.MustNewDecFromString("-0.0703055329498285"),
-				TopicId:     topicId,
-				BlockHeight: inferenceBlockHeight,
-			},
-		},
+	// Set worker regrets
+	for i, worker := range workers {
+		err = keeper.SetInfererNetworkRegret(s.Ctx(), topicId, worker, getWorkerRegretValue(fmt.Sprintf("0.%d", i+1)))
+		require.NoError(err)
 	}
 
-	err = keeper.InsertActiveInferences(s.ctx, topicId, inferenceNonce.BlockHeight, inferences)
-	s.Require().NoError(err)
-
-	// Set Forecasts
-	forecasts := types.Forecasts{
-		Forecasts: []*types.Forecast{
-			{
-				Forecaster: forecaster0,
-				ForecastElements: []*types.ForecastElement{
-					{Inferer: worker0, Value: alloraMath.MustNewDecFromString("0.1")},
-					{Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.2")},
-					{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.3")},
-					{Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.4")},
-					{Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.5")},
-				},
-				TopicId:     topicId,
-				BlockHeight: inferenceBlockHeight,
-			},
-			{
-				Forecaster: forecaster1,
-				ForecastElements: []*types.ForecastElement{
-					{Inferer: worker0, Value: alloraMath.MustNewDecFromString("0.5")},
-					{Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.4")},
-					{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.3")},
-					{Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.2")},
-					{Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.1")},
-				},
-				TopicId:     topicId,
-				BlockHeight: inferenceBlockHeight,
-			},
-			{
-				Forecaster: forecaster2,
-				ForecastElements: []*types.ForecastElement{
-					{Inferer: worker0, Value: alloraMath.MustNewDecFromString("0.2")},
-					{Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.3")},
-					{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.4")},
-					{Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.3")},
-					{Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.2")},
-				},
-				TopicId:     topicId,
-				BlockHeight: inferenceBlockHeight,
-			},
-		},
+	// Set forecaster regrets
+	for i, forecaster := range forecasters {
+		err = keeper.SetForecasterNetworkRegret(s.Ctx(), topicId, forecaster, getWorkerRegretValue(fmt.Sprintf("0.%d", i+1)))
+		require.NoError(err)
 	}
 
-	err = keeper.InsertActiveForecasts(s.ctx, topicId, inferenceNonce.BlockHeight, forecasts)
+	// Set inferences and forecasts
+	inferernces := getInferencesForBlockHeight(workers, inferenceBlockHeight, topicId)
+	err = keeper.InsertActiveInferences(s.Ctx(), topicId, inferenceNonce.BlockHeight, inferernces)
 	require.NoError(err)
 
-	// Update epoch topic epoch last ended
-	err = keeper.UpdateTopicEpochLastEnded(s.ctx, topicId, inferenceBlockHeight)
+	forecasts := getForecastsForBlockHeight(workers, forecasters, inferenceBlockHeight, topicId)
+	err = keeper.InsertActiveForecasts(s.Ctx(), topicId, inferenceNonce.BlockHeight, forecasts)
 	require.NoError(err)
 
-	// Now calculate and set the network inferences
+	// Update epoch
+	err = keeper.UpdateTopicEpochLastEnded(s.Ctx(), topicId, inferenceBlockHeight)
+	require.NoError(err)
+
+	// Calculate network inferences
 	networkInferences, err := synth.GetNetworkInferences(
-		sdk.UnwrapSDKContext(s.ctx),
+		sdk.UnwrapSDKContext(s.Ctx()),
 		keeper,
 		topicId,
 		&inferenceNonce.BlockHeight,
-		&inferences,
-		&forecasts,
+		ptr.To(inferernces),
+		ptr.To(forecasts),
 		false,
 	)
 	require.NoError(err)
-	err = keeper.InsertNetworkInferences(s.ctx, topicId, inferenceNonce.BlockHeight, *networkInferences.NetworkInferences)
+
+	err = keeper.InsertNetworkInferences(s.Ctx(), topicId, inferenceNonce.BlockHeight, *networkInferences.NetworkInferences)
 	require.NoError(err)
 
-	// Test querying the server
-	req := &types.GetLatestNetworkInferencesRequest{
+	// Test query
+	response, err := queryServer.GetLatestNetworkInferences(s.Ctx(), &types.GetLatestNetworkInferencesRequest{
 		TopicId: topicId,
-	}
-	response, err := queryServer.GetLatestNetworkInferences(s.ctx, req)
+	})
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil")
-	require.Equal(len(response.NetworkInferences.ForecasterValues), 3)
-	require.Equal(len(response.NetworkInferences.InfererValues), 5)
+	require.Equal(len(response.NetworkInferences.ForecasterValues), len(forecasters))
+	require.Equal(len(response.NetworkInferences.InfererValues), len(workers))
 }
 
 func (s *QueryServerTestSuite) TestIsWorkerNonceUnfulfilled() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 	newNonce := &types.Nonce{BlockHeight: 42}
 
@@ -529,7 +352,7 @@ func (s *QueryServerTestSuite) TestIsWorkerNonceUnfulfilled() {
 		TopicId:     topicId,
 		BlockHeight: newNonce.BlockHeight,
 	}
-	response, err := s.queryServer.IsWorkerNonceUnfulfilled(s.ctx, req)
+	response, err := s.EmissionsQueryServer().IsWorkerNonceUnfulfilled(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().NotNil(response, "Response should not be nil")
 	s.Require().False(response.IsWorkerNonceUnfulfilled)
@@ -538,22 +361,22 @@ func (s *QueryServerTestSuite) TestIsWorkerNonceUnfulfilled() {
 	err = keeper.AddWorkerNonce(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 
-	response, err = s.queryServer.IsWorkerNonceUnfulfilled(s.ctx, req)
+	response, err = s.EmissionsQueryServer().IsWorkerNonceUnfulfilled(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().NotNil(response, "Response should not be nil")
 	s.Require().True(response.IsWorkerNonceUnfulfilled)
 }
 
 func (s *QueryServerTestSuite) TestGetUnfulfilledWorkerNonces() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 
 	// Initially, ensure no unfulfilled nonces exist
 	req := &types.GetUnfulfilledWorkerNoncesRequest{
 		TopicId: topicId,
 	}
-	response, err := s.queryServer.GetUnfulfilledWorkerNonces(s.ctx, req)
+	response, err := s.EmissionsQueryServer().GetUnfulfilledWorkerNonces(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().NotNil(response, "Response should not be nil")
 	s.Require().Len(response.Nonces.Nonces, 0, "Initial unfulfilled nonces should be empty")
@@ -566,7 +389,7 @@ func (s *QueryServerTestSuite) TestGetUnfulfilledWorkerNonces() {
 	}
 
 	// Retrieve and verify the nonces
-	response, err = s.queryServer.GetUnfulfilledWorkerNonces(s.ctx, req)
+	response, err = s.EmissionsQueryServer().GetUnfulfilledWorkerNonces(s.Ctx(), req)
 	s.Require().NoError(err, "Error retrieving nonces after adding")
 	s.Require().Len(response.Nonces.Nonces, len(nonceValues), "Should match the number of added nonces")
 
@@ -577,10 +400,10 @@ func (s *QueryServerTestSuite) TestGetUnfulfilledWorkerNonces() {
 }
 
 func (s *QueryServerTestSuite) TestGetInfererNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := s.CreateOneTopic()
-	worker := s.addrsStr[1]
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	topicId := uint64(1)
+	worker := s.AddrsStr(1)
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(10)}
 	emptyRegret := types.TimestampedValue{
 		BlockHeight: 0,
@@ -591,7 +414,7 @@ func (s *QueryServerTestSuite) TestGetInfererNetworkRegret() {
 		TopicId: topicId,
 		ActorId: worker,
 	}
-	response, err := s.queryServer.GetInfererNetworkRegret(s.ctx, req)
+	response, err := s.EmissionsQueryServer().GetInfererNetworkRegret(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().Equal(response.Regret, &emptyRegret)
 
@@ -600,16 +423,16 @@ func (s *QueryServerTestSuite) TestGetInfererNetworkRegret() {
 	s.Require().NoError(err)
 
 	// Get Inferer Network Regret
-	response, err = s.queryServer.GetInfererNetworkRegret(s.ctx, req)
+	response, err = s.EmissionsQueryServer().GetInfererNetworkRegret(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().Equal(response.Regret, &regret)
 }
 
 func (s *QueryServerTestSuite) TestGetForecasterNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := s.CreateOneTopic()
-	worker := s.addrsStr[1]
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	topicId := uint64(1)
+	worker := s.AddrsStr(1)
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(10)}
 	emptyRegret := types.TimestampedValue{
 		BlockHeight: 0,
@@ -620,7 +443,7 @@ func (s *QueryServerTestSuite) TestGetForecasterNetworkRegret() {
 		TopicId: topicId,
 		Worker:  worker,
 	}
-	response, err := s.queryServer.GetForecasterNetworkRegret(s.ctx, req)
+	response, err := s.EmissionsQueryServer().GetForecasterNetworkRegret(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().Equal(response.Regret, &emptyRegret)
 
@@ -629,17 +452,17 @@ func (s *QueryServerTestSuite) TestGetForecasterNetworkRegret() {
 	s.Require().NoError(err)
 
 	// Get Forecaster Network Regret
-	response, err = s.queryServer.GetForecasterNetworkRegret(s.ctx, req)
+	response, err = s.EmissionsQueryServer().GetForecasterNetworkRegret(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().Equal(response.Regret, &regret)
 }
 
 func (s *QueryServerTestSuite) TestGetOneInForecasterNetworkRegret() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := s.CreateOneTopic()
-	forecaster := s.addrsStr[3]
-	inferer := s.addrsStr[1]
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	topicId := uint64(1)
+	forecaster := s.AddrsStr(3)
+	inferer := s.AddrsStr(1)
 	regret := types.TimestampedValue{BlockHeight: 100, Value: alloraMath.NewDecFromInt64(10)}
 	emptyRegret := types.TimestampedValue{
 		BlockHeight: 0,
@@ -651,7 +474,7 @@ func (s *QueryServerTestSuite) TestGetOneInForecasterNetworkRegret() {
 		Forecaster: forecaster,
 		Inferer:    inferer,
 	}
-	response, err := s.queryServer.GetOneInForecasterNetworkRegret(s.ctx, req)
+	response, err := s.EmissionsQueryServer().GetOneInForecasterNetworkRegret(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().Equal(response.Regret, &emptyRegret)
 
@@ -660,22 +483,22 @@ func (s *QueryServerTestSuite) TestGetOneInForecasterNetworkRegret() {
 	s.Require().NoError(err)
 
 	// Get One In Forecaster Network Regret
-	response, err = s.queryServer.GetOneInForecasterNetworkRegret(s.ctx, req)
+	response, err = s.EmissionsQueryServer().GetOneInForecasterNetworkRegret(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().Equal(response.Regret, &regret)
 }
 
 func (s *QueryServerTestSuite) TestGetLatestTopicInferences() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 
-	topicId := s.CreateOneTopic()
+	topicId := uint64(1)
 
 	// Initially, there should be no inferences, so we expect an empty result
 	req := &types.GetLatestTopicInferencesRequest{
 		TopicId: topicId,
 	}
-	response, err := s.queryServer.GetLatestTopicInferences(ctx, req)
+	response, err := s.EmissionsQueryServer().GetLatestTopicInferences(ctx, req)
 	s.Require().NoError(err)
 	emptyInferences := response.Inferences
 	emptyBlockHeight := response.BlockHeight
@@ -689,7 +512,7 @@ func (s *QueryServerTestSuite) TestGetLatestTopicInferences() {
 	newInference1 := types.Inference{
 		TopicId:     topicId,
 		BlockHeight: blockHeight1,
-		Inferer:     s.addrsStr[1],
+		Inferer:     s.AddrsStr(1),
 		Value:       alloraMath.MustNewDecFromString("10"),
 		ExtraData:   []byte("data1"),
 		Proof:       "proof1",
@@ -706,7 +529,7 @@ func (s *QueryServerTestSuite) TestGetLatestTopicInferences() {
 	newInference2 := types.Inference{
 		TopicId:     topicId,
 		BlockHeight: blockHeight2,
-		Inferer:     s.addrsStr[2],
+		Inferer:     s.AddrsStr(2),
 		Value:       alloraMath.MustNewDecFromString("20"),
 		ExtraData:   []byte("data2"),
 		Proof:       "proof2",
@@ -719,7 +542,7 @@ func (s *QueryServerTestSuite) TestGetLatestTopicInferences() {
 	s.Require().NoError(err, "Inserting second set of inferences should not fail")
 
 	// Retrieve the latest inferences
-	response, err = s.queryServer.GetLatestTopicInferences(ctx, req)
+	response, err = s.EmissionsQueryServer().GetLatestTopicInferences(ctx, req)
 	s.Require().NoError(err)
 	latestInferences := response.Inferences
 	latestBlockHeight := response.BlockHeight
@@ -729,36 +552,37 @@ func (s *QueryServerTestSuite) TestGetLatestTopicInferences() {
 }
 
 func (s *QueryServerTestSuite) TestGetLatestNetworkInferencesWithMissingInferences() {
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	require := s.Require()
-	topicId := s.CreateOneTopic()
-	topic, err := keeper.GetTopic(s.ctx, topicId)
+	topicId := uint64(1)
+	topic, err := keeper.GetTopic(s.Ctx(), topicId)
 	require.NoError(err)
 
 	epochLength := topic.EpochLength
 	epochLastEnded := int64(1) // topic.EpochLastEnded , but 0 is not a valid nonce
+	blockHeights := map[string]int64{
+		"loss":       epochLastEnded,
+		"inference":  epochLastEnded + epochLength,
+		"inference2": epochLastEnded + 2*epochLength,
+	}
 
-	lossBlockHeight := epochLastEnded
-	inferenceBlockHeight := epochLastEnded + epochLength
-	inferenceBlockHeight2 := inferenceBlockHeight + epochLength
+	nonces := map[string]*types.Nonce{
+		"loss":       {BlockHeight: blockHeights["loss"]},
+		"inference2": {BlockHeight: blockHeights["inference2"]},
+	}
 
-	lossNonce := types.Nonce{BlockHeight: lossBlockHeight}
-	// inferenceNonce := types.Nonce{BlockHeight: inferenceBlockHeight}
-	inferenceNonce2 := types.Nonce{BlockHeight: inferenceBlockHeight2}
+	reputerLossRequestNonce := &types.ReputerRequestNonce{ReputerNonce: nonces["loss"]}
 
-	reputerLossRequestNonce := &types.ReputerRequestNonce{ReputerNonce: &lossNonce}
-
-	s.ctx = s.ctx.WithBlockHeight(lossBlockHeight)
+	s.WithBlockHeight(blockHeights["loss"])
 
 	// Set Loss bundles
 	lossBundle := types.ValueBundle{
 		CombinedValue:       alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
 		ReputerRequestNonce: reputerLossRequestNonce,
 		TopicId:             topicId,
-		Reputer:             s.addrsStr[0],
-		ExtraData:           nil,
+		Reputer:             s.AddrsStr(0),
 		NaiveValue:          alloraMath.MustNewDecFromString("0.00001342819294865661936622664543402969"),
 		InfererValues: []*types.WorkerAttributedValue{
 			{
@@ -766,170 +590,125 @@ func (s *QueryServerTestSuite) TestGetLatestNetworkInferencesWithMissingInferenc
 				Value:  alloraMath.MustNewDecFromString("1"),
 			},
 		},
-		ForecasterValues:              nil,
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
 	}
-	err = keeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, lossBlockHeight, lossBundle)
+	err = keeper.InsertNetworkLossBundleAtBlock(s.Ctx(), topicId, blockHeights["loss"], lossBundle)
 	require.NoError(err)
 
 	// Set Inferences
-	s.ctx = s.ctx.WithBlockHeight(inferenceBlockHeight)
+	s.WithBlockHeight(blockHeights["inference"])
 
 	getWorkerRegretValue := func(value string) types.TimestampedValue {
 		return types.TimestampedValue{
-			BlockHeight: inferenceBlockHeight,
+			BlockHeight: blockHeights["inference"],
 			Value:       alloraMath.MustNewDecFromString(value),
 		}
 	}
 
-	worker0 := s.addrsStr[1]
-	worker1 := s.addrsStr[2]
-	worker2 := s.addrsStr[3]
-	worker3 := s.addrsStr[4]
-	worker4 := s.addrsStr[5]
-
-	forecaster0 := s.addrsStr[6]
-	forecaster1 := s.addrsStr[7]
-	forecaster2 := s.addrsStr[8]
-
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker0, getWorkerRegretValue("0.1"))
-	require.NoError(err)
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker1, getWorkerRegretValue("0.2"))
-	require.NoError(err)
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker2, getWorkerRegretValue("0.3"))
-	require.NoError(err)
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker3, getWorkerRegretValue("0.4"))
-	require.NoError(err)
-	err = keeper.SetInfererNetworkRegret(s.ctx, topicId, worker4, getWorkerRegretValue("0.5"))
-	require.NoError(err)
-
-	err = keeper.SetForecasterNetworkRegret(s.ctx, topicId, forecaster0, getWorkerRegretValue("0.1"))
-	require.NoError(err)
-	err = keeper.SetForecasterNetworkRegret(s.ctx, topicId, forecaster1, getWorkerRegretValue("0.2"))
-	require.NoError(err)
-	err = keeper.SetForecasterNetworkRegret(s.ctx, topicId, forecaster2, getWorkerRegretValue("0.3"))
-	require.NoError(err)
-
-	getInferencesForBlockHeight := func(blockHeight int64) types.Inferences {
-		return types.Inferences{
-			Inferences: []*types.Inference{
-				{
-					Inferer:     worker0,
-					Value:       alloraMath.MustNewDecFromString("-0.035995138925040600"),
-					TopicId:     topicId,
-					BlockHeight: blockHeight,
-				},
-				{
-					Inferer:     worker1,
-					Value:       alloraMath.MustNewDecFromString("-0.07333303938740420"),
-					TopicId:     topicId,
-					BlockHeight: blockHeight,
-				},
-				{
-					Inferer:     worker2,
-					Value:       alloraMath.MustNewDecFromString("-0.1495482917094790"),
-					TopicId:     topicId,
-					BlockHeight: blockHeight,
-				},
-				{
-					Inferer:     worker3,
-					Value:       alloraMath.MustNewDecFromString("-0.12952123274063800"),
-					TopicId:     topicId,
-					BlockHeight: blockHeight,
-				},
-				{
-					Inferer:     worker4,
-					Value:       alloraMath.MustNewDecFromString("-0.0703055329498285"),
-					TopicId:     topicId,
-					BlockHeight: blockHeight,
-				},
-			},
-		}
+	workers := make([]string, 5)
+	forecasters := make([]string, 3)
+	for i := range workers {
+		workers[i] = s.AddrsStr(i + 1)
+	}
+	for i := range forecasters {
+		forecasters[i] = s.AddrsStr(i + 6)
 	}
 
-	getForecastsForBlockHeight := func(blockHeight int64) types.Forecasts {
-		return types.Forecasts{
-			Forecasts: []*types.Forecast{
-				{
-					Forecaster: forecaster0,
-					ForecastElements: []*types.ForecastElement{
-						{Inferer: worker0, Value: alloraMath.MustNewDecFromString("0.1")},
-						{Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.2")},
-						{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.3")},
-						{Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.4")},
-						{Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.5")},
-					},
-					TopicId:     topicId,
-					BlockHeight: blockHeight,
-				},
-				{
-					Forecaster: forecaster1,
-					ForecastElements: []*types.ForecastElement{
-						{Inferer: worker0, Value: alloraMath.MustNewDecFromString("0.5")},
-						{Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.4")},
-						{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.3")},
-						{Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.2")},
-						{Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.1")},
-					},
-					TopicId:     topicId,
-					BlockHeight: blockHeight,
-				},
-				{
-					Forecaster: forecaster2,
-					ForecastElements: []*types.ForecastElement{
-						{Inferer: worker0, Value: alloraMath.MustNewDecFromString("0.2")},
-						{Inferer: worker1, Value: alloraMath.MustNewDecFromString("0.3")},
-						{Inferer: worker2, Value: alloraMath.MustNewDecFromString("0.4")},
-						{Inferer: worker3, Value: alloraMath.MustNewDecFromString("0.3")},
-						{Inferer: worker4, Value: alloraMath.MustNewDecFromString("0.2")},
-					},
-					TopicId:     topicId,
-					BlockHeight: blockHeight,
-				},
-			},
-		}
+	// Set network regrets
+	for i, worker := range workers {
+		err = keeper.SetInfererNetworkRegret(s.Ctx(), topicId, worker, getWorkerRegretValue(alloraMath.NewDecFromInt64(int64(i+1)/10).String()))
+		require.NoError(err)
 	}
 
-	// dont insert inferences at the blockheight that matches with the losses
+	for i, forecaster := range forecasters {
+		err = keeper.SetForecasterNetworkRegret(s.Ctx(), topicId, forecaster, getWorkerRegretValue(alloraMath.NewDecFromInt64(int64(i+1)/10).String()))
+		require.NoError(err)
+	}
 
-	err = keeper.InsertActiveInferences(s.ctx, topicId, inferenceNonce2.BlockHeight, getInferencesForBlockHeight(inferenceBlockHeight2))
+	// Insert active inferences and forecasts
+	err = keeper.InsertActiveInferences(s.Ctx(), topicId, nonces["inference2"].BlockHeight, getInferencesForBlockHeight(workers, blockHeights["inference2"], topicId))
 	s.Require().NoError(err)
 
-	err = keeper.InsertActiveForecasts(s.ctx, topicId, inferenceNonce2.BlockHeight, getForecastsForBlockHeight(inferenceBlockHeight2))
+	err = keeper.InsertActiveForecasts(s.Ctx(), topicId, nonces["inference2"].BlockHeight, getForecastsForBlockHeight(workers, forecasters, blockHeights["inference2"], topicId))
 	require.NoError(err)
 
 	// Update epoch topic epoch last ended
-	err = keeper.UpdateTopicEpochLastEnded(s.ctx, topicId, inferenceBlockHeight2)
+	err = keeper.UpdateTopicEpochLastEnded(s.Ctx(), topicId, blockHeights["inference2"])
 	require.NoError(err)
 
 	// Test querying the server
 	req := &types.GetLatestNetworkInferencesRequest{
 		TopicId: topicId,
 	}
-	response, err := queryServer.GetLatestNetworkInferences(s.ctx, req)
+	response, err := queryServer.GetLatestNetworkInferences(s.Ctx(), req)
 
 	require.NoError(err)
 	require.NotNil(response)
 	require.Equal(response.NetworkInferences.Reputer, "")
 	require.Equal(response.NetworkInferences.ReputerRequestNonce.ReputerNonce.BlockHeight, int64(0))
+}
 
+// Helper function to generate inferences
+func getInferencesForBlockHeight(workers []string, blockHeight int64, topicId uint64) types.Inferences {
+	var inferences []*types.Inference
+	inferenceValues := []string{
+		"-0.035995138925040600",
+		"-0.07333303938740420",
+		"-0.1495482917094790",
+		"-0.12952123274063800",
+		"-0.0703055329498285",
+	}
+
+	for i, worker := range workers {
+		inferences = append(inferences, &types.Inference{
+			Inferer:     worker,
+			Value:       alloraMath.MustNewDecFromString(inferenceValues[i]),
+			TopicId:     topicId,
+			BlockHeight: blockHeight,
+		})
+	}
+
+	return types.Inferences{Inferences: inferences}
+}
+
+// Helper function to generate forecasts
+func getForecastsForBlockHeight(workers []string, forecasters []string, blockHeight int64, topicId uint64) types.Forecasts {
+	forecastValues := [][]string{
+		{"0.1", "0.2", "0.3", "0.4", "0.5"},
+		{"0.5", "0.4", "0.3", "0.2", "0.1"},
+		{"0.2", "0.3", "0.4", "0.3", "0.2"},
+	}
+
+	var forecasts []*types.Forecast
+	for i, forecaster := range forecasters {
+		var elements []*types.ForecastElement
+		for j, worker := range workers {
+			elements = append(elements, &types.ForecastElement{
+				Inferer: worker,
+				Value:   alloraMath.MustNewDecFromString(forecastValues[i][j]),
+			})
+		}
+		forecasts = append(forecasts, &types.Forecast{
+			Forecaster:       forecaster,
+			ForecastElements: elements,
+			TopicId:          topicId,
+			BlockHeight:      blockHeight,
+		})
+	}
+
+	return types.Forecasts{Forecasts: forecasts}
 }
 
 func (s *QueryServerTestSuite) TestGetActiveInferersForTopic() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryServer := s.queryServer
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	queryServer := s.EmissionsQueryServer()
 	topicId := uint64(1)
 
 	// Add some active inferers
 	activeInferers := []string{
-		s.addrsStr[0],
-		s.addrsStr[1],
-		s.addrsStr[2],
+		s.AddrsStr(0),
+		s.AddrsStr(1),
+		s.AddrsStr(2),
 	}
 
 	for _, inferer := range activeInferers {
@@ -966,7 +745,7 @@ func (s *QueryServerTestSuite) TestGetActiveInferersForTopic() {
 	s.Require().Contains(err.Error(), "not found")
 
 	// Test with no active inferers
-	emptyTopicId := s.CreateOneTopic()
+	emptyTopicId := s.CreateTopic()
 	emptyResponse, err := queryServer.GetActiveInferersForTopic(
 		ctx,
 		&types.GetActiveInferersForTopicRequest{

--- a/x/emissions/keeper/queryserver/query_server_inferences_test.go
+++ b/x/emissions/keeper/queryserver/query_server_inferences_test.go
@@ -7,9 +7,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/utils/ptr"
 	synth "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/keeper/queryserver/query_server_losses_test.go
+++ b/x/emissions/keeper/queryserver/query_server_losses_test.go
@@ -2,22 +2,22 @@ package queryserver_test
 
 import (
 	cosmosMath "cosmossdk.io/math"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 func (s *QueryServerTestSuite) TestGetNetworkLossBundleAtBlock() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryServer := s.queryServer
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	queryServer := s.EmissionsQueryServer()
 	topicId := uint64(1)
 	blockHeight := types.BlockHeight(100)
 
 	// Set up a sample NetworkLossBundle
 	expectedBundle := &types.ValueBundle{
 		TopicId: topicId,
-		Reputer: s.addrsStr[0],
+		Reputer: s.AddrsStr(0),
 		ReputerRequestNonce: &types.ReputerRequestNonce{
 			ReputerNonce: &types.Nonce{
 				BlockHeight: blockHeight,
@@ -57,8 +57,8 @@ func (s *QueryServerTestSuite) TestGetNetworkLossBundleAtBlock() {
 }
 
 func (s *QueryServerTestSuite) TestIsReputerNonceUnfulfilled() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 	newNonce := &types.Nonce{BlockHeight: 42}
 
@@ -66,7 +66,7 @@ func (s *QueryServerTestSuite) TestIsReputerNonceUnfulfilled() {
 		TopicId:     topicId,
 		BlockHeight: newNonce.BlockHeight,
 	}
-	response, err := s.queryServer.IsReputerNonceUnfulfilled(s.ctx, req)
+	response, err := s.EmissionsQueryServer().IsReputerNonceUnfulfilled(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().NotNil(response, "Response should not be nil")
 	s.Require().False(response.IsReputerNonceUnfulfilled)
@@ -75,22 +75,22 @@ func (s *QueryServerTestSuite) TestIsReputerNonceUnfulfilled() {
 	err = keeper.AddReputerNonce(ctx, topicId, newNonce)
 	s.Require().NoError(err)
 
-	response, err = s.queryServer.IsReputerNonceUnfulfilled(s.ctx, req)
+	response, err = s.EmissionsQueryServer().IsReputerNonceUnfulfilled(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().NotNil(response, "Response should not be nil")
 	s.Require().True(response.IsReputerNonceUnfulfilled)
 }
 
 func (s *QueryServerTestSuite) TestGetUnfulfilledReputerNonces() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 
 	// Initially, ensure no unfulfilled nonces exist
 	req := &types.GetUnfulfilledReputerNoncesRequest{
 		TopicId: topicId,
 	}
-	response, err := s.queryServer.GetUnfulfilledReputerNonces(s.ctx, req)
+	response, err := s.EmissionsQueryServer().GetUnfulfilledReputerNonces(s.Ctx(), req)
 	s.Require().NoError(err)
 	s.Require().NotNil(response, "Response should not be nil")
 	s.Require().Len(response.Nonces.Nonces, 0, "Initial unfulfilled nonces should be empty")
@@ -103,7 +103,7 @@ func (s *QueryServerTestSuite) TestGetUnfulfilledReputerNonces() {
 	}
 
 	// Retrieve and verify the nonces
-	response, err = s.queryServer.GetUnfulfilledReputerNonces(s.ctx, req)
+	response, err = s.EmissionsQueryServer().GetUnfulfilledReputerNonces(s.Ctx(), req)
 	s.Require().NoError(err, "Error retrieving nonces after adding")
 	s.Require().Len(response.Nonces.Nonces, len(nonceValues), "Should match the number of added nonces")
 
@@ -114,13 +114,14 @@ func (s *QueryServerTestSuite) TestGetUnfulfilledReputerNonces() {
 }
 
 func (s *QueryServerTestSuite) TestGetReputerLossBundlesAtBlock() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
 	topicId := uint64(1)
 	block := types.BlockHeight(100)
+	//nolint:exhaustruct
 	valueBundle := types.ValueBundle{
 		TopicId:             topicId,
-		Reputer:             s.addrsStr[0],
+		Reputer:             s.AddrsStr(0),
 		ReputerRequestNonce: &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
 		ExtraData:           []byte("sample_extra_data"),
 		CombinedValue:       alloraMath.NewDecFromInt64(100),
@@ -132,19 +133,14 @@ func (s *QueryServerTestSuite) TestGetReputerLossBundlesAtBlock() {
 				Value:  alloraMath.MustNewDecFromString("1"),
 			},
 		},
-		ForecasterValues:              nil,
-		OneOutInfererValues:           nil,
-		OneOutForecasterValues:        nil,
-		OneInForecasterValues:         nil,
-		OneOutInfererForecasterValues: nil,
 	}
-	signature := s.signValueBundle(&valueBundle, s.privKeys[0])
+	signature := s.SignValueBundle(&valueBundle, s.PrivKeys(0))
 	reputerLossBundles := types.ReputerValueBundles{
 		ReputerValueBundles: []*types.ReputerValueBundle{
 			{
 				ValueBundle: &valueBundle,
 				Signature:   signature,
-				Pubkey:      s.pubKeyHexStr[0],
+				Pubkey:      s.PubKeyHexStr(0),
 			},
 		},
 	}
@@ -152,15 +148,15 @@ func (s *QueryServerTestSuite) TestGetReputerLossBundlesAtBlock() {
 		TopicId:     topicId,
 		BlockHeight: block,
 	}
-	response, err := s.queryServer.GetReputerLossBundlesAtBlock(ctx, req)
+	response, err := s.EmissionsQueryServer().GetReputerLossBundlesAtBlock(ctx, req)
 	require.NoError(err)
 	require.Empty(response.LossBundles.ReputerValueBundles)
 
 	// Test inserting data
-	err = s.emissionsKeeper.InsertActiveReputerLosses(ctx, topicId, block, reputerLossBundles)
+	err = s.EmissionsKeeper().InsertActiveReputerLosses(ctx, topicId, block, reputerLossBundles)
 	require.NoError(err, "InsertActiveReputerLosses should not return an error")
 
-	response, err = s.queryServer.GetReputerLossBundlesAtBlock(ctx, req)
+	response, err = s.EmissionsQueryServer().GetReputerLossBundlesAtBlock(ctx, req)
 	require.NotEmpty(response)
 	require.NoError(err)
 
@@ -170,8 +166,8 @@ func (s *QueryServerTestSuite) TestGetReputerLossBundlesAtBlock() {
 }
 
 func (s *QueryServerTestSuite) TestGetDeleteDelegateStake() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 
 	// Create sample delegate stake removal information
 	removalInfo := types.DelegateStakeRemovalInfo{
@@ -193,13 +189,13 @@ func (s *QueryServerTestSuite) TestGetDeleteDelegateStake() {
 		Reputer:     removalInfo.Reputer,
 		Delegator:   removalInfo.Delegator,
 	}
-	response, err := s.queryServer.GetDelegateStakeRemoval(ctx, req)
+	response, err := s.EmissionsQueryServer().GetDelegateStakeRemoval(ctx, req)
 	s.Require().Error(err)
 	s.Require().Nil(response)
 
 	req.BlockHeight = removalInfo.BlockRemovalCompleted
 
-	response, err = s.queryServer.GetDelegateStakeRemoval(ctx, req)
+	response, err = s.EmissionsQueryServer().GetDelegateStakeRemoval(ctx, req)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 
@@ -213,17 +209,16 @@ func (s *QueryServerTestSuite) TestGetDeleteDelegateStake() {
 }
 
 func (s *QueryServerTestSuite) TestGetActiveReputersForTopic() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryServer := s.queryServer
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	queryServer := s.EmissionsQueryServer()
 	topicId := uint64(1)
 
 	// Add some active reputers
 	activeReputers := []string{
-		s.addrsStr[0],
-		s.addrsStr[1],
-		s.addrsStr[2],
+		s.AddrsStr(0),
+		s.AddrsStr(1),
+		s.AddrsStr(2),
 	}
 
 	for _, reputer := range activeReputers {
@@ -260,7 +255,7 @@ func (s *QueryServerTestSuite) TestGetActiveReputersForTopic() {
 	s.Require().Contains(err.Error(), "not found")
 
 	// Test with no active reputers
-	emptyTopicId := s.CreateOneTopic()
+	emptyTopicId := s.CreateTopic()
 	emptyResponse, err := queryServer.GetActiveReputersForTopic(
 		ctx,
 		&types.GetActiveReputersForTopicRequest{

--- a/x/emissions/keeper/queryserver/query_server_params_test.go
+++ b/x/emissions/keeper/queryserver/query_server_params_test.go
@@ -5,16 +5,12 @@ import (
 )
 
 func (s *QueryServerTestSuite) TestParams() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryServer := s.queryServer
-
 	expectedParams := types.DefaultParams()
 
-	err := keeper.SetParams(ctx, expectedParams)
+	err := s.EmissionsKeeper().SetParams(s.Ctx(), expectedParams)
 	s.Require().NoError(err, "Setting parameters should not produce an error")
 
-	response, err := queryServer.GetParams(ctx, &types.GetParamsRequest{})
+	response, err := s.EmissionsQueryServer().GetParams(s.Ctx(), &types.GetParamsRequest{})
 
 	s.Require().NoError(err, "Retrieving parameters should not produce an error")
 	s.Require().NotNil(response, "The response should not be nil")

--- a/x/emissions/keeper/queryserver/query_server_registrations_test.go
+++ b/x/emissions/keeper/queryserver/query_server_registrations_test.go
@@ -1,20 +1,21 @@
 package queryserver_test
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/allora-network/allora-chain/app/params"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 	minttypes "github.com/allora-network/allora-chain/x/mint/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (s *QueryServerTestSuite) TestGetWorkerNodeInfo() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryServer := s.queryServer
-	worker := s.addrsStr[0]
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	queryServer := s.EmissionsQueryServer()
+	worker := s.AddrsStr(0)
 
 	expectedNode := types.OffchainNode{
-		Owner:       s.addrsStr[1],
+		Owner:       s.AddrsStr(1),
 		NodeAddress: worker,
 	}
 
@@ -41,13 +42,13 @@ func (s *QueryServerTestSuite) TestGetWorkerNodeInfo() {
 }
 
 func (s *QueryServerTestSuite) TestGetReputerNodeInfo() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	queryServer := s.queryServer
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	queryServer := s.EmissionsQueryServer()
 
-	reputer := s.addrsStr[1]
+	reputer := s.AddrsStr(1)
 	expectedReputer := types.OffchainNode{
-		NodeAddress: s.addrsStr[0],
+		NodeAddress: s.AddrsStr(0),
 		Owner:       reputer,
 	}
 
@@ -74,9 +75,8 @@ func (s *QueryServerTestSuite) TestGetReputerNodeInfo() {
 }
 
 func (s *QueryServerTestSuite) TestUnregisteredWorkerIsUnregisteredInTopicId() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryServer := s.queryServer
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
 
 	notRegisteredWorkerAddr := "allo12gjf2mrtva0p33gqtvsxp37zgglmdgpwaq22m2"
 
@@ -92,19 +92,19 @@ func (s *QueryServerTestSuite) TestUnregisteredWorkerIsUnregisteredInTopicId() {
 }
 
 func (s *QueryServerTestSuite) TestRegisteredWorkerIsRegisteredInTopicId() {
-	ctx, msgServer := s.ctx, s.msgServer
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
 	require := s.Require()
 
 	// Mock setup for addresses
-	workerAddr := s.addrs[1]
+	workerAddr := s.Addrs(1)
 	workerAddrString := workerAddr.String()
 	topicId := uint64(1)
-	topic1 := s.mockTopic()
+	topic1 := s.MockTopic()
 
 	// Topic register
-	err := s.emissionsKeeper.SetTopic(ctx, topicId, topic1)
+	err := s.EmissionsKeeper().SetTopic(ctx, topicId, topic1)
 	require.NoError(err, "SetTopic should not return an error")
-	err = s.emissionsKeeper.ActivateTopic(ctx, topicId)
+	err = s.EmissionsKeeper().ActivateTopic(ctx, topicId)
 	require.NoError(err, "ActivateTopic should not return an error")
 	// Worker register
 	registerMsg := &types.RegisterRequest{
@@ -114,12 +114,12 @@ func (s *QueryServerTestSuite) TestRegisteredWorkerIsRegisteredInTopicId() {
 		Owner:     workerAddrString,
 	}
 
-	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
+	moduleParams, err := s.EmissionsKeeper().GetParams(ctx)
 	s.Require().NoError(err)
 	mintAmount := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, moduleParams.RegistrationFee))
-	err = s.bankKeeper.MintCoins(ctx, minttypes.ModuleName, mintAmount)
+	err = s.BankKeeper().MintCoins(ctx, minttypes.ModuleName, mintAmount)
 	require.NoError(err, "MintCoins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(
+	err = s.BankKeeper().SendCoinsFromModuleToAccount(
 		ctx,
 		minttypes.ModuleName,
 		workerAddr,
@@ -131,31 +131,32 @@ func (s *QueryServerTestSuite) TestRegisteredWorkerIsRegisteredInTopicId() {
 		Address: workerAddrString,
 		TopicId: topicId,
 	}
-	queryResp, err := s.queryServer.IsWorkerRegisteredInTopicId(ctx, queryReq)
+	queryResp, err := s.EmissionsQueryServer().IsWorkerRegisteredInTopicId(ctx, queryReq)
 	require.NoError(err, "IsWorkerRegisteredInTopicId should not return an error")
 	require.False(queryResp.IsRegistered, "Query response should confirm worker is registered")
 
 	_, err = msgServer.Register(ctx, registerMsg)
 	require.NoError(err, "Registering worker should not return an error")
 
-	queryResp, err = s.queryServer.IsWorkerRegisteredInTopicId(ctx, queryReq)
+	queryResp, err = s.EmissionsQueryServer().IsWorkerRegisteredInTopicId(ctx, queryReq)
 	require.NoError(err, "IsWorkerRegisteredInTopicId should not return an error")
 	require.True(queryResp.IsRegistered, "Query response should confirm worker is registered")
 }
 
 func (s *QueryServerTestSuite) TestRegisteredReputerIsRegisteredInTopicId() {
-	ctx, msgServer := s.ctx, s.msgServer
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
 	require := s.Require()
 
 	// Mock setup for addresses
-	reputerAddr := s.addrs[2]
+	reputerAddr := s.Addrs(2)
 	topicId := uint64(1)
-	topic1 := s.mockTopic()
+	topic1, err := s.EmissionsKeeper().GetTopic(s.Ctx(), topicId)
+	s.Require().NoError(err, "Getting topic should not fail")
 
 	// Topic register
-	err := s.emissionsKeeper.SetTopic(ctx, topicId, topic1)
+	err = s.EmissionsKeeper().SetTopic(ctx, topicId, topic1)
 	require.NoError(err, "SetTopic should not return an error")
-	err = s.emissionsKeeper.ActivateTopic(ctx, topicId)
+	err = s.EmissionsKeeper().ActivateTopic(ctx, topicId)
 	require.NoError(err, "ActivateTopic should not return an error")
 	// Register reputer
 	registerMsg := &types.RegisterRequest{
@@ -165,26 +166,26 @@ func (s *QueryServerTestSuite) TestRegisteredReputerIsRegisteredInTopicId() {
 		Owner:     reputerAddr.String(),
 	}
 
-	moduleParams, err := s.emissionsKeeper.GetParams(ctx)
+	moduleParams, err := s.EmissionsKeeper().GetParams(ctx)
 	s.Require().NoError(err)
 	mintAmount := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, moduleParams.RegistrationFee))
-	err = s.bankKeeper.MintCoins(ctx, minttypes.ModuleName, mintAmount)
+	err = s.BankKeeper().MintCoins(ctx, minttypes.ModuleName, mintAmount)
 	require.NoError(err, "MintCoins should not return an error")
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, reputerAddr, mintAmount)
+	err = s.BankKeeper().SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, reputerAddr, mintAmount)
 	require.NoError(err, "SendCoinsFromModuleToAccount should not return an error")
 
 	queryReq := &types.IsReputerRegisteredInTopicIdRequest{
 		Address: reputerAddr.String(),
 		TopicId: topicId,
 	}
-	queryResp, err := s.queryServer.IsReputerRegisteredInTopicId(ctx, queryReq)
+	queryResp, err := s.EmissionsQueryServer().IsReputerRegisteredInTopicId(ctx, queryReq)
 	require.NoError(err, "IsReputerRegisteredInTopicId should not return an error")
 	require.False(queryResp.IsRegistered, "Query response should confirm reputer is registered")
 
 	_, err = msgServer.Register(ctx, registerMsg)
 	require.NoError(err, "Registering reputer should not return an error")
 
-	queryResp, err = s.queryServer.IsReputerRegisteredInTopicId(ctx, queryReq)
+	queryResp, err = s.EmissionsQueryServer().IsReputerRegisteredInTopicId(ctx, queryReq)
 	require.NoError(err, "IsReputerRegisteredInTopicId should not return an error")
 	require.True(queryResp.IsRegistered, "Query response should confirm reputer is registered")
 }

--- a/x/emissions/keeper/queryserver/query_server_reward_test.go
+++ b/x/emissions/keeper/queryserver/query_server_reward_test.go
@@ -6,17 +6,17 @@ import (
 )
 
 func (s *QueryServerTestSuite) TestGetPreviousReputerRewardFraction() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputer := s.addrsStr[2]
+	reputer := s.AddrsStr(2)
 
 	// Attempt to fetch a reward fraction before setting it
 	req := &types.GetPreviousReputerRewardFractionRequest{
 		TopicId: topicId,
 		Reputer: reputer,
 	}
-	response, err := s.queryServer.GetPreviousReputerRewardFraction(ctx, req)
+	response, err := s.EmissionsQueryServer().GetPreviousReputerRewardFraction(ctx, req)
 	s.Require().NoError(err)
 	defaultReward := response.RewardFraction
 	notFound := response.NotFound
@@ -30,7 +30,7 @@ func (s *QueryServerTestSuite) TestGetPreviousReputerRewardFraction() {
 	_ = keeper.SetPreviousReputerRewardFraction(ctx, topicId, reputer, setReward)
 
 	// Fetch and verify the reward fraction after setting
-	response, err = s.queryServer.GetPreviousReputerRewardFraction(ctx, req)
+	response, err = s.EmissionsQueryServer().GetPreviousReputerRewardFraction(ctx, req)
 	s.Require().NoError(err)
 	fetchedReward := response.RewardFraction
 	notFound = response.NotFound
@@ -40,17 +40,17 @@ func (s *QueryServerTestSuite) TestGetPreviousReputerRewardFraction() {
 }
 
 func (s *QueryServerTestSuite) TestGetPreviousInferenceRewardFraction() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[1]
+	worker := s.AddrsStr(1)
 
 	// Attempt to fetch a reward fraction before setting it
 	req := &types.GetPreviousInferenceRewardFractionRequest{
 		TopicId: topicId,
 		Worker:  worker,
 	}
-	response, err := s.queryServer.GetPreviousInferenceRewardFraction(ctx, req)
+	response, err := s.EmissionsQueryServer().GetPreviousInferenceRewardFraction(ctx, req)
 	s.Require().NoError(err)
 	defaultReward := response.RewardFraction
 	noPrior := response.NotFound
@@ -66,24 +66,24 @@ func (s *QueryServerTestSuite) TestGetPreviousInferenceRewardFraction() {
 	// Fetch and verify the reward fraction after setting
 	fetchedReward, _, err := keeper.GetPreviousInferenceRewardFraction(ctx, topicId, worker)
 	s.Require().NoError(err)
-	response, err = s.queryServer.GetPreviousInferenceRewardFraction(ctx, req)
+	response, err = s.EmissionsQueryServer().GetPreviousInferenceRewardFraction(ctx, req)
 	s.Require().NoError(err, "Fetching reward fraction should not fail after setting")
 	s.Require().True(fetchedReward.Equal(setReward), "The fetched reward fraction should match the set value")
 	s.Require().True(response.RewardFraction.Equal(setReward), "The fetched reward fraction should match the set value")
 }
 
 func (s *QueryServerTestSuite) TestGetPreviousForecastRewardFraction() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[3]
+	worker := s.AddrsStr(3)
 
 	// Attempt to fetch the reward fraction before setting it, expecting default value
 	req := &types.GetPreviousForecastRewardFractionRequest{
 		TopicId: topicId,
 		Worker:  worker,
 	}
-	response, err := s.queryServer.GetPreviousForecastRewardFraction(ctx, req)
+	response, err := s.EmissionsQueryServer().GetPreviousForecastRewardFraction(ctx, req)
 	s.Require().NoError(err)
 	defaultReward := response.RewardFraction
 	noPrior := response.NotFound
@@ -97,7 +97,7 @@ func (s *QueryServerTestSuite) TestGetPreviousForecastRewardFraction() {
 	_ = keeper.SetPreviousForecastRewardFraction(ctx, topicId, worker, setReward)
 
 	// Fetch and verify the reward fraction after setting
-	response, err = s.queryServer.GetPreviousForecastRewardFraction(ctx, req)
+	response, err = s.EmissionsQueryServer().GetPreviousForecastRewardFraction(ctx, req)
 	s.Require().NoError(err)
 	fetchedReward := response.RewardFraction
 	noPrior = response.NotFound
@@ -107,8 +107,8 @@ func (s *QueryServerTestSuite) TestGetPreviousForecastRewardFraction() {
 }
 
 func (s *QueryServerTestSuite) TestGetPreviousPercentageRewardToStakedReputers() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	previousPercentageReward := alloraMath.NewDecFromInt64(50)
 
 	// Set the previous percentage reward to staked reputers
@@ -125,7 +125,7 @@ func (s *QueryServerTestSuite) TestGetPreviousPercentageRewardToStakedReputers()
 		previousPercentageReward.String(),
 	)
 	req := &types.GetPreviousPercentageRewardToStakedReputersRequest{}
-	response, err := s.queryServer.GetPreviousPercentageRewardToStakedReputers(ctx, req)
+	response, err := s.EmissionsQueryServer().GetPreviousPercentageRewardToStakedReputers(ctx, req)
 	s.Require().NoError(err)
 	fetchedPercentageReward = response.PercentageReward
 

--- a/x/emissions/keeper/queryserver/query_server_score_test.go
+++ b/x/emissions/keeper/queryserver/query_server_score_test.go
@@ -6,10 +6,10 @@ import (
 )
 
 func (s *QueryServerTestSuite) TestGetInfererScoreEma() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[0]
+	worker := s.AddrsStr(0)
 	newScore := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker, Score: alloraMath.NewDecFromInt64(95)}
 
 	// Set an initial score for inferer and attempt to update with an older score
@@ -20,7 +20,7 @@ func (s *QueryServerTestSuite) TestGetInfererScoreEma() {
 		TopicId: topicId,
 		Inferer: worker,
 	}
-	response, err := s.queryServer.GetInfererScoreEma(ctx, req)
+	response, err := s.EmissionsQueryServer().GetInfererScoreEma(ctx, req)
 	s.Require().NoError(err)
 
 	s.Require().True(
@@ -31,11 +31,11 @@ func (s *QueryServerTestSuite) TestGetInfererScoreEma() {
 }
 
 func (s *QueryServerTestSuite) TestGetForecasterScoreEma() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[0]
-	forecaster := s.addrsStr[2]
+	worker := s.AddrsStr(0)
+	forecaster := s.AddrsStr(2)
 	newScore := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker, Score: alloraMath.NewDecFromInt64(95)}
 
 	// Set a new score for forecaster
@@ -45,7 +45,7 @@ func (s *QueryServerTestSuite) TestGetForecasterScoreEma() {
 		TopicId:    topicId,
 		Forecaster: forecaster,
 	}
-	response, err := s.queryServer.GetForecasterScoreEma(ctx, req)
+	response, err := s.EmissionsQueryServer().GetForecasterScoreEma(ctx, req)
 	s.Require().NoError(err)
 
 	forecasterScore := response.Score
@@ -53,11 +53,11 @@ func (s *QueryServerTestSuite) TestGetForecasterScoreEma() {
 }
 
 func (s *QueryServerTestSuite) TestGetReputerScoreEma() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	worker := s.addrsStr[0]
-	reputer := s.addrsStr[2]
+	worker := s.AddrsStr(0)
+	reputer := s.AddrsStr(2)
 	newScore := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker, Score: alloraMath.NewDecFromInt64(95)}
 
 	// Set a new score for reputer
@@ -67,7 +67,7 @@ func (s *QueryServerTestSuite) TestGetReputerScoreEma() {
 		TopicId: topicId,
 		Reputer: reputer,
 	}
-	response, err := s.queryServer.GetReputerScoreEma(ctx, req)
+	response, err := s.EmissionsQueryServer().GetReputerScoreEma(ctx, req)
 	s.Require().NoError(err)
 
 	reputerScore := response.Score
@@ -75,10 +75,10 @@ func (s *QueryServerTestSuite) TestGetReputerScoreEma() {
 }
 
 func (s *QueryServerTestSuite) TestGetInferenceScoresUntilBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	workerAddress := s.addrs[0]
+	workerAddress := s.Addrs(0)
 	blockHeight := int64(105)
 
 	// Insert scores for different workers and blocks
@@ -87,7 +87,7 @@ func (s *QueryServerTestSuite) TestGetInferenceScoresUntilBlock() {
 		scoreForWorker := types.Score{
 			TopicId:     topicId,
 			BlockHeight: blockHeight,
-			Address:     s.addrsStr[0],
+			Address:     s.AddrsStr(0),
 			Score:       alloraMath.NewDecFromInt64(blockHeight),
 		}
 		_ = keeper.InsertWorkerInferenceScore(ctx, topicId, blockHeight, scoreForWorker)
@@ -98,7 +98,7 @@ func (s *QueryServerTestSuite) TestGetInferenceScoresUntilBlock() {
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
 	}
-	response, err := s.queryServer.GetInferenceScoresUntilBlock(ctx, req)
+	response, err := s.EmissionsQueryServer().GetInferenceScoresUntilBlock(ctx, req)
 	s.Require().NoError(err)
 	scores := response.Scores
 
@@ -116,14 +116,14 @@ func (s *QueryServerTestSuite) TestGetInferenceScoresUntilBlock() {
 }
 
 func (s *QueryServerTestSuite) TestGetWorkerInferenceScoresAtBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(100)
 	score := types.Score{
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
-		Address:     s.addrsStr[0],
+		Address:     s.AddrsStr(0),
 		Score:       alloraMath.NewDecFromInt64(95),
 	}
 
@@ -146,7 +146,7 @@ func (s *QueryServerTestSuite) TestGetWorkerInferenceScoresAtBlock() {
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
 	}
-	response, err := s.queryServer.GetWorkerInferenceScoresAtBlock(ctx, req)
+	response, err := s.EmissionsQueryServer().GetWorkerInferenceScoresAtBlock(ctx, req)
 	scores := response.Scores
 
 	s.Require().NoError(err, "Fetching scores at block should not fail")
@@ -154,8 +154,8 @@ func (s *QueryServerTestSuite) TestGetWorkerInferenceScoresAtBlock() {
 }
 
 func (s *QueryServerTestSuite) TestGetForecastScoresUntilBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(105)
 
@@ -164,7 +164,7 @@ func (s *QueryServerTestSuite) TestGetForecastScoresUntilBlock() {
 		score := types.Score{
 			TopicId:     topicId,
 			BlockHeight: i,
-			Address:     s.addrsStr[i-100],
+			Address:     s.AddrsStr(int(i - 100)),
 			Score:       alloraMath.NewDecFromInt64(i),
 		}
 		err := keeper.InsertWorkerForecastScore(ctx, topicId, i, score)
@@ -175,15 +175,15 @@ func (s *QueryServerTestSuite) TestGetForecastScoresUntilBlock() {
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
 	}
-	response, err := s.queryServer.GetForecastScoresUntilBlock(ctx, req)
+	response, err := s.EmissionsQueryServer().GetForecastScoresUntilBlock(ctx, req)
 	scores := response.Scores
 	s.Require().NoError(err, "Fetching worker forecast scores until block should not fail")
 	s.Require().Len(scores, 6, "Should retrieve correct number of scores up to block 105")
 }
 
 func (s *QueryServerTestSuite) TestGetWorkerForecastScoresAtBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(100)
 
@@ -192,7 +192,7 @@ func (s *QueryServerTestSuite) TestGetWorkerForecastScoresAtBlock() {
 		score := types.Score{
 			TopicId:     topicId,
 			BlockHeight: blockHeight,
-			Address:     s.addrsStr[i],
+			Address:     s.AddrsStr(i),
 			Score:       alloraMath.NewDecFromInt64(int64(100 + i)),
 		}
 		_ = keeper.InsertWorkerForecastScore(ctx, topicId, blockHeight, score)
@@ -203,7 +203,7 @@ func (s *QueryServerTestSuite) TestGetWorkerForecastScoresAtBlock() {
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
 	}
-	response, err := s.queryServer.GetWorkerForecastScoresAtBlock(ctx, req)
+	response, err := s.EmissionsQueryServer().GetWorkerForecastScoresAtBlock(ctx, req)
 	scores := response.Scores
 
 	s.Require().NoError(err, "Fetching forecast scores at block should not fail")
@@ -211,8 +211,8 @@ func (s *QueryServerTestSuite) TestGetWorkerForecastScoresAtBlock() {
 }
 
 func (s *QueryServerTestSuite) TestGetReputersScoresAtBlock() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 	blockHeight := int64(100)
 
@@ -221,7 +221,7 @@ func (s *QueryServerTestSuite) TestGetReputersScoresAtBlock() {
 		score := types.Score{
 			TopicId:     topicId,
 			BlockHeight: blockHeight,
-			Address:     s.addrsStr[i],
+			Address:     s.AddrsStr(i),
 			Score:       alloraMath.NewDecFromInt64(int64(100 + i)),
 		}
 		_ = keeper.InsertReputerScore(ctx, topicId, blockHeight, score)
@@ -232,7 +232,7 @@ func (s *QueryServerTestSuite) TestGetReputersScoresAtBlock() {
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
 	}
-	response, err := s.queryServer.GetReputersScoresAtBlock(ctx, req)
+	response, err := s.EmissionsQueryServer().GetReputersScoresAtBlock(ctx, req)
 	s.Require().NoError(err)
 	scores := response.Scores
 
@@ -241,17 +241,17 @@ func (s *QueryServerTestSuite) TestGetReputersScoresAtBlock() {
 }
 
 func (s *QueryServerTestSuite) TestGetListeningCoefficient() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputer := s.addrsStr[1]
+	reputer := s.AddrsStr(1)
 
 	// Attempt to fetch a coefficient before setting it
 	req := &types.GetListeningCoefficientRequest{
 		TopicId: topicId,
 		Reputer: reputer,
 	}
-	response, err := s.queryServer.GetListeningCoefficient(ctx, req)
+	response, err := s.EmissionsQueryServer().GetListeningCoefficient(ctx, req)
 	s.Require().NoError(err)
 	defaultCoef := response.ListeningCoefficient
 
@@ -265,7 +265,7 @@ func (s *QueryServerTestSuite) TestGetListeningCoefficient() {
 	_ = keeper.SetListeningCoefficient(ctx, topicId, reputer, setCoef)
 
 	// Fetch and verify the coefficient after setting
-	response, err = s.queryServer.GetListeningCoefficient(ctx, req)
+	response, err = s.EmissionsQueryServer().GetListeningCoefficient(ctx, req)
 	s.Require().NoError(err)
 	fetchedCoef := response.ListeningCoefficient
 
@@ -274,7 +274,7 @@ func (s *QueryServerTestSuite) TestGetListeningCoefficient() {
 }
 
 func (s *QueryServerTestSuite) TestGetCurrentLowestInfererScore() {
-	ctx, keeper, require := s.ctx, s.emissionsKeeper, s.Require()
+	ctx, keeper, require := s.Ctx(), s.EmissionsKeeper(), s.Require()
 
 	topicId := uint64(1)
 	blockHeight := int64(100)
@@ -283,14 +283,14 @@ func (s *QueryServerTestSuite) TestGetCurrentLowestInfererScore() {
 	score := types.Score{
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
-		Address:     s.addrsStr[0],
+		Address:     s.AddrsStr(0),
 		Score:       alloraMath.NewDecFromInt64(95),
 	}
 	err := keeper.SetLowestInfererScoreEma(ctx, topicId, score)
 	require.NoError(err, "Setting inferer score ema should not fail")
 
 	req := &types.GetCurrentLowestInfererScoreRequest{TopicId: topicId}
-	response, err := s.queryServer.GetCurrentLowestInfererScore(ctx, req)
+	response, err := s.EmissionsQueryServer().GetCurrentLowestInfererScore(ctx, req)
 	require.NoError(err, "Fetching current lowest inferer score should not fail")
 	require.True(
 		response.Score.Score.Equal(alloraMath.NewDecFromInt64(95)),
@@ -300,7 +300,7 @@ func (s *QueryServerTestSuite) TestGetCurrentLowestInfererScore() {
 }
 
 func (s *QueryServerTestSuite) TestGetCurrentLowestForecasterScore() {
-	ctx, keeper, require := s.ctx, s.emissionsKeeper, s.Require()
+	ctx, keeper, require := s.Ctx(), s.EmissionsKeeper(), s.Require()
 
 	topicId := uint64(1)
 	blockHeight := int64(100)
@@ -309,14 +309,14 @@ func (s *QueryServerTestSuite) TestGetCurrentLowestForecasterScore() {
 	score := types.Score{
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
-		Address:     s.addrsStr[0],
+		Address:     s.AddrsStr(0),
 		Score:       alloraMath.NewDecFromInt64(95),
 	}
 	err := keeper.SetLowestForecasterScoreEma(ctx, topicId, score)
 	require.NoError(err, "Setting forecaster score ema should not fail")
 
 	req := &types.GetCurrentLowestForecasterScoreRequest{TopicId: topicId}
-	response, err := s.queryServer.GetCurrentLowestForecasterScore(ctx, req)
+	response, err := s.EmissionsQueryServer().GetCurrentLowestForecasterScore(ctx, req)
 	require.NoError(err, "Fetching current lowest forecaster score should not fail")
 	require.True(
 		response.Score.Score.Equal(score.Score),
@@ -326,7 +326,7 @@ func (s *QueryServerTestSuite) TestGetCurrentLowestForecasterScore() {
 }
 
 func (s *QueryServerTestSuite) TestGetCurrentLowestReputerScore() {
-	ctx, keeper, require := s.ctx, s.emissionsKeeper, s.Require()
+	ctx, keeper, require := s.Ctx(), s.EmissionsKeeper(), s.Require()
 
 	topicId := uint64(1)
 	blockHeight := int64(100)
@@ -335,14 +335,14 @@ func (s *QueryServerTestSuite) TestGetCurrentLowestReputerScore() {
 	score := types.Score{
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
-		Address:     s.addrsStr[0],
+		Address:     s.AddrsStr(0),
 		Score:       alloraMath.NewDecFromInt64(95),
 	}
 	err := keeper.SetLowestReputerScoreEma(ctx, topicId, score)
 	require.NoError(err, "Setting reputer score ema should not fail")
 
 	req := &types.GetCurrentLowestReputerScoreRequest{TopicId: topicId}
-	response, err := s.queryServer.GetCurrentLowestReputerScore(ctx, req)
+	response, err := s.EmissionsQueryServer().GetCurrentLowestReputerScore(ctx, req)
 	require.NoError(err, "Fetching current lowest reputer score should not fail")
 	require.True(
 		response.Score.Score.Equal(alloraMath.NewDecFromInt64(95)),
@@ -352,9 +352,9 @@ func (s *QueryServerTestSuite) TestGetCurrentLowestReputerScore() {
 }
 
 func (s *QueryServerTestSuite) TestGetTopicInitialInfererEmaScore() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := s.CreateOneTopic()
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	topicId := uint64(1)
 	initialScore := alloraMath.MustNewDecFromString("95.5")
 
 	// Set initial score
@@ -364,7 +364,7 @@ func (s *QueryServerTestSuite) TestGetTopicInitialInfererEmaScore() {
 	req := &types.GetTopicInitialInfererEmaScoreRequest{
 		TopicId: topicId,
 	}
-	response, err := s.queryServer.GetTopicInitialInfererEmaScore(ctx, req)
+	response, err := s.EmissionsQueryServer().GetTopicInitialInfererEmaScore(ctx, req)
 	s.Require().NoError(err)
 	s.Require().Equal(initialScore, response.Score, "Initial inferer score should match what was set")
 
@@ -372,14 +372,14 @@ func (s *QueryServerTestSuite) TestGetTopicInitialInfererEmaScore() {
 	req = &types.GetTopicInitialInfererEmaScoreRequest{
 		TopicId: 999,
 	}
-	_, err = s.queryServer.GetTopicInitialInfererEmaScore(ctx, req)
+	_, err = s.EmissionsQueryServer().GetTopicInitialInfererEmaScore(ctx, req)
 	s.Require().Error(err, "Query for non-existent topic should fail")
 }
 
 func (s *QueryServerTestSuite) TestGetTopicInitialForecasterEmaScore() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := s.CreateOneTopic()
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	topicId := uint64(1)
 	initialScore := alloraMath.MustNewDecFromString("92.5")
 
 	// Set initial score
@@ -389,7 +389,7 @@ func (s *QueryServerTestSuite) TestGetTopicInitialForecasterEmaScore() {
 	req := &types.GetTopicInitialForecasterEmaScoreRequest{
 		TopicId: topicId,
 	}
-	response, err := s.queryServer.GetTopicInitialForecasterEmaScore(ctx, req)
+	response, err := s.EmissionsQueryServer().GetTopicInitialForecasterEmaScore(ctx, req)
 	s.Require().NoError(err)
 	s.Require().Equal(initialScore, response.Score, "Initial forecaster score should match what was set")
 
@@ -397,14 +397,14 @@ func (s *QueryServerTestSuite) TestGetTopicInitialForecasterEmaScore() {
 	req = &types.GetTopicInitialForecasterEmaScoreRequest{
 		TopicId: 999,
 	}
-	_, err = s.queryServer.GetTopicInitialForecasterEmaScore(ctx, req)
+	_, err = s.EmissionsQueryServer().GetTopicInitialForecasterEmaScore(ctx, req)
 	s.Require().Error(err, "Query for non-existent topic should fail")
 }
 
 func (s *QueryServerTestSuite) TestGetTopicInitialReputerEmaScore() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := s.CreateOneTopic()
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	topicId := uint64(1)
 	initialScore := alloraMath.MustNewDecFromString("93.5")
 
 	// Set initial score
@@ -414,7 +414,7 @@ func (s *QueryServerTestSuite) TestGetTopicInitialReputerEmaScore() {
 	req := &types.GetTopicInitialReputerEmaScoreRequest{
 		TopicId: topicId,
 	}
-	response, err := s.queryServer.GetTopicInitialReputerEmaScore(ctx, req)
+	response, err := s.EmissionsQueryServer().GetTopicInitialReputerEmaScore(ctx, req)
 	s.Require().NoError(err)
 	s.Require().Equal(initialScore, response.Score, "Initial reputer score should match what was set")
 
@@ -422,6 +422,6 @@ func (s *QueryServerTestSuite) TestGetTopicInitialReputerEmaScore() {
 	req = &types.GetTopicInitialReputerEmaScoreRequest{
 		TopicId: 999,
 	}
-	_, err = s.queryServer.GetTopicInitialReputerEmaScore(ctx, req)
+	_, err = s.EmissionsQueryServer().GetTopicInitialReputerEmaScore(ctx, req)
 	s.Require().Error(err, "Query for non-existent topic should fail")
 }

--- a/x/emissions/keeper/queryserver/query_server_stake_test.go
+++ b/x/emissions/keeper/queryserver/query_server_stake_test.go
@@ -4,14 +4,15 @@ import (
 	"strconv"
 
 	cosmosMath "cosmossdk.io/math"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 func (s *QueryServerTestSuite) TestGetTotalStake() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	expectedTotalStake := cosmosMath.NewInt(1000)
 	err := keeper.SetTotalStake(ctx, expectedTotalStake)
@@ -25,12 +26,11 @@ func (s *QueryServerTestSuite) TestGetTotalStake() {
 }
 
 func (s *QueryServerTestSuite) TestGetReputerStakeInTopic() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputerAddr := s.addrsStr[1]
+	reputerAddr := s.AddrsStr(1)
 	initialStake := cosmosMath.NewInt(250)
 
 	err := keeper.AddReputerStake(ctx, topicId, reputerAddr, initialStake)
@@ -48,13 +48,12 @@ func (s *QueryServerTestSuite) TestGetReputerStakeInTopic() {
 }
 
 func (s *QueryServerTestSuite) TestGetMultiReputerStakeInTopic() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputer1Addr := s.addrsStr[1]
-	reputer2Addr := s.addrsStr[2]
+	reputer1Addr := s.AddrsStr(1)
+	reputer2Addr := s.AddrsStr(2)
 	initialStake1 := cosmosMath.NewInt(250)
 	initialStake2 := cosmosMath.NewInt(251)
 
@@ -77,13 +76,12 @@ func (s *QueryServerTestSuite) TestGetMultiReputerStakeInTopic() {
 }
 
 func (s *QueryServerTestSuite) TestGetDelegateStakeInTopicInReputer() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	delegatorAddr := s.addrsStr[0]
-	reputerAddr := s.addrsStr[1]
+	delegatorAddr := s.AddrsStr(0)
+	reputerAddr := s.AddrsStr(1)
 	initialStakeAmount := cosmosMath.NewInt(1000)
 
 	err := keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, initialStakeAmount)
@@ -101,14 +99,13 @@ func (s *QueryServerTestSuite) TestGetDelegateStakeInTopicInReputer() {
 }
 
 func (s *QueryServerTestSuite) TestGetStakeFromDelegatorInTopicInReputer() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	topicId := uint64(1)
-	delegatorAddr := s.addrsStr[0]
-	reputerAddr := s.addrsStr[1]
+	delegatorAddr := s.AddrsStr(0)
+	reputerAddr := s.AddrsStr(1)
 	stakeAmount := cosmosMath.NewInt(50)
 
 	err := keeper.AddDelegateStake(ctx, topicId, delegatorAddr, reputerAddr, stakeAmount)
@@ -127,20 +124,19 @@ func (s *QueryServerTestSuite) TestGetStakeFromDelegatorInTopicInReputer() {
 }
 
 func (s *QueryServerTestSuite) TestGetStakeFromDelegatorInTopic() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	topicId := uint64(1)
-	delegatorAddr := s.addrsStr[0]
+	delegatorAddr := s.AddrsStr(0)
 	initialStakeAmount := cosmosMath.NewInt(500)
 	additionalStakeAmount := cosmosMath.NewInt(300)
 
-	err := keeper.AddDelegateStake(ctx, topicId, delegatorAddr, s.addrsStr[1], initialStakeAmount)
+	err := keeper.AddDelegateStake(ctx, topicId, delegatorAddr, s.AddrsStr(1), initialStakeAmount)
 	s.Require().NoError(err)
 
-	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, s.addrsStr[1], additionalStakeAmount)
+	err = keeper.AddDelegateStake(ctx, topicId, delegatorAddr, s.AddrsStr(1), additionalStakeAmount)
 	s.Require().NoError(err)
 
 	req := &types.GetStakeFromDelegatorInTopicRequest{
@@ -156,13 +152,12 @@ func (s *QueryServerTestSuite) TestGetStakeFromDelegatorInTopic() {
 }
 
 func (s *QueryServerTestSuite) TestGetTopicStake() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	topicId := uint64(1)
-	reputerAddr := s.addrsStr[0]
+	reputerAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(500)
 
 	err := keeper.AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
@@ -179,13 +174,12 @@ func (s *QueryServerTestSuite) TestGetTopicStake() {
 }
 
 func (s *QueryServerTestSuite) TestGetStakeRemovalInfo() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 	blockHeight := int64(1234)
 	topicId := uint64(1)
-	address := s.addrsStr[0]
+	address := s.AddrsStr(0)
 	removal := types.StakeRemovalInfo{
 		BlockRemovalStarted:   0,
 		BlockRemovalCompleted: blockHeight,
@@ -206,15 +200,14 @@ func (s *QueryServerTestSuite) TestGetStakeRemovalInfo() {
 }
 
 func (s *QueryServerTestSuite) TestGetDelegateStakeRemovalInfo() {
-	s.CreateOneTopic()
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 	require := s.Require()
 	blockHeight := int64(1234)
 	topicId := uint64(1)
-	delegatorAddress := s.addrsStr[0]
-	reputerAddress := s.addrsStr[1]
+	delegatorAddress := s.AddrsStr(0)
+	reputerAddress := s.AddrsStr(1)
 	expectedRemoval := types.DelegateStakeRemovalInfo{
 		BlockRemovalStarted:   0,
 		BlockRemovalCompleted: blockHeight,
@@ -239,9 +232,9 @@ func (s *QueryServerTestSuite) TestGetDelegateStakeRemovalInfo() {
 }
 
 func (s *QueryServerTestSuite) TestGetStakeRemovalsForBlock() {
-	ctx := s.ctx
-	qs := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	qs := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 	require := s.Require()
 	blockHeight := int64(1234)
 	expecteds := []types.StakeRemovalInfo{
@@ -249,14 +242,14 @@ func (s *QueryServerTestSuite) TestGetStakeRemovalsForBlock() {
 			BlockRemovalStarted:   0,
 			BlockRemovalCompleted: blockHeight,
 			TopicId:               1,
-			Reputer:               s.addrsStr[0],
+			Reputer:               s.AddrsStr(0),
 			Amount:                cosmosMath.NewInt(100),
 		},
 		{
 			BlockRemovalStarted:   0,
 			BlockRemovalCompleted: blockHeight,
 			TopicId:               2,
-			Reputer:               s.addrsStr[1],
+			Reputer:               s.AddrsStr(1),
 			Amount:                cosmosMath.NewInt(200),
 		},
 	}
@@ -278,9 +271,9 @@ func (s *QueryServerTestSuite) TestGetStakeRemovalsForBlock() {
 }
 
 func (s *QueryServerTestSuite) TestGetDelegateStakeRemovalsForBlock() {
-	ctx := s.ctx
-	qs := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	qs := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 	require := s.Require()
 	blockHeight := int64(1234)
 	expecteds := []types.DelegateStakeRemovalInfo{
@@ -288,16 +281,16 @@ func (s *QueryServerTestSuite) TestGetDelegateStakeRemovalsForBlock() {
 			BlockRemovalStarted:   0,
 			BlockRemovalCompleted: blockHeight,
 			TopicId:               1,
-			Reputer:               s.addrsStr[0],
-			Delegator:             s.addrsStr[1],
+			Reputer:               s.AddrsStr(0),
+			Delegator:             s.AddrsStr(1),
 			Amount:                cosmosMath.NewInt(100),
 		},
 		{
 			BlockRemovalStarted:   0,
 			BlockRemovalCompleted: blockHeight,
 			TopicId:               2,
-			Reputer:               s.addrsStr[2],
-			Delegator:             s.addrsStr[3],
+			Reputer:               s.AddrsStr(2),
+			Delegator:             s.AddrsStr(3),
 			Amount:                cosmosMath.NewInt(200),
 		},
 	}
@@ -319,10 +312,10 @@ func (s *QueryServerTestSuite) TestGetDelegateStakeRemovalsForBlock() {
 }
 
 func (s *QueryServerTestSuite) TestGetStakeReputerAuthority() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	reputerAddr := s.addrsStr[0]
+	reputerAddr := s.AddrsStr(0)
 	stakeAmount := cosmosMath.NewInt(500)
 
 	// Add stake
@@ -333,7 +326,7 @@ func (s *QueryServerTestSuite) TestGetStakeReputerAuthority() {
 		TopicId: topicId,
 		Reputer: reputerAddr,
 	}
-	response, err := s.queryServer.GetStakeReputerAuthority(ctx, req)
+	response, err := s.EmissionsQueryServer().GetStakeReputerAuthority(ctx, req)
 	stakeAuthority := response.Authority
 
 	s.Require().NoError(err)
@@ -341,20 +334,20 @@ func (s *QueryServerTestSuite) TestGetStakeReputerAuthority() {
 }
 
 func (s *QueryServerTestSuite) TestGetDelegateStakePlacement() {
-	ctx := s.ctx
+	ctx := s.Ctx()
 	require := s.Require()
-	keeper := s.emissionsKeeper
+	keeper := s.EmissionsKeeper()
 
-	delegator := s.addrs[0]
-	delegatorAddr := s.addrsStr[0]
-	reputerAddr := s.addrsStr[1]
-	topicId := s.CreateOneTopic()
+	delegator := s.Addrs(0)
+	delegatorAddr := s.AddrsStr(0)
+	reputerAddr := s.AddrsStr(1)
+	topicId := uint64(1)
 	stakeAmount := cosmosMath.NewInt(50)
 	s.MintTokensToAddress(delegator, cosmosMath.NewInt(1000))
 
 	reputerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[7],
-		NodeAddress: s.addrsStr[8],
+		Owner:       s.AddrsStr(7),
+		NodeAddress: s.AddrsStr(8),
 	}
 
 	err := keeper.InsertReputer(ctx, topicId, reputerAddr, reputerInfo)
@@ -367,7 +360,7 @@ func (s *QueryServerTestSuite) TestGetDelegateStakePlacement() {
 		Amount:  stakeAmount,
 	}
 
-	reputerStake, err := s.emissionsKeeper.GetStakeReputerAuthority(ctx, topicId, reputerAddr)
+	reputerStake, err := s.EmissionsKeeper().GetStakeReputerAuthority(ctx, topicId, reputerAddr)
 	require.NoError(err)
 	require.Equal(cosmosMath.ZeroInt(), reputerStake, "Stake amount mismatch")
 
@@ -376,20 +369,20 @@ func (s *QueryServerTestSuite) TestGetDelegateStakePlacement() {
 		Delegator: delegatorAddr,
 		Target:    reputerAddr,
 	}
-	queryResponse, err := s.queryServer.GetDelegateStakePlacement(ctx, req)
+	queryResponse, err := s.EmissionsQueryServer().GetDelegateStakePlacement(ctx, req)
 	require.NoError(err)
 	require.Equal(alloraMath.NewDecFromInt64(0), queryResponse.DelegatorInfo.Amount)
 
 	// Perform the stake delegation
-	response, err := s.msgServer.DelegateStake(ctx, msg)
+	response, err := s.EmissionsMsgServer().DelegateStake(ctx, msg)
 	require.NoError(err)
 	require.NotNil(response, "Response should not be nil after successful delegation")
 
-	reputerStake, err = s.emissionsKeeper.GetStakeReputerAuthority(ctx, topicId, reputerAddr)
+	reputerStake, err = s.EmissionsKeeper().GetStakeReputerAuthority(ctx, topicId, reputerAddr)
 	require.NoError(err)
 	require.Equal(stakeAmount, reputerStake, "Stake amount mismatch")
 
-	queryResponse, err = s.queryServer.GetDelegateStakePlacement(ctx, req)
+	queryResponse, err = s.EmissionsQueryServer().GetDelegateStakePlacement(ctx, req)
 	require.NoError(err)
 
 	value0, err := strconv.ParseFloat(stakeAmount.ToLegacyDec().String(), 64)
@@ -402,11 +395,11 @@ func (s *QueryServerTestSuite) TestGetDelegateStakePlacement() {
 }
 
 func (s *QueryServerTestSuite) TestGetDelegateStakeUponReputer() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
-	delegatorAddr := s.addrsStr[0]
-	reputerAddr := s.addrsStr[1]
+	delegatorAddr := s.AddrsStr(0)
+	reputerAddr := s.AddrsStr(1)
 	initialStakeAmount := cosmosMath.NewInt(1000)
 	removeStakeAmount := cosmosMath.NewInt(500)
 	moduleParams, err := keeper.GetParams(ctx)
@@ -447,16 +440,16 @@ func (s *QueryServerTestSuite) TestGetDelegateStakeUponReputer() {
 		TopicId: topicId,
 		Target:  reputerAddr,
 	}
-	queryResponse, err := s.queryServer.GetDelegateStakeUponReputer(ctx, req)
+	queryResponse, err := s.EmissionsQueryServer().GetDelegateStakeUponReputer(ctx, req)
 	stakeUponReputer = queryResponse.Stake
 	s.Require().NoError(err)
 	s.Require().Equal(expected, stakeUponReputer, "Remaining reputer stake should be initial minus removed amount")
 }
 
 func (s *QueryServerTestSuite) TestGetStakeRemovalForReputerAndTopicId() {
-	k := s.emissionsKeeper
-	ctx := s.ctx
-	reputer := s.addrsStr[2]
+	k := s.EmissionsKeeper()
+	ctx := s.Ctx()
+	reputer := s.AddrsStr(2)
 	topicId := uint64(1)
 
 	// Create a stake removal info
@@ -469,7 +462,7 @@ func (s *QueryServerTestSuite) TestGetStakeRemovalForReputerAndTopicId() {
 	}
 	anotherStakeRemoval := types.StakeRemovalInfo{
 		BlockRemovalStarted:   0,
-		Reputer:               s.addrsStr[3],
+		Reputer:               s.AddrsStr(3),
 		TopicId:               topicId,
 		Amount:                cosmosMath.NewInt(200),
 		BlockRemovalCompleted: 30,
@@ -485,7 +478,7 @@ func (s *QueryServerTestSuite) TestGetStakeRemovalForReputerAndTopicId() {
 		Reputer: reputer,
 		TopicId: topicId,
 	}
-	response, err := s.queryServer.GetStakeRemovalForReputerAndTopicId(ctx, req)
+	response, err := s.EmissionsQueryServer().GetStakeRemovalForReputerAndTopicId(ctx, req)
 	s.Require().NoError(err)
 	s.Require().Equal(&stakeRemovalInfo, response.StakeRemovalInfo)
 }

--- a/x/emissions/keeper/queryserver/query_server_test.go
+++ b/x/emissions/keeper/queryserver/query_server_test.go
@@ -1,262 +1,65 @@
 package queryserver_test
 
 import (
-	"crypto/ed25519"
-	"encoding/hex"
 	"testing"
-	"time"
 
-	"cosmossdk.io/core/header"
-	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
-	storetypes "cosmossdk.io/store/types"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	"github.com/cosmos/cosmos-sdk/codec/address"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/testutil"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/allora-network/allora-chain/app/params"
-	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
-	"github.com/allora-network/allora-chain/x/emissions/keeper/queryserver"
-	"github.com/allora-network/allora-chain/x/emissions/module"
+	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	mintTypes "github.com/allora-network/allora-chain/x/mint/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/stretchr/testify/suite"
 )
-
-const (
-	multiPerm  = "multiple permissions account"
-	randomPerm = "random permission"
-)
-
-type ChainKey struct {
-	pubKey ed25519.PublicKey
-	priKey ed25519.PrivateKey
-}
 
 type QueryServerTestSuite struct {
-	suite.Suite
-
-	ctx             sdk.Context
-	accountKeeper   keeper.AccountKeeper
-	bankKeeper      keeper.BankKeeper
-	emissionsKeeper keeper.Keeper
-	appModule       module.AppModule
-	msgServer       types.MsgServiceServer
-	queryServer     types.QueryServiceServer
-	key             *storetypes.KVStoreKey
-	privKeys        []secp256k1.PrivKey
-	addrs           []sdk.AccAddress
-	addrsStr        []string
-	pubKeyHexStr    []string
+	alloratestutil.TestSuite
 }
 
 func TestQueryServerTestSuite(t *testing.T) {
-	suite.Run(t, new(QueryServerTestSuite))
-}
-
-func (s *QueryServerTestSuite) SetupTest() {
-	key := storetypes.NewKVStoreKey("emissions")
-	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()}) // nolint: exhaustruct
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
-	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
-
-	maccPerms := map[string][]string{
-		"fee_collector":                {"minter"},
-		"mint":                         {"minter"},
-		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
-		mintTypes.EcosystemModuleName:  {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName: {"minter"},
-		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
-		"bonded_tokens_pool":                             {"burner", "staking"},
-		"not_bonded_tokens_pool":                         {"burner", "staking"},
-		multiPerm:                                        {"burner", "minter", "staking"},
-		randomPerm:                                       {"random"},
-	}
-
-	accountKeeper := authkeeper.NewAccountKeeper(
-		encCfg.Codec,
-		storeService,
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
-		params.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress("gov").String(),
-	)
-
-	countAddrs := 11
-	var privKeys = make([]secp256k1.PrivKey, countAddrs)
-	var pubKeyHexStr = make([]string, countAddrs)
-	var addrs = make([]sdk.AccAddress, countAddrs)
-	var addrsStr = make([]string, countAddrs)
-	for i := 0; i < countAddrs; i++ {
-		privKeys[i] = secp256k1.GenPrivKey()
-		addrs[i] = sdk.AccAddress(privKeys[i].PubKey().Address())
-		pubKeyHexStr[i] = hex.EncodeToString(privKeys[i].PubKey().Bytes())
-		addrsStr[i] = addrs[i].String()
-	}
-	s.privKeys = privKeys
-	s.addrs = addrs
-	s.addrsStr = addrsStr
-	s.pubKeyHexStr = pubKeyHexStr
-
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		log.NewNopLogger(),
-	)
-
-	s.ctx = ctx
-	s.accountKeeper = accountKeeper
-	s.bankKeeper = bankKeeper
-	s.emissionsKeeper = keeper.NewKeeper(
-		encCfg.Codec,
-		addressCodec,
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-	s.key = key
-	appModule := module.NewAppModule(encCfg.Codec, s.emissionsKeeper)
-	defaultGenesis := appModule.DefaultGenesis(encCfg.Codec)
-	appModule.InitGenesis(ctx, encCfg.Codec, defaultGenesis)
-	s.msgServer = msgserver.NewMsgServerImpl(s.emissionsKeeper)
-	s.queryServer = queryserver.NewQueryServerImpl(s.emissionsKeeper)
-
-	s.appModule = appModule
-
-	// Add all tests addresses in whitelists
-	for _, addr := range addrsStr {
-		err := s.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToGlobalWhitelist(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, addr)
-		s.Require().NoError(err)
-	}
-}
-
-func GeneratePrivateKeys(numKeys int) []ChainKey {
-	testAddrs := make([]ChainKey, numKeys)
-	for i := 0; i < numKeys; i++ {
-		pk, prk, _ := ed25519.GenerateKey(nil)
-		testAddrs[i] = ChainKey{
-			pubKey: pk,
-			priKey: prk,
-		}
-	}
-
-	return testAddrs
+	suite.Run(t, &QueryServerTestSuite{
+		alloratestutil.NewTestSuite("emissions_query_server"),
+	})
 }
 
 func (s *QueryServerTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
 
-	err := s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
+	err := s.BankKeeper().MintCoins(s.Ctx(), types.AlloraStakingAccountName, creatorInitialBalanceCoins)
 	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
+	err = s.BankKeeper().SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
 	s.Require().NoError(err)
-}
-
-func (s *QueryServerTestSuite) CreateOneTopic() uint64 {
-	ctx, msgServer := s.ctx, s.msgServer
-	require := s.Require()
-
-	// Create a topic first
-	metadata := "Some metadata for the new topic"
-	// Create a CreateNewTopicRequest message
-
-	creator := s.addrs[0]
-
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  creator.String(),
-		Metadata:                 metadata,
-		LossMethod:               "method",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-
-	s.MintTokensToAddress(creator, types.DefaultParams().CreateTopicFee)
-
-	result, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
-	require.NoError(err, "CreateTopic fails on first creation")
-
-	return result.TopicId
 }
 
 func (s *QueryServerTestSuite) TestCreateSeveralTopics() {
-	ctx, msgServer := s.ctx, s.msgServer
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
 	require := s.Require()
 	// Mock setup for metadata and validation steps
 	metadata := "Some metadata for the new topic"
 	// Create a CreateNewTopicRequest message
 
-	creator := s.addrs[0]
+	creator := s.Addrs(0)
 
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  creator.String(),
-		Metadata:                 metadata,
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AllowNegative:            false,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
+	newTopicMsg := s.MockTopicMsg()
+	newTopicMsg.Metadata = metadata
 
 	creatorInitialBalance := types.DefaultParams().CreateTopicFee.Mul(cosmosMath.NewInt(3))
 	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, creatorInitialBalance))
 
-	err := s.bankKeeper.MintCoins(ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
+	err := s.BankKeeper().MintCoins(ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
 	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, creator, creatorInitialBalanceCoins)
+	err = s.BankKeeper().SendCoinsFromModuleToAccount(ctx, types.AlloraStakingAccountName, creator, creatorInitialBalanceCoins)
 	s.Require().NoError(err)
 
-	initialTopicId, err := s.emissionsKeeper.GetNextTopicId(s.ctx)
+	initialTopicId, err := s.EmissionsKeeper().GetNextTopicId(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().NotNil(initialTopicId)
 
 	_, err = msgServer.CreateNewTopic(ctx, newTopicMsg)
 	require.NoError(err, "CreateTopic fails on first creation")
 
-	result, err := s.emissionsKeeper.GetNextTopicId(s.ctx)
+	result, err := s.EmissionsKeeper().GetNextTopicId(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(initialTopicId+1, result)
@@ -265,42 +68,8 @@ func (s *QueryServerTestSuite) TestCreateSeveralTopics() {
 	_, err = msgServer.CreateNewTopic(ctx, newTopicMsg)
 	require.NoError(err, "CreateTopic fails on second topic")
 
-	result, err = s.emissionsKeeper.GetNextTopicId(s.ctx)
+	result, err = s.EmissionsKeeper().GetNextTopicId(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(initialTopicId+2, result)
-}
-
-func (s *QueryServerTestSuite) mockTopic() types.Topic {
-	return types.Topic{
-		Id:                       uint64(1),
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "whatever",
-		LossMethod:               "loss",
-		EpochLastEnded:           2,
-		EpochLength:              100,
-		GroundTruthLag:           100,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		WorkerSubmissionWindow:   100,
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.1"),
-		InitialRegret:            alloraMath.MustNewDecFromString("0.1"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.1"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.1"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.1"),
-	}
-}
-
-func (s *QueryServerTestSuite) signValueBundle(valueBundle *types.ValueBundle, privateKey secp256k1.PrivKey) []byte {
-	require := s.Require()
-	src := make([]byte, 0)
-	src, err := valueBundle.XXX_Marshal(src, true)
-	require.NoError(err, "Marshall reputer value bundle should not return an error")
-
-	valueBundleSignature, err := privateKey.Sign(src)
-	require.NoError(err, "Sign should not return an error")
-
-	return valueBundleSignature
 }

--- a/x/emissions/keeper/queryserver/query_server_test.go
+++ b/x/emissions/keeper/queryserver/query_server_test.go
@@ -23,15 +23,6 @@ func TestQueryServerTestSuite(t *testing.T) {
 	})
 }
 
-func (s *QueryServerTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
-	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
-
-	err := s.BankKeeper().MintCoins(s.Ctx(), types.AlloraStakingAccountName, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
-	err = s.BankKeeper().SendCoinsFromModuleToAccount(s.Ctx(), types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
-}
-
 func (s *QueryServerTestSuite) TestCreateSeveralTopics() {
 	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
 	require := s.Require()

--- a/x/emissions/keeper/queryserver/query_server_test.go
+++ b/x/emissions/keeper/queryserver/query_server_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/allora-network/allora-chain/app/params"
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
+	testutil "github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type QueryServerTestSuite struct {
-	alloratestutil.TestSuite
+	testutil.TestSuite
 }
 
 func TestQueryServerTestSuite(t *testing.T) {
 	suite.Run(t, &QueryServerTestSuite{
-		alloratestutil.NewTestSuite("emissions_query_server"),
+		testutil.NewTestSuite("emissions_query_server"),
 	})
 }
 

--- a/x/emissions/keeper/queryserver/query_server_topics_test.go
+++ b/x/emissions/keeper/queryserver/query_server_topics_test.go
@@ -2,28 +2,23 @@ package queryserver_test
 
 import (
 	cosmosMath "cosmossdk.io/math"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 func (s *QueryServerTestSuite) TestGetNextTopicId() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	// Get the initial next topic ID
 	initialNextTopicId, err := keeper.GetNextTopicId(ctx)
 	s.Require().NoError(err, "Fetching the initial next topic ID should not fail")
 
 	topicsToCreate := 5
-	for i := 1; i <= topicsToCreate; i++ {
-		topicId, err := keeper.IncrementTopicId(ctx)
-		s.Require().NoError(err, "Incrementing topic ID should not fail")
-
-		newTopic := s.mockTopic()
-		newTopic.Id = topicId
-		err = keeper.SetTopic(ctx, topicId, newTopic)
-		s.Require().NoError(err, "Setting a new topic should not fail")
+	for range topicsToCreate {
+		s.CreateTopic()
 	}
 
 	req := &types.GetNextTopicIdRequest{}
@@ -36,9 +31,9 @@ func (s *QueryServerTestSuite) TestGetNextTopicId() {
 }
 
 func (s *QueryServerTestSuite) TestGetTopic() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	topicId, err := keeper.GetNextTopicId(ctx)
 	s.Require().NoError(err)
@@ -46,7 +41,7 @@ func (s *QueryServerTestSuite) TestGetTopic() {
 	req := &types.GetTopicRequest{TopicId: topicId}
 
 	// Setting up a new topic
-	newTopic := s.mockTopic()
+	newTopic := s.MockTopic()
 	newTopic.Id = topicId
 	newTopic.Metadata = metadata
 	err = keeper.SetTopic(ctx, topicId, newTopic)
@@ -62,15 +57,15 @@ func (s *QueryServerTestSuite) TestGetTopic() {
 }
 
 func (s *QueryServerTestSuite) TestGetLatestCommit() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 	blockHeight := 100
 	nonce := types.Nonce{
 		BlockHeight: 95,
 	}
 
-	topic := s.mockTopic()
+	topic := s.MockTopic()
 	_ = keeper.SetReputerTopicLastCommit(
 		ctx,
 		topic.Id,
@@ -88,7 +83,7 @@ func (s *QueryServerTestSuite) TestGetLatestCommit() {
 	s.Require().Equal(int64(blockHeight), response.LastCommit.BlockHeight, "Retrieved blockheight should match")
 	s.Require().Equal(&nonce, response.LastCommit.Nonce, "The metadata of the retrieved nonce should match")
 
-	topic2 := s.mockTopic()
+	topic2 := s.MockTopic()
 	topic2.Id = 2
 	blockHeight = 101
 	nonce = types.Nonce{
@@ -114,17 +109,17 @@ func (s *QueryServerTestSuite) TestGetLatestCommit() {
 }
 
 func (s *QueryServerTestSuite) TestGetSetDeleteTopicRewardNonce() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 
 	// Test Get on an unset topicId, should return 0
 	req := &types.GetTopicRewardNonceRequest{
 		TopicId: topicId,
 	}
-	response, err := s.queryServer.GetTopicRewardNonce(ctx, req)
-	nonce := response.Nonce
+	response, err := s.EmissionsQueryServer().GetTopicRewardNonce(ctx, req)
 	s.Require().NoError(err, "Getting an unset topic reward nonce should not fail")
+	nonce := response.Nonce
 	s.Require().Equal(int64(0), nonce, "Nonce for an unset topicId should be 0")
 
 	// Test Set
@@ -133,9 +128,9 @@ func (s *QueryServerTestSuite) TestGetSetDeleteTopicRewardNonce() {
 	s.Require().NoError(err, "Setting topic reward nonce should not fail")
 
 	// Test Get after Set, should return the set value
-	response, err = s.queryServer.GetTopicRewardNonce(ctx, req)
-	nonce = response.Nonce
+	response, err = s.EmissionsQueryServer().GetTopicRewardNonce(ctx, req)
 	s.Require().NoError(err, "Getting set topic reward nonce should not fail")
+	nonce = response.Nonce
 	s.Require().Equal(expectedNonce, nonce, "Nonce should match the value set earlier")
 
 	// Test Delete
@@ -143,15 +138,15 @@ func (s *QueryServerTestSuite) TestGetSetDeleteTopicRewardNonce() {
 	s.Require().NoError(err, "Deleting topic reward nonce should not fail")
 
 	// Test Get after Delete, should return 0
-	response, err = s.queryServer.GetTopicRewardNonce(ctx, req)
-	nonce = response.Nonce
+	response, err = s.EmissionsQueryServer().GetTopicRewardNonce(ctx, req)
 	s.Require().NoError(err, "Getting deleted topic reward nonce should not fail")
+	nonce = response.Nonce
 	s.Require().Equal(int64(0), nonce, "Nonce should be 0 after deletion")
 }
 
 func (s *QueryServerTestSuite) TestGetPreviousTopicWeight() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(1)
 
 	// Set previous topic weight
@@ -161,30 +156,30 @@ func (s *QueryServerTestSuite) TestGetPreviousTopicWeight() {
 
 	// Get the previously set topic weight
 	req := &types.GetPreviousTopicWeightRequest{TopicId: topicId}
-	response, err := s.queryServer.GetPreviousTopicWeight(ctx, req)
-	retrievedWeight := response.Weight
-
+	response, err := s.EmissionsQueryServer().GetPreviousTopicWeight(ctx, req)
 	s.Require().NoError(err, "Getting previous topic weight should not fail")
+
+	retrievedWeight := response.Weight
 	s.Require().Equal(weightToSet, retrievedWeight, "Retrieved weight should match the set weight")
 }
 
 func (s *QueryServerTestSuite) TestTopicExists() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 
 	// Test a topic ID that does not exist
 	nonExistentTopicId := uint64(999) // Assuming this ID has not been used
 	req := &types.TopicExistsRequest{TopicId: nonExistentTopicId}
-	response, err := s.queryServer.TopicExists(ctx, req)
-	exists := response.Exists
+	response, err := s.EmissionsQueryServer().TopicExists(ctx, req)
 	s.Require().NoError(err, "Checking existence for a non-existent topic should not fail")
+	exists := response.Exists
 	s.Require().False(exists, "No topic should exist for an unused topic ID")
 
 	// Create a topic to test existence
 	existentTopicId, err := keeper.IncrementTopicId(ctx)
 	s.Require().NoError(err, "Incrementing topic ID should not fail")
 
-	newTopic := s.mockTopic()
+	newTopic := s.MockTopic()
 	newTopic.Id = existentTopicId
 
 	err = keeper.SetTopic(ctx, existentTopicId, newTopic)
@@ -192,19 +187,19 @@ func (s *QueryServerTestSuite) TestTopicExists() {
 
 	// Test the newly created topic ID
 	req = &types.TopicExistsRequest{TopicId: existentTopicId}
-	response, err = s.queryServer.TopicExists(ctx, req)
-	exists = response.Exists
+	response, err = s.EmissionsQueryServer().TopicExists(ctx, req)
 	s.Require().NoError(err, "Checking existence for an existent topic should not fail")
+	exists = response.Exists
 	s.Require().True(exists, "Topic should exist for a newly created topic ID")
 }
 
 func (s *QueryServerTestSuite) TestIsTopicActive() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
 	topicId := uint64(3)
 
 	// Assume topic initially active
-	initialTopic := s.mockTopic()
+	initialTopic := s.MockTopic()
 	initialTopic.Id = topicId
 	_ = keeper.SetTopic(ctx, topicId, initialTopic)
 
@@ -214,10 +209,10 @@ func (s *QueryServerTestSuite) TestIsTopicActive() {
 
 	// Check if topic is active
 	req := &types.IsTopicActiveRequest{TopicId: topicId}
-	response, err := s.queryServer.IsTopicActive(ctx, req)
-	topicActive := response.IsActive
-
+	response, err := s.EmissionsQueryServer().IsTopicActive(ctx, req)
 	s.Require().NoError(err, "Getting topic should not fail after reactivation")
+
+	topicActive := response.IsActive
 	s.Require().True(topicActive, "Topic should be active again")
 
 	// Inactivate the topic
@@ -226,9 +221,9 @@ func (s *QueryServerTestSuite) TestIsTopicActive() {
 
 	// Check if topic is inactive
 	req = &types.IsTopicActiveRequest{TopicId: topicId}
-	response, err = s.queryServer.IsTopicActive(ctx, req)
-	topicActive = response.IsActive
+	response, err = s.EmissionsQueryServer().IsTopicActive(ctx, req)
 	s.Require().NoError(err, "Getting topic should not fail after inactivation")
+	topicActive = response.IsActive
 	s.Require().False(topicActive, "Topic should be inactive")
 
 	// Activate the topic
@@ -237,27 +232,22 @@ func (s *QueryServerTestSuite) TestIsTopicActive() {
 
 	// Check if topic is active again
 	req = &types.IsTopicActiveRequest{TopicId: topicId}
-	response, err = s.queryServer.IsTopicActive(ctx, req)
-	topicActive = response.IsActive
+	response, err = s.EmissionsQueryServer().IsTopicActive(ctx, req)
 	s.Require().NoError(err, "Getting topic should not fail after reactivation")
+	topicActive = response.IsActive
 	s.Require().True(topicActive, "Topic should be active again")
 }
 
 func (s *QueryServerTestSuite) TestGetTopicFeeRevenue() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-
-	newTopic := s.mockTopic()
-	newTopic.Id = topicId
-	err := keeper.SetTopic(ctx, topicId, newTopic)
-	s.Require().NoError(err, "Setting a new topic should not fail")
+	ctx := s.Ctx()
+	keeper := s.EmissionsKeeper()
+	topicId := uint64(2)
 
 	// Test getting revenue for a topic with no existing revenue
 	req := &types.GetTopicFeeRevenueRequest{TopicId: topicId}
-	response, err := s.queryServer.GetTopicFeeRevenue(ctx, req)
-	feeRev := response.FeeRevenue
+	response, err := s.EmissionsQueryServer().GetTopicFeeRevenue(ctx, req)
 	s.Require().NoError(err, "Should not error when revenue does not exist")
+	feeRev := response.FeeRevenue
 	s.Require().Equal(cosmosMath.ZeroInt(), feeRev, "Revenue should be zero for non-existing entries")
 
 	// Setup a topic with some revenue
@@ -268,8 +258,8 @@ func (s *QueryServerTestSuite) TestGetTopicFeeRevenue() {
 
 	// Test getting revenue for a topic with existing revenue
 	req = &types.GetTopicFeeRevenueRequest{TopicId: topicId}
-	response, err = s.queryServer.GetTopicFeeRevenue(ctx, req)
-	feeRev = response.FeeRevenue
+	response, err = s.EmissionsQueryServer().GetTopicFeeRevenue(ctx, req)
 	s.Require().NoError(err, "Should not error when retrieving existing revenue")
+	feeRev = response.FeeRevenue
 	s.Require().Equal(feeRev.String(), initialRevenueInt.String(), "Revenue should match the initial setup")
 }

--- a/x/emissions/keeper/queryserver/query_server_weights_test.go
+++ b/x/emissions/keeper/queryserver/query_server_weights_test.go
@@ -6,12 +6,12 @@ import (
 )
 
 func (s *QueryServerTestSuite) TestGetInfererWeight() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	topicId := uint64(1)
-	worker := s.addrsStr[0]
+	worker := s.AddrsStr(0)
 	weight := alloraMath.NewDecFromInt64(100)
 
 	// Set initial weight
@@ -27,7 +27,7 @@ func (s *QueryServerTestSuite) TestGetInfererWeight() {
 	s.Require().Equal(weight, response.Weight, "Retrieved weight should match set weight")
 
 	// Test non-existent worker
-	nonExistentWorker := s.addrsStr[1]
+	nonExistentWorker := s.AddrsStr(1)
 	req.ActorId = nonExistentWorker
 	response, err = queryServer.GetLatestInfererWeight(ctx, req)
 	s.Require().NoError(err)
@@ -35,12 +35,12 @@ func (s *QueryServerTestSuite) TestGetInfererWeight() {
 }
 
 func (s *QueryServerTestSuite) TestGetForecasterWeight() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	topicId := uint64(1)
-	forecaster := s.addrsStr[0]
+	forecaster := s.AddrsStr(0)
 	weight := alloraMath.NewDecFromInt64(100)
 
 	// Set initial weight
@@ -56,7 +56,7 @@ func (s *QueryServerTestSuite) TestGetForecasterWeight() {
 	s.Require().Equal(weight, response.Weight, "Retrieved weight should match set weight")
 
 	// Test non-existent forecaster
-	nonExistentForecaster := s.addrsStr[1]
+	nonExistentForecaster := s.AddrsStr(1)
 	req.ActorId = nonExistentForecaster
 	response, err = queryServer.GetLatestForecasterWeight(ctx, req)
 	s.Require().NoError(err)
@@ -64,9 +64,9 @@ func (s *QueryServerTestSuite) TestGetForecasterWeight() {
 }
 
 func (s *QueryServerTestSuite) TestGetLatestStdnorm() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	topicId := uint64(1)
 	stdnorm := alloraMath.NewDecFromInt64(100)

--- a/x/emissions/keeper/queryserver/query_server_whitelist_test.go
+++ b/x/emissions/keeper/queryserver/query_server_whitelist_test.go
@@ -5,9 +5,9 @@ import (
 )
 
 func (s *QueryServerTestSuite) TestIsWhitelistAdmin() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	// Create a test address
 	testAddress := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
@@ -36,9 +36,9 @@ func (s *QueryServerTestSuite) TestIsWhitelistAdmin() {
 }
 
 func (s *QueryServerTestSuite) TestIsWhitelistedGlobalWorker() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddress := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
 	antitestAddress := "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh"
@@ -66,9 +66,9 @@ func (s *QueryServerTestSuite) TestIsWhitelistedGlobalWorker() {
 }
 
 func (s *QueryServerTestSuite) TestIsWhitelistedGlobalReputer() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddress := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
 	antitestAddress := "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh"
@@ -96,9 +96,9 @@ func (s *QueryServerTestSuite) TestIsWhitelistedGlobalReputer() {
 }
 
 func (s *QueryServerTestSuite) TestIsWhitelistedGlobalAdmin() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddress := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
 	antitestAddress := "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh"
@@ -126,11 +126,11 @@ func (s *QueryServerTestSuite) TestIsWhitelistedGlobalAdmin() {
 }
 
 func (s *QueryServerTestSuite) TestIsTopicWhitelistEnabled() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
-	topicId := uint64(1)
+	topicId := uint64(2)
 
 	// Initially should be disabled
 	req := &types.IsTopicWorkerWhitelistEnabledRequest{
@@ -153,11 +153,11 @@ func (s *QueryServerTestSuite) TestIsTopicWhitelistEnabled() {
 }
 
 func (s *QueryServerTestSuite) TestIsTopicReputerWhitelistEnabled() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
-	topicId := uint64(1)
+	topicId := uint64(2)
 
 	// Initially should be disabled
 	req := &types.IsTopicReputerWhitelistEnabledRequest{
@@ -180,9 +180,9 @@ func (s *QueryServerTestSuite) TestIsTopicReputerWhitelistEnabled() {
 }
 
 func (s *QueryServerTestSuite) TestIsWhitelistedTopicCreator() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
 
@@ -207,9 +207,9 @@ func (s *QueryServerTestSuite) TestIsWhitelistedTopicCreator() {
 }
 
 func (s *QueryServerTestSuite) TestIsWhitelistedGlobalActor() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
 
@@ -234,12 +234,12 @@ func (s *QueryServerTestSuite) TestIsWhitelistedGlobalActor() {
 }
 
 func (s *QueryServerTestSuite) TestIsWhitelistedTopicWorker() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
-	topicId := uint64(1)
+	topicId := uint64(2)
 
 	req := &types.IsWhitelistedTopicWorkerRequest{
 		TopicId: topicId,
@@ -263,9 +263,9 @@ func (s *QueryServerTestSuite) TestIsWhitelistedTopicWorker() {
 }
 
 func (s *QueryServerTestSuite) TestIsWhitelistedTopicReputer() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
 	topicId := uint64(1)
@@ -292,9 +292,9 @@ func (s *QueryServerTestSuite) TestIsWhitelistedTopicReputer() {
 }
 
 func (s *QueryServerTestSuite) TestCanUpdateGlobalWhitelists() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
 
@@ -319,9 +319,9 @@ func (s *QueryServerTestSuite) TestCanUpdateGlobalWhitelists() {
 }
 
 func (s *QueryServerTestSuite) TestCanUpdateParams() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo10es2a97cr7u2m3aa08tcu7yd0d300thdct45ve"
 
@@ -346,14 +346,14 @@ func (s *QueryServerTestSuite) TestCanUpdateParams() {
 }
 
 func (s *QueryServerTestSuite) TestCanUpdateTopicWhitelist() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh"
 
 	// Create topic
-	topicId := s.CreateOneTopic()
+	topicId := uint64(1)
 
 	req := &types.CanUpdateTopicWhitelistRequest{
 		TopicId: topicId,
@@ -377,9 +377,9 @@ func (s *QueryServerTestSuite) TestCanUpdateTopicWhitelist() {
 }
 
 func (s *QueryServerTestSuite) TestCanCreateTopic() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo14s7gd09y7mkje8547ukm0c8gjnd3hak7v3fwz6"
 
@@ -423,9 +423,9 @@ func (s *QueryServerTestSuite) TestCanCreateTopic() {
 }
 
 func (s *QueryServerTestSuite) TestCanSubmitWorkerPayload() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh"
 	topicId := uint64(1)
@@ -467,9 +467,9 @@ func (s *QueryServerTestSuite) TestCanSubmitWorkerPayload() {
 }
 
 func (s *QueryServerTestSuite) TestCanSubmitReputerPayload() {
-	ctx := s.ctx
-	queryServer := s.queryServer
-	keeper := s.emissionsKeeper
+	ctx := s.Ctx()
+	queryServer := s.EmissionsQueryServer()
+	keeper := s.EmissionsKeeper()
 
 	testAddr := "allo1snm6pxg7p9jetmkhz0jz9ku3vdzmszegy9q5lh"
 	topicId := uint64(1)

--- a/x/emissions/keeper/score_utils_test.go
+++ b/x/emissions/keeper/score_utils_test.go
@@ -1,73 +1,53 @@
 package keeper_test
 
 import (
+	"context"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
-	keeper "github.com/allora-network/allora-chain/x/emissions/keeper"
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func (s *KeeperTestSuite) TestGetLowScoreFromAllInferences() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
+func (s *KeeperTestSuite) TestGetLowestScore() {
+	k := s.EmissionsKeeper()
+	ctx := s.Ctx()
 	topicId := uint64(1)
 
-	worker1 := s.addrsStr[0]
-	worker2 := s.addrsStr[1]
-	worker3 := s.addrsStr[2]
-	workerAddresses := []string{worker1, worker2, worker3}
+	testCases := []struct {
+		name           string
+		setScore       func(ctx context.Context, topicId uint64, addr string, score types.Score) error
+		getLowestScore func(ctx context.Context, k *keeper.Keeper, topicId uint64, addresses []string) (types.Score, error)
+	}{
+		{
+			name:           "inferences",
+			setScore:       k.SetInfererScoreEma,
+			getLowestScore: keeper.GetLowestScoreFromAllInferers,
+		}, {
+			name:           "forecasts",
+			setScore:       k.SetForecasterScoreEma,
+			getLowestScore: keeper.GetLowestScoreFromAllForecasters,
+		}, {
+			name:           "loss bundles",
+			setScore:       k.SetReputerScoreEma,
+			getLowestScore: keeper.GetLowestScoreFromAllReputers,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			workers := []string{s.AddrsStr(0), s.AddrsStr(1), s.AddrsStr(2)}
+			scores := []types.Score{
+				{TopicId: topicId, BlockHeight: 2, Address: workers[0], Score: alloraMath.NewDecFromInt64(95)},
+				{TopicId: topicId, BlockHeight: 2, Address: workers[1], Score: alloraMath.NewDecFromInt64(90)},
+				{TopicId: topicId, BlockHeight: 2, Address: workers[2], Score: alloraMath.NewDecFromInt64(99)},
+			}
 
-	score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker1, Score: alloraMath.NewDecFromInt64(95)}
-	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker2, Score: alloraMath.NewDecFromInt64(90)}
-	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker3, Score: alloraMath.NewDecFromInt64(99)}
-	_ = k.SetInfererScoreEma(ctx, topicId, worker1, score1)
-	_ = k.SetInfererScoreEma(ctx, topicId, worker2, score2)
-	_ = k.SetInfererScoreEma(ctx, topicId, worker3, score3)
+			for i := range workers {
+				_ = tc.setScore(ctx, topicId, workers[i], scores[i])
+			}
 
-	lowScore, err := keeper.GetLowestScoreFromAllInferers(ctx, &k, topicId, workerAddresses)
-	s.Require().NoError(err)
-	s.Require().Equal(lowScore, score2)
-}
-
-func (s *KeeperTestSuite) TestGetLowScoreFromAllForecasts() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := uint64(1)
-
-	worker1 := s.addrsStr[0]
-	worker2 := s.addrsStr[1]
-	worker3 := s.addrsStr[2]
-	forecasterAddresses := []string{worker1, worker2, worker3}
-
-	score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker1, Score: alloraMath.NewDecFromInt64(95)}
-	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker2, Score: alloraMath.NewDecFromInt64(90)}
-	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: worker3, Score: alloraMath.NewDecFromInt64(99)}
-	_ = k.SetForecasterScoreEma(ctx, topicId, worker1, score1)
-	_ = k.SetForecasterScoreEma(ctx, topicId, worker2, score2)
-	_ = k.SetForecasterScoreEma(ctx, topicId, worker3, score3)
-
-	lowScore, err := keeper.GetLowestScoreFromAllForecasters(ctx, &k, topicId, forecasterAddresses)
-	s.Require().NoError(err)
-	s.Require().Equal(lowScore, score2)
-}
-
-func (s *KeeperTestSuite) TestGetLowScoreFromAllLossBundles() {
-	ctx := s.ctx
-	k := s.emissionsKeeper
-	topicId := uint64(1)
-
-	reputer1 := s.addrsStr[0]
-	reputer2 := s.addrsStr[1]
-	reputer3 := s.addrsStr[2]
-	reputerAddresses := []string{reputer1, reputer2, reputer3}
-
-	score1 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer1, Score: alloraMath.NewDecFromInt64(95)}
-	score2 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer2, Score: alloraMath.NewDecFromInt64(90)}
-	score3 := types.Score{TopicId: topicId, BlockHeight: 2, Address: reputer3, Score: alloraMath.NewDecFromInt64(99)}
-	_ = k.SetReputerScoreEma(ctx, topicId, reputer1, score1)
-	_ = k.SetReputerScoreEma(ctx, topicId, reputer2, score2)
-	_ = k.SetReputerScoreEma(ctx, topicId, reputer3, score3)
-
-	lowScore, err := keeper.GetLowestScoreFromAllReputers(ctx, &k, topicId, reputerAddresses)
-	s.Require().NoError(err)
-	s.Require().Equal(lowScore, score2)
+			lowScore, err := tc.getLowestScore(ctx, k, topicId, workers)
+			s.Require().NoError(err)
+			s.Require().Equal(lowScore, scores[1])
+		})
+	}
 }

--- a/x/emissions/keeper/whitelist_test.go
+++ b/x/emissions/keeper/whitelist_test.go
@@ -16,12 +16,15 @@ func (s *KeeperTestSuite) TestWhitelistOperations() {
 	invalidAddr := "invalid"
 
 	testCases := []struct {
-		name         string
-		setup        func(context.Context, string) error
-		setup1       func(context.Context, uint64, string) error
-		check        func(context.Context, string) (bool, error)
-		check1       func(context.Context, uint64, string) (bool, error)
-		remove       func(context.Context, string) error
+		name  string
+		setup func(context.Context, string) error
+		// alternative setup for topic-specific whitelists
+		setup1 func(context.Context, uint64, string) error
+		check  func(context.Context, string) (bool, error)
+		// alternative check for topic-specific whitelists
+		check1 func(context.Context, uint64, string) (bool, error)
+		remove func(context.Context, string) error
+		// alternative remove for topic-specific whitelists
 		remove1      func(context.Context, uint64, string) error
 		needsTopicId bool
 	}{

--- a/x/emissions/keeper/whitelist_test.go
+++ b/x/emissions/keeper/whitelist_test.go
@@ -16,49 +16,46 @@ func (s *KeeperTestSuite) TestWhitelistOperations() {
 	invalidAddr := "invalid"
 
 	testCases := []struct {
-		name  string
-		setup func(context.Context, string) error
-		// alternative setup for topic-specific whitelists
-		setup1 func(context.Context, uint64, string) error
-		check  func(context.Context, string) (bool, error)
-		// alternative check for topic-specific whitelists
-		check1 func(context.Context, uint64, string) (bool, error)
-		remove func(context.Context, string) error
-		// alternative remove for topic-specific whitelists
-		remove1      func(context.Context, uint64, string) error
-		needsTopicId bool
+		name                 string
+		setupWhitelist       func(context.Context, string) error
+		setupTopicWhitelist  func(context.Context, uint64, string) error
+		checkWhitelist       func(context.Context, string) (bool, error)
+		checkTopicWhitelist  func(context.Context, uint64, string) (bool, error)
+		removeWhitelist      func(context.Context, string) error
+		removeTopicWhitelist func(context.Context, uint64, string) error
+		needsTopicId         bool
 	}{
 		{
-			name:   "Admin whitelist operations",
-			setup:  k.AddWhitelistAdmin,
-			check:  k.IsWhitelistAdmin,
-			remove: k.RemoveWhitelistAdmin,
+			name:            "Admin whitelist operations",
+			setupWhitelist:  k.AddWhitelistAdmin,
+			checkWhitelist:  k.IsWhitelistAdmin,
+			removeWhitelist: k.RemoveWhitelistAdmin,
 		},
 		{
-			name:   "Global whitelist operations",
-			setup:  k.AddToGlobalWhitelist,
-			check:  k.IsWhitelistedGlobalActor,
-			remove: k.RemoveFromGlobalWhitelist,
+			name:            "Global whitelist operations",
+			setupWhitelist:  k.AddToGlobalWhitelist,
+			checkWhitelist:  k.IsWhitelistedGlobalActor,
+			removeWhitelist: k.RemoveFromGlobalWhitelist,
 		},
 		{
-			name:   "Topic creator whitelist operations",
-			setup:  k.AddToTopicCreatorWhitelist,
-			check:  k.IsWhitelistedTopicCreator,
-			remove: k.RemoveFromTopicCreatorWhitelist,
+			name:            "Topic creator whitelist operations",
+			setupWhitelist:  k.AddToTopicCreatorWhitelist,
+			checkWhitelist:  k.IsWhitelistedTopicCreator,
+			removeWhitelist: k.RemoveFromTopicCreatorWhitelist,
 		},
 		{
-			name:         "Topic worker whitelist operations",
-			setup1:       k.AddToTopicWorkerWhitelist,
-			check1:       k.IsWhitelistedTopicWorker,
-			remove1:      k.RemoveFromTopicWorkerWhitelist,
-			needsTopicId: true,
+			name:                 "Topic worker whitelist operations",
+			setupTopicWhitelist:  k.AddToTopicWorkerWhitelist,
+			checkTopicWhitelist:  k.IsWhitelistedTopicWorker,
+			removeTopicWhitelist: k.RemoveFromTopicWorkerWhitelist,
+			needsTopicId:         true,
 		},
 		{
-			name:         "Topic reputer whitelist operations",
-			setup1:       k.AddToTopicReputerWhitelist,
-			check1:       k.IsWhitelistedTopicReputer,
-			remove1:      k.RemoveFromTopicReputerWhitelist,
-			needsTopicId: true,
+			name:                 "Topic reputer whitelist operations",
+			setupTopicWhitelist:  k.AddToTopicReputerWhitelist,
+			checkTopicWhitelist:  k.IsWhitelistedTopicReputer,
+			removeTopicWhitelist: k.RemoveFromTopicReputerWhitelist,
+			needsTopicId:         true,
 		},
 	}
 
@@ -66,60 +63,60 @@ func (s *KeeperTestSuite) TestWhitelistOperations() {
 		s.Run(tc.name, func() {
 			// Test basic operations
 			var err error
-			if tc.setup1 != nil {
-				err = tc.setup1(ctx, topicId, address)
+			if tc.setupTopicWhitelist != nil {
+				err = tc.setupTopicWhitelist(ctx, topicId, address)
 			} else {
-				err = tc.setup(ctx, address)
+				err = tc.setupWhitelist(ctx, address)
 			}
 			s.Require().NoError(err)
 
 			var isWhitelisted bool
-			if tc.check1 != nil {
-				isWhitelisted, err = tc.check1(ctx, topicId, address)
+			if tc.checkTopicWhitelist != nil {
+				isWhitelisted, err = tc.checkTopicWhitelist(ctx, topicId, address)
 			} else {
-				isWhitelisted, err = tc.check(ctx, address)
+				isWhitelisted, err = tc.checkWhitelist(ctx, address)
 			}
 			s.Require().NoError(err)
 			s.Require().True(isWhitelisted)
 
 			// Test removal
-			if tc.remove1 != nil {
-				err = tc.remove1(ctx, topicId, address)
+			if tc.removeTopicWhitelist != nil {
+				err = tc.removeTopicWhitelist(ctx, topicId, address)
 			} else {
-				err = tc.remove(ctx, address)
+				err = tc.removeWhitelist(ctx, address)
 			}
 			s.Require().NoError(err)
 
 			// Verify removal
-			if tc.check1 != nil {
-				isWhitelisted, err = tc.check1(ctx, topicId, address)
+			if tc.checkTopicWhitelist != nil {
+				isWhitelisted, err = tc.checkTopicWhitelist(ctx, topicId, address)
 			} else {
-				isWhitelisted, err = tc.check(ctx, address)
+				isWhitelisted, err = tc.checkWhitelist(ctx, address)
 			}
 			s.Require().NoError(err)
 			s.Require().False(isWhitelisted)
 
 			// Test removing non-existent entry (should not error)
-			if tc.remove1 != nil {
-				err = tc.remove1(ctx, topicId, nonExistentAddr)
+			if tc.removeTopicWhitelist != nil {
+				err = tc.removeTopicWhitelist(ctx, topicId, nonExistentAddr)
 			} else {
-				err = tc.remove(ctx, nonExistentAddr)
+				err = tc.removeWhitelist(ctx, nonExistentAddr)
 			}
 			s.Require().NoError(err)
 
 			// Test invalid address (should error)
-			if tc.setup1 != nil {
-				err = tc.setup1(ctx, topicId, invalidAddr)
+			if tc.setupTopicWhitelist != nil {
+				err = tc.setupTopicWhitelist(ctx, topicId, invalidAddr)
 			} else {
-				err = tc.setup(ctx, invalidAddr)
+				err = tc.setupWhitelist(ctx, invalidAddr)
 			}
 			s.Require().Error(err)
 			s.Require().Contains(err.Error(), "error validating admin id")
 
-			if tc.remove1 != nil {
-				err = tc.remove1(ctx, topicId, invalidAddr)
+			if tc.removeTopicWhitelist != nil {
+				err = tc.removeTopicWhitelist(ctx, topicId, invalidAddr)
 			} else {
-				err = tc.remove(ctx, invalidAddr)
+				err = tc.removeWhitelist(ctx, invalidAddr)
 			}
 			s.Require().Error(err)
 			s.Require().Contains(err.Error(), "error validating admin id")

--- a/x/emissions/keeper/whitelist_test.go
+++ b/x/emissions/keeper/whitelist_test.go
@@ -6,6 +6,7 @@ import (
 	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
 )
 
+//nolint:exhaustruct
 func (s *KeeperTestSuite) TestWhitelistOperations() {
 	ctx := s.Ctx()
 	k := s.EmissionsKeeper()
@@ -123,6 +124,7 @@ func (s *KeeperTestSuite) TestWhitelistOperations() {
 	}
 }
 
+//nolint:exhaustruct
 func (s *KeeperTestSuite) TestWhitelistEnableDisableOperations() {
 	ctx := s.Ctx()
 	k := s.EmissionsKeeper()
@@ -384,6 +386,7 @@ func (s *KeeperTestSuite) TestTopicPermissionCanUpdateTopicWhitelist() {
 	s.Require().NoError(err)
 }
 
+//nolint:exhaustruct
 func (s *KeeperTestSuite) TestWhitelistBasedPermissions() {
 	ctx := s.Ctx()
 	k := s.EmissionsKeeper()

--- a/x/emissions/keeper/whitelist_test.go
+++ b/x/emissions/keeper/whitelist_test.go
@@ -1,724 +1,503 @@
 package keeper_test
 
-func (s *KeeperTestSuite) TestWhitelistAdminOperations() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	adminAddress := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
+import (
+	"context"
 
-	// Test Adding to whitelist
-	err := keeper.AddWhitelistAdmin(ctx, adminAddress)
-	s.Require().NoError(err, "Adding whitelist admin should not fail")
+	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
+)
 
-	// Test Checking whitelist
-	isAdmin, err := keeper.IsWhitelistAdmin(ctx, adminAddress)
-	s.Require().NoError(err, "Checking if address is an admin should not fail")
-	s.Require().True(isAdmin, "Address should be an admin after being added")
-
-	// Test Removing from whitelist
-	err = keeper.RemoveWhitelistAdmin(ctx, adminAddress)
-	s.Require().NoError(err, "Removing whitelist admin should not fail")
-
-	// Verify removal
-	isAdmin, err = keeper.IsWhitelistAdmin(ctx, adminAddress)
-	s.Require().NoError(err, "Checking admin status after removal should not fail")
-	s.Require().False(isAdmin, "Address should not be an admin after being removed")
-
-	// Test invalid address
+func (s *KeeperTestSuite) TestWhitelistOperations() {
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := uint64(1)
+	address := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
+	nonExistentAddr := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv"
 	invalidAddr := "invalid"
-	err = keeper.AddWhitelistAdmin(ctx, invalidAddr)
-	s.Require().Error(err)
-	err = keeper.RemoveWhitelistAdmin(ctx, invalidAddr)
-	s.Require().Error(err)
+
+	testCases := []struct {
+		name         string
+		setup        func(context.Context, string) error
+		setup1       func(context.Context, uint64, string) error
+		check        func(context.Context, string) (bool, error)
+		check1       func(context.Context, uint64, string) (bool, error)
+		remove       func(context.Context, string) error
+		remove1      func(context.Context, uint64, string) error
+		needsTopicId bool
+	}{
+		{
+			name:   "Admin whitelist operations",
+			setup:  k.AddWhitelistAdmin,
+			check:  k.IsWhitelistAdmin,
+			remove: k.RemoveWhitelistAdmin,
+		},
+		{
+			name:   "Global whitelist operations",
+			setup:  k.AddToGlobalWhitelist,
+			check:  k.IsWhitelistedGlobalActor,
+			remove: k.RemoveFromGlobalWhitelist,
+		},
+		{
+			name:   "Topic creator whitelist operations",
+			setup:  k.AddToTopicCreatorWhitelist,
+			check:  k.IsWhitelistedTopicCreator,
+			remove: k.RemoveFromTopicCreatorWhitelist,
+		},
+		{
+			name:         "Topic worker whitelist operations",
+			setup1:       k.AddToTopicWorkerWhitelist,
+			check1:       k.IsWhitelistedTopicWorker,
+			remove1:      k.RemoveFromTopicWorkerWhitelist,
+			needsTopicId: true,
+		},
+		{
+			name:         "Topic reputer whitelist operations",
+			setup1:       k.AddToTopicReputerWhitelist,
+			check1:       k.IsWhitelistedTopicReputer,
+			remove1:      k.RemoveFromTopicReputerWhitelist,
+			needsTopicId: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Test basic operations
+			var err error
+			if tc.setup1 != nil {
+				err = tc.setup1(ctx, topicId, address)
+			} else {
+				err = tc.setup(ctx, address)
+			}
+			s.Require().NoError(err)
+
+			var isWhitelisted bool
+			if tc.check1 != nil {
+				isWhitelisted, err = tc.check1(ctx, topicId, address)
+			} else {
+				isWhitelisted, err = tc.check(ctx, address)
+			}
+			s.Require().NoError(err)
+			s.Require().True(isWhitelisted)
+
+			// Test removal
+			if tc.remove1 != nil {
+				err = tc.remove1(ctx, topicId, address)
+			} else {
+				err = tc.remove(ctx, address)
+			}
+			s.Require().NoError(err)
+
+			// Verify removal
+			if tc.check1 != nil {
+				isWhitelisted, err = tc.check1(ctx, topicId, address)
+			} else {
+				isWhitelisted, err = tc.check(ctx, address)
+			}
+			s.Require().NoError(err)
+			s.Require().False(isWhitelisted)
+
+			// Test removing non-existent entry (should not error)
+			if tc.remove1 != nil {
+				err = tc.remove1(ctx, topicId, nonExistentAddr)
+			} else {
+				err = tc.remove(ctx, nonExistentAddr)
+			}
+			s.Require().NoError(err)
+
+			// Test invalid address (should error)
+			if tc.setup1 != nil {
+				err = tc.setup1(ctx, topicId, invalidAddr)
+			} else {
+				err = tc.setup(ctx, invalidAddr)
+			}
+			s.Require().Error(err)
+			s.Require().Contains(err.Error(), "error validating admin id")
+
+			if tc.remove1 != nil {
+				err = tc.remove1(ctx, topicId, invalidAddr)
+			} else {
+				err = tc.remove(ctx, invalidAddr)
+			}
+			s.Require().Error(err)
+			s.Require().Contains(err.Error(), "error validating admin id")
+		})
+	}
 }
 
-func (s *KeeperTestSuite) TestGlobalWhitelistOperations() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
+func (s *KeeperTestSuite) TestWhitelistEnableDisableOperations() {
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicId := uint64(2)
 
-	// Test global whitelist operations
-	isWhitelisted, err := keeper.IsWhitelistedGlobalActor(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(isWhitelisted)
+	testCases := []struct {
+		name    string
+		enable  func(context.Context, uint64) error
+		check   func(context.Context, uint64) (bool, error)
+		disable func(context.Context, uint64) error
+	}{
+		{
+			name:    "Topic worker whitelist enable/disable",
+			enable:  k.EnableTopicWorkerWhitelist,
+			check:   k.IsTopicWorkerWhitelistEnabled,
+			disable: k.DisableTopicWorkerWhitelist,
+		},
+		{
+			name:    "Topic reputer whitelist enable/disable",
+			enable:  k.EnableTopicReputerWhitelist,
+			check:   k.IsTopicReputerWhitelistEnabled,
+			disable: k.DisableTopicReputerWhitelist,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Initially should be disabled
+			enabled, err := tc.check(ctx, topicId)
+			s.Require().NoError(err)
+			s.Require().False(enabled)
 
-	err = keeper.AddToGlobalWhitelist(ctx, testAddr)
-	s.Require().NoError(err)
+			// Test enabling
+			err = tc.enable(ctx, topicId)
+			s.Require().NoError(err)
 
-	isWhitelisted, err = keeper.IsWhitelistedGlobalActor(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(isWhitelisted)
+			enabled, err = tc.check(ctx, topicId)
+			s.Require().NoError(err)
+			s.Require().True(enabled)
 
-	err = keeper.RemoveFromGlobalWhitelist(ctx, testAddr)
-	s.Require().NoError(err)
+			// Test disabling
+			err = tc.disable(ctx, topicId)
+			s.Require().NoError(err)
 
-	// Test invalid address
-	invalidAddr := "invalid"
-	err = keeper.AddToGlobalWhitelist(ctx, invalidAddr)
-	s.Require().Error(err)
-	err = keeper.RemoveFromGlobalWhitelist(ctx, invalidAddr)
-	s.Require().Error(err)
+			enabled, err = tc.check(ctx, topicId)
+			s.Require().NoError(err)
+			s.Require().False(enabled)
+
+			// Test disabling when already disabled (should not error)
+			err = tc.disable(ctx, topicId)
+			s.Require().NoError(err)
+
+			enabled, err = tc.check(ctx, topicId)
+			s.Require().NoError(err)
+			s.Require().False(enabled)
+		})
+	}
 }
 
-func (s *KeeperTestSuite) TestRemoveWhitelistAdmin() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
+func (s *KeeperTestSuite) TestWhitelistEnabledOperations() {
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	address := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
 
-	// Test removing non-existent admin
-	nonExistentAdmin := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv"
-	err := keeper.RemoveWhitelistAdmin(ctx, nonExistentAdmin)
-	s.Require().NoError(err)
+	testCases := []struct {
+		name         string
+		setupAddr    func(context.Context, string) error
+		checkEnabled func(context.Context, string) (bool, error)
+		cleanupAddr  func(context.Context, string) error
+	}{
+		{
+			name:         "IsEnabledGlobalActor",
+			setupAddr:    k.AddToGlobalWhitelist,
+			checkEnabled: k.IsEnabledGlobalActor,
+			cleanupAddr:  k.RemoveFromGlobalWhitelist,
+		},
+		{
+			name:         "IsEnabledWhitelistedTopicCreator",
+			setupAddr:    k.AddToTopicCreatorWhitelist,
+			checkEnabled: k.IsEnabledWhitelistedTopicCreator,
+			cleanupAddr:  k.RemoveFromTopicCreatorWhitelist,
+		},
+	}
 
-	// Test removing existing admin
-	admin := "allo14s7gd09y7mkje8547ukm0c8gjnd3hak7v3fwz6"
-	err = keeper.AddWhitelistAdmin(ctx, admin)
-	s.Require().NoError(err)
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Initially should be false (not whitelisted)
+			enabled, err := tc.checkEnabled(ctx, address)
+			s.Require().NoError(err)
+			s.Require().False(enabled)
 
-	err = keeper.RemoveWhitelistAdmin(ctx, admin)
-	s.Require().NoError(err)
+			// Add to whitelist
+			err = tc.setupAddr(ctx, address)
+			s.Require().NoError(err)
 
-	// Verify admin was removed
-	has, err := keeper.IsWhitelistAdmin(ctx, admin)
-	s.Require().NoError(err)
-	s.Require().False(has)
+			// Should now be enabled
+			enabled, err = tc.checkEnabled(ctx, address)
+			s.Require().NoError(err)
+			s.Require().True(enabled)
 
-	// Test invalid bech32 address
-	invalidAdmin := "invalid-address"
-	err = keeper.RemoveWhitelistAdmin(ctx, invalidAdmin)
-	s.Require().Error(err)
+			// Clean up
+			err = tc.cleanupAddr(ctx, address)
+			s.Require().NoError(err)
+		})
+	}
 }
 
-func (s *KeeperTestSuite) TestTopicCreatorWhitelistOperations() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-
-	// Test topic creator whitelist operations
-	isWhitelisted, err := keeper.IsWhitelistedTopicCreator(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(isWhitelisted)
-
-	err = keeper.AddToTopicCreatorWhitelist(ctx, testAddr)
-	s.Require().NoError(err)
-
-	isWhitelisted, err = keeper.IsWhitelistedTopicCreator(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(isWhitelisted)
-
-	err = keeper.RemoveFromTopicCreatorWhitelist(ctx, testAddr)
-	s.Require().NoError(err)
-
-	// Test invalid address
-	invalidAddr := "invalid"
-	err = keeper.AddToTopicCreatorWhitelist(ctx, invalidAddr)
-	s.Require().Error(err)
-	err = keeper.RemoveFromTopicCreatorWhitelist(ctx, invalidAddr)
-	s.Require().Error(err)
-}
-
-func (s *KeeperTestSuite) TestTopicWorkerWhitelistOperations() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
+func (s *KeeperTestSuite) TestTopicWhitelistEnabledOperations() {
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	address := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
 	topicId := uint64(1)
 
-	// Test topic worker whitelist operations
-	isWhitelisted, err := keeper.IsWhitelistedTopicWorker(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(isWhitelisted)
+	testCases := []struct {
+		name           string
+		enableList     func(context.Context, uint64) error
+		disableList    func(context.Context, uint64) error
+		addToList      func(context.Context, uint64, string) error
+		removeFromList func(context.Context, uint64, string) error
+		checkEnabled   func(context.Context, uint64, string) (bool, error)
+	}{
+		{
+			name:           "IsEnabledTopicWorker",
+			enableList:     k.EnableTopicWorkerWhitelist,
+			disableList:    k.DisableTopicWorkerWhitelist,
+			addToList:      k.AddToTopicWorkerWhitelist,
+			removeFromList: k.RemoveFromTopicWorkerWhitelist,
+			checkEnabled:   k.IsEnabledTopicWorker,
+		},
+		{
+			name:           "IsEnabledTopicReputer",
+			enableList:     k.EnableTopicReputerWhitelist,
+			disableList:    k.DisableTopicReputerWhitelist,
+			addToList:      k.AddToTopicReputerWhitelist,
+			removeFromList: k.RemoveFromTopicReputerWhitelist,
+			checkEnabled:   k.IsEnabledTopicReputer,
+		},
+	}
 
-	err = keeper.AddToTopicWorkerWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Clean state first
+			_ = tc.removeFromList(ctx, topicId, address)
+			_ = tc.disableList(ctx, topicId)
 
-	isWhitelisted, err = keeper.IsWhitelistedTopicWorker(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(isWhitelisted)
+			// When whitelist disabled, should be enabled for everyone
+			enabled, err := tc.checkEnabled(ctx, topicId, address)
+			s.Require().NoError(err)
+			s.Require().True(enabled)
 
-	err = keeper.RemoveFromTopicWorkerWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
+			// Enable whitelist
+			err = tc.enableList(ctx, topicId)
+			s.Require().NoError(err)
 
-	// Test invalid address
-	invalidAddr := "invalid"
-	err = keeper.AddToTopicWorkerWhitelist(ctx, topicId, invalidAddr)
-	s.Require().Error(err)
-	err = keeper.RemoveFromTopicWorkerWhitelist(ctx, topicId, invalidAddr)
-	s.Require().Error(err)
+			// When whitelist enabled but not in list, should be false
+			enabled, err = tc.checkEnabled(ctx, topicId, address)
+			s.Require().NoError(err)
+			s.Require().False(enabled)
+
+			// Add to whitelist
+			err = tc.addToList(ctx, topicId, address)
+			s.Require().NoError(err)
+
+			// Should now be enabled
+			enabled, err = tc.checkEnabled(ctx, topicId, address)
+			s.Require().NoError(err)
+			s.Require().True(enabled)
+
+			// Clean up
+			_ = tc.removeFromList(ctx, topicId, address)
+			_ = tc.disableList(ctx, topicId)
+		})
+	}
 }
 
-func (s *KeeperTestSuite) TestTopicReputerWhitelistOperations() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-	topicId := uint64(1)
+func (s *KeeperTestSuite) TestPermissionOperations() {
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	address := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
 
-	// Test topic reputer whitelist operations
-	isWhitelisted, err := keeper.IsWhitelistedTopicReputer(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(isWhitelisted)
+	testCases := []struct {
+		name         string
+		setupAdmin   func(context.Context, string) error
+		checkPerm    func(context.Context, string) (bool, error)
+		cleanupAdmin func(context.Context, string) error
+	}{
+		{
+			name:         "CanUpdateAllGlobalWhitelists",
+			setupAdmin:   k.AddWhitelistAdmin,
+			checkPerm:    k.CanUpdateAllGlobalWhitelists,
+			cleanupAdmin: k.RemoveWhitelistAdmin,
+		},
+		{
+			name:         "CanUpdateParams",
+			setupAdmin:   k.AddWhitelistAdmin,
+			checkPerm:    k.CanUpdateParams,
+			cleanupAdmin: k.RemoveWhitelistAdmin,
+		},
+		{
+			name:         "CanUpdateTopicCreatorWhitelist",
+			setupAdmin:   k.AddWhitelistAdmin,
+			checkPerm:    k.CanUpdateTopicCreatorWhitelist,
+			cleanupAdmin: k.RemoveWhitelistAdmin,
+		},
+	}
 
-	err = keeper.AddToTopicReputerWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Initially should be false (not admin)
+			canUpdate, err := tc.checkPerm(ctx, address)
+			s.Require().NoError(err)
+			s.Require().False(canUpdate)
 
-	isWhitelisted, err = keeper.IsWhitelistedTopicReputer(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(isWhitelisted)
+			// Add admin
+			err = tc.setupAdmin(ctx, address)
+			s.Require().NoError(err)
 
-	err = keeper.RemoveFromTopicReputerWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
+			// Should now have permission
+			canUpdate, err = tc.checkPerm(ctx, address)
+			s.Require().NoError(err)
+			s.Require().True(canUpdate)
 
-	// Test invalid address
-	invalidAddr := "invalid"
-	err = keeper.AddToTopicReputerWhitelist(ctx, topicId, invalidAddr)
-	s.Require().Error(err)
-	err = keeper.RemoveFromTopicReputerWhitelist(ctx, topicId, invalidAddr)
-	s.Require().Error(err)
+			// Clean up
+			err = tc.cleanupAdmin(ctx, address)
+			s.Require().NoError(err)
+		})
+	}
 }
 
-func (s *KeeperTestSuite) TestIsTopicWhitelistEnabled() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
+func (s *KeeperTestSuite) TestTopicPermissionCanUpdateTopicWhitelist() {
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	address := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
+	topicId := s.CreateTopic(alloratestutil.WithEpochLength(60))
 
-	enabled, err := keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
+	// Get topic creator for comparison
+	topic, err := k.GetTopic(ctx, topicId)
 	s.Require().NoError(err)
-	s.Require().False(enabled)
 
-	err = keeper.EnableTopicWorkerWhitelist(ctx, topicId)
+	// Topic creator should have permission
+	canUpdate, err := k.CanUpdateTopicWhitelist(ctx, topicId, topic.Creator)
 	s.Require().NoError(err)
+	s.Require().True(canUpdate)
 
-	enabled, err = keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().True(enabled)
-}
-
-func (s *KeeperTestSuite) TestIsEnabledGlobalActor() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-
-	enabled, err := keeper.IsEnabledGlobalActor(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(enabled)
-
-	err = keeper.AddToGlobalWhitelist(ctx, testAddr)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsEnabledGlobalActor(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(enabled)
-}
-
-func (s *KeeperTestSuite) TestDisableTopicWorkerWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-
-	// Test disabling when not enabled
-	err := keeper.DisableTopicWorkerWhitelist(ctx, topicId)
-	s.Require().NoError(err, "Disabling non-enabled whitelist should not error")
-
-	enabled, err := keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().False(enabled, "Whitelist should remain disabled")
-
-	// Enable whitelist first
-	err = keeper.EnableTopicWorkerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().True(enabled, "Whitelist should be enabled")
-
-	// Test disabling when enabled
-	err = keeper.DisableTopicWorkerWhitelist(ctx, topicId)
-	s.Require().NoError(err, "Disabling enabled whitelist should not error")
-
-	enabled, err = keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().False(enabled, "Whitelist should be disabled")
-}
-
-func (s *KeeperTestSuite) TestDisableTopicReputerWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-
-	// Test disabling when not enabled
-	err := keeper.DisableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err, "Disabling non-enabled whitelist should not error")
-
-	enabled, err := keeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().False(enabled, "Whitelist should remain disabled")
-
-	// Enable whitelist first
-	err = keeper.EnableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().True(enabled, "Whitelist should be enabled")
-
-	// Test disabling when enabled
-	err = keeper.DisableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err, "Disabling enabled whitelist should not error")
-
-	enabled, err = keeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().False(enabled, "Whitelist should be disabled")
-}
-
-func (s *KeeperTestSuite) TestRemoveFromGlobalWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-
-	// Test removing non-existent actor
-	nonExistentActor := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv"
-	err := keeper.RemoveFromGlobalWhitelist(ctx, nonExistentActor)
-	s.Require().NoError(err)
-
-	// Test removing existing actor
-	actor := "allo14s7gd09y7mkje8547ukm0c8gjnd3hak7v3fwz6"
-	err = keeper.AddToGlobalWhitelist(ctx, actor)
-	s.Require().NoError(err)
-
-	err = keeper.RemoveFromGlobalWhitelist(ctx, actor)
-	s.Require().NoError(err)
-
-	// Verify actor was removed
-	isWhitelisted, err := keeper.IsWhitelistedGlobalActor(ctx, actor)
-	s.Require().NoError(err)
-	s.Require().False(isWhitelisted)
-
-	// Test invalid bech32 address
-	invalidActor := "invalid-address"
-	err = keeper.RemoveFromGlobalWhitelist(ctx, invalidActor)
-	s.Require().Error(err)
-}
-
-func (s *KeeperTestSuite) TestRemoveFromTopicCreatorWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-
-	actor := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv" // Replace with a valid Bech32 actor ID for testing
-
-	// Test case: Actor is not in the whitelist
-	err := keeper.RemoveFromTopicCreatorWhitelist(ctx, actor)
-	s.Require().NoError(err, "Expected no error when actor is not in the whitelist")
-
-	// Test case: Actor is in the whitelist
-	err = keeper.AddToTopicCreatorWhitelist(ctx, actor)
-	s.Require().NoError(err)
-
-	err = keeper.RemoveFromTopicCreatorWhitelist(ctx, actor)
-	s.Require().NoError(err)
-
-	// Verify actor is removed
-	isWhitelisted, err := keeper.IsWhitelistedTopicCreator(ctx, actor)
-	s.Require().NoError(err)
-	s.Require().False(isWhitelisted)
-
-	// Test case: Invalid Bech32 actor ID
-	invalidActor := "invalidActorId"
-	err = keeper.RemoveFromTopicCreatorWhitelist(ctx, invalidActor)
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "error validating admin id", "Expected validation error message")
-}
-
-func (s *KeeperTestSuite) TestRemoveFromTopicWorkerWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-
-	// Test removing non-existent worker
-	nonExistentWorker := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv"
-	err := keeper.RemoveFromTopicWorkerWhitelist(ctx, topicId, nonExistentWorker)
-	s.Require().NoError(err, "Expected no error when worker is not in the whitelist")
-
-	// Test removing existing worker
-	worker := "allo14s7gd09y7mkje8547ukm0c8gjnd3hak7v3fwz6"
-	err = keeper.AddToTopicWorkerWhitelist(ctx, topicId, worker)
-	s.Require().NoError(err)
-
-	err = keeper.RemoveFromTopicWorkerWhitelist(ctx, topicId, worker)
-	s.Require().NoError(err)
-
-	// Verify worker was removed
-	isWhitelisted, err := keeper.IsWhitelistedTopicWorker(ctx, topicId, worker)
-	s.Require().NoError(err)
-	s.Require().False(isWhitelisted)
-
-	// Test invalid bech32 address
-	invalidWorker := "invalid-address"
-	err = keeper.RemoveFromTopicWorkerWhitelist(ctx, topicId, invalidWorker)
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "error validating admin id")
-}
-
-func (s *KeeperTestSuite) TestRemoveFromTopicReputerWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-
-	// Test removing non-existent reputer
-	nonExistentReputer := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv"
-	err := keeper.RemoveFromTopicReputerWhitelist(ctx, topicId, nonExistentReputer)
-	s.Require().NoError(err, "Expected no error when reputer is not in the whitelist")
-
-	// Test removing existing reputer
-	reputer := "allo14s7gd09y7mkje8547ukm0c8gjnd3hak7v3fwz6"
-	err = keeper.AddToTopicReputerWhitelist(ctx, topicId, reputer)
-	s.Require().NoError(err)
-
-	err = keeper.RemoveFromTopicReputerWhitelist(ctx, topicId, reputer)
-	s.Require().NoError(err)
-
-	// Verify reputer was removed
-	isWhitelisted, err := keeper.IsWhitelistedTopicReputer(ctx, topicId, reputer)
-	s.Require().NoError(err)
-	s.Require().False(isWhitelisted)
-
-	// Test invalid bech32 address
-	invalidReputer := "invalid-address"
-	err = keeper.RemoveFromTopicReputerWhitelist(ctx, topicId, invalidReputer)
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "error validating admin id")
-}
-
-func (s *KeeperTestSuite) TestIsEnabledWhitelistedTopicCreator() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-
-	enabled, err := keeper.IsEnabledWhitelistedTopicCreator(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(enabled)
-
-	err = keeper.AddToTopicCreatorWhitelist(ctx, testAddr)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsEnabledWhitelistedTopicCreator(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(enabled)
-}
-
-func (s *KeeperTestSuite) TestIsEnabledTopicWorker() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-	topicId := uint64(1)
-
-	err := keeper.RemoveFromTopicWorkerWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-
-	err = keeper.DisableTopicWorkerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err := keeper.IsEnabledTopicWorker(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(enabled)
-
-	err = keeper.EnableTopicWorkerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsEnabledTopicWorker(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(enabled)
-
-	err = keeper.AddToTopicWorkerWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsEnabledTopicWorker(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(enabled)
-}
-
-func (s *KeeperTestSuite) TestIsEnabledTopicReputer() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-	topicId := uint64(1)
-
-	err := keeper.RemoveFromTopicReputerWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-
-	err = keeper.DisableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err := keeper.IsEnabledTopicReputer(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(enabled)
-
-	err = keeper.EnableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsEnabledTopicReputer(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(enabled)
-
-	err = keeper.AddToTopicReputerWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsEnabledTopicReputer(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(enabled)
-}
-
-func (s *KeeperTestSuite) TestCanUpdateGlobalWhitelists() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-
-	can, err := keeper.CanUpdateAllGlobalWhitelists(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(can)
-
-	err = keeper.AddWhitelistAdmin(ctx, testAddr)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanUpdateAllGlobalWhitelists(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(can)
-}
-
-func (s *KeeperTestSuite) TestCanUpdateParams() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-
-	can, err := keeper.CanUpdateParams(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(can)
-
-	err = keeper.AddWhitelistAdmin(ctx, testAddr)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanUpdateParams(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(can)
-}
-
-func (s *KeeperTestSuite) TestCanUpdateTopicWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-	topicId := s.CreateOneTopic(60)
-	topic, err := keeper.GetTopic(ctx, topicId)
-	s.Require().NoError(err)
-
-	can, err := keeper.CanUpdateTopicWhitelist(ctx, topicId, topic.Creator)
-	s.Require().NoError(err)
-	s.Require().True(can)
-
-	can, err = keeper.CanUpdateTopicWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(can)
-
-	err = keeper.AddWhitelistAdmin(ctx, testAddr)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanUpdateTopicWhitelist(ctx, topicId, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(can)
-}
-
-func (s *KeeperTestSuite) TestCanCreateTopicWithWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	testAddr := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-
-	can, err := keeper.CanCreateTopic(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().False(can)
-
-	err = keeper.AddToTopicCreatorWhitelist(ctx, testAddr)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanCreateTopic(ctx, testAddr)
-	s.Require().NoError(err)
-	s.Require().True(can)
-}
-
-func (s *KeeperTestSuite) TestCanSubmitWorkerPayloadWithWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	enabledTopicWorker := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-	enabledGlobalActor := "allo14s7gd09y7mkje8547ukm0c8gjnd3hak7v3fwz6"
-	neitherAddr := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv"
-	topicId := uint64(1)
-
-	err := keeper.EnableTopicWorkerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	can, err := keeper.CanSubmitWorkerPayload(ctx, topicId, neitherAddr)
-	s.Require().NoError(err)
-	s.Require().False(can)
-
-	err = keeper.AddToTopicWorkerWhitelist(ctx, topicId, enabledTopicWorker)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanSubmitWorkerPayload(ctx, topicId, enabledTopicWorker)
-	s.Require().NoError(err)
-	s.Require().True(can)
-
-	err = keeper.AddToGlobalWhitelist(ctx, enabledGlobalActor)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanSubmitWorkerPayload(ctx, topicId, enabledGlobalActor)
-	s.Require().NoError(err)
-	s.Require().True(can)
-
-	err = keeper.DisableTopicWorkerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanSubmitWorkerPayload(ctx, topicId, neitherAddr)
-	s.Require().NoError(err)
-	s.Require().True(can)
-}
-
-func (s *KeeperTestSuite) TestCanSubmitReputerPayloadWithWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	enabledTopicReputer := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-	enabledGlobalActor := "allo14s7gd09y7mkje8547ukm0c8gjnd3hak7v3fwz6"
-	neitherAddr := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv"
-	topicId := uint64(1)
-
-	err := keeper.EnableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	can, err := keeper.CanSubmitReputerPayload(ctx, topicId, neitherAddr)
-	s.Require().NoError(err)
-	s.Require().False(can)
-
-	err = keeper.AddToTopicReputerWhitelist(ctx, topicId, enabledTopicReputer)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanSubmitReputerPayload(ctx, topicId, enabledTopicReputer)
-	s.Require().NoError(err)
-	s.Require().True(can)
-
-	err = keeper.AddToGlobalWhitelist(ctx, enabledGlobalActor)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanSubmitReputerPayload(ctx, topicId, enabledGlobalActor)
-	s.Require().NoError(err)
-	s.Require().True(can)
-
-	err = keeper.DisableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanSubmitReputerPayload(ctx, topicId, neitherAddr)
-	s.Require().NoError(err)
-	s.Require().True(can)
-}
-
-func (s *KeeperTestSuite) TestCanAddReputerStakeWithWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	enabledTopicReputer := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-	enabledGlobalActor := "allo14s7gd09y7mkje8547ukm0c8gjnd3hak7v3fwz6"
-	neitherAddr := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv"
-	topicId := uint64(1)
-
-	err := keeper.EnableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	can, err := keeper.CanAddReputerStake(ctx, topicId, neitherAddr)
-	s.Require().NoError(err)
-	s.Require().False(can)
-
-	err = keeper.AddToTopicReputerWhitelist(ctx, topicId, enabledTopicReputer)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanAddReputerStake(ctx, topicId, enabledTopicReputer)
-	s.Require().NoError(err)
-	s.Require().True(can)
-
-	err = keeper.AddToGlobalWhitelist(ctx, enabledGlobalActor)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanAddReputerStake(ctx, topicId, enabledGlobalActor)
-	s.Require().NoError(err)
-	s.Require().True(can)
-
-	err = keeper.DisableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	can, err = keeper.CanAddReputerStake(ctx, topicId, neitherAddr)
-	s.Require().NoError(err)
-	s.Require().True(can)
-}
-
-func (s *KeeperTestSuite) TestEnableDisableTopicWorkerWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-
-	// Initially should be disabled
-	enabled, err := keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().False(enabled)
-
-	// Test enabling
-	err = keeper.EnableTopicWorkerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().True(enabled)
-
-	// Test disabling
-	err = keeper.DisableTopicWorkerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsTopicWorkerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().False(enabled)
-}
-
-func (s *KeeperTestSuite) TestEnableDisableTopicReputerWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-	topicId := uint64(1)
-
-	// Initially should be disabled
-	enabled, err := keeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().False(enabled)
-
-	// Test enabling
-	err = keeper.EnableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().True(enabled)
-
-	// Test disabling
-	err = keeper.DisableTopicReputerWhitelist(ctx, topicId)
-	s.Require().NoError(err)
-
-	enabled, err = keeper.IsTopicReputerWhitelistEnabled(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().False(enabled)
-}
-
-func (s *KeeperTestSuite) TestCanUpdateTopicCreatorWhitelist() {
-	ctx := s.ctx
-	keeper := s.emissionsKeeper
-
-	// Test non-admin actor
-	nonAdmin := "allo1w6uwgrv77szudkve7g84uazuhyw6j4q9hdqelv"
-	canUpdate, err := keeper.CanUpdateTopicCreatorWhitelist(ctx, nonAdmin)
+	// Non-creator should not have permission
+	canUpdate, err = k.CanUpdateTopicWhitelist(ctx, topicId, address)
 	s.Require().NoError(err)
 	s.Require().False(canUpdate)
 
-	// Test admin actor
-	admin := "allo14s7gd09y7mkje8547ukm0c8gjnd3hak7v3fwz6"
-	err = keeper.AddWhitelistAdmin(ctx, admin)
+	// Admin should have permission
+	err = k.AddWhitelistAdmin(ctx, address)
 	s.Require().NoError(err)
 
-	canUpdate, err = keeper.CanUpdateTopicCreatorWhitelist(ctx, admin)
+	canUpdate, err = k.CanUpdateTopicWhitelist(ctx, topicId, address)
 	s.Require().NoError(err)
 	s.Require().True(canUpdate)
+
+	// Clean up
+	err = k.RemoveWhitelistAdmin(ctx, address)
+	s.Require().NoError(err)
+}
+
+func (s *KeeperTestSuite) TestWhitelistBasedPermissions() {
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+	topicCreator := s.AddrsStr(0)
+	topicWorker := s.AddrsStr(1)
+	topicReputer := s.AddrsStr(2)
+	globalActor := s.AddrsStr(3)
+	nonWhitelistedAddr := "allo1b6uwgrv77szudkve7g84uazuhyw6j4q9hdqely"
+	topicId := uint64(2)
+
+	testCases := []struct {
+		name             string
+		setupWhitelist   func(context.Context, string) error
+		setupWhitelist1  func(context.Context, uint64, string) error
+		enableWhitelist  func(context.Context, uint64) error
+		disableWhitelist func(context.Context, uint64) error
+		checkPermission  func(context.Context, uint64, string) (bool, error)
+		checkPermission1 func(context.Context, string) (bool, error) // For CanCreateTopic
+		whitelistedAddr  string
+		hasEnableDisable bool
+	}{
+		{
+			name:             "CanCreateTopic",
+			setupWhitelist:   k.AddToTopicCreatorWhitelist,
+			checkPermission1: k.CanCreateTopic,
+			whitelistedAddr:  topicCreator,
+			hasEnableDisable: false,
+		},
+		{
+			name:             "CanSubmitWorkerPayload",
+			setupWhitelist1:  k.AddToTopicWorkerWhitelist,
+			enableWhitelist:  k.EnableTopicWorkerWhitelist,
+			disableWhitelist: k.DisableTopicWorkerWhitelist,
+			checkPermission:  k.CanSubmitWorkerPayload,
+			whitelistedAddr:  topicWorker,
+			hasEnableDisable: true,
+		},
+		{
+			name:             "CanSubmitReputerPayload",
+			setupWhitelist1:  k.AddToTopicReputerWhitelist,
+			enableWhitelist:  k.EnableTopicReputerWhitelist,
+			disableWhitelist: k.DisableTopicReputerWhitelist,
+			checkPermission:  k.CanSubmitReputerPayload,
+			whitelistedAddr:  topicReputer,
+			hasEnableDisable: true,
+		},
+		{
+			name:             "CanAddReputerStake",
+			setupWhitelist1:  k.AddToTopicReputerWhitelist,
+			enableWhitelist:  k.EnableTopicReputerWhitelist,
+			disableWhitelist: k.DisableTopicReputerWhitelist,
+			checkPermission:  k.CanAddReputerStake,
+			whitelistedAddr:  topicReputer,
+			hasEnableDisable: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Setup whitelists
+			if tc.setupWhitelist != nil {
+				err := tc.setupWhitelist(ctx, tc.whitelistedAddr)
+				s.Require().NoError(err)
+			} else {
+				err := tc.setupWhitelist1(ctx, topicId, tc.whitelistedAddr)
+				s.Require().NoError(err)
+			}
+
+			if tc.hasEnableDisable {
+				err := k.AddToGlobalWhitelist(ctx, globalActor)
+				s.Require().NoError(err)
+				// When whitelist disabled, all should have permission
+				can, err := tc.checkPermission(ctx, topicId, nonWhitelistedAddr)
+				s.Require().NoError(err)
+				s.Require().True(can)
+
+				// Enable whitelist
+				err = tc.enableWhitelist(ctx, topicId)
+				s.Require().NoError(err)
+
+				// Non-whitelisted should not have permission
+				can, err = tc.checkPermission(ctx, topicId, nonWhitelistedAddr)
+				s.Require().NoError(err)
+				s.Require().False(can)
+
+				// Whitelisted actor should have permission
+				can, err = tc.checkPermission(ctx, topicId, tc.whitelistedAddr)
+				s.Require().NoError(err)
+				s.Require().True(can)
+
+				// Global actor should have permission
+				can, err = tc.checkPermission(ctx, topicId, globalActor)
+				s.Require().NoError(err)
+				s.Require().True(can)
+
+				// Disable whitelist
+				err = tc.disableWhitelist(ctx, topicId)
+				s.Require().NoError(err)
+
+				// All should have permission again
+				can, err = tc.checkPermission(ctx, topicId, nonWhitelistedAddr)
+				s.Require().NoError(err)
+				s.Require().True(can)
+			} else {
+				// For topic creator (no enable/disable), non-whitelisted should not have permission
+				can, err := tc.checkPermission1(ctx, nonWhitelistedAddr)
+				s.Require().NoError(err)
+				s.Require().False(can)
+
+				// Whitelisted should have permission
+				can, err = tc.checkPermission1(ctx, tc.whitelistedAddr)
+				s.Require().NoError(err)
+				s.Require().True(can)
+			}
+		})
+	}
 }

--- a/x/emissions/keeper/whitelist_test.go
+++ b/x/emissions/keeper/whitelist_test.go
@@ -3,7 +3,7 @@ package keeper_test
 import (
 	"context"
 
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 )
 
 //nolint:exhaustruct
@@ -360,7 +360,7 @@ func (s *KeeperTestSuite) TestTopicPermissionCanUpdateTopicWhitelist() {
 	ctx := s.Ctx()
 	k := s.EmissionsKeeper()
 	address := "allo1wmvlvr82nlnu2y6hewgjwex30spyqgzvjhc80h"
-	topicId := s.CreateTopic(alloratestutil.WithEpochLength(60))
+	topicId := s.CreateTopic(testutil.WithEpochLength(60))
 
 	// Get topic creator for comparison
 	topic, err := k.GetTopic(ctx, topicId)

--- a/x/emissions/migrations/v11/migrate_test.go
+++ b/x/emissions/migrations/v11/migrate_test.go
@@ -6,8 +6,8 @@ import (
 	cosmosMath "cosmossdk.io/math"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/allora-network/allora-chain/test/testutil"
 	v11 "github.com/allora-network/allora-chain/x/emissions/migrations/v11"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 )
 
 type EmissionsV11MigrationTestSuite struct {

--- a/x/emissions/migrations/v11/migrate_test.go
+++ b/x/emissions/migrations/v11/migrate_test.go
@@ -4,81 +4,38 @@ import (
 	"testing"
 
 	cosmosMath "cosmossdk.io/math"
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-
-	"cosmossdk.io/core/store"
-	"github.com/allora-network/allora-chain/app/params"
-
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-
-	v11 "github.com/allora-network/allora-chain/x/emissions/migrations/v11"
-	emissions "github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstestutil "github.com/allora-network/allora-chain/x/emissions/testutil"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-
-	storetypes "cosmossdk.io/store/types"
-	cosmostestutil "github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/allora-network/allora-chain/test/testutil"
+	v11 "github.com/allora-network/allora-chain/x/emissions/migrations/v11"
 )
 
-type EmissionsV10MigrationTestSuite struct {
-	suite.Suite
-	ctrl *gomock.Controller
-
-	ctx             sdk.Context
-	storeService    store.KVStoreService
-	emissionsKeeper *keeper.Keeper
+type EmissionsV11MigrationTestSuite struct {
+	testutil.TestSuite
 }
 
-func TestEmissionsV10MigrationTestSuite(t *testing.T) {
-	suite.Run(t, new(EmissionsV10MigrationTestSuite))
-}
-
-func (s *EmissionsV10MigrationTestSuite) SetupTest() {
-	encCfg := moduletestutil.MakeTestEncodingConfig(emissions.AppModule{})
-	key := storetypes.NewKVStoreKey(emissionstypes.StoreKey)
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := cosmostestutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	s.ctx = testCtx.Ctx
-
-	// gomock initializations
-	s.ctrl = gomock.NewController(s.T())
-	accountKeeper := emissionstestutil.NewMockAccountKeeper(s.ctrl)
-	bankKeeper := emissionstestutil.NewMockBankKeeper(s.ctrl)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-
-	s.emissionsKeeper = &emissionsKeeper
+func TestEmissionsV11MigrationTestSuite(t *testing.T) {
+	suite.Run(t, &EmissionsV11MigrationTestSuite{
+		testutil.NewTestSuite("emissions_V11Migrations"),
+	})
 }
 
 // Test that the migration correctly initializes the monthly rewards values.
-func (s *EmissionsV10MigrationTestSuite) TestMigrateStore() {
+func (s *EmissionsV11MigrationTestSuite) TestMigrateStore() {
 	// Manually set some non-zero initial values to ensure the migration overwrites them
-	err := s.emissionsKeeper.AddMonthlyRewards(s.ctx, cosmosMath.NewInt(100), cosmosMath.NewInt(200))
+	err := s.EmissionsKeeper().AddMonthlyRewards(s.Ctx(), cosmosMath.NewInt(100), cosmosMath.NewInt(200))
 	s.Require().NoError(err)
 
 	// Run migration
-	err = v11.MigrateStore(s.ctx, *s.emissionsKeeper)
+	err = v11.MigrateStore(s.Ctx(), *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the values are set to zero
-	reputerRewards, err := s.emissionsKeeper.GetMonthlyReputerRewards(s.ctx)
+	reputerRewards, err := s.EmissionsKeeper().GetMonthlyReputerRewards(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(reputerRewards.Equal(cosmosMath.ZeroInt()), "Monthly reputer rewards should be zero after migration")
 
-	topicRewards, err := s.emissionsKeeper.GetMonthlyTopicRewards(s.ctx)
+	topicRewards, err := s.EmissionsKeeper().GetMonthlyTopicRewards(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(topicRewards.Equal(cosmosMath.ZeroInt()), "Monthly topic rewards should be zero after migration")
 }

--- a/x/emissions/migrations/v2/migrate_test.go
+++ b/x/emissions/migrations/v2/migrate_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	v2 "github.com/allora-network/allora-chain/x/emissions/migrations/v2"
 	oldtypes "github.com/allora-network/allora-chain/x/emissions/migrations/v2/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/migrations/v2/migrate_test.go
+++ b/x/emissions/migrations/v2/migrate_test.go
@@ -2,112 +2,43 @@ package v2_test
 
 import (
 	"testing"
-	"time"
 
 	"cosmossdk.io/collections"
-	"cosmossdk.io/core/header"
-	"cosmossdk.io/core/store"
-	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
 	"cosmossdk.io/store/prefix"
-	storetypes "cosmossdk.io/store/types"
-	"github.com/allora-network/allora-chain/app/params"
-	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	v2 "github.com/allora-network/allora-chain/x/emissions/migrations/v2"
-	oldtypes "github.com/allora-network/allora-chain/x/emissions/migrations/v2/oldtypes"
-	"github.com/allora-network/allora-chain/x/emissions/module"
-	"github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/codec/address"
-	runtime "github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/testutil"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/suite"
 
-	minttypes "github.com/allora-network/allora-chain/x/mint/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
+	v2 "github.com/allora-network/allora-chain/x/emissions/migrations/v2"
+	oldtypes "github.com/allora-network/allora-chain/x/emissions/migrations/v2/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-type EmissionsV2MigrationsTestSuite struct {
-	suite.Suite
-	ctx             sdk.Context
-	codec           codec.Codec
-	storeService    store.KVStoreService
-	emissionsKeeper keeper.Keeper
+type EmissionsV2MigrationTestSuite struct {
+	testutil.TestSuite
 }
 
-func (s *EmissionsV2MigrationsTestSuite) SetupTest() {
-	key := storetypes.NewKVStoreKey("emissions")
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()}) // nolint: exhaustruct
-	s.ctx = ctx
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
-	s.codec = encCfg.Codec
-	addressCodec := address.NewBech32Codec(params.Bech32PrefixAccAddr)
-	maccPerms := map[string][]string{
-		"fee_collector":                {"minter"},
-		"mint":                         {"minter"},
-		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName: {"minter"},
-		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
-		minttypes.EcosystemModuleName:                    nil,
-		"bonded_tokens_pool":                             {"burner", "staking"},
-		"not_bonded_tokens_pool":                         {"burner", "staking"},
-		"multiple permissions account":                   {"burner", "minter", "staking"},
-		"random permission":                              {"random"},
-	}
-	accountKeeper := authkeeper.NewAccountKeeper(
-		encCfg.Codec,
-		storeService,
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
-		params.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress("gov").String(),
-	)
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		log.NewNopLogger(),
-	)
-	s.emissionsKeeper = keeper.NewKeeper(
-		encCfg.Codec,
-		addressCodec,
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
+func TestEmissionsV2MigrationTestSuite(t *testing.T) {
+	suite.Run(t, &EmissionsV2MigrationTestSuite{
+		testutil.NewTestSuite("emissions_V2Migrations"),
+	})
 }
 
-func TestEmissionsV2MigrationsTestSuite(t *testing.T) {
-	suite.Run(t, new(EmissionsV2MigrationsTestSuite))
-}
-
-func (s *EmissionsV2MigrationsTestSuite) TestMigrateStore() {
-	err := v2.MigrateStore(s.ctx, s.emissionsKeeper)
+func (s *EmissionsV2MigrationTestSuite) TestMigrateStore() {
+	err := v2.MigrateStore(s.Ctx(), *s.EmissionsKeeper())
 	s.Require().NoError(err)
 }
 
-func (s *EmissionsV2MigrationsTestSuite) TestMigrateTopic() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV2MigrationTestSuite) TestMigrateTopic() {
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	oldTopic := oldtypes.Topic{
-		Id:              1,
+		Id:              2,
 		Creator:         "creator",
 		Metadata:        "metadata",
 		LossLogic:       "losslogic",
@@ -135,6 +66,7 @@ func (s *EmissionsV2MigrationsTestSuite) TestMigrateTopic() {
 	// Verify the store has been updated correctly
 	iterator := topicStore.Iterator(nil, nil)
 	s.Require().True(iterator.Valid())
+	iterator.Next() // skip the already existing topic at ID 1
 
 	var newMsg types.Topic
 	err = proto.Unmarshal(iterator.Value(), &newMsg)
@@ -152,7 +84,7 @@ func (s *EmissionsV2MigrationsTestSuite) TestMigrateTopic() {
 	s.Require().Equal(oldTopic.EpochLastEnded, newMsg.EpochLastEnded)
 }
 
-func (s *EmissionsV2MigrationsTestSuite) MigrateOffchainNodeStore(store prefix.Store, cdc codec.BinaryCodec, prefixKey collections.Prefix) {
+func (s *EmissionsV2MigrationTestSuite) MigrateOffchainNodeStore(store prefix.Store, cdc codec.BinaryCodec, prefixKey collections.Prefix) {
 	oldOffchainNode := oldtypes.OffchainNode{
 		LibP2PKey:    "testLibP2PKey",
 		MultiAddress: "testMultiAddress",
@@ -204,16 +136,16 @@ func (s *EmissionsV2MigrationsTestSuite) MigrateOffchainNodeStore(store prefix.S
 	s.Require().Equal(oldOffchainNode2.NodeAddress, newMsg.NodeAddress)
 }
 
-func (s *EmissionsV2MigrationsTestSuite) TestMigrateOffchainNodeWorkers() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV2MigrationTestSuite) TestMigrateOffchainNodeWorkers() {
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 	offchainNodeStoreWorker := prefix.NewStore(store, types.WorkerNodesKey)
 	s.MigrateOffchainNodeStore(offchainNodeStoreWorker, cdc, types.WorkerNodesKey)
 }
 
-func (s *EmissionsV2MigrationsTestSuite) TestMigrateOffchainNodeReputers() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV2MigrationTestSuite) TestMigrateOffchainNodeReputers() {
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 	offchainNodeStoreReputer := prefix.NewStore(store, types.ReputerNodesKey)
 	s.MigrateOffchainNodeStore(offchainNodeStoreReputer, cdc, types.ReputerNodesKey)
 }
@@ -242,9 +174,9 @@ func areWithHeldArraysEqual(oldValues []*oldtypes.WithheldWorkerAttributedValue,
 	return true
 }
 
-func (s *EmissionsV2MigrationsTestSuite) TestMigrateValueBundle() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV2MigrationTestSuite) TestMigrateValueBundle() {
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	reputerNonce := &oldtypes.Nonce{
 		BlockHeight: 1,
@@ -324,9 +256,9 @@ func (s *EmissionsV2MigrationsTestSuite) TestMigrateValueBundle() {
 	s.Require().Empty(newMsg.OneOutInfererForecasterValues)
 }
 
-func (s *EmissionsV2MigrationsTestSuite) TestMigrateAllLossBundles() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV2MigrationTestSuite) TestMigrateAllLossBundles() {
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	reputerNonce := &oldtypes.Nonce{
 		BlockHeight: 1,
@@ -423,9 +355,9 @@ func (s *EmissionsV2MigrationsTestSuite) TestMigrateAllLossBundles() {
 	s.Require().Equal(reputerValueBundle.Pubkey, newMsg.ReputerValueBundles[0].Pubkey)
 }
 
-func (s *EmissionsV2MigrationsTestSuite) TestMigrateAllRecordCommits() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV2MigrationTestSuite) TestMigrateAllRecordCommits() {
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	oldTimestampedActorNonce1 := oldtypes.TimestampedActorNonce{
 		BlockHeight: 1,
@@ -480,13 +412,13 @@ func (s *EmissionsV2MigrationsTestSuite) TestMigrateAllRecordCommits() {
 	s.Require().Equal(oldTimestampedActorNonce2.Nonce.BlockHeight, newMsg2.Nonce.BlockHeight)
 }
 
-func (s *EmissionsV2MigrationsTestSuite) TestMigrateParams() {
-	storageService := s.emissionsKeeper.GetStorageService()
-	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV2MigrationTestSuite) TestMigrateParams() {
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 	// Create a Params with garbage in it
 	defaultParams := types.DefaultParams()
-	prevParams := oldtypes.Params{ //nolint: exhaustruct
+	prevParams := oldtypes.Params{ // nolint: exhaustruct
 		Version:                         "v1",
 		MinTopicWeight:                  alloraMath.OneDec(),
 		RequiredMinimumStake:            cosmosMath.OneUint(),
@@ -515,9 +447,9 @@ func (s *EmissionsV2MigrationsTestSuite) TestMigrateParams() {
 	s.Require().NoError(err)
 
 	// Run migration
-	err = v2.MigrateParams(s.ctx, s.emissionsKeeper)
+	err = v2.MigrateParams(s.Ctx(), *s.EmissionsKeeper())
 	s.Require().NoError(err)
-	newParams, err := s.emissionsKeeper.GetParams(s.ctx)
+	newParams, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 
 	// Check params after migration

--- a/x/emissions/migrations/v3/migrate_test.go
+++ b/x/emissions/migrations/v3/migrate_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	v3 "github.com/allora-network/allora-chain/x/emissions/migrations/v3"
 	oldtypes "github.com/allora-network/allora-chain/x/emissions/migrations/v3/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/migrations/v3/migrate_test.go
+++ b/x/emissions/migrations/v3/migrate_test.go
@@ -4,74 +4,33 @@ import (
 	"strconv"
 	"testing"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
-
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-
-	"cosmossdk.io/core/store"
 	cosmosMath "cosmossdk.io/math"
-	"github.com/allora-network/allora-chain/app/params"
-
 	"cosmossdk.io/store/prefix"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	v3 "github.com/allora-network/allora-chain/x/emissions/migrations/v3"
-	oldtypes "github.com/allora-network/allora-chain/x/emissions/migrations/v3/oldtypes"
-	emissions "github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstestutil "github.com/allora-network/allora-chain/x/emissions/testutil"
-	"github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/gogo/protobuf/proto"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-
-	storetypes "cosmossdk.io/store/types"
-	cosmostestutil "github.com/cosmos/cosmos-sdk/testutil"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
+	v3 "github.com/allora-network/allora-chain/x/emissions/migrations/v3"
+	oldtypes "github.com/allora-network/allora-chain/x/emissions/migrations/v3/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type EmissionsV3MigrationTestSuite struct {
-	suite.Suite
-	ctrl *gomock.Controller
-
-	ctx             sdk.Context
-	storeService    store.KVStoreService
-	emissionsKeeper *keeper.Keeper
+	testutil.TestSuite
 }
 
 func TestEmissionsV3MigrationTestSuite(t *testing.T) {
-	suite.Run(t, new(EmissionsV3MigrationTestSuite))
-}
-
-func (s *EmissionsV3MigrationTestSuite) SetupTest() {
-	encCfg := moduletestutil.MakeTestEncodingConfig(emissions.AppModule{})
-	key := storetypes.NewKVStoreKey(types.StoreKey)
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := cosmostestutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	s.ctx = testCtx.Ctx
-
-	// gomock initializations
-	s.ctrl = gomock.NewController(s.T())
-	accountKeeper := emissionstestutil.NewMockAccountKeeper(s.ctrl)
-	bankKeeper := emissionstestutil.NewMockBankKeeper(s.ctrl)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-
-	s.emissionsKeeper = &emissionsKeeper
+	suite.Run(t, &EmissionsV3MigrationTestSuite{
+		testutil.NewTestSuite("emissions_V3Migrations"),
+	})
 }
 
 func (s *EmissionsV3MigrationTestSuite) TestMigrate() {
-	storageService := s.emissionsKeeper.GetStorageService()
-	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	defaultParams := types.DefaultParams()
 	paramsOld := oldtypes.Params{
@@ -125,7 +84,7 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrate() {
 	store.Set(types.ParamsKey, cdc.MustMarshal(&paramsOld))
 
 	// Run migration
-	err := v3.MigrateStore(s.ctx, *s.emissionsKeeper)
+	err := v3.MigrateStore(s.Ctx(), *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// TO BE ADDED VIA DEFAULT PARAMS
@@ -134,7 +93,7 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrate() {
 
 	paramsExpected := defaultParams
 
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(paramsExpected.Version, params.Version)
 	s.Require().Equal(paramsExpected.MaxSerializedMsgLength, params.MaxSerializedMsgLength)
@@ -177,15 +136,15 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrate() {
 	s.Require().Equal(paramsExpected.MaxElementsPerForecast, params.MaxElementsPerForecast)
 	s.Require().Equal(paramsExpected.MaxActiveTopicsPerBlock, params.MaxActiveTopicsPerBlock)
 	// commenting this out as this migration has already happened, so this test is no longer relevant
-	//s.Require().Equal(paramsExpected, params)
+	// s.Require().Equal(paramsExpected, params)
 }
 
 func (s *EmissionsV3MigrationTestSuite) TestMigrateTopics() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	oldTopic := oldtypes.Topic{
-		Id:             1,
+		Id:             2,
 		Creator:        "creator",
 		Metadata:       "metadata",
 		LossMethod:     "lossmethod",
@@ -207,12 +166,13 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrateTopics() {
 	topicStore := prefix.NewStore(store, types.TopicsKey)
 	topicStore.Set([]byte("testKey"), bz)
 
-	err = v3.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v3.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
 	iterator := topicStore.Iterator(nil, nil)
 	s.Require().True(iterator.Valid())
+	iterator.Next() // skip the already existing topic at ID 1
 	defer iterator.Close()
 
 	var newMsg types.Topic
@@ -240,8 +200,8 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrateTopics() {
 }
 
 func (s *EmissionsV3MigrationTestSuite) TestMigrateTopicsWithWeightSameEpoch() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	oldTopics := []oldtypes.Topic{
 		{
@@ -291,18 +251,18 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrateTopicsWithWeightSameEpoch() {
 			WorkerSubmissionWindow: 130,
 		},
 	}
-	err := s.emissionsKeeper.AddTopicFeeRevenue(s.ctx, 1, cosmosMath.NewInt(40000))
+	err := s.EmissionsKeeper().AddTopicFeeRevenue(s.Ctx(), 1, cosmosMath.NewInt(40000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddTopicFeeRevenue(s.ctx, 2, cosmosMath.NewInt(70000))
+	err = s.EmissionsKeeper().AddTopicFeeRevenue(s.Ctx(), 2, cosmosMath.NewInt(70000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddTopicFeeRevenue(s.ctx, 3, cosmosMath.NewInt(60000))
+	err = s.EmissionsKeeper().AddTopicFeeRevenue(s.Ctx(), 3, cosmosMath.NewInt(60000))
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.SetTopicStake(s.ctx, 1, cosmosMath.NewInt(40000))
+	err = s.EmissionsKeeper().SetTopicStake(s.Ctx(), 1, cosmosMath.NewInt(40000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.SetTopicStake(s.ctx, 2, cosmosMath.NewInt(70000))
+	err = s.EmissionsKeeper().SetTopicStake(s.Ctx(), 2, cosmosMath.NewInt(70000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.SetTopicStake(s.ctx, 3, cosmosMath.NewInt(60000))
+	err = s.EmissionsKeeper().SetTopicStake(s.Ctx(), 3, cosmosMath.NewInt(60000))
 	s.Require().NoError(err)
 
 	topicStore := prefix.NewStore(store, types.TopicsKey)
@@ -313,7 +273,7 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrateTopicsWithWeightSameEpoch() {
 		topicStore.Set([]byte("testKey"+strconv.Itoa(i+1)), bz)
 	}
 
-	err = v3.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v3.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
@@ -324,28 +284,28 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrateTopicsWithWeightSameEpoch() {
 	// this is from topic.BlockHeightEnded + topic.EpochLength
 	blockHeightEnded := int64(100)
 
-	churningBlock, inFuture, err := s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, 1)
+	churningBlock, inFuture, err := s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), 1)
 	s.Require().NoError(err)
 	s.Require().Equal(int64(0), churningBlock)
 	s.Require().False(inFuture)
 
-	churningBlock, inFuture, err = s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, 2)
+	churningBlock, inFuture, err = s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), 2)
 	s.Require().NoError(err)
 	s.Require().Equal(churningBlock, blockHeightEnded)
 	s.Require().True(inFuture)
 
-	churningBlock, inFuture, err = s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, 3)
+	churningBlock, inFuture, err = s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), 3)
 	s.Require().NoError(err)
 	s.Require().Equal(int64(0), churningBlock)
 	s.Require().False(inFuture)
 
 	// not the same as feeRev * stake because weight is EMAd with 0
-	lowestWeight, noPrior, err := s.emissionsKeeper.GetLowestActiveTopicWeightAtBlock(s.ctx, blockHeightEnded)
+	lowestWeight, noPrior, err := s.EmissionsKeeper().GetLowestActiveTopicWeightAtBlock(s.Ctx(), blockHeightEnded)
 	s.Require().False(noPrior)
 	s.Require().NoError(err)
 	s.Require().True(lowestWeight.Weight.Gt(alloraMath.ZeroDec()))
 
-	activeTopicIds, err := s.emissionsKeeper.GetActiveTopicIdsAtBlock(s.ctx, blockHeightEnded)
+	activeTopicIds, err := s.EmissionsKeeper().GetActiveTopicIdsAtBlock(s.Ctx(), blockHeightEnded)
 	s.Require().NoError(err)
 	s.Require().Len(activeTopicIds.TopicIds, 1)
 	s.Require().NotContains(activeTopicIds.TopicIds, uint64(1))
@@ -354,8 +314,8 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrateTopicsWithWeightSameEpoch() {
 }
 
 func (s *EmissionsV3MigrationTestSuite) TestMigrateTopicsWithWeightDifferentEpoch() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	blockHeightEnded1 := int64(100)
 	blockHeightEnded2 := int64(200)
@@ -409,18 +369,18 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrateTopicsWithWeightDifferentEpoc
 			WorkerSubmissionWindow: 130,
 		},
 	}
-	err := s.emissionsKeeper.AddTopicFeeRevenue(s.ctx, 1, cosmosMath.NewInt(20000))
+	err := s.EmissionsKeeper().AddTopicFeeRevenue(s.Ctx(), 1, cosmosMath.NewInt(20000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddTopicFeeRevenue(s.ctx, 2, cosmosMath.NewInt(40000))
+	err = s.EmissionsKeeper().AddTopicFeeRevenue(s.Ctx(), 2, cosmosMath.NewInt(40000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddTopicFeeRevenue(s.ctx, 3, cosmosMath.NewInt(60000))
+	err = s.EmissionsKeeper().AddTopicFeeRevenue(s.Ctx(), 3, cosmosMath.NewInt(60000))
 	s.Require().NoError(err)
 
-	err = s.emissionsKeeper.SetTopicStake(s.ctx, 1, cosmosMath.NewInt(20000))
+	err = s.EmissionsKeeper().SetTopicStake(s.Ctx(), 1, cosmosMath.NewInt(20000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.SetTopicStake(s.ctx, 2, cosmosMath.NewInt(40000))
+	err = s.EmissionsKeeper().SetTopicStake(s.Ctx(), 2, cosmosMath.NewInt(40000))
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.SetTopicStake(s.ctx, 3, cosmosMath.NewInt(60000))
+	err = s.EmissionsKeeper().SetTopicStake(s.Ctx(), 3, cosmosMath.NewInt(60000))
 	s.Require().NoError(err)
 
 	topicStore := prefix.NewStore(store, types.TopicsKey)
@@ -431,7 +391,7 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrateTopicsWithWeightDifferentEpoc
 		topicStore.Set([]byte("testKey"+strconv.Itoa(i+1)), bz)
 	}
 
-	err = v3.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v3.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
@@ -441,56 +401,56 @@ func (s *EmissionsV3MigrationTestSuite) TestMigrateTopicsWithWeightDifferentEpoc
 
 	// this is from topic.BlockHeightEnded + topic.EpochLength
 
-	churningBlock, inFuture, err := s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, 1)
+	churningBlock, inFuture, err := s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), 1)
 	s.Require().NoError(err)
 	s.Require().Equal(churningBlock, blockHeightEnded1)
 	s.Require().True(inFuture)
 
-	churningBlock, inFuture, err = s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, 2)
+	churningBlock, inFuture, err = s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), 2)
 	s.Require().NoError(err)
 	s.Require().Equal(churningBlock, blockHeightEnded2)
 	s.Require().True(inFuture)
 
-	churningBlock, inFuture, err = s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, 3)
+	churningBlock, inFuture, err = s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), 3)
 	s.Require().NoError(err)
 	s.Require().Equal(churningBlock, blockHeightEnded3)
 	s.Require().True(inFuture)
 
 	// not the same as feeRev * stake because weight is EMAd with 0
-	lowestWeight, noPrior, err := s.emissionsKeeper.GetLowestActiveTopicWeightAtBlock(s.ctx, blockHeightEnded1)
+	lowestWeight, noPrior, err := s.EmissionsKeeper().GetLowestActiveTopicWeightAtBlock(s.Ctx(), blockHeightEnded1)
 	s.Require().False(noPrior)
 	s.Require().NoError(err)
 	s.Require().True(lowestWeight.Weight.Gt(alloraMath.ZeroDec()))
 
-	lowestWeight, noPrior, err = s.emissionsKeeper.GetLowestActiveTopicWeightAtBlock(s.ctx, blockHeightEnded2)
+	lowestWeight, noPrior, err = s.EmissionsKeeper().GetLowestActiveTopicWeightAtBlock(s.Ctx(), blockHeightEnded2)
 	s.Require().False(noPrior)
 	s.Require().NoError(err)
 	s.Require().True(lowestWeight.Weight.Gt(alloraMath.ZeroDec()))
 
-	lowestWeight, noPrior, err = s.emissionsKeeper.GetLowestActiveTopicWeightAtBlock(s.ctx, blockHeightEnded3)
+	lowestWeight, noPrior, err = s.EmissionsKeeper().GetLowestActiveTopicWeightAtBlock(s.Ctx(), blockHeightEnded3)
 	s.Require().False(noPrior)
 	s.Require().NoError(err)
 	s.Require().True(lowestWeight.Weight.Gt(alloraMath.ZeroDec()))
 
-	activeTopicIds, err := s.emissionsKeeper.GetActiveTopicIdsAtBlock(s.ctx, blockHeightEnded1)
+	activeTopicIds, err := s.EmissionsKeeper().GetActiveTopicIdsAtBlock(s.Ctx(), blockHeightEnded1)
 	s.Require().NoError(err)
 	s.Require().Len(activeTopicIds.TopicIds, 1)
 	s.Require().Contains(activeTopicIds.TopicIds, uint64(1))
 
-	activeTopicIds, err = s.emissionsKeeper.GetActiveTopicIdsAtBlock(s.ctx, blockHeightEnded2)
+	activeTopicIds, err = s.EmissionsKeeper().GetActiveTopicIdsAtBlock(s.Ctx(), blockHeightEnded2)
 	s.Require().NoError(err)
 	s.Require().Len(activeTopicIds.TopicIds, 1)
 	s.Require().Contains(activeTopicIds.TopicIds, uint64(2))
 
-	activeTopicIds, err = s.emissionsKeeper.GetActiveTopicIdsAtBlock(s.ctx, blockHeightEnded3)
+	activeTopicIds, err = s.EmissionsKeeper().GetActiveTopicIdsAtBlock(s.Ctx(), blockHeightEnded3)
 	s.Require().NoError(err)
 	s.Require().Len(activeTopicIds.TopicIds, 1)
 	s.Require().Contains(activeTopicIds.TopicIds, uint64(3))
 }
 
 func (s *EmissionsV3MigrationTestSuite) TestResetMapsWithNonNumericValues() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	score := []*types.Score{
 		{
@@ -510,19 +470,16 @@ func (s *EmissionsV3MigrationTestSuite) TestResetMapsWithNonNumericValues() {
 
 	// Sanity check
 	iterator := infererScoresByBlock.Iterator(nil, nil)
-	defer iterator.Close()
 	s.Require().True(iterator.Valid())
 	err = proto.Unmarshal(iterator.Value(), &scores)
 	s.Require().NoError(err)
-	iterator.Close()
 	s.Require().Len(scores.Scores, 1)
 
-	err = v3.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
+	err = v3.ResetMapsWithNonNumericValues(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
 	iterator = infererScoresByBlock.Iterator(nil, nil)
 	defer iterator.Close()
 	s.Require().False(iterator.Valid(), "iterator should be invalid because the store should be empty")
-	iterator.Close()
 }

--- a/x/emissions/migrations/v4/migrate_test.go
+++ b/x/emissions/migrations/v4/migrate_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	oldV2Types "github.com/allora-network/allora-chain/x/emissions/migrations/v3/oldtypes"
 	v4 "github.com/allora-network/allora-chain/x/emissions/migrations/v4"
 	oldV3Types "github.com/allora-network/allora-chain/x/emissions/migrations/v4/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/migrations/v4/migrate_test.go
+++ b/x/emissions/migrations/v4/migrate_test.go
@@ -3,78 +3,38 @@ package v4_test
 import (
 	"testing"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
-
-	collections "cosmossdk.io/collections"
-	"github.com/cosmos/cosmos-sdk/codec"
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-
-	"cosmossdk.io/core/store"
-	"github.com/allora-network/allora-chain/app/params"
-
+	"cosmossdk.io/collections"
 	"cosmossdk.io/store/prefix"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/suite"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
 	oldV2Types "github.com/allora-network/allora-chain/x/emissions/migrations/v3/oldtypes"
 	v4 "github.com/allora-network/allora-chain/x/emissions/migrations/v4"
 	oldV3Types "github.com/allora-network/allora-chain/x/emissions/migrations/v4/oldtypes"
-	emissions "github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstestutil "github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/gogo/protobuf/proto"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/suite"
-
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-
-	storetypes "cosmossdk.io/store/types"
-	cosmostestutil "github.com/cosmos/cosmos-sdk/testutil"
 )
 
 type EmissionsV4MigrationTestSuite struct {
-	suite.Suite
-	ctrl *gomock.Controller
-
-	ctx             sdk.Context
-	storeService    store.KVStoreService
-	emissionsKeeper *keeper.Keeper
+	testutil.TestSuite
 }
 
 func TestEmissionsV4MigrationTestSuite(t *testing.T) {
-	suite.Run(t, new(EmissionsV4MigrationTestSuite))
-}
-
-func (s *EmissionsV4MigrationTestSuite) SetupTest() {
-	encCfg := moduletestutil.MakeTestEncodingConfig(emissions.AppModule{})
-	key := storetypes.NewKVStoreKey(emissionstypes.StoreKey)
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := cosmostestutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	s.ctx = testCtx.Ctx
-
-	// gomock initializations
-	s.ctrl = gomock.NewController(s.T())
-	accountKeeper := emissionstestutil.NewMockAccountKeeper(s.ctrl)
-	bankKeeper := emissionstestutil.NewMockBankKeeper(s.ctrl)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-
-	s.emissionsKeeper = &emissionsKeeper
+	suite.Run(t, &EmissionsV4MigrationTestSuite{
+		testutil.NewTestSuite("emissions_V4Migrations"),
+	})
 }
 
 // in this test we check that the emissions module params have been migrated
 // and the expected new field is set.
 func (s *EmissionsV4MigrationTestSuite) TestMigrateParams() {
-	storageService := s.emissionsKeeper.GetStorageService()
-	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	defaultParams := emissionstypes.DefaultParams()
 	paramsOld := oldV3Types.Params{
@@ -131,7 +91,7 @@ func (s *EmissionsV4MigrationTestSuite) TestMigrateParams() {
 
 	paramsExpected := defaultParams
 
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(paramsExpected.Version, params.Version)
 	s.Require().Equal(paramsExpected.MaxSerializedMsgLength, params.MaxSerializedMsgLength)
@@ -175,17 +135,19 @@ func (s *EmissionsV4MigrationTestSuite) TestMigrateParams() {
 	s.Require().Equal(paramsExpected.MaxActiveTopicsPerBlock, params.MaxActiveTopicsPerBlock)
 	s.Require().Equal(paramsExpected.MaxStringLength, params.MaxStringLength)
 	// commenting this out as this migration has already happened, so this test is no longer relevant
-	//s.Require().Equal(paramsExpected, params)
+	// s.Require().Equal(paramsExpected, params)
 }
 
 // in this test, we check that an already migrated topic, that has all the new fields
 // for merit sortition, and everything looks correct, will not change at all
 func (s *EmissionsV4MigrationTestSuite) TestMigratedTopicWithNoProblems() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
+
+	topicId := uint64(2)
 
 	migratedOldTopic := emissionstypes.Topic{
-		Id:                       1,
+		Id:                       topicId,
 		Creator:                  "creator",
 		Metadata:                 "metadata",
 		LossMethod:               "lossMethod",
@@ -214,12 +176,13 @@ func (s *EmissionsV4MigrationTestSuite) TestMigratedTopicWithNoProblems() {
 	s.Require().NotEqual(0, countWritten)
 	topicStore.Set(bytesKey, bz)
 
-	err = v4.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v4.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
 	iterator := topicStore.Iterator(nil, nil)
 	s.Require().True(iterator.Valid())
+	iterator.Next() // skip the already existing topic at ID 1
 	defer iterator.Close()
 
 	var newMsg emissionstypes.Topic
@@ -246,7 +209,7 @@ func (s *EmissionsV4MigrationTestSuite) TestMigratedTopicWithNoProblems() {
 	s.Require().Equal(migratedOldTopic.ActiveReputerQuantile.String(), newMsg.ActiveReputerQuantile.String())
 
 	// sanity check that the emissions keeper collections.go API also gets the same data
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, 1)
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(newMsg, topic)
 }
@@ -255,8 +218,8 @@ func (s *EmissionsV4MigrationTestSuite) TestMigratedTopicWithNoProblems() {
 // for merit sortition, but has a NaN for initial regret, will have its initial regret
 // set to 0 but everything else will remain the same
 func (s *EmissionsV4MigrationTestSuite) TestMigratedTopicWithNaNInitialRegret() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	migratedOldTopicWithNaNInitialRegret := emissionstypes.Topic{
 		Id:                       1,
@@ -287,7 +250,7 @@ func (s *EmissionsV4MigrationTestSuite) TestMigratedTopicWithNaNInitialRegret() 
 	s.Require().NoError(err)
 	s.Require().NotEqual(0, countWritten)
 	topicStore.Set(bytesKey, bz)
-	err = v4.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v4.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
@@ -320,7 +283,7 @@ func (s *EmissionsV4MigrationTestSuite) TestMigratedTopicWithNaNInitialRegret() 
 	s.Require().Equal("0", newMsg.InitialRegret.String())
 
 	// sanity check that the emissions keeper collections.go API also gets the same data
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, 1)
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), 1)
 	s.Require().NoError(err)
 	s.Require().Equal(newMsg, topic)
 }
@@ -329,8 +292,8 @@ func (s *EmissionsV4MigrationTestSuite) TestMigratedTopicWithNaNInitialRegret() 
 // new fields for merit sortition, will have all the new fields set to the default values
 // and everything else will remain the same
 func (s *EmissionsV4MigrationTestSuite) TestNotMigratedTopic() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	notMigratedTopic := oldV2Types.Topic{
 		Id:                     1,
@@ -357,10 +320,10 @@ func (s *EmissionsV4MigrationTestSuite) TestNotMigratedTopic() {
 	s.Require().NoError(err)
 	s.Require().NotEqual(0, countWritten)
 	topicStore.Set(bytesKey, bz)
-	err = v4.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v4.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
-	err = v4.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v4.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
@@ -393,7 +356,7 @@ func (s *EmissionsV4MigrationTestSuite) TestNotMigratedTopic() {
 	s.Require().Equal("0.25", newMsg.ActiveReputerQuantile.String())
 
 	// sanity check that the emissions keeper collections.go API also gets the same data
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, 1)
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), 1)
 	s.Require().NoError(err)
 	s.Require().Equal(newMsg, topic)
 }
@@ -402,8 +365,8 @@ func (s *EmissionsV4MigrationTestSuite) TestNotMigratedTopic() {
 // new fields for merit sortition, and also  has a NaN for initial regret,
 // will have its initial regret set to 0 and all the new fields set to the default values
 func (s *EmissionsV4MigrationTestSuite) TestNotMigratedTopicWithNaNInitialRegret() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	notMigratedTopicWithNaNInitialRegret := oldV2Types.Topic{
 		Id:                     1,
@@ -430,13 +393,13 @@ func (s *EmissionsV4MigrationTestSuite) TestNotMigratedTopicWithNaNInitialRegret
 	s.Require().NoError(err)
 	s.Require().NotEqual(0, countWritten)
 	topicStore.Set(bytesKey, bz)
-	err = v4.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v4.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
-	err = v4.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v4.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
-	err = v4.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v4.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
@@ -470,7 +433,7 @@ func (s *EmissionsV4MigrationTestSuite) TestNotMigratedTopicWithNaNInitialRegret
 	s.Require().Equal("0", newMsg.InitialRegret.String())
 
 	// sanity check that the emissions keeper collections.go API also gets the same data
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, 1)
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), 1)
 	s.Require().NoError(err)
 	s.Require().Equal(newMsg, topic)
 }
@@ -501,16 +464,13 @@ func testScoreMapDeletion(
 	s.Require().True(iterator.Valid())
 	err = proto.Unmarshal(iterator.Value(), &score)
 	s.Require().NoError(err)
-	iterator.Close()
 
-	err = v4.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
+	err = v4.ResetMapsWithNonNumericValues(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
 	iterator = mapStore.Iterator(nil, nil)
-	defer iterator.Close()
 	s.Require().False(iterator.Valid(), "iterator should be invalid because the store should be empty")
-	iterator.Close()
 }
 
 // test for deletes on maps that have scores as the value of the map
@@ -540,23 +500,20 @@ func testScoresMapDeletion(
 	s.Require().True(iterator.Valid())
 	err = proto.Unmarshal(iterator.Value(), &scores)
 	s.Require().NoError(err)
-	iterator.Close()
 	s.Require().Len(scores.Scores, 1)
 
-	err = v4.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
+	err = v4.ResetMapsWithNonNumericValues(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
 	iterator = mapStore.Iterator(nil, nil)
-	defer iterator.Close()
 	s.Require().False(iterator.Valid(), "iterator should be invalid because the store should be empty")
-	iterator.Close()
 }
 
 // check that the specified maps are reset correctly
 func (s *EmissionsV4MigrationTestSuite) TestResetMapsWithNonNumericValues() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 	testScoresMapDeletion(s, store, cdc, emissionstypes.InferenceScoresKey)
 	testScoresMapDeletion(s, store, cdc, emissionstypes.ForecastScoresKey)
 	testScoresMapDeletion(s, store, cdc, emissionstypes.ReputerScoresKey)
@@ -575,7 +532,7 @@ func (s *EmissionsV4MigrationTestSuite) TestResetMapsWithNonNumericValues() {
 	testTimeStampedValueMapDeletion(s, store, cdc, emissionstypes.LatestOneOutForecasterForecasterNetworkRegretsKey)
 }
 
-/// HELPER FUNCTIONS
+// / HELPER FUNCTIONS
 
 // example value bundle for testing
 func getBundle() emissionstypes.ValueBundle {
@@ -645,17 +602,14 @@ func testValueBundleMapDeletion(
 	s.Require().True(iterator.Valid())
 	err = proto.Unmarshal(iterator.Value(), &bundle)
 	s.Require().NoError(err)
-	iterator.Close()
 	s.Require().Equal(bundle, getBundle())
 
-	err = v4.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
+	err = v4.ResetMapsWithNonNumericValues(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
 	iterator = mapStore.Iterator(nil, nil)
-	defer iterator.Close()
 	s.Require().False(iterator.Valid(), "iterator should be invalid because the store should be empty")
-	iterator.Close()
 }
 
 // test for deletes on maps that have ReputerValueBundles as the value of the map
@@ -687,17 +641,14 @@ func testReputerValueBundleMapDeletion(
 	s.Require().True(iterator.Valid())
 	err = proto.Unmarshal(iterator.Value(), &reputerValueBundles)
 	s.Require().NoError(err)
-	iterator.Close()
 	s.Require().Len(reputerValueBundles.ReputerValueBundles, 1)
 
-	err = v4.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
+	err = v4.ResetMapsWithNonNumericValues(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
 	iterator = mapStore.Iterator(nil, nil)
-	defer iterator.Close()
 	s.Require().False(iterator.Valid(), "iterator should be invalid because the store should be empty")
-	iterator.Close()
 }
 
 // test for deletes on maps that have TimeStampedValues as the value of the map
@@ -724,14 +675,11 @@ func testTimeStampedValueMapDeletion(
 	s.Require().True(iterator.Valid())
 	err = proto.Unmarshal(iterator.Value(), &timeStampedValue)
 	s.Require().NoError(err)
-	iterator.Close()
 
-	err = v4.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
+	err = v4.ResetMapsWithNonNumericValues(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
 	iterator = mapStore.Iterator(nil, nil)
-	defer iterator.Close()
 	s.Require().False(iterator.Valid(), "iterator should be invalid because the store should be empty")
-	iterator.Close()
 }

--- a/x/emissions/migrations/v5/migrate_test.go
+++ b/x/emissions/migrations/v5/migrate_test.go
@@ -3,77 +3,37 @@ package v5_test
 import (
 	"testing"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
-	oldV4Types "github.com/allora-network/allora-chain/x/emissions/migrations/v5/oldtypes"
-
-	collections "cosmossdk.io/collections"
-	"github.com/cosmos/cosmos-sdk/codec"
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-
-	"cosmossdk.io/core/store"
-	"github.com/allora-network/allora-chain/app/params"
-
+	"cosmossdk.io/collections"
 	"cosmossdk.io/store/prefix"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	v5 "github.com/allora-network/allora-chain/x/emissions/migrations/v5"
-	emissions "github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstestutil "github.com/allora-network/allora-chain/x/emissions/testutil"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/gogo/protobuf/proto"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-
-	storetypes "cosmossdk.io/store/types"
-	cosmostestutil "github.com/cosmos/cosmos-sdk/testutil"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/test/testutil"
+	v5 "github.com/allora-network/allora-chain/x/emissions/migrations/v5"
+	oldV4Types "github.com/allora-network/allora-chain/x/emissions/migrations/v5/oldtypes"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type EmissionsV5MigrationTestSuite struct {
-	suite.Suite
-	ctrl *gomock.Controller
-
-	ctx             sdk.Context
-	storeService    store.KVStoreService
-	emissionsKeeper *keeper.Keeper
+	testutil.TestSuite
 }
 
 func TestEmissionsV5MigrationTestSuite(t *testing.T) {
-	suite.Run(t, new(EmissionsV5MigrationTestSuite))
-}
-
-func (s *EmissionsV5MigrationTestSuite) SetupTest() {
-	encCfg := moduletestutil.MakeTestEncodingConfig(emissions.AppModule{})
-	key := storetypes.NewKVStoreKey(emissionstypes.StoreKey)
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := cosmostestutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	s.ctx = testCtx.Ctx
-
-	// gomock initializations
-	s.ctrl = gomock.NewController(s.T())
-	accountKeeper := emissionstestutil.NewMockAccountKeeper(s.ctrl)
-	bankKeeper := emissionstestutil.NewMockBankKeeper(s.ctrl)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-
-	s.emissionsKeeper = &emissionsKeeper
+	suite.Run(t, &EmissionsV5MigrationTestSuite{
+		testutil.NewTestSuite("emissions_V5Migrations"),
+	})
 }
 
 // in this test we check that the emissions module params have been migrated
 // and the expected new field is set.
 func (s *EmissionsV5MigrationTestSuite) TestMigrateParams() {
-	storageService := s.emissionsKeeper.GetStorageService()
-	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	defaultParams := emissionstypes.DefaultParams()
 	paramsOld := oldV4Types.Params{
@@ -132,7 +92,7 @@ func (s *EmissionsV5MigrationTestSuite) TestMigrateParams() {
 
 	paramsExpected := defaultParams
 
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(paramsExpected.Version, params.Version)
 	s.Require().Equal(paramsExpected.MaxSerializedMsgLength, params.MaxSerializedMsgLength)
@@ -185,13 +145,11 @@ func (s *EmissionsV5MigrationTestSuite) TestMigrateParams() {
 // in this test, we check that an already migrated topic, that only initialRegret
 // set to 0 but everything else will remain the same
 func (s *EmissionsV5MigrationTestSuite) TestMigratedTopicWithNaNInitialRegret() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
-	_, err := s.emissionsKeeper.IncrementTopicId(s.ctx)
-	s.Require().NoError(err)
 	migratedOldTopicWithNaNInitialRegret := emissionstypes.Topic{
-		Id:                       1,
+		Id:                       2,
 		Creator:                  "creator",
 		Metadata:                 "metadata",
 		LossMethod:               "lossMethod",
@@ -210,7 +168,7 @@ func (s *EmissionsV5MigrationTestSuite) TestMigratedTopicWithNaNInitialRegret() 
 		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.1337"),
 	}
 
-	_, err = s.emissionsKeeper.IncrementTopicId(s.ctx)
+	_, err := s.EmissionsKeeper().IncrementTopicId(s.Ctx())
 	s.Require().NoError(err)
 	bz, err := proto.Marshal(&migratedOldTopicWithNaNInitialRegret)
 	s.Require().NoError(err)
@@ -221,12 +179,13 @@ func (s *EmissionsV5MigrationTestSuite) TestMigratedTopicWithNaNInitialRegret() 
 	s.Require().NoError(err)
 	s.Require().NotEqual(0, countWritten)
 	topicStore.Set(bytesKey, bz)
-	err = v5.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v5.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the store has been updated correctly
 	iterator := topicStore.Iterator(nil, nil)
 	s.Require().True(iterator.Valid())
+	iterator.Next() // skip the already existing topic at ID 1
 	defer iterator.Close()
 
 	var newMsg emissionstypes.Topic
@@ -254,19 +213,17 @@ func (s *EmissionsV5MigrationTestSuite) TestMigratedTopicWithNaNInitialRegret() 
 	s.Require().Equal("0", newMsg.InitialRegret.String())
 
 	// sanity check that the emissions keeper collections.go API also gets the same data
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, 1)
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), 2)
 	s.Require().NoError(err)
 	s.Require().Equal(newMsg, topic)
 }
 
 func (s *EmissionsV5MigrationTestSuite) TestMigratedSumTotalPreviousTopicWeights() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
-	_, err := s.emissionsKeeper.IncrementTopicId(s.ctx)
-	s.Require().NoError(err)
 	migratedOldTopic1 := emissionstypes.Topic{
-		Id:                       1,
+		Id:                       2,
 		Creator:                  "creator",
 		Metadata:                 "metadata",
 		LossMethod:               "lossMethod",
@@ -285,9 +242,9 @@ func (s *EmissionsV5MigrationTestSuite) TestMigratedSumTotalPreviousTopicWeights
 		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.1337"),
 	}
 	migratedOldTopic2 := migratedOldTopic1
-	migratedOldTopic2.Id = 2
+	migratedOldTopic2.Id = 3
 
-	_, err = s.emissionsKeeper.IncrementTopicId(s.ctx)
+	_, err := s.EmissionsKeeper().IncrementTopicId(s.Ctx())
 	s.Require().NoError(err)
 
 	// Create 2 topics
@@ -302,7 +259,7 @@ func (s *EmissionsV5MigrationTestSuite) TestMigratedSumTotalPreviousTopicWeights
 	topicStore.Set(bytesKey, bz)
 
 	// Topic 2
-	_, err = s.emissionsKeeper.IncrementTopicId(s.ctx)
+	_, err = s.EmissionsKeeper().IncrementTopicId(s.Ctx())
 	s.Require().NoError(err)
 
 	bz, err = proto.Marshal(&migratedOldTopic2)
@@ -334,7 +291,7 @@ func (s *EmissionsV5MigrationTestSuite) TestMigratedSumTotalPreviousTopicWeights
 	s.Require().NoError(err)
 	topicWeightStore.Set(bytesKey, marshaledWeight)
 
-	err = v5.MigrateTopics(s.ctx, store, cdc, *s.emissionsKeeper)
+	err = v5.MigrateTopics(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify the sumPreviousTopicWeights store has been updated correctly
@@ -351,6 +308,7 @@ func (s *EmissionsV5MigrationTestSuite) TestMigratedSumTotalPreviousTopicWeights
 	// Verify the rest of the topic store has been updated correctly
 	topicIterator := topicStore.Iterator(nil, nil)
 	s.Require().True(topicIterator.Valid())
+	topicIterator.Next() // skip the already existing topic at ID 1
 	defer topicIterator.Close()
 
 	// Check topic 1
@@ -403,19 +361,19 @@ func (s *EmissionsV5MigrationTestSuite) TestMigratedSumTotalPreviousTopicWeights
 	s.Require().Equal("0", topic2.InitialRegret.String())
 
 	// sanity check that the emissions keeper collections.go API also gets the same data
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, 1)
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), 2)
 	s.Require().NoError(err)
 	s.Require().Equal(topic1, topic)
 }
 
 // check that the specified maps are reset correctly
 func (s *EmissionsV5MigrationTestSuite) TestResetMapsWithNonNumericValues() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 	testPreviousQuantileMapDeletion(s, store, cdc, emissionstypes.PreviousTopicQuantileInfererScoreEmaKey)
 }
 
-/// HELPER FUNCTIONS
+// / HELPER FUNCTIONS
 
 // test for deletes on maps that have previous quantile as the value of the map
 func testPreviousQuantileMapDeletion(
@@ -454,7 +412,7 @@ func testPreviousQuantileMapDeletion(
 	s.Require().True(iterator.Valid())
 	defer iterator.Close()
 
-	err = v5.ResetMapsWithNonNumericValues(s.ctx, store, cdc)
+	err = v5.ResetMapsWithNonNumericValues(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// Verify the inferer store has been updated correctly

--- a/x/emissions/migrations/v5/migrate_test.go
+++ b/x/emissions/migrations/v5/migrate_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	v5 "github.com/allora-network/allora-chain/x/emissions/migrations/v5"
 	oldV4Types "github.com/allora-network/allora-chain/x/emissions/migrations/v5/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/migrations/v6/migrate_test.go
+++ b/x/emissions/migrations/v6/migrate_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/allora-network/allora-chain/test/testutil"
 	v5 "github.com/allora-network/allora-chain/x/emissions/migrations/v5"
 	v6 "github.com/allora-network/allora-chain/x/emissions/migrations/v6"
 	oldV5Types "github.com/allora-network/allora-chain/x/emissions/migrations/v6/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/migrations/v6/migrate_test.go
+++ b/x/emissions/migrations/v6/migrate_test.go
@@ -3,75 +3,33 @@ package v6_test
 import (
 	"testing"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
-	v6 "github.com/allora-network/allora-chain/x/emissions/migrations/v6"
-	oldV5Types "github.com/allora-network/allora-chain/x/emissions/migrations/v6/oldtypes"
-
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-
-	"cosmossdk.io/core/store"
-	"github.com/allora-network/allora-chain/app/params"
-
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	v5 "github.com/allora-network/allora-chain/x/emissions/migrations/v5"
-	emissions "github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstestutil "github.com/allora-network/allora-chain/x/emissions/testutil"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-
-	storetypes "cosmossdk.io/store/types"
-	cosmostestutil "github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/allora-network/allora-chain/test/testutil"
+	v5 "github.com/allora-network/allora-chain/x/emissions/migrations/v5"
+	v6 "github.com/allora-network/allora-chain/x/emissions/migrations/v6"
+	oldV5Types "github.com/allora-network/allora-chain/x/emissions/migrations/v6/oldtypes"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type EmissionsV6MigrationTestSuite struct {
-	suite.Suite
-	ctrl *gomock.Controller
-
-	ctx             sdk.Context
-	storeService    store.KVStoreService
-	emissionsKeeper *keeper.Keeper
+	testutil.TestSuite
 }
 
 func TestEmissionsV6MigrationTestSuite(t *testing.T) {
-	suite.Run(t, new(EmissionsV6MigrationTestSuite))
-}
-
-func (s *EmissionsV6MigrationTestSuite) SetupTest() {
-	encCfg := moduletestutil.MakeTestEncodingConfig(emissions.AppModule{})
-	key := storetypes.NewKVStoreKey(emissionstypes.StoreKey)
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := cosmostestutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	s.ctx = testCtx.Ctx
-
-	// gomock initializations
-	s.ctrl = gomock.NewController(s.T())
-	accountKeeper := emissionstestutil.NewMockAccountKeeper(s.ctrl)
-	bankKeeper := emissionstestutil.NewMockBankKeeper(s.ctrl)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-
-	s.emissionsKeeper = &emissionsKeeper
+	suite.Run(t, &EmissionsV6MigrationTestSuite{
+		testutil.NewTestSuite("emissions_V6Migrations"),
+	})
 }
 
 // In this test we check that the emissions module params have been migrated
 // and the expected new fields are added and set to true:
 // GlobalWhitelistEnabled, TopicCreatorWhitelistEnabled
 func (s *EmissionsV6MigrationTestSuite) TestMigrateParams() {
-	storageService := s.emissionsKeeper.GetStorageService()
-	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	defaultParams := emissionstypes.DefaultParams()
 	paramsOld := oldV5Types.Params{
@@ -132,7 +90,7 @@ func (s *EmissionsV6MigrationTestSuite) TestMigrateParams() {
 
 	paramsExpected := defaultParams
 
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(paramsExpected.Version, params.Version)
 	s.Require().Equal(paramsExpected.MaxSerializedMsgLength, params.MaxSerializedMsgLength)
@@ -184,54 +142,38 @@ func (s *EmissionsV6MigrationTestSuite) TestMigrateParams() {
 // In this test we check that the topic worker and reputer whitelists
 // have been turned on for all topics.
 func (s *EmissionsV6MigrationTestSuite) TestFlipOnTopicWhitelists() {
-	store := runtime.KVStoreAdapter(s.storeService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+	store := runtime.KVStoreAdapter(s.StoreServiceEmissions().OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
+
+	const (
+		startTopicID = 2
+		numTopics    = 4
+	)
 
 	// Create 3 test topics
-	for i := uint64(1); i <= 3; i++ {
-		_, err := s.emissionsKeeper.IncrementTopicId(s.ctx)
+	for i := uint64(startTopicID); i <= numTopics-startTopicID; i++ {
+		_, err := s.EmissionsKeeper().IncrementTopicId(s.Ctx())
 		s.Require().NoError(err)
 
-		topic := emissionstypes.Topic{
-			Id:                       i,
-			Creator:                  "allo1qgqeu0twe5t6gr30k3e3sumaqs5a29ug5um8lr",
-			Metadata:                 "metadata",
-			LossMethod:               "mse",
-			EpochLastEnded:           0,
-			EpochLength:              1000,
-			GroundTruthLag:           1000,
-			PNorm:                    alloraMath.NewDecFromInt64(3),
-			AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-			AllowNegative:            false,
-			Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-			InitialRegret:            alloraMath.ZeroDec(),
-			WorkerSubmissionWindow:   120,
-			MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-			ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.1337"),
-			ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.1337"),
-			ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.1337"),
-		}
+		s.CreateTopic()
 
-		err = s.emissionsKeeper.SetTopic(s.ctx, i, topic)
-		s.Require().NoError(err)
-
-		_, err = s.emissionsKeeper.IncrementTopicId(s.ctx)
+		_, err = s.EmissionsKeeper().IncrementTopicId(s.Ctx())
 		s.Require().NoError(err)
 	}
 
 	// Run the migration
-	err := v6.FlipOnTopicWhitelists(s.ctx, store, cdc, *s.emissionsKeeper)
+	err := v6.FlipOnTopicWhitelists(s.Ctx(), store, cdc, *s.EmissionsKeeper())
 	s.Require().NoError(err)
 
 	// Verify each topic has whitelists enabled
-	for i := uint64(1); i <= 3; i++ {
+	for i := uint64(startTopicID); i <= numTopics-startTopicID; i++ {
 		// Check worker whitelist is enabled
-		workerWhitelistEnabled, err := s.emissionsKeeper.IsTopicWorkerWhitelistEnabled(s.ctx, i)
+		workerWhitelistEnabled, err := s.EmissionsKeeper().IsTopicWorkerWhitelistEnabled(s.Ctx(), i)
 		s.Require().NoError(err)
 		s.Require().True(workerWhitelistEnabled)
 
 		// Check reputer whitelist is enabled
-		reputerWhitelistEnabled, err := s.emissionsKeeper.IsTopicReputerWhitelistEnabled(s.ctx, i)
+		reputerWhitelistEnabled, err := s.EmissionsKeeper().IsTopicReputerWhitelistEnabled(s.Ctx(), i)
 		s.Require().NoError(err)
 		s.Require().True(reputerWhitelistEnabled)
 	}

--- a/x/emissions/migrations/v7/migrate_test.go
+++ b/x/emissions/migrations/v7/migrate_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/allora-network/allora-chain/test/testutil"
 	v7 "github.com/allora-network/allora-chain/x/emissions/migrations/v7"
 	oldV6Types "github.com/allora-network/allora-chain/x/emissions/migrations/v7/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/migrations/v7/migrate_test.go
+++ b/x/emissions/migrations/v7/migrate_test.go
@@ -3,74 +3,32 @@ package v7_test
 import (
 	"testing"
 
-	v7 "github.com/allora-network/allora-chain/x/emissions/migrations/v7"
-	oldV6Types "github.com/allora-network/allora-chain/x/emissions/migrations/v7/oldtypes"
-
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-
-	"cosmossdk.io/core/store"
-	"github.com/allora-network/allora-chain/app/params"
-
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-
-	emissions "github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstestutil "github.com/allora-network/allora-chain/x/emissions/testutil"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-
-	storetypes "cosmossdk.io/store/types"
-	cosmostestutil "github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/allora-network/allora-chain/test/testutil"
+	v7 "github.com/allora-network/allora-chain/x/emissions/migrations/v7"
+	oldV6Types "github.com/allora-network/allora-chain/x/emissions/migrations/v7/oldtypes"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-type EmissionsV6MigrationTestSuite struct {
-	suite.Suite
-	ctrl *gomock.Controller
-
-	ctx             sdk.Context
-	storeService    store.KVStoreService
-	emissionsKeeper *keeper.Keeper
+type EmissionsV7MigrationTestSuite struct {
+	testutil.TestSuite
 }
 
-func TestEmissionsV6MigrationTestSuite(t *testing.T) {
-	suite.Run(t, new(EmissionsV6MigrationTestSuite))
-}
-
-func (s *EmissionsV6MigrationTestSuite) SetupTest() {
-	encCfg := moduletestutil.MakeTestEncodingConfig(emissions.AppModule{})
-	key := storetypes.NewKVStoreKey(emissionstypes.StoreKey)
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := cosmostestutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	s.ctx = testCtx.Ctx
-
-	// gomock initializations
-	s.ctrl = gomock.NewController(s.T())
-	accountKeeper := emissionstestutil.NewMockAccountKeeper(s.ctrl)
-	bankKeeper := emissionstestutil.NewMockBankKeeper(s.ctrl)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-
-	s.emissionsKeeper = &emissionsKeeper
+func TestEmissionsV7MigrationTestSuite(t *testing.T) {
+	suite.Run(t, &EmissionsV7MigrationTestSuite{
+		testutil.NewTestSuite("emissions_V7Migrations"),
+	})
 }
 
 // In this test we check that the emissions module params have been migrated
 // and the expected new fields are added and set to true:
 // GlobalWhitelistEnabled, TopicCreatorWhitelistEnabled
-func (s *EmissionsV6MigrationTestSuite) TestMigrateParams() {
-	storageService := s.emissionsKeeper.GetStorageService()
-	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV7MigrationTestSuite) TestMigrateParams() {
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	defaultParams := emissionstypes.DefaultParams()
 	paramsOld := oldV6Types.Params{
@@ -125,7 +83,7 @@ func (s *EmissionsV6MigrationTestSuite) TestMigrateParams() {
 	store.Set(emissionstypes.ParamsKey, cdc.MustMarshal(&paramsOld))
 
 	// Run migration
-	err := v7.MigrateParams(s.ctx, store, cdc)
+	err := v7.MigrateParams(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// TO BE ADDED VIA DEFAULT PARAMS:
@@ -134,7 +92,7 @@ func (s *EmissionsV6MigrationTestSuite) TestMigrateParams() {
 	// - LambdaInitialScore
 	paramsExpected := defaultParams
 
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(paramsExpected.Version, params.Version)
 	s.Require().Equal(paramsExpected.MaxSerializedMsgLength, params.MaxSerializedMsgLength)

--- a/x/emissions/migrations/v8/migrate_test.go
+++ b/x/emissions/migrations/v8/migrate_test.go
@@ -3,74 +3,32 @@ package v8_test
 import (
 	"testing"
 
-	v8 "github.com/allora-network/allora-chain/x/emissions/migrations/v8"
-	oldV7Types "github.com/allora-network/allora-chain/x/emissions/migrations/v8/oldtypes"
-
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-
-	"cosmossdk.io/core/store"
-	"github.com/allora-network/allora-chain/app/params"
-
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-
-	emissions "github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstestutil "github.com/allora-network/allora-chain/x/emissions/testutil"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-
-	storetypes "cosmossdk.io/store/types"
-	cosmostestutil "github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/allora-network/allora-chain/test/testutil"
+	v8 "github.com/allora-network/allora-chain/x/emissions/migrations/v8"
+	oldV7Types "github.com/allora-network/allora-chain/x/emissions/migrations/v8/oldtypes"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-type EmissionsV7MigrationTestSuite struct {
-	suite.Suite
-	ctrl *gomock.Controller
-
-	ctx             sdk.Context
-	storeService    store.KVStoreService
-	emissionsKeeper *keeper.Keeper
+type EmissionsV8MigrationTestSuite struct {
+	testutil.TestSuite
 }
 
-func TestEmissionsV7MigrationTestSuite(t *testing.T) {
-	suite.Run(t, new(EmissionsV7MigrationTestSuite))
-}
-
-func (s *EmissionsV7MigrationTestSuite) SetupTest() {
-	encCfg := moduletestutil.MakeTestEncodingConfig(emissions.AppModule{})
-	key := storetypes.NewKVStoreKey(emissionstypes.StoreKey)
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := cosmostestutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	s.ctx = testCtx.Ctx
-
-	// gomock initializations
-	s.ctrl = gomock.NewController(s.T())
-	accountKeeper := emissionstestutil.NewMockAccountKeeper(s.ctrl)
-	bankKeeper := emissionstestutil.NewMockBankKeeper(s.ctrl)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-
-	s.emissionsKeeper = &emissionsKeeper
+func TestEmissionsV8MigrationTestSuite(t *testing.T) {
+	suite.Run(t, &EmissionsV8MigrationTestSuite{
+		testutil.NewTestSuite("emissions_V8Migrations"),
+	})
 }
 
 // In this test we check that the emissions module params have been migrated
 // and the expected new fields are added and set to true:
 // GlobalWhitelistEnabled, TopicCreatorWhitelistEnabled
-func (s *EmissionsV7MigrationTestSuite) TestMigrateParams() {
-	storageService := s.emissionsKeeper.GetStorageService()
-	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV8MigrationTestSuite) TestMigrateParams() {
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	defaultParams := emissionstypes.DefaultParams()
 	paramsOld := oldV7Types.Params{ // nolint: exhaustruct // this is an old version of the params => expected to fail lint
@@ -132,14 +90,14 @@ func (s *EmissionsV7MigrationTestSuite) TestMigrateParams() {
 	store.Set(emissionstypes.ParamsKey, cdc.MustMarshal(&paramsOld))
 
 	// Run migration
-	err := v8.MigrateParams(s.ctx, store, cdc)
+	err := v8.MigrateParams(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// TO BE ADDED VIA DEFAULT PARAMS:
 	// MinWeightThresholdForStdnorm
 	paramsExpected := defaultParams
 
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(paramsExpected.Version, params.Version)
 	s.Require().Equal(paramsExpected.MaxSerializedMsgLength, params.MaxSerializedMsgLength)

--- a/x/emissions/migrations/v8/migrate_test.go
+++ b/x/emissions/migrations/v8/migrate_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/allora-network/allora-chain/test/testutil"
 	v8 "github.com/allora-network/allora-chain/x/emissions/migrations/v8"
 	oldV7Types "github.com/allora-network/allora-chain/x/emissions/migrations/v8/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/migrations/v9/migrate_test.go
+++ b/x/emissions/migrations/v9/migrate_test.go
@@ -3,77 +3,35 @@ package v9_test
 import (
 	"testing"
 
-	v9 "github.com/allora-network/allora-chain/x/emissions/migrations/v9"
-	oldV8Types "github.com/allora-network/allora-chain/x/emissions/migrations/v9/oldtypes"
-
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-
-	"cosmossdk.io/core/store"
-	"github.com/allora-network/allora-chain/app/params"
-
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-
-	emissions "github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstestutil "github.com/allora-network/allora-chain/x/emissions/testutil"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-
-	storetypes "cosmossdk.io/store/types"
-	cosmostestutil "github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/allora-network/allora-chain/test/testutil"
+	v9 "github.com/allora-network/allora-chain/x/emissions/migrations/v9"
+	oldV9Types "github.com/allora-network/allora-chain/x/emissions/migrations/v9/oldtypes"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-type EmissionsV8MigrationTestSuite struct {
-	suite.Suite
-	ctrl *gomock.Controller
-
-	ctx             sdk.Context
-	storeService    store.KVStoreService
-	emissionsKeeper *keeper.Keeper
+type EmissionsV9MigrationTestSuite struct {
+	testutil.TestSuite
 }
 
-func TestEmissionsV8MigrationTestSuite(t *testing.T) {
-	suite.Run(t, new(EmissionsV8MigrationTestSuite))
-}
-
-func (s *EmissionsV8MigrationTestSuite) SetupTest() {
-	encCfg := moduletestutil.MakeTestEncodingConfig(emissions.AppModule{})
-	key := storetypes.NewKVStoreKey(emissionstypes.StoreKey)
-	storeService := runtime.NewKVStoreService(key)
-	s.storeService = storeService
-	testCtx := cosmostestutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	s.ctx = testCtx.Ctx
-
-	// gomock initializations
-	s.ctrl = gomock.NewController(s.T())
-	accountKeeper := emissionstestutil.NewMockAccountKeeper(s.ctrl)
-	bankKeeper := emissionstestutil.NewMockBankKeeper(s.ctrl)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-
-	s.emissionsKeeper = &emissionsKeeper
+func TestEmissionsV9MigrationTestSuite(t *testing.T) {
+	suite.Run(t, &EmissionsV9MigrationTestSuite{
+		testutil.NewTestSuite("emissions_V9Migrations"),
+	})
 }
 
 // In this test we check that the emissions module params have been migrated
 // and the expected new fields are added and set to true:
 // GlobalWhitelistEnabled, TopicCreatorWhitelistEnabled
-func (s *EmissionsV8MigrationTestSuite) TestMigrateParams() {
-	storageService := s.emissionsKeeper.GetStorageService()
-	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.ctx))
-	cdc := s.emissionsKeeper.GetBinaryCodec()
+func (s *EmissionsV9MigrationTestSuite) TestMigrateParams() {
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
 
 	defaultParams := emissionstypes.DefaultParams()
-	paramsOld := oldV8Types.Params{ // nolint: exhaustruct // this is an old version of the params => expected to fail lint
+	paramsOld := oldV9Types.Params{ // nolint: exhaustruct // this is an old version of the params => expected to fail lint
 		Version:                             defaultParams.Version,
 		MaxSerializedMsgLength:              defaultParams.MaxSerializedMsgLength,
 		MinTopicWeight:                      defaultParams.MinTopicWeight,
@@ -133,13 +91,13 @@ func (s *EmissionsV8MigrationTestSuite) TestMigrateParams() {
 	store.Set(emissionstypes.ParamsKey, cdc.MustMarshal(&paramsOld))
 
 	// Run migration
-	err := v9.MigrateParams(s.ctx, store, cdc)
+	err := v9.MigrateParams(s.Ctx(), store, cdc)
 	s.Require().NoError(err)
 
 	// TO BE ADDED VIA DEFAULT PARAMS:
 	paramsExpected := defaultParams
 
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(paramsExpected.Version, params.Version)
 	s.Require().Equal(paramsExpected.MaxSerializedMsgLength, params.MaxSerializedMsgLength)

--- a/x/emissions/migrations/v9/migrate_test.go
+++ b/x/emissions/migrations/v9/migrate_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/allora-network/allora-chain/test/testutil"
 	v9 "github.com/allora-network/allora-chain/x/emissions/migrations/v9"
 	oldV9Types "github.com/allora-network/allora-chain/x/emissions/migrations/v9/oldtypes"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/module/rewards/nonce_management_test.go
+++ b/x/emissions/module/rewards/nonce_management_test.go
@@ -3,8 +3,8 @@ package rewards_test
 import (
 	"cosmossdk.io/collections"
 
-	"github.com/allora-network/allora-chain/test/testutil"
 	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/module/rewards/nonce_management_test.go
+++ b/x/emissions/module/rewards/nonce_management_test.go
@@ -2,189 +2,96 @@ package rewards_test
 
 import (
 	"cosmossdk.io/collections"
-	cosmosMath "cosmossdk.io/math"
-	alloraMath "github.com/allora-network/allora-chain/math"
+
+	"github.com/allora-network/allora-chain/test/testutil"
 	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
-	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Test defer execution of CloseReputerNonce
 func (s *RewardsTestSuite) TestCloseReputerNonceTest_DeferExecWhenError() {
 	currentBlockHeight := int64(10)
-	s.ctx = s.ctx.WithBlockHeight(currentBlockHeight)
+	s.WithBlockHeight(currentBlockHeight)
+
+	reputerIndexes := testutil.ReturnIndexes(0, 5)
+	workerIndexes := testutil.ReturnIndexes(5, 5)
 
 	// Create topic
-	createTopicReq := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "test-topic-close-nonce",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		AllowNegative:            false,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, createTopicReq)
-	s.Require().NoError(err)
-	topicId := res.TopicId
-
-	// Reputer Addresses
-	reputerIndexes := s.returnIndexes(0, 5)
-
-	workerIndexes := s.returnIndexes(5, 5)
-
-	// Register and add stakes for reputers
-	for _, index := range reputerIndexes {
-		registerReq := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err = s.msgServer.Register(s.ctx, registerReq)
-		s.Require().NoError(err)
-	}
-
-	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
-	stakeAmount := cosmosMath.NewInt(100).Mul(cosmosOneE18)
-
-	for _, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakeAmount)
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakeAmount,
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	// Register workers
-	for _, index := range workerIndexes {
-		registerReq := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err = s.msgServer.Register(s.ctx, registerReq)
-		s.Require().NoError(err)
-	}
-
+	topic := s.FullTopicSetup(workerIndexes, reputerIndexes)
 	// Insert unfullfiled nonces
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
+	err := s.EmissionsKeeper().AddWorkerNonce(s.Ctx(), topic.Id, &types.Nonce{
 		BlockHeight: currentBlockHeight,
 	})
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
+	err = s.EmissionsKeeper().AddReputerNonce(s.Ctx(), topic.Id, &types.Nonce{
 		BlockHeight: currentBlockHeight,
 	})
 	s.Require().NoError(err)
 
-	workerValues := make([]TestWorkerValue, len(workerIndexes))
-	for i, index := range workerIndexes {
-		workerValues[i] = TestWorkerValue{
-			Index: index,
-			Value: "100",
-		}
-	}
-
-	getIndexesFromValues := func(values []TestWorkerValue) []int {
-		indexes := make([]int, 0)
-		for _, value := range values {
-			indexes = append(indexes, value.Index)
-		}
-		return indexes
-	}
-
-	workerIndexesFromValues := getIndexesFromValues(workerValues)
+	workerValues := testutil.GetWorkerValuesFromIndexes(workerIndexes, "100")
 
 	// Insert inference from workers
-	inferenceBundles := generateSimpleWorkerDataBundles(s, topicId, currentBlockHeight, currentBlockHeight, workerValues, workerIndexesFromValues)
-	for _, payload := range inferenceBundles {
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
+	workerNonce := s.SetupInferences(topic.Id, currentBlockHeight, workerIndexes, workerValues...)
 
 	// Move to end of worker submission window
-	s.ctx = s.ctx.WithBlockHeight(currentBlockHeight + topic.WorkerSubmissionWindow)
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
+	s.WithBlockHeight(currentBlockHeight + topic.WorkerSubmissionWindow)
+	err = actorutils.CloseWorkerNonce(s.EmissionsKeeper(), s.Ctx(), topic, workerNonce)
 	s.Require().NoError(err)
 
 	newBlockheight := currentBlockHeight + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
+	s.WithBlockHeight(newBlockheight)
 	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
+	s.EndBlock()
 
 	// Insert loss bundle from reputer
 	// Use different indexes to enforce different workers are used
 	// This will trigger an error and test if the defer execution of CloseReputerNonce works properly
-	workerIndexes = s.returnIndexes(10, 5)
-	lossBundles := generateLossBundles(s, currentBlockHeight, topicId, reputerIndexes, workerIndexes)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
+	workerIndexes = testutil.ReturnIndexes(10, 5)
+	reputerValues := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.1")
+	reputerNonce := types.Nonce{BlockHeight: currentBlockHeight}
+
+	err = s.InsertReputerLossBundle(
+		topic.Id,
+		currentBlockHeight,
+		reputerIndexes,
+		testutil.WithReputerValues(reputerValues),
+		testutil.WithSkipNetworkInferences(),
+	)
+	s.Require().NoError(err)
 
 	// before closing the nonce, the nonce should be unfulfilled
-	unfulfilled, err := s.emissionsKeeper.IsReputerNonceUnfulfilled(s.ctx, topicId, lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce)
+	unfulfilled, err := s.EmissionsKeeper().IsReputerNonceUnfulfilled(s.Ctx(), topic.Id, &reputerNonce)
 	s.Require().NoError(err)
 	s.Require().True(unfulfilled)
 
 	// before closing the nonce, the active reputers for topic should not be
-	activeReputers, err := s.emissionsKeeper.GetActiveReputersForTopic(s.ctx, topicId)
+	activeReputers, err := s.EmissionsKeeper().GetActiveReputersForTopic(s.Ctx(), topic.Id)
 	s.Require().NoError(err)
 	s.Require().Equal(len(reputerIndexes), len(activeReputers))
 
 	// before closing the nonce, the submissions for the topic should not be empty
-	for _, bundle := range lossBundles.ReputerValueBundles {
-		submissions, err := s.emissionsKeeper.GetReputerLatestLossByTopicId(s.ctx, topicId, bundle.ValueBundle.Reputer)
+	for _, idx := range reputerIndexes {
+		submissions, err := s.EmissionsKeeper().GetReputerLatestLossByTopicId(s.Ctx(), topic.Id, s.AddrsStr(idx))
 		s.Require().NoError(err)
 		s.Require().NotNil(submissions)
 	}
 
-	err = actorutils.CloseReputerNonce(
-		&s.emissionsKeeper, s.ctx, topic,
-		*lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce,
-	)
+	err = actorutils.CloseReputerNonce(s.EmissionsKeeper(), s.Ctx(), topic, reputerNonce)
 	s.Require().Error(err)
 
 	// Check if reputer nonce is fulfilled
-	unfulfilled, err = s.emissionsKeeper.IsReputerNonceUnfulfilled(s.ctx, topicId, lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce)
+	unfulfilled, err = s.EmissionsKeeper().IsReputerNonceUnfulfilled(s.Ctx(), topic.Id, &reputerNonce)
 	s.Require().NoError(err)
 	s.Require().False(unfulfilled)
 
 	// Check if the active reputers for topic have been reset
-	activeReputers, err = s.emissionsKeeper.GetActiveReputersForTopic(s.ctx, topicId)
+	activeReputers, err = s.EmissionsKeeper().GetActiveReputersForTopic(s.Ctx(), topic.Id)
 	s.Require().NoError(err)
 	s.Require().Equal(0, len(activeReputers))
 
 	// Check if the submissions for the topic have been reset
-	for _, bundle := range lossBundles.ReputerValueBundles {
-		_, err := s.emissionsKeeper.GetReputerLatestLossByTopicId(s.ctx, topicId, bundle.ValueBundle.Reputer)
+	for _, idx := range reputerIndexes {
+		_, err := s.EmissionsKeeper().GetReputerLatestLossByTopicId(s.Ctx(), topic.Id, s.AddrsStr(idx))
 		s.Require().ErrorIs(err, collections.ErrNotFound)
 	}
 }
@@ -192,120 +99,63 @@ func (s *RewardsTestSuite) TestCloseReputerNonceTest_DeferExecWhenError() {
 // Test defer execution of CloseWorkerNonce
 func (s *RewardsTestSuite) TestCloseWorkerNonce_DeferExecWhenError() {
 	currentBlockHeight := int64(20)
-	s.ctx = s.ctx.WithBlockHeight(currentBlockHeight)
+	s.WithBlockHeight(currentBlockHeight)
+
+	reputerIndexes := testutil.ReturnIndexes(0, 5)
+	workerIndexes := testutil.ReturnIndexes(5, 5)
 
 	// Create topic
-	createTopicReq := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[0],
-		Metadata:                 "test-topic-close-worker-nonce",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		AllowNegative:            false,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, createTopicReq)
-	s.Require().NoError(err)
-	topicId := res.TopicId
-
-	workerIndexes := s.returnIndexes(0, 5)
-
-	// Register workers
-	for _, index := range workerIndexes {
-		registerReq := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err = s.msgServer.Register(s.ctx, registerReq)
-		s.Require().NoError(err)
-	}
+	topic := s.FullTopicSetup(workerIndexes, reputerIndexes)
 
 	// Insert unfulfilled worker nonce
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
+	err := s.EmissionsKeeper().AddWorkerNonce(s.Ctx(), topic.Id, &types.Nonce{
 		BlockHeight: currentBlockHeight,
 	})
 	s.Require().NoError(err)
 
-	workerValues := make([]TestWorkerValue, len(workerIndexes))
-	for i, index := range workerIndexes {
-		workerValues[i] = TestWorkerValue{
-			Index: index,
-			Value: "100",
-		}
-	}
-
-	getIndexesFromValues := func(values []TestWorkerValue) []int {
-		indexes := make([]int, 0)
-		for _, value := range values {
-			indexes = append(indexes, value.Index)
-		}
-		return indexes
-	}
-
-	workerIndexesFromValues := getIndexesFromValues(workerValues)
+	workerValues := testutil.GetWorkerValuesFromIndexes(workerIndexes, "100")
 
 	// Insert inference from workers
-	inferenceBundles := generateSimpleWorkerDataBundles(s, topicId, currentBlockHeight, currentBlockHeight, workerValues, workerIndexesFromValues)
-	for _, payload := range inferenceBundles {
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
+	workerNonce := s.SetupInferences(topic.Id, currentBlockHeight, workerIndexes, workerValues...)
 
 	// Move to end of worker submission window
-	s.ctx = s.ctx.WithBlockHeight(currentBlockHeight + topic.WorkerSubmissionWindow)
+	s.WithBlockHeight(currentBlockHeight + topic.WorkerSubmissionWindow)
 
 	// Before closing, check nonce is unfulfilled, active workers exist, and submissions exist
-	unfulfilled, err := s.emissionsKeeper.IsWorkerNonceUnfulfilled(s.ctx, topicId, inferenceBundles[0].Nonce)
+	unfulfilled, err := s.EmissionsKeeper().IsWorkerNonceUnfulfilled(s.Ctx(), topic.Id, &workerNonce)
 	s.Require().NoError(err)
 	s.Require().True(unfulfilled)
 
-	activeInferers, err := s.emissionsKeeper.GetActiveInferersForTopic(s.ctx, topicId)
+	activeInferers, err := s.EmissionsKeeper().GetActiveInferersForTopic(s.Ctx(), topic.Id)
 	s.Require().NoError(err)
 	s.Require().Equal(len(workerIndexes), len(activeInferers))
 
-	for _, bundle := range inferenceBundles {
-		submissions, err := s.emissionsKeeper.GetWorkerLatestInferenceByTopicId(s.ctx, topicId, bundle.Worker)
+	for _, idx := range workerIndexes {
+		submissions, err := s.EmissionsKeeper().GetWorkerLatestInferenceByTopicId(s.Ctx(), topic.Id, s.AddrsStr(idx))
 		s.Require().NoError(err)
 		s.Require().NotNil(submissions)
 	}
 
 	// Enforcing that the active inferer to create an error
-	enforcedInferer := s.addrsStr[10]
-	err = s.emissionsKeeper.AddActiveInferer(s.ctx, topicId, enforcedInferer)
+	enforcedInferer := s.AddrsStr(10)
+	err = s.EmissionsKeeper().AddActiveInferer(s.Ctx(), topic.Id, enforcedInferer)
 	s.Require().NoError(err)
 
 	// Call CloseWorkerNonce, expecting an error
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
+	err = actorutils.CloseWorkerNonce(s.EmissionsKeeper(), s.Ctx(), topic, workerNonce)
 	s.Require().Error(err)
 
 	// After closing, check nonce is fulfilled, active workers are reset, and submissions are cleared
-	unfulfilled, err = s.emissionsKeeper.IsWorkerNonceUnfulfilled(s.ctx, topicId, inferenceBundles[0].Nonce)
+	unfulfilled, err = s.EmissionsKeeper().IsWorkerNonceUnfulfilled(s.Ctx(), topic.Id, &workerNonce)
 	s.Require().NoError(err)
 	s.Require().False(unfulfilled)
 
-	activeInferers, err = s.emissionsKeeper.GetActiveInferersForTopic(s.ctx, topicId)
+	activeInferers, err = s.EmissionsKeeper().GetActiveInferersForTopic(s.Ctx(), topic.Id)
 	s.Require().NoError(err)
 	s.Require().Equal(0, len(activeInferers))
 
-	for _, bundle := range inferenceBundles {
-		_, err := s.emissionsKeeper.GetWorkerLatestInferenceByTopicId(s.ctx, topicId, bundle.Worker)
+	for _, idx := range workerIndexes {
+		_, err = s.EmissionsKeeper().GetWorkerLatestInferenceByTopicId(s.Ctx(), topic.Id, s.AddrsStr(idx))
 		s.Require().ErrorIs(err, collections.ErrNotFound)
 	}
 }

--- a/x/emissions/module/rewards/reputer_rewards_test.go
+++ b/x/emissions/module/rewards/reputer_rewards_test.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
+	cosmostestutil "github.com/allora-network/allora-chain/test/testutil"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
@@ -425,7 +426,7 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldOutputZeroForRepu
 }
 
 func (s *RewardsTestSuite) TestGetReputersRewardFractionsFromCsv() {
-	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
+	epochGet := cosmostestutil.GetSimulatedValuesGetterForEpochs()
 	epoch3Get := epochGet[300]
 
 	topicId := uint64(1)
@@ -509,7 +510,7 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsFromCsv() {
 		epoch3Get("reputer_reward_fraction_4"),
 	}
 	for i, reputerRewardFraction := range reputersRewardFractions {
-		testutil.InEpsilon5(
+		cosmostestutil.InEpsilon5(
 			s.T(),
 			expectedFractions[i],
 			reputerRewardFraction.String(),
@@ -518,7 +519,7 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsFromCsv() {
 }
 
 func (s *RewardsTestSuite) TestGetReputerTaskEntropyFromCsv() {
-	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
+	epochGet := cosmostestutil.GetSimulatedValuesGetterForEpochs()
 	epoch1Get := epochGet[301]
 	epoch2Get := epochGet[302]
 	topicId := uint64(1)
@@ -567,7 +568,7 @@ func (s *RewardsTestSuite) TestGetReputerTaskEntropyFromCsv() {
 	s.Require().NoError(err)
 
 	expectedEntropy := epoch2Get("reputers_entropy")
-	testutil.InEpsilon5(
+	cosmostestutil.InEpsilon5(
 		s.T(),
 		expectedEntropy,
 		reputerEntropy.String(),

--- a/x/emissions/module/rewards/reputer_rewards_test.go
+++ b/x/emissions/module/rewards/reputer_rewards_test.go
@@ -1,34 +1,32 @@
 package rewards_test
 
 import (
-	"context"
-
 	cosmosMath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/test/testutil"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (s *RewardsTestSuite) TestGetReputersRewards() {
 	topicId := uint64(1)
 	block := int64(1003)
 
-	reputerIndexes := []int{0, 1, 2, 3, 4}
+	reputerIndexes := testutil.ReturnIndexes(0, 5)
 	reputerAddrs := []string{
-		s.addrs[0].String(),
-		s.addrs[1].String(),
-		s.addrs[2].String(),
-		s.addrs[3].String(),
-		s.addrs[4].String(),
+		s.AddrsStr(0),
+		s.AddrsStr(1),
+		s.AddrsStr(2),
+		s.AddrsStr(3),
+		s.AddrsStr(4),
 	}
 
 	// Generate reputers data for tests
-	_, err := mockReputersData(s, topicId, block, reputerIndexes)
-	s.Require().NoError(err)
+	mockReputersData(s, topicId, block, reputerIndexes)
 
 	// Reputers fractions of total reward
 	reputerFractions := []alloraMath.Dec{
@@ -41,8 +39,8 @@ func (s *RewardsTestSuite) TestGetReputersRewards() {
 
 	// Get reputer rewards
 	reputerRewards, err := rewards.GetRewardPerReputer(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.MustNewDecFromString("1017.5559072418691"),
 		reputerAddrs,
@@ -76,11 +74,11 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldOutputSameFractio
 	block := int64(1003)
 
 	reputerAddrs := []string{
-		s.addrs[0].String(),
-		s.addrs[1].String(),
-		s.addrs[2].String(),
-		s.addrs[3].String(),
-		s.addrs[4].String(),
+		s.AddrsStr(0),
+		s.AddrsStr(1),
+		s.AddrsStr(2),
+		s.AddrsStr(3),
+		s.AddrsStr(4),
 	}
 
 	// Generate reputers - same scores and stakes
@@ -93,7 +91,7 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldOutputSameFractio
 	}
 	scores := make([]types.Score, 0)
 	for i, reputerAddr := range reputerAddrs {
-		err := s.emissionsKeeper.AddReputerStake(s.ctx, topicId, reputerAddr, stakes[i])
+		err := s.EmissionsKeeper().AddReputerStake(s.Ctx(), topicId, reputerAddr, stakes[i])
 		s.Require().NoError(err)
 
 		scoreToAdd := types.Score{
@@ -107,8 +105,8 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldOutputSameFractio
 
 	// Get reputer rewards
 	reputers, reputersRewardFractions, err := rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		scores,
@@ -140,8 +138,8 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldOutputSameFractio
 
 	// Get reputer rewards
 	reputers, reputersRewardFractions, err = rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		scores,
@@ -166,28 +164,27 @@ func (s *RewardsTestSuite) TestGetReputersRewardsShouldGenerateRewardsForDelegat
 
 	reputerIndexes := []int{0, 1, 2, 3, 4}
 	reputerAddrs := []string{
-		s.addrs[0].String(),
-		s.addrs[1].String(),
-		s.addrs[2].String(),
-		s.addrs[3].String(),
-		s.addrs[4].String(),
+		s.AddrsStr(0),
+		s.AddrsStr(1),
+		s.AddrsStr(2),
+		s.AddrsStr(3),
+		s.AddrsStr(4),
 	}
 
 	// Generate reputers data for tests
-	_, err := mockReputersData(s, topicId, block, reputerIndexes)
-	s.Require().NoError(err)
+	mockReputersData(s, topicId, block, reputerIndexes)
 
 	// Add balance to the reward account
 	rewardToDistribute := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(100000000)))
-	err = s.bankKeeper.MintCoins(s.ctx, types.AlloraRewardsAccountName, rewardToDistribute)
+	err := s.BankKeeper().MintCoins(s.Ctx(), types.AlloraRewardsAccountName, rewardToDistribute)
 	s.Require().NoError(err)
 
 	// Check delegator rewards account balance
-	moduleAccAddr := s.accountKeeper.GetModuleAddress(types.AlloraPendingRewardForDelegatorAccountName)
-	inicialBalance := s.bankKeeper.GetBalance(s.ctx, moduleAccAddr, params.DefaultBondDenom)
+	moduleAccAddr := s.AccountKeeper().GetModuleAddress(types.AlloraPendingRewardForDelegatorAccountName)
+	inicialBalance := s.BankKeeper().GetBalance(s.Ctx(), moduleAccAddr, params.DefaultBondDenom)
 
 	// Add delegator for the reputer 1
-	err = s.emissionsKeeper.AddDelegateStake(s.ctx, topicId, s.addrs[5].String(), reputerAddrs[0], cosmosMath.NewInt(10000000000))
+	err = s.EmissionsKeeper().AddDelegateStake(s.Ctx(), topicId, s.AddrsStr(5), reputerAddrs[0], cosmosMath.NewInt(10000000000))
 	s.Require().NoError(err)
 
 	// Reputers fractions of total reward
@@ -201,8 +198,8 @@ func (s *RewardsTestSuite) TestGetReputersRewardsShouldGenerateRewardsForDelegat
 
 	// Get reputer rewards
 	reputerRewards, err := rewards.GetRewardPerReputer(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.MustNewDecFromString("1017.5559072418691"),
 		reputerAddrs,
@@ -211,7 +208,7 @@ func (s *RewardsTestSuite) TestGetReputersRewardsShouldGenerateRewardsForDelegat
 	s.Require().NoError(err)
 	s.Require().Equal(5, len(reputerRewards))
 
-	finalBalance := s.bankKeeper.GetBalance(s.ctx, moduleAccAddr, params.DefaultBondDenom)
+	finalBalance := s.BankKeeper().GetBalance(s.Ctx(), moduleAccAddr, params.DefaultBondDenom)
 
 	// Check that the delegator has received rewards
 	s.Require().True(
@@ -227,11 +224,10 @@ func (s *RewardsTestSuite) TestGetReputersRewardsShouldIncreaseRewardsAfterRemov
 	reputerIndexes := []int{0, 1, 2, 3, 4}
 
 	// Generate reputers data for tests
-	_, err := mockReputersData(s, topicId, block, reputerIndexes)
-	s.Require().NoError(err)
+	mockReputersData(s, topicId, block, reputerIndexes)
 
 	// Calculate and Set the reputer scores
-	scores, err := s.emissionsKeeper.GetReputersScoresAtBlock(s.ctx, topicId, block)
+	scores, err := s.EmissionsKeeper().GetReputersScoresAtBlock(s.Ctx(), topicId, block)
 	s.Require().NoError(err)
 
 	var reward_score []types.Score
@@ -245,16 +241,16 @@ func (s *RewardsTestSuite) TestGetReputersRewardsShouldIncreaseRewardsAfterRemov
 	}
 	// Get reputer rewards
 	reputers, reputersRewardFractions, err := rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		reward_score,
 	)
 	s.Require().NoError(err)
 	reputerRewards, err := rewards.GetRewardPerReputer(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.MustNewDecFromString("1017.5559072418691"),
 		reputers,
@@ -289,11 +285,10 @@ func (s *RewardsTestSuite) TestGetReputersRewardsShouldIncreaseRewardsAfterRemov
 	reputerIndexes = []int{5, 6, 7, 8}
 
 	// Generate reputers same loss data for less reputers
-	_, err = mockReputersData(s, topicId, block, reputerIndexes)
-	s.Require().NoError(err)
+	mockReputersData(s, topicId, block, reputerIndexes)
 
 	// Calculate and Set the reputer scores
-	scores, err = s.emissionsKeeper.GetReputersScoresAtBlock(s.ctx, topicId, block)
+	scores, err = s.EmissionsKeeper().GetReputersScoresAtBlock(s.Ctx(), topicId, block)
 	s.Require().NoError(err)
 
 	reward_score = make([]types.Score, 0)
@@ -308,16 +303,16 @@ func (s *RewardsTestSuite) TestGetReputersRewardsShouldIncreaseRewardsAfterRemov
 
 	// Get reputer rewards
 	reputers, reputersRewardFractions, err = rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		reward_score,
 	)
 	s.Require().NoError(err)
 	newReputerRewards, err := rewards.GetRewardPerReputer(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.MustNewDecFromString("1017.5559072418691"),
 		reputers,
@@ -340,22 +335,20 @@ func (s *RewardsTestSuite) TestGetReputersRewardsShouldIncreaseRewardsAfterRemov
 func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldIncreaseFractionOfRewardsForHigherStake() {
 	reputerIndexes := []int{0, 1, 2, 3, 4}
 
-	topicId, err := CreateTopic(s.ctx, s.msgServer, s.addrs[0].String())
-	s.Require().NoError(err)
+	topicId := s.CreateTopic()
 	block := int64(1003)
 
 	// Generate reputers data for tests
-	reputerValueBundles, err := mockReputersData(s, topicId, block, reputerIndexes)
-	s.Require().NoError(err)
+	reputerValueBundles := mockReputersData(s, topicId, block, reputerIndexes)
 
 	// Calculate and Set the reputer scores
-	scores, err := rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err := rewards.GenerateReputerScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block, reputerValueBundles)
 	s.Require().NoError(err)
 
 	// Get reputer rewards
 	_, reputersRewardFractions, err := rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		scores,
@@ -363,13 +356,13 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldIncreaseFractionO
 	s.Require().NoError(err)
 
 	// Increase stake for the first reputer
-	err = s.emissionsKeeper.AddReputerStake(s.ctx, topicId, s.addrsStr[0], cosmosMath.NewInt(1000000))
+	err = s.EmissionsKeeper().AddReputerStake(s.Ctx(), topicId, s.AddrsStr(0), cosmosMath.NewInt(1000000))
 	s.Require().NoError(err)
 
 	// Get new reputer rewards
 	_, newReputersRewardFractions, err := rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		scores,
@@ -386,41 +379,39 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsShouldOutputZeroForRepu
 	block := int64(1003)
 	reputerIndexes := []int{0, 1, 2, 3, 4}
 
-	topicId, err := CreateTopic(s.ctx, s.msgServer, s.addrs[0].String())
-	s.Require().NoError(err)
+	topicId := s.CreateTopic()
 
 	// Generate reputers data for tests
-	reputerValueBundles, err := mockReputersData(s, topicId, block, reputerIndexes)
-	s.Require().NoError(err)
+	reputerValueBundles := mockReputersData(s, topicId, block, reputerIndexes)
 
 	// Remove stake for the first reputer
 	amount := cosmosMath.NewInt(1176644)
-	err = s.emissionsKeeper.SetStakeRemoval(s.ctx, types.StakeRemovalInfo{
+	err := s.EmissionsKeeper().SetStakeRemoval(s.Ctx(), types.StakeRemovalInfo{
 		TopicId:               topicId,
-		Reputer:               s.addrsStr[0],
+		Reputer:               s.AddrsStr(0),
 		Amount:                amount,
 		BlockRemovalStarted:   0,
 		BlockRemovalCompleted: block,
 	})
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.RemoveReputerStake(s.ctx, block, topicId, s.addrsStr[0], amount)
+	err = s.EmissionsKeeper().RemoveReputerStake(s.Ctx(), block, topicId, s.AddrsStr(0), amount)
 	s.Require().NoError(err)
 
 	// Check if stake is zero
-	stake, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId, s.addrsStr[0])
+	stake, err := s.EmissionsKeeper().GetStakeReputerAuthority(s.Ctx(), topicId, s.AddrsStr(0))
 	s.Require().NoError(err)
 	s.Require().True(
 		stake.IsZero(),
 	)
 
 	// Calculate and Set the reputer scores
-	scores, err := rewards.GenerateReputerScores(s.ctx, s.emissionsKeeper, topicId, block, reputerValueBundles)
+	scores, err := rewards.GenerateReputerScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block, reputerValueBundles)
 	s.Require().NoError(err)
 
 	// Get reputer rewards
 	_, reputersRewardFractions, err := rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		scores,
@@ -440,11 +431,11 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsFromCsv() {
 	topicId := uint64(1)
 	block := int64(1003)
 
-	reputer0 := s.addrs[0].String()
-	reputer1 := s.addrs[1].String()
-	reputer2 := s.addrs[2].String()
-	reputer3 := s.addrs[3].String()
-	reputer4 := s.addrs[4].String()
+	reputer0 := s.AddrsStr(0)
+	reputer1 := s.AddrsStr(1)
+	reputer2 := s.AddrsStr(2)
+	reputer3 := s.AddrsStr(3)
+	reputer4 := s.AddrsStr(4)
 	reputerAddresses := []string{reputer0, reputer1, reputer2, reputer3, reputer4}
 
 	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
@@ -488,7 +479,7 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsFromCsv() {
 	}
 	scoreStructs := make([]types.Score, 0)
 	for i, reputerAddr := range reputerAddresses {
-		err := s.emissionsKeeper.AddReputerStake(s.ctx, topicId, reputerAddr, stakes[i])
+		err := s.EmissionsKeeper().AddReputerStake(s.Ctx(), topicId, reputerAddr, stakes[i])
 		s.Require().NoError(err)
 
 		scoreToAdd := types.Score{
@@ -502,8 +493,8 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsFromCsv() {
 
 	// Get reputer rewards
 	_, reputersRewardFractions, err := rewards.GetReputersRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		alloraMath.OneDec(),
 		scoreStructs,
@@ -535,11 +526,11 @@ func (s *RewardsTestSuite) TestGetReputerTaskEntropyFromCsv() {
 	taskRewardAlpha := alloraMath.MustNewDecFromString("0.1")
 	betaEntropy := alloraMath.MustNewDecFromString("0.25")
 
-	reputer0 := s.addrs[0].String()
-	reputer1 := s.addrs[1].String()
-	reputer2 := s.addrs[2].String()
-	reputer3 := s.addrs[3].String()
-	reputer4 := s.addrs[4].String()
+	reputer0 := s.AddrsStr(0)
+	reputer1 := s.AddrsStr(1)
+	reputer2 := s.AddrsStr(2)
+	reputer3 := s.AddrsStr(3)
+	reputer4 := s.AddrsStr(4)
 	reputerAddresses := []string{reputer0, reputer1, reputer2, reputer3, reputer4}
 
 	// Add previous epoch reward fractions
@@ -551,7 +542,7 @@ func (s *RewardsTestSuite) TestGetReputerTaskEntropyFromCsv() {
 		epoch1Get("reputer_reward_fraction_smooth_4"),
 	}
 	for i, reputerAddr := range reputerAddresses {
-		err := s.emissionsKeeper.SetPreviousReputerRewardFraction(s.ctx, topicId, reputerAddr, reputerFractionsEpoch1[i])
+		err := s.EmissionsKeeper().SetPreviousReputerRewardFraction(s.Ctx(), topicId, reputerAddr, reputerFractionsEpoch1[i])
 		s.Require().NoError(err)
 	}
 
@@ -565,8 +556,8 @@ func (s *RewardsTestSuite) TestGetReputerTaskEntropyFromCsv() {
 
 	// Get reputer task entropy
 	reputerEntropy, err := rewards.GetReputerTaskEntropy(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		taskRewardAlpha,
 		betaEntropy,
@@ -584,7 +575,7 @@ func (s *RewardsTestSuite) TestGetReputerTaskEntropyFromCsv() {
 }
 
 // mockReputersData generates reputer scores, stakes and losses
-func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64, reputerIndexes []int) (types.ReputerValueBundles, error) {
+func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64, reputerIndexes []int) types.ReputerValueBundles {
 	var scores = []alloraMath.Dec{
 		alloraMath.MustNewDecFromString("17.53436"),
 		alloraMath.MustNewDecFromString("20.29489"),
@@ -602,79 +593,41 @@ func mockReputersData(s *RewardsTestSuite, topicId uint64, block int64, reputerI
 
 	var reputerValueBundles types.ReputerValueBundles
 	for i, reputerIndex := range reputerIndexes {
-		err := s.emissionsKeeper.AddReputerStake(s.ctx, topicId, s.addrsStr[reputerIndex], stakes[i])
-		if err != nil {
-			return types.ReputerValueBundles{}, err
-		}
+		err := s.EmissionsKeeper().AddReputerStake(s.Ctx(), topicId, s.AddrsStr(reputerIndex), stakes[i])
+		s.Require().NoError(err)
 
 		scoreToAdd := types.Score{
 			TopicId:     topicId,
 			BlockHeight: block,
-			Address:     s.addrsStr[reputerIndex],
+			Address:     s.AddrsStr(reputerIndex),
 			Score:       scores[i],
 		}
-		err = s.emissionsKeeper.InsertReputerScore(s.ctx, topicId, block, scoreToAdd)
-		if err != nil {
-			return types.ReputerValueBundles{}, err
-		}
-		valueBundle := &types.ValueBundle{
+		err = s.EmissionsKeeper().InsertReputerScore(s.Ctx(), topicId, block, scoreToAdd)
+		s.Require().NoError(err)
+		valueBundle := &types.ValueBundle{ //nolint:exhaustruct
 			TopicId: topicId,
 			ReputerRequestNonce: &types.ReputerRequestNonce{
 				ReputerNonce: &types.Nonce{BlockHeight: block}},
-			Reputer:       s.addrsStr[reputerIndex],
+			Reputer:       s.AddrsStr(reputerIndex),
 			ExtraData:     nil,
 			CombinedValue: alloraMath.MustNewDecFromString("1500.0"),
 			InfererValues: []*types.WorkerAttributedValue{{
 				Worker: "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
 				Value:  alloraMath.MustNewDecFromString("1"),
 			}},
-			ForecasterValues:              nil,
-			NaiveValue:                    alloraMath.MustNewDecFromString("1500.0"),
-			OneOutInfererValues:           nil,
-			OneOutForecasterValues:        nil,
-			OneInForecasterValues:         nil,
-			OneOutInfererForecasterValues: nil,
+			NaiveValue: alloraMath.MustNewDecFromString("1500.0"),
 		}
-		signature := s.signValueBundle(valueBundle, s.privKeys[reputerIndex])
+		signature := s.SignValueBundle(valueBundle, s.PrivKeys(reputerIndex))
+		s.Require().NoError(err)
 		reputerValueBundle := &types.ReputerValueBundle{
 			ValueBundle: valueBundle,
 			Signature:   signature,
-			Pubkey:      s.pubKeyHexStr[reputerIndex],
+			Pubkey:      s.PubKeyHexStr(reputerIndex),
 		}
 		reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, reputerValueBundle)
 	}
 
-	err := s.emissionsKeeper.InsertActiveReputerLosses(s.ctx, topicId, block, reputerValueBundles)
-	if err != nil {
-		return types.ReputerValueBundles{}, err
-	}
-
-	return reputerValueBundles, nil
-}
-
-func CreateTopic(ctx context.Context, msgServer types.MsgServiceServer, creator string) (uint64, error) {
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  creator,
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		AllowNegative:            false,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := msgServer.CreateNewTopic(ctx, newTopicMsg)
-	if err != nil {
-		return 0, err
-	}
-	return res.TopicId, nil
+	err := s.EmissionsKeeper().InsertActiveReputerLosses(s.Ctx(), topicId, block, reputerValueBundles)
+	s.Require().NoError(err)
+	return reputerValueBundles
 }

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -4,11 +4,12 @@ import (
 	"cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type CalcTopicRewardsArgs struct {
@@ -156,10 +157,10 @@ func EmitRewards(args EmitRewardsArgs) error {
 		})
 		if err != nil {
 			// return reward to ecosystem account
-			err = args.K.MoveCoinsFromAlloraRewardsToEcosystem(args.Ctx, *topicRewards[topicId])
-			if err != nil {
-				Logger(args.Ctx).Error("Failed to move coins from allora rewards to ecosystem", "topicId", topicId, "error", err)
-				panic(err)
+			errMC := args.K.MoveCoinsFromAlloraRewardsToEcosystem(args.Ctx, *topicRewards[topicId])
+			if errMC != nil {
+				Logger(args.Ctx).Error("Failed to move coins from allora rewards to ecosystem", "topicId", topicId, "error", errMC)
+				panic(errMC)
 			}
 			*topicRewards[topicId] = alloraMath.ZeroDec()
 

--- a/x/emissions/module/rewards/rewards_internal_test.go
+++ b/x/emissions/module/rewards/rewards_internal_test.go
@@ -4,14 +4,15 @@ import (
 	"strconv"
 	"testing"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
-	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 type RewardsMathTestSuite struct {
@@ -786,7 +787,7 @@ func TestGetAllConsensusScores(t *testing.T) {
 func (s *RewardsTestSuite) TestGetAllReputersOutput() {
 	require := s.Require()
 
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	params.EpsilonReputer = alloraMath.MustNewDecFromString("0.01")
 	require.NoError(err)
 

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/allora-network/allora-chain/app/params"
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/module"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 	minttypes "github.com/allora-network/allora-chain/x/mint/types"
 

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -1,620 +1,104 @@
 package rewards_test
 
 import (
-	"fmt"
+	"slices"
 	"testing"
-	"time"
 
-	"cosmossdk.io/core/header"
-	"cosmossdk.io/log"
 	cosmosMath "cosmossdk.io/math"
-	storetypes "cosmossdk.io/store/types"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/allora-network/allora-chain/app/params"
-	alloralog "github.com/allora-network/allora-chain/log"
 	alloraMath "github.com/allora-network/allora-chain/math"
-	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
-	"github.com/allora-network/allora-chain/x/emissions/keeper"
-	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	"github.com/allora-network/allora-chain/test/testutil"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
-	"github.com/allora-network/allora-chain/x/emissions/keeper/msgserver"
 	"github.com/allora-network/allora-chain/x/emissions/module"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	mintkeeper "github.com/allora-network/allora-chain/x/mint/keeper"
-	mint "github.com/allora-network/allora-chain/x/mint/module"
 	minttypes "github.com/allora-network/allora-chain/x/mint/types"
 
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	codecAddress "github.com/cosmos/cosmos-sdk/codec/address"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	auth "github.com/cosmos/cosmos-sdk/x/auth"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
-	"github.com/stretchr/testify/suite"
-)
-
-const (
-	multiPerm  = "multiple permissions account"
-	randomPerm = "random permission"
 )
 
 type RewardsTestSuite struct {
-	suite.Suite
-
-	ctx                sdk.Context
-	accountKeeper      authkeeper.AccountKeeper
-	bankKeeper         bankkeeper.BaseKeeper
-	emissionsKeeper    keeper.Keeper
-	emissionsAppModule module.AppModule
-	mintAppModule      mint.AppModule
-	msgServer          types.MsgServiceServer
-	key                *storetypes.KVStoreKey
-	privKeys           []secp256k1.PrivKey
-	addrs              []sdk.AccAddress
-	addrsStr           []string
-	pubKeyHexStr       []string
-}
-
-func (s *RewardsTestSuite) SetupTest() {
-	key := storetypes.NewKVStoreKey("emissions")
-	storeService := runtime.NewKVStoreService(key)
-	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
-	// Set logger to show logs from the rewards module too
-
-	logger := alloralog.NewTestLogger(s.T()).With("module", "rewards")
-	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()}).WithLogger(logger) // nolint: exhaustruct
-	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, module.AppModule{})
-
-	maccPerms := map[string][]string{
-		"fee_collector":                {"minter"},
-		"mint":                         {"minter"},
-		types.AlloraStakingAccountName: {"burner", "minter", "staking"},
-		types.AlloraRewardsAccountName: {"minter"},
-		types.AlloraPendingRewardForDelegatorAccountName: {"minter"},
-		"ecosystem":              {"minter"},
-		"bonded_tokens_pool":     {"burner", "staking"},
-		"not_bonded_tokens_pool": {"burner", "staking"},
-		multiPerm:                {"burner", "minter", "staking"},
-		randomPerm:               {"random"},
-	}
-
-	accountKeeper := authkeeper.NewAccountKeeper(
-		encCfg.Codec,
-		storeService,
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(params.Bech32PrefixAccAddr),
-		params.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress("gov").String(),
-	)
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		log.NewNopLogger(),
-	)
-	emissionsKeeper := keeper.NewKeeper(
-		encCfg.Codec,
-		codecAddress.NewBech32Codec(params.Bech32PrefixAccAddr),
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.FeeCollectorName)
-	stakingKeeper := stakingkeeper.NewKeeper(
-		encCfg.Codec,
-		storeService,
-		accountKeeper,
-		bankKeeper,
-		authtypes.NewModuleAddress("gov").String(),
-		codecAddress.NewBech32Codec(sdk.Bech32PrefixValAddr),
-		codecAddress.NewBech32Codec(sdk.Bech32PrefixConsAddr),
-	)
-	mintKeeper := mintkeeper.NewKeeper(
-		encCfg.Codec,
-		storeService,
-		stakingKeeper,
-		accountKeeper,
-		bankKeeper,
-		emissionsKeeper,
-		authtypes.FeeCollectorName,
-	)
-
-	s.ctx = ctx
-	s.accountKeeper = accountKeeper
-	s.bankKeeper = bankKeeper
-	s.emissionsKeeper = emissionsKeeper
-	s.key = key
-	emissionsAppModule := module.NewAppModule(encCfg.Codec, s.emissionsKeeper)
-	defaultEmissionsGenesis := emissionsAppModule.DefaultGenesis(encCfg.Codec)
-	emissionsAppModule.InitGenesis(ctx, encCfg.Codec, defaultEmissionsGenesis)
-	s.msgServer = msgserver.NewMsgServerImpl(s.emissionsKeeper)
-	s.emissionsAppModule = emissionsAppModule
-	mintAppModule := mint.NewAppModule(encCfg.Codec, mintKeeper, accountKeeper)
-	defaultMintGenesis := mintAppModule.DefaultGenesis(encCfg.Codec)
-	mintAppModule.InitGenesis(ctx, encCfg.Codec, defaultMintGenesis)
-	s.mintAppModule = mintAppModule
-
-	// Fund the rewards account generously
-	s.FundAccount(10000000000, s.accountKeeper.GetModuleAddress(types.AlloraRewardsAccountName))
-
-	s.privKeys, s.pubKeyHexStr, s.addrs, s.addrsStr = alloratestutil.GenerateTestAccounts(50)
-	for _, addr := range s.addrs {
-		s.FundAccount(10000000000, addr)
-	}
-
-	// Add all tests addresses in whitelists
-	for _, addr := range s.addrsStr {
-		err := s.emissionsKeeper.AddWhitelistAdmin(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToTopicCreatorWhitelist(ctx, addr)
-		s.Require().NoError(err)
-
-		err = s.emissionsKeeper.AddToGlobalWhitelist(ctx, addr)
-		s.Require().NoError(err)
-	}
-	// topic id must not start at 0
-	id, err := s.emissionsKeeper.IncrementTopicId(s.ctx)
-	s.Require().NoError(err)
-	s.Require().NotEqual(0, id)
-}
-
-func (s *RewardsTestSuite) FundAccount(amount int64, accAddress sdk.AccAddress) {
-	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(amount)))
-	err := s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, accAddress, initialStakeCoins)
-	s.Require().NoError(err)
+	testutil.TestSuite
 }
 
 func TestRewardsTestSuite(t *testing.T) {
-	suite.Run(t, new(RewardsTestSuite))
-}
-
-func (s *RewardsTestSuite) signValueBundle(
-	reputerValueBundle *types.ValueBundle,
-	privateKey secp256k1.PrivKey,
-) []byte {
-	require := s.Require()
-	src := make([]byte, 0)
-	src, err := reputerValueBundle.XXX_Marshal(src, true)
-	require.NoError(err, "Marshall reputer value bundle should not return an error")
-	valueBundleSignature, err := privateKey.Sign(src)
-	require.NoError(err, "Sign should not return an error")
-	return valueBundleSignature
-}
-
-func (s *RewardsTestSuite) MintTokensToAddress(address sdk.AccAddress, amount cosmosMath.Int) {
-	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
-
-	err := s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, address, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
-}
-
-func (s *RewardsTestSuite) MintTokensToModule(moduleName string, amount cosmosMath.Int) {
-	creatorInitialBalanceCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, amount))
-	err := s.bankKeeper.MintCoins(s.ctx, moduleName, creatorInitialBalanceCoins)
-	s.Require().NoError(err)
-}
-
-func (s *RewardsTestSuite) RegisterAllWorkersOfPayload(topicId types.TopicId, payload *types.InputWorkerDataBundle) {
-	worker := payload.InferenceForecastsBundle.Inference.Inferer
-	// Define sample OffchainNode information for a worker
-	workerInfo := types.OffchainNode{
-		Owner:       s.addrsStr[4],
-		NodeAddress: worker,
-	}
-	err := s.emissionsKeeper.InsertWorker(s.ctx, topicId, worker, workerInfo)
-	s.Require().NoError(err)
-	for _, element := range payload.InferenceForecastsBundle.Forecast.ForecastElements {
-		worker = element.Inferer
-		workerInfo = types.OffchainNode{
-			Owner:       worker,
-			NodeAddress: worker,
-		}
-		err := s.emissionsKeeper.InsertWorker(s.ctx, topicId, worker, workerInfo)
-		s.Require().NoError(err)
-	}
-}
-
-func (s *RewardsTestSuite) RegisterAllReputersOfPayload(topicId types.TopicId, payload *types.InputReputerValueBundle) {
-	reputer := payload.ValueBundle.Reputer
-	// Define sample OffchainNode information for a worker
-	reputerInfo := types.OffchainNode{
-		Owner:       reputer,
-		NodeAddress: reputer,
-	}
-	err := s.emissionsKeeper.InsertReputer(s.ctx, topicId, reputer, reputerInfo)
-	s.Require().NoError(err)
-}
-func (s *RewardsTestSuite) TestStandardRewardEmission() {
-	block := int64(600)
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	// Reputer Addresses
-	reputerIndexes := s.returnIndexes(0, 5)
-
-	// Worker Addresses
-	workerIndexes := s.returnIndexes(5, 5)
-
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		AllowNegative:            false,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-
-	// Get Topic Id
-	topicId := res.TopicId
-
-	// Register 5 workers
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 5 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
-
-	// Add Stake for reputers
-	var stakes = []cosmosMath.Int{
-		cosmosMath.NewInt(1176644).Mul(cosmosOneE18),
-		cosmosMath.NewInt(384623).Mul(cosmosOneE18),
-		cosmosMath.NewInt(394676).Mul(cosmosOneE18),
-		cosmosMath.NewInt(207999).Mul(cosmosOneE18),
-		cosmosMath.NewInt(368582).Mul(cosmosOneE18),
-	}
-	for i, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	// Insert unfullfiled nonces
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
+	suite.Run(t, &RewardsTestSuite{
+		testutil.NewTestSuite("rewards"),
 	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
+}
+
+func (s *RewardsTestSuite) GenerateRewards(topicId uint64, block int64) ([]types.TaskReward, alloraMath.Dec) {
+	topicTotalRewards := alloraMath.NewDecFromInt64(1000000)
+	p, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 
-	// Insert inference from workers
-	InputInferenceBundles := generateWorkerDataBundles(s, block, topicId)
-	for _, payload := range InputInferenceBundles {
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
+	rewardsDistribution, totalReputerReward, err := rewards.GenerateRewardsDistributionByTopicParticipant(
+		rewards.GenerateRewardsDistributionByTopicParticipantArgs{
+			Ctx:          s.Ctx(),
+			K:            *s.EmissionsKeeper(),
+			TopicId:      topicId,
+			TopicReward:  &topicTotalRewards,
+			BlockHeight:  block,
+			ModuleParams: p,
 		})
-		s.Require().NoError(err)
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
 	s.Require().NoError(err)
-
-	newBlockheight := block + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-
-	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	block = 600 + 10800
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
+	return rewardsDistribution, totalReputerReward
 }
 
 func (s *RewardsTestSuite) TestStandardRewardEmissionShouldRewardTopicsWithFulfilledNonces() {
 	s.SetParamsForTest()
-	block := int64(600)
-	s.ctx = s.ctx.WithBlockHeight(block)
 
-	// Reputer Addresses
-	reputerIndexes := s.returnIndexes(0, 5)
+	reputerIndexes := testutil.ReturnIndexes(0, 5)
+	workerIndexes := testutil.ReturnIndexes(5, 5)
 
-	// Worker Addresses
-	workerIndexes := s.returnIndexes(5, 5)
+	// TOPIC 1 - PRE PASS
+	topicId, newBlockheight := s.FullTopicPass(workerIndexes, reputerIndexes)
 
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		AllowNegative:            false,
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
+	// TOPIC 1 - FIRST PASS
+	s.FullTopicPass(workerIndexes, reputerIndexes, testutil.WithTopicID(topicId))
+
+	beforeRewardsTopic1FeeRevenue, err := s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
-	// Get Topic Id
-	topicId := res.TopicId
+	reputerIndexes2 := testutil.ReturnIndexes(10, 5)
+	workerIndexes2 := testutil.ReturnIndexes(15, 5)
 
-	// Register 5 workers
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
+	// TOPIC 2 - PRE PASS
+	topic2 := s.FullTopicSetup(workerIndexes2, reputerIndexes2)
 
-	// Register 5 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
-
-	// Add Stake for reputers
-	var stakes = []cosmosMath.Int{
-		cosmosMath.NewInt(1176644).Mul(cosmosOneE18),
-		cosmosMath.NewInt(384623).Mul(cosmosOneE18),
-		cosmosMath.NewInt(394676).Mul(cosmosOneE18),
-		cosmosMath.NewInt(207999).Mul(cosmosOneE18),
-		cosmosMath.NewInt(368582).Mul(cosmosOneE18),
-	}
-	for i, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	initialStake := cosmosMath.NewInt(1000)
-	s.MintTokensToAddress(s.addrs[reputerIndexes[0]], initialStake)
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  initialStake,
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
+	afterRewardsTopic1FeeRevenue, err := s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topicId)
 	s.Require().NoError(err)
+
+	// Topic 1 should have less revenue after rewards distribution -> rewards distributed
 	s.Require().True(
-		s.bankKeeper.HasBalance(
-			s.ctx,
-			s.accountKeeper.GetModuleAddress(minttypes.EcosystemModuleName),
-			sdk.NewCoin(params.DefaultBondDenom, initialStake),
-		),
-		"ecosystem account should have something in it after funding",
+		beforeRewardsTopic1FeeRevenue.Equal(afterRewardsTopic1FeeRevenue),
+		"Topic 1 should not lose influence of their fee revenue yet: %s = %s",
+		beforeRewardsTopic1FeeRevenue.String(),
+		afterRewardsTopic1FeeRevenue.String(),
 	)
-
-	// Insert unfullfiled nonces
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-
-	// Insert inference from workers
-	inferenceBundles := generateWorkerDataBundles(s, block, topicId)
-	for _, payload := range inferenceBundles {
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	newBlockheight := block + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-
-	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	// Create topic 2
-	// Reputer Addresses
-	reputerIndexes = s.returnIndexes(10, 5)
-
-	// Worker Addresses
-	workerIndexes = s.returnIndexes(15, 5)
-
-	// Create topic
-	newTopicMsg = &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		AllowNegative:            false,
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err = s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-
-	// Get Topic Id
-	topicId2 := res.TopicId
-
-	// Register 5 workers
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId2,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 5 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId2,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	for i, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId2,
-		})
-		s.Require().NoError(err)
-	}
-
-	initialStake = cosmosMath.NewInt(1000)
-	s.MintTokensToAddress(s.addrs[reputerIndexes[0]], initialStake)
-	fundTopicMessage = types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId2,
-		Amount:  initialStake,
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	// Insert unfullfiled nonces
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId2, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId2, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
 
 	// Do not send bundles for topic 2 yet
 
-	beforeRewardsTopic1FeeRevenue, err := s.emissionsKeeper.GetTopicFeeRevenue(s.ctx, topicId)
+	beforeRewardsTopic2FeeRevenue, err := s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topic2.GetId())
 	s.Require().NoError(err)
-	beforeRewardsTopic2FeeRevenue, err := s.emissionsKeeper.GetTopicFeeRevenue(s.ctx, topicId2)
-	s.Require().NoError(err)
+
+	// TOPIC 2 - FIRST PASS
+	s.FullTopicPass(workerIndexes2, reputerIndexes2, testutil.WithTopicID(topic2.GetId()))
 
 	// mint some rewards to give out
 	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
 
-	newBlockheight += topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
+	newBlockheight += topic2.EpochLength + topic2.GroundTruthLag
+	s.WithBlockHeight(newBlockheight)
 
 	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
+	s.EndBlock()
 
-	afterRewardsTopic1FeeRevenue, err := s.emissionsKeeper.GetTopicFeeRevenue(s.ctx, topicId)
+	afterRewardsTopic1FeeRevenue, err = s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topicId)
 	s.Require().NoError(err)
-	afterRewardsTopic2FeeRevenue, err := s.emissionsKeeper.GetTopicFeeRevenue(s.ctx, topicId2)
+	afterRewardsTopic2FeeRevenue, err := s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topic2.GetId())
 	s.Require().NoError(err)
 
 	// Topic 1 should have less revenue after rewards distribution -> rewards distributed
@@ -634,355 +118,60 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionShouldRewardTopicsWithFulfi
 	)
 }
 
-func (s *RewardsTestSuite) setUpTopic(
-	blockHeight int64,
-	workerIndexes []int,
-	reputerIndexes []int,
-	stake cosmosMath.Int,
-	alphaRegret alloraMath.Dec,
-) uint64 {
-	return s.setUpTopicWithEpochLength(blockHeight, workerIndexes, reputerIndexes, stake, alphaRegret, 10800)
-}
-
-// Creates topic
-// Registers workers and reputers from addresses in addrsStr
-// Mints stake to reputers
-// Funds topic
-// Returns topicId
-func (s *RewardsTestSuite) setUpTopicWithEpochLength(
-	blockHeight int64,
-	workerIndexes []int,
-	reputerIndexes []int,
-	stake cosmosMath.Int,
-	alphaRegret alloraMath.Dec,
-	epochLength int64,
-) uint64 {
-	require := s.Require()
-	s.ctx = s.ctx.WithBlockHeight(blockHeight)
-
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              epochLength,
-		AllowNegative:            false,
-		GroundTruthLag:           epochLength,
-		WorkerSubmissionWindow:   min(10, epochLength-2),
-		AlphaRegret:              alphaRegret,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	require.NoError(err)
-
-	// Get Topic Id
-	topicId := res.TopicId
-
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		require.NoError(err)
-	}
-
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		require.NoError(err)
-	}
-	for _, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stake)
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stake,
-			TopicId: topicId,
-		})
-		require.NoError(err)
-	}
-
-	var initialStake int64 = 1000
-	s.MintTokensToAddress(s.addrs[reputerIndexes[0]], cosmosMath.NewInt(initialStake))
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	require.NoError(err)
-
-	return topicId
-}
-
-// Moves to end of this epoch
-// Sets current block emission
-// Ends block
-// -------
-// Moves +1 block,
-// Inserts worker bundles from workers
-// Moves to end of epoch
-// Closes reputer nonce
-// Sets rewards distribution
-// Ends Block
-// -------
-// Insert reputer bundles from reputers
-// Moves to end of ground truth lag
-// Closes reputer nonce
-// Returns rewards distribution (GenerateRewardsDistributionByTopicParticipant)
-func (s *RewardsTestSuite) getRewardsDistribution(
-	topicId uint64,
-	workerValues []TestWorkerValue,
-	reputerValues []TestWorkerValue,
-	workerZeroAddress sdk.AccAddress,
-	workerZeroOneOutInfererValue string,
-	workerZeroInfererValue string,
-) []types.TaskReward {
-	require := s.Require()
-
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
-	require.NoError(err)
-
-	// Move to end of this epoch block
-	nextBlock, _, err := s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId)
-	s.T().Logf("Moving nonce for TopicId: %d, Next block: %v", topicId, nextBlock)
-	s.Require().NoError(err)
-	blockHeight := nextBlock
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(blockHeight)
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	require.NoError(err)
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	// Advance one to send the worker data
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(blockHeight + 1)
-
-	getIndexesFromValues := func(values []TestWorkerValue) []int {
-		indexes := make([]int, 0)
-		for _, value := range values {
-			indexes = append(indexes, value.Index)
-		}
-		return indexes
-	}
-
-	workerIndexes := getIndexesFromValues(workerValues)
-
-	inferenceBundles := generateSimpleWorkerDataBundles(s, topicId, topic.EpochLastEnded, blockHeight, workerValues, workerIndexes)
-	for _, payload := range inferenceBundles {
-		s.RegisterAllWorkersOfPayload(topicId, payload)
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		require.NoError(err)
-	}
-	// Advance to close the window
-	newBlock := blockHeight + topic.WorkerSubmissionWindow
-	s.T().Logf("SubmissionWindow Next block: %v", nextBlock)
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlock)
-	// EndBlock closes the nonce
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-
-	// Insert loss bundle from reputers
-	lossBundles := generateSimpleLossBundles(
-		s,
-		topicId,
-		topic.EpochLastEnded,
-		workerValues,
-		reputerValues,
-		workerZeroAddress,
-		workerZeroOneOutInfererValue,
-		workerZeroInfererValue,
-	)
-
-	newBlockheight := blockHeight + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		s.RegisterAllReputersOfPayload(topicId, payload)
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		require.NoError(err)
-	}
-	err = actorutils.CloseReputerNonce(
-		&s.emissionsKeeper, s.ctx, topic,
-		*lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce,
-	)
-	s.Require().NoError(err)
-
-	topicTotalRewards := alloraMath.NewDecFromInt64(1000000)
-
-	rewardsDistributionByTopicParticipant, _, err := rewards.GenerateRewardsDistributionByTopicParticipant(
-		rewards.GenerateRewardsDistributionByTopicParticipantArgs{
-			Ctx:          s.ctx,
-			K:            s.emissionsKeeper,
-			TopicId:      topicId,
-			TopicReward:  &topicTotalRewards,
-			BlockHeight:  blockHeight,
-			ModuleParams: params,
-		},
-	)
-	require.NoError(err)
-
-	return rewardsDistributionByTopicParticipant
-}
-
-func areTaskRewardsEqualIgnoringTopicId(s *RewardsTestSuite, A []types.TaskReward, B []types.TaskReward) bool {
-	if len(A) != len(B) {
-		s.Fail("Lengths are different")
-	}
-
-	for _, taskRewardA := range A {
-		found := false
-		for _, taskRewardB := range B {
-			if taskRewardA.Address == taskRewardB.Address && taskRewardA.Type == taskRewardB.Type {
-				if found {
-					s.Fail("Worker %v found twice", taskRewardA.Address)
-				}
-				found = true
-				inDelta, err := alloraMath.InDelta(
-					taskRewardA.Reward,
-					taskRewardB.Reward,
-					alloraMath.MustNewDecFromString("0.00001"),
-				)
-				if err != nil {
-					s.Fail("Error finding out if taskRewardA in delta with taskRewardB",
-						taskRewardA.Reward.String(),
-						taskRewardB.Reward.String(),
-					)
-				}
-				if !inDelta {
-					return false
-				}
-			}
-		}
-		if !found {
-			s.T().Logf("Worker %v not found", taskRewardA.Address)
-			return false
-		}
-	}
-
-	return true
-}
-
 // We have 2 trials with 2 epochs each, and the first worker does better in the 2nd epoch in both trials.
 // We show that keeping the TaskRewardAlpha the same means that the worker is rewarded the same amount
 // in both cases.
 // This is a sanity test to ensure that we are isolating the effect of TaskRewardAlpha in subsequent tests.
 func (s *RewardsTestSuite) TestFixingTaskRewardAlphaDoesNotChangePerformanceImportanceOfPastVsPresent() {
-	/// SETUP
 	require := s.Require()
-	k := s.emissionsKeeper
 
-	currentParams, err := k.GetParams(s.ctx)
+	currentParams, err := s.EmissionsKeeper().GetParams(s.Ctx())
+	require.NoError(err)
+	currentParams.TaskRewardAlpha = alloraMath.MustNewDecFromString("0.1")
+	err = s.EmissionsKeeper().SetParams(s.Ctx(), currentParams)
 	require.NoError(err)
 
-	blockHeight0 := int64(100)
-	blockHeightDelta := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(blockHeight0)
-
-	workerIndexes := s.returnIndexes(0, 3)
-	reputerIndexes := s.returnIndexes(3, 3)
-
+	workerIndexes := testutil.ReturnIndexes(0, 3)
+	reputerIndexes := testutil.ReturnIndexes(3, 3)
+	values := []string{"0.1", "0.2", "0.3"}
+	workerValues := testutil.GetWorkerValuesFromIndexes(workerIndexes, values...)
+	reputerValues := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, values...)
 	stake := cosmosMath.NewInt(1000000000000000000).Mul(inferencesynthesis.CosmosIntOneE18())
-
 	alphaRegret := alloraMath.MustNewDecFromString("0.1")
-	topicId := s.setUpTopic(blockHeight0, workerIndexes, reputerIndexes, stake, alphaRegret)
 
-	workerValues := []TestWorkerValue{
-		{Index: 0, Value: "0.1"},
-		{Index: 1, Value: "0.2"},
-		{Index: 2, Value: "0.3"},
+	topicPassOpts := []testutil.Option{
+		testutil.WithReputerStake(&stake),
+		testutil.WithReputerValues(reputerValues),
+		testutil.WithWorkerValues(workerValues),
+		testutil.WithAlphaRegret(alphaRegret),
 	}
 
-	reputerValues := []TestWorkerValue{
-		{Index: 3, Value: "0.1"},
-		{Index: 4, Value: "0.2"},
-		{Index: 5, Value: "0.3"},
+	var (
+		numTopics  = 2
+		allRewards = make([][][]types.TaskReward, numTopics)
+	)
+
+	for topicNum := 0; topicNum < numTopics; topicNum++ {
+		allRewards[topicNum] = make([][]types.TaskReward, 2)
+
+		// pre-emptive run for topic setup
+		topicId, _ := s.FullTopicPass(workerIndexes, reputerIndexes, topicPassOpts...)
+
+		// for both parts of the test (A and B)
+		for part := 0; part < 2; part++ {
+			// run a full topic pass
+			opts := append(topicPassOpts, testutil.WithTopicID(topicId))
+			_, blockHeight := s.FullTopicPass(workerIndexes, reputerIndexes, opts...)
+
+			// generate rewards
+			allRewards[topicNum][part], _ = s.GenerateRewards(topicId, blockHeight)
+		}
 	}
 
-	currentParams.TaskRewardAlpha = alloraMath.MustNewDecFromString(("0.1"))
-	err = k.SetParams(s.ctx, currentParams)
-	require.NoError(err)
-
-	/// TEST 0 PART A
-
-	rewardsDistribution0_0 := s.getRewardsDistribution(
-		topicId,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	/// TEST 0 PART B
-
-	blockHeight1 := blockHeight0 + blockHeightDelta
-	s.ctx = s.ctx.WithBlockHeight(blockHeight1)
-
-	rewardsDistribution0_1 := s.getRewardsDistribution(
-		topicId,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.2",
-		"0.1",
-	)
-
-	/// TEST 1 PART A
-
-	blockHeight2 := blockHeight1 + blockHeightDelta
-	s.ctx = s.ctx.WithBlockHeight(blockHeight2)
-
-	topicId1 := s.setUpTopic(blockHeight0, workerIndexes, reputerIndexes, stake, alphaRegret)
-
-	rewardsDistribution1_0 := s.getRewardsDistribution(
-		topicId1,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	/// TEST 1 PART B
-
-	blockHeight3 := blockHeight2 + blockHeightDelta
-	s.ctx = s.ctx.WithBlockHeight(blockHeight3)
-
-	rewardsDistribution1_1 := s.getRewardsDistribution(
-		topicId1,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.2",
-		"0.1",
-	)
-
-	require.True(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_0, rewardsDistribution1_0))
-	require.True(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_1, rewardsDistribution1_1))
+	require.True(areTaskRewardsEqualIgnoringTopicId(s, allRewards[0][0], allRewards[1][0]),
+		"First part rewards should be equal between topics")
+	require.True(areTaskRewardsEqualIgnoringTopicId(s, allRewards[0][1], allRewards[1][1]),
+		"Second part rewards should be equal between topics")
 }
 
 // We have 2 trials with 2 epochs each, and the first worker does better in the 2nd epoch in both trials,
@@ -991,131 +180,105 @@ func (s *RewardsTestSuite) TestFixingTaskRewardAlphaDoesNotChangePerformanceImpo
 // means that the worker is rewarded more for their better performance in the 2nd epoch of the 2nd trial.
 func (s *RewardsTestSuite) TestIncreasingTaskRewardAlphaIncreasesImportanceOfPresentPerformance() {
 	require := s.Require()
-	k := s.emissionsKeeper
-
-	currentParams, err := k.GetParams(s.ctx)
-	require.NoError(err)
-
-	blockHeight0 := int64(100)
-	blockHeightDelta := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(blockHeight0)
-
-	workerIndexes := s.returnIndexes(0, 3)
-	reputerIndexes := s.returnIndexes(3, 3)
-
-	stake := cosmosMath.NewInt(1000000000000000000).Mul(inferencesynthesis.CosmosIntOneE18())
-
+	k := s.EmissionsKeeper()
 	alphaRegret := alloraMath.MustNewDecFromString("0.1")
-	topicId := s.setUpTopic(blockHeight0, workerIndexes, reputerIndexes, stake, alphaRegret)
 
-	workerValues := []TestWorkerValue{
-		{Index: workerIndexes[0], Value: "0.1"},
-		{Index: workerIndexes[1], Value: "0.2"},
-		{Index: workerIndexes[2], Value: "0.3"},
+	workerIndexes := testutil.ReturnIndexes(0, 3)
+	reputerIndexes := testutil.ReturnIndexes(3, 3)
+	stake := cosmosMath.NewInt(1000000000000000000).Mul(inferencesynthesis.CosmosIntOneE18())
+	workerValues := testutil.GetWorkerValuesFromIndexes(workerIndexes, "0.1", "0.2", "0.3")
+	// define the different reputer performance values for each test phase
+	normalPerformance := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.1", "0.2", "0.3")
+	improvedPerformance := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.1", "0.2", "0.3")
+	improvedPerformance[0].OneOutInfValues = map[string]string{s.AddrsStr(workerIndexes[0]): "0.2"} // first worker performs better
+	alphaValues := []string{"0.1", "0.2"}
+
+	var rewardsDistributions [2][2][]types.TaskReward // [alphaIndex][testPhase]
+
+	// run tests for each alpha value
+	for alphaIndex, alpha := range alphaValues {
+		// set the task reward alpha for this test series
+		currentParams, err := k.GetParams(s.Ctx())
+		require.NoError(err)
+		currentParams.TaskRewardAlpha = alloraMath.MustNewDecFromString(alpha)
+		err = k.SetParams(s.Ctx(), currentParams)
+		require.NoError(err)
+
+		baseOpts := []testutil.Option{
+			testutil.WithReputerStake(&stake),
+			testutil.WithAlphaRegret(alphaRegret),
+			testutil.WithWorkerValues(workerValues),
+		}
+
+		// pre-emptive run to create the topic
+		topicId, _ := s.FullTopicPass(workerIndexes, reputerIndexes, baseOpts...)
+
+		// for each test phase (normal performance and improved performance)
+		for phase := 0; phase < 2; phase++ {
+			// set the reputer values based on the phase
+			reputerPerformance := normalPerformance
+			if phase == 1 {
+				reputerPerformance = improvedPerformance
+			}
+
+			// run a full topic pass
+			opts := append(baseOpts,
+				testutil.WithTopicID(topicId),
+				testutil.WithReputerValues(reputerPerformance),
+			)
+
+			_, blockHeight := s.FullTopicPass(workerIndexes, reputerIndexes, opts...)
+
+			// generate and store rewards for comparison
+			rewardsDistributions[alphaIndex][phase], _ = s.GenerateRewards(topicId, blockHeight)
+		}
 	}
 
-	reputerValues := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.1"},
-		{Index: reputerIndexes[1], Value: "0.2"},
-		{Index: reputerIndexes[2], Value: "0.3"},
-	}
+	// ASSERTIONS
 
-	currentParams.TaskRewardAlpha = alloraMath.MustNewDecFromString("0.1")
-	err = k.SetParams(s.ctx, currentParams)
-	require.NoError(err)
+	// Check that phase 0 rewards are equal between alpha values
+	// TODO: is this necessary?
+	// require.True(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistributions[0][0], rewardsDistributions[1][0]),
+	//	"Rewards in the first phase should be equal between alphas")
 
-	/// TEST 0 PART A
+	// Check that phase 1 rewards are NOT equal between alpha values
+	require.False(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistributions[0][1], rewardsDistributions[1][1]),
+		"Rewards in the second phase should differ between alphas")
 
-	rewardsDistribution0_0 := s.getRewardsDistribution(
-		topicId,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
+	// Extract worker[0] rewards for comparing phase 1 improvements
+	var workerReward_0_1_Reward, workerReward_1_1_Reward alloraMath.Dec
 
-	/// TEST 0 PART B
-
-	blockHeight1 := blockHeight0 + blockHeightDelta
-	s.ctx = s.ctx.WithBlockHeight(blockHeight1)
-
-	rewardsDistribution0_1 := s.getRewardsDistribution(
-		topicId,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.2",
-		"0.1",
-	)
-
-	/// CHANGE TASK REWARD ALPHA
-
-	currentParams.TaskRewardAlpha = alloraMath.MustNewDecFromString(("0.2"))
-	err = k.SetParams(s.ctx, currentParams)
-	require.NoError(err)
-
-	/// TEST 1 PART A
-
-	blockHeight2 := blockHeight1 + blockHeightDelta
-	s.ctx = s.ctx.WithBlockHeight(blockHeight2)
-
-	topicId1 := s.setUpTopic(blockHeight2, workerIndexes, reputerIndexes, stake, alphaRegret)
-
-	rewardsDistribution1_0 := s.getRewardsDistribution(
-		topicId1,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	/// TEST 1 PART B
-
-	blockHeight3 := blockHeight2 + blockHeightDelta
-	s.ctx = s.ctx.WithBlockHeight(blockHeight3)
-
-	rewardsDistribution1_1 := s.getRewardsDistribution(
-		topicId1,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.2",
-		"0.1",
-	)
-
-	require.True(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_0, rewardsDistribution1_0))
-	require.False(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistribution0_1, rewardsDistribution1_1))
-
-	var workerReward_0_0_1_Reward alloraMath.Dec
+	// Get worker[0] reward for alpha=0.1, phase 1
 	found := false
-	for _, reward := range rewardsDistribution0_1 {
-		if reward.Address == s.addrsStr[workerIndexes[0]] && reward.Type == types.WorkerInferenceRewardType {
+	for _, reward := range rewardsDistributions[0][1] {
+		if reward.Address == s.AddrsStr(workerIndexes[0]) &&
+			reward.Type == types.WorkerInferenceRewardType {
 			found = true
-			workerReward_0_0_1_Reward = reward.Reward
+			workerReward_0_1_Reward = reward.Reward
+			break
 		}
 	}
-	if !found {
-		require.Fail("Worker not found")
-	}
+	require.True(found, "Worker[0] reward not found for alpha=0.1 in phase 1")
 
-	var workerReward_0_1_1_Reward alloraMath.Dec
+	// Get worker[0] reward for alpha=0.2, phase 1
 	found = false
-	for _, reward := range rewardsDistribution1_1 {
-		if reward.Address == s.addrsStr[workerIndexes[0]] && reward.Type == types.WorkerInferenceRewardType {
+	for _, reward := range rewardsDistributions[1][1] {
+		if reward.Address == s.AddrsStr(workerIndexes[0]) &&
+			reward.Type == types.WorkerInferenceRewardType {
 			found = true
-			workerReward_0_1_1_Reward = reward.Reward
+			workerReward_1_1_Reward = reward.Reward
+			break
 		}
 	}
-	if !found {
-		require.Fail("Worker not found")
-	}
+	require.True(found, "Worker[1] reward not found for alpha=0.2 in phase 1")
 
-	require.True(workerReward_0_0_1_Reward.Lt(workerReward_0_1_1_Reward))
+	// Check that worker[0] gets higher reward with higher alpha
+	require.True(workerReward_0_1_Reward.Lt(workerReward_1_1_Reward),
+		"Worker[1] reward should be higher with alpha=0.2 (%s) than with alpha=0.1 (%s)",
+		workerReward_1_1_Reward.String(), workerReward_0_1_Reward.String())
 }
 
-// We have 2 trials with 2 epochs each, and the first worker does worse in 2nd epoch in both trials,
+// We have 2 trials with 2 epochs each, and the reputer does worse in 2nd epoch in both trials,
 // enacted by their increasing loss between epochs.
 // We increase alpha between the trials to prove that their worsening performance decreases regret.
 // This is somewhat counterintuitive, but can be explained by the following passage from the litepaper:
@@ -1123,303 +286,159 @@ func (s *RewardsTestSuite) TestIncreasingTaskRewardAlphaIncreasesImportanceOfPre
 // the network's previously reported accuracy, whereas a negative regret indicates that the network
 // is expected to be more accurate."
 func (s *RewardsTestSuite) TestIncreasingAlphaRegretIncreasesPresentEffectOnRegret() {
-	/// SETUP
+	// SETUP
 	require := s.Require()
-	k := s.emissionsKeeper
+	k := s.EmissionsKeeper()
 
-	currentParams, err := k.GetParams(s.ctx)
-	require.NoError(err)
+	// Initialize indices and values
+	workerIndexes := testutil.ReturnIndexes(0, 3)
+	reputerIndexes := testutil.ReturnIndexes(3, 3)
 
-	blockHeight0 := int64(100)
-	blockHeightDelta := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(blockHeight0)
+	// Common test parameters
+	stake := cosmosMath.NewInt(1000000000000000000).Mul(cosmosMath.NewInt(1000000000000000000))
+	epochLength := int64(60)
+	groundTruthLag := int64(60)
 
-	workerIndexes := s.returnIndexes(0, 3)
-	reputerIndexes := s.returnIndexes(3, 3)
+	// Alpha values for the two trials
+	alphaValues := []string{"0.1", "0.2"}
 
-	stake := cosmosMath.NewInt(1000000000000000000).Mul(inferencesynthesis.CosmosIntOneE18())
+	addrs := []string{
+		s.AddrsStr(0),
+		s.AddrsStr(1),
+		s.AddrsStr(2),
+	}
+	slices.Sort(addrs)
 
-	alphaRegret := alloraMath.MustNewDecFromString("0.1")
-	topicId0 := s.setUpTopic(blockHeight0, workerIndexes, reputerIndexes, stake, alphaRegret)
+	// Create constant reputer values across all phases
+	phase1ReputerValues := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.1", "0.2", "0.3")
+	phase2ReputerValues := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.2", "0.2", "0.2")
+	phase2ReputerValues[0].CombinedValue = "0.1"
+	phase2ReputerValues[1].CombinedValue = "0.2"
+	phase2ReputerValues[2].CombinedValue = "0.3"
 
-	workerValues := []TestWorkerValue{
-		{Index: workerIndexes[0], Value: "0.1"},
-		{Index: workerIndexes[1], Value: "0.2"},
-		{Index: workerIndexes[2], Value: "0.3"},
+	// Worker values
+	workerValues := testutil.GetWorkerValuesFromIndexes(workerIndexes, "0.1", "0.2", "0.3")
+
+	// Common options for FullTopicPass
+	baseOptions := func(alphaRegret alloraMath.Dec, topicId uint64) []testutil.Option {
+		return []testutil.Option{
+			testutil.WithEpochLength(epochLength),
+			testutil.WithGroundTruthLag(groundTruthLag),
+			testutil.WithTopicID(topicId),
+			testutil.WithReputerStake(&stake),
+			testutil.WithAlphaRegret(alphaRegret),
+			testutil.WithWorkerValues(workerValues),
+		}
 	}
 
-	reputerValues := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.1"},
-		{Index: reputerIndexes[1], Value: "0.2"},
-		{Index: reputerIndexes[2], Value: "0.3"},
+	// Define a trial structure to store results
+	type Trial struct {
+		alphaRegret   alloraMath.Dec
+		topicId       uint64
+		firstRegret   alloraMath.Dec
+		secondRegret  alloraMath.Dec
+		decrease      alloraMath.Dec
+		decreaseRate  alloraMath.Dec
+		workerRegrets map[int]alloraMath.Dec
 	}
 
-	topic, err := k.GetTopic(s.ctx, topicId0)
-	s.Require().NoError(err)
-	topic.AlphaRegret = alloraMath.MustNewDecFromString("0.1")
-	err = k.SetTopic(s.ctx, topicId0, topic)
+	trials := make([]Trial, 2)
+
+	// Run both trials
+	for i := range trials {
+		trial := &trials[i]
+		trial.alphaRegret = alloraMath.MustNewDecFromString(alphaValues[i])
+		trial.workerRegrets = make(map[int]alloraMath.Dec)
+
+		// Set task reward alpha in params for second trial
+		if i == 1 {
+			currentParams, err := k.GetParams(s.Ctx())
+			require.NoError(err)
+			currentParams.TaskRewardAlpha = trial.alphaRegret
+			err = k.SetParams(s.Ctx(), currentParams)
+			require.NoError(err)
+		}
+
+		// Prepare options for this trial
+		options := baseOptions(trial.alphaRegret, trial.topicId)
+
+		// PHASE 0: Pre-emptive run to set up the topic
+		// Set up topic and do initial run with first phase worker values
+		phaseOptions := append(options, testutil.WithReputerValues(phase1ReputerValues))
+		trial.topicId, _ = s.FullTopicPass(workerIndexes, reputerIndexes, phaseOptions...)
+
+		// PHASE 1: First real run with initial worker values
+		phaseOptions = append(baseOptions(trial.alphaRegret, trial.topicId), testutil.WithReputerValues(phase1ReputerValues))
+		s.FullTopicPass(workerIndexes, reputerIndexes, phaseOptions...)
+
+		// Get first epoch regret for worker 0
+		worker0, _, err := k.GetInfererNetworkRegret(s.Ctx(), trial.topicId, addrs[0])
+		require.NoError(err)
+		trial.firstRegret = worker0.Value
+
+		// PHASE 2: Second run with worse worker values
+		phaseOptions = append(baseOptions(trial.alphaRegret, trial.topicId), testutil.WithReputerValues(phase2ReputerValues))
+		s.FullTopicPass(workerIndexes, reputerIndexes, phaseOptions...)
+
+		// Collect regrets for all workers
+		for j, idx := range workerIndexes {
+			worker, _, err := k.GetInfererNetworkRegret(s.Ctx(), trial.topicId, addrs[idx])
+			require.NoError(err)
+			if j == 0 {
+				trial.secondRegret = worker.Value
+			} else {
+				trial.workerRegrets[idx] = worker.Value
+			}
+		}
+
+		// Calculate regret decrease
+		trial.decrease, err = trial.firstRegret.Sub(trial.secondRegret)
+		require.NoError(err)
+		trial.decreaseRate, err = trial.decrease.Quo(trial.firstRegret)
+		require.NoError(err)
+
+		// Verify the decrease rate equals the alpha
+		require.True(trial.decreaseRate.Equal(trial.alphaRegret),
+			"Regret decrease rate should equal alpha: got %s, expected %s",
+			trial.decreaseRate.String(), trial.alphaRegret.String())
+	}
+
+	// VERIFY CROSS-TRIAL EFFECTS
+
+	// Check that higher alpha resulted in greater regret decrease rate
+	require.True(trials[1].decreaseRate.Gt(trials[0].decreaseRate),
+		"Higher alpha should cause greater regret decrease rate")
+
+	// Verify other workers' regrets behave as expected across trials
+	worker1Idx := workerIndexes[1]
+	worker2Idx := workerIndexes[2]
+
+	delta, err := alloraMath.InDelta(
+		trials[0].workerRegrets[worker1Idx],
+		trials[1].workerRegrets[worker1Idx],
+		alloraMath.MustNewDecFromString("0.00001"))
 	require.NoError(err)
+	require.True(delta, "Worker 1 regrets should be nearly identical across trials")
 
-	/// TEST 0 PART A
-
-	s.getRewardsDistribution(
-		topicId0,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	worker0_0, _, err := k.GetInfererNetworkRegret(s.ctx, topicId0, s.addrsStr[workerIndexes[0]])
-	require.NoError(err)
-
-	/// TEST 0 PART B
-
-	blockHeight1 := blockHeight0 + blockHeightDelta
-	s.ctx = s.ctx.WithBlockHeight(blockHeight1)
-
-	s.getRewardsDistribution(
-		topicId0,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.2",
-	)
-
-	worker0_0FirstRegret := worker0_0.Value
-
-	worker0_0, _, err = k.GetInfererNetworkRegret(s.ctx, topicId0, s.addrsStr[workerIndexes[0]])
-	require.NoError(err)
-
-	worker1_0, _, err := k.GetInfererNetworkRegret(s.ctx, topicId0, s.addrsStr[workerIndexes[1]])
-	require.NoError(err)
-
-	worker2_0, _, err := k.GetInfererNetworkRegret(s.ctx, topicId0, s.addrsStr[workerIndexes[2]])
-	require.NoError(err)
-
-	worker0_0RegretDecrease, err := worker0_0FirstRegret.Sub(worker0_0.Value)
-	require.NoError(err)
-	worker0_0RegretDecreaseRate, err := worker0_0RegretDecrease.Quo(worker0_0FirstRegret)
-	require.NoError(err)
-
-	require.True(worker0_0RegretDecreaseRate.Equal(alphaRegret))
-
-	/// INCREASE ALPHA REGRET
-
-	alphaRegret = alloraMath.MustNewDecFromString(("0.2"))
-	err = k.SetParams(s.ctx, currentParams)
-	require.NoError(err)
-
-	/// TEST 1 PART A
-
-	blockHeight2 := blockHeight1 + blockHeightDelta
-	s.ctx = s.ctx.WithBlockHeight(blockHeight2)
-
-	topicId1 := s.setUpTopic(blockHeight2, workerIndexes, reputerIndexes, stake, alphaRegret)
-
-	s.getRewardsDistribution(
-		topicId1,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	worker0_1, _, err := k.GetInfererNetworkRegret(s.ctx, topicId1, s.addrsStr[workerIndexes[0]])
-	require.NoError(err)
-
-	/// TEST 1 PART B
-
-	blockHeight3 := blockHeight2 + blockHeightDelta
-	s.ctx = s.ctx.WithBlockHeight(blockHeight3)
-
-	s.getRewardsDistribution(
-		topicId1,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.2",
-	)
-
-	worker0_1FirstRegret := worker0_1.Value
-
-	worker0_1, _, err = k.GetInfererNetworkRegret(s.ctx, topicId1, s.addrsStr[workerIndexes[0]])
-	require.NoError(err)
-
-	worker1_1, _, err := k.GetInfererNetworkRegret(s.ctx, topicId1, s.addrsStr[workerIndexes[1]])
-	require.NoError(err)
-
-	worker2_1, _, err := k.GetInfererNetworkRegret(s.ctx, topicId1, s.addrsStr[workerIndexes[2]])
-	require.NoError(err)
-
-	worker0_1RegretDecrease, err := worker0_1FirstRegret.Sub(worker0_1.Value)
-	require.NoError(err)
-	worker0_1RegretDecreaseRate, err := worker0_1RegretDecrease.Quo(worker0_1FirstRegret)
-	require.NoError(err)
-	require.True(worker0_1RegretDecreaseRate.Equal(alphaRegret))
-
-	// Check alpha impact in regrets - Topic 0 (alpha 0.1) vs Topic 1 (alpha 0.2)
-	require.True(worker0_1RegretDecreaseRate.Gt(worker0_0RegretDecreaseRate))
-
-	require.True(alloraMath.InDelta(worker1_0.Value, worker1_1.Value, alloraMath.MustNewDecFromString("0.00001")))
-	require.True(worker2_0.Value.Gt(worker2_1.Value))
+	require.True(trials[0].workerRegrets[worker2Idx].Gt(trials[1].workerRegrets[worker2Idx]),
+		"Worker 2 regret in trial 0 should be greater than in trial 1")
 }
 
 func (s *RewardsTestSuite) TestGenerateTasksRewardsShouldIncreaseRewardShareIfMoreParticipants() {
-	block := int64(100)
-	s.ctx = s.ctx.WithBlockHeight(block)
+	// TOPIC 1 - PRE PASS
+	workerIndexes := testutil.ReturnIndexes(5, 5)
+	reputerIndexes := testutil.ReturnIndexes(0, 3)
+	topicId, _ := s.FullTopicPass(workerIndexes, reputerIndexes)
 
-	reputerIndexes := s.returnIndexes(0, 3)
-	workerIndexes := s.returnIndexes(5, 5)
+	// TOPIC 1 - FIRST PASS
+	_, block := s.FullTopicPass(workerIndexes, reputerIndexes, testutil.WithTopicID(topicId))
 
-	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
+	firstRewardsDistribution, firstTotalReputerReward := s.GenerateRewards(topicId, block)
 
-	stakes := []cosmosMath.Int{
-		cosmosMath.NewInt(1000000000000000000).Mul(cosmosOneE18),
-		cosmosMath.NewInt(1000000000000000000).Mul(cosmosOneE18),
-		cosmosMath.NewInt(1000000000000000000).Mul(cosmosOneE18),
-	}
-
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		AllowNegative:            false,
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-
-	// Get Topic Id
-	topicId := res.TopicId
-
-	// Register 5 workers
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 3 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-	// Add Stake for reputers
-	for i, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	var initialStake int64 = 1000
-	s.FundAccount(initialStake, s.addrs[reputerIndexes[0]])
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-
-	// Insert inference from workers
-	inferenceBundles := generateWorkerDataBundles(s, block, topicId)
-	for _, payload := range inferenceBundles {
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	// Move to end of worker submission window
-	s.ctx = s.ctx.WithBlockHeight(block + topic.WorkerSubmissionWindow)
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
-	s.Require().NoError(err)
-
-	newBlockheight := block + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-
-	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-	err = actorutils.CloseReputerNonce(
-		&s.emissionsKeeper, s.ctx, topic,
-		*lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce,
+	var (
+		calcFirstTotalReputerReward = alloraMath.ZeroDec()
+		err                         error
 	)
-	s.Require().NoError(err)
-
-	topicTotalRewards := alloraMath.NewDecFromInt64(1000000)
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
-	s.Require().NoError(err)
-
-	firstRewardsDistribution, firstTotalReputerReward, err := rewards.GenerateRewardsDistributionByTopicParticipant(rewards.GenerateRewardsDistributionByTopicParticipantArgs{
-		Ctx:          s.ctx,
-		K:            s.emissionsKeeper,
-		TopicId:      topicId,
-		TopicReward:  &topicTotalRewards,
-		BlockHeight:  block,
-		ModuleParams: params,
-	})
-	s.Require().NoError(err)
-
-	calcFirstTotalReputerReward := alloraMath.ZeroDec()
 	for _, reward := range firstRewardsDistribution {
 		if reward.Type == types.ReputerAndDelegatorRewardType {
 			calcFirstTotalReputerReward, err = calcFirstTotalReputerReward.Add(reward.Reward)
@@ -1439,151 +458,15 @@ func (s *RewardsTestSuite) TestGenerateTasksRewardsShouldIncreaseRewardShareIfMo
 		calcFirstTotalReputerReward.String(),
 	)
 
-	block += 1
-	s.ctx = s.ctx.WithBlockHeight(block)
+	// TOPIC 2 - PRE PASS
+	workerIndexes2 := testutil.ReturnIndexes(5, 5)
+	reputerIndexes2 := testutil.ReturnIndexes(0, 5)
+	topicId2, _ := s.FullTopicPass(workerIndexes2, reputerIndexes2)
 
-	// Add new reputers and stakes
-	newReputerIndexes := []int{3, 4}
-	reputerIndexes = append(reputerIndexes, newReputerIndexes...)
+	// TOPIC 2 - FIRST PASS
+	_, block = s.FullTopicPass(workerIndexes2, reputerIndexes2, testutil.WithTopicID(topicId2))
 
-	// Add Stake for new reputers
-	newStakes := []cosmosMath.Int{
-		cosmosMath.NewInt(1000000000000000000).Mul(cosmosOneE18),
-		cosmosMath.NewInt(1000000000000000000).Mul(cosmosOneE18),
-	}
-	stakes = append(stakes, newStakes...)
-
-	// Create new topic
-	newTopicMsg = &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		AllowNegative:            false,
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err = s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-
-	// Get Topic Id
-	topicId = res.TopicId
-
-	// Register 5 workers
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 5 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-	// Add Stake for reputers
-	for i, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	s.FundAccount(initialStake, s.addrs[reputerIndexes[0]])
-
-	fundTopicMessage = types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-
-	// Insert inference from workers
-	inferenceBundles = generateWorkerDataBundles(s, block, topicId)
-	for _, payload := range inferenceBundles {
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err = s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	// Move to end of worker submission window
-	s.ctx = s.ctx.WithBlockHeight(block + topic.WorkerSubmissionWindow)
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
-	s.Require().NoError(err)
-
-	newBlockheight += topic.GroundTruthLag - 1
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-
-	// Insert loss bundle from reputers
-	lossBundles = generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-	err = actorutils.CloseReputerNonce(
-		&s.emissionsKeeper, s.ctx, topic,
-		*lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce,
-	)
-	s.Require().NoError(err)
-
-	secondRewardsDistribution, secondTotalReputerReward, err := rewards.GenerateRewardsDistributionByTopicParticipant(
-		rewards.GenerateRewardsDistributionByTopicParticipantArgs{
-			Ctx:          s.ctx,
-			K:            s.emissionsKeeper,
-			TopicId:      topicId,
-			TopicReward:  &topicTotalRewards,
-			BlockHeight:  block,
-			ModuleParams: params,
-		})
-	s.Require().NoError(err)
+	secondRewardsDistribution, secondTotalReputerReward := s.GenerateRewards(topicId2, block)
 
 	calcSecondTotalReputerReward := alloraMath.ZeroDec()
 	for _, reward := range secondRewardsDistribution {
@@ -1614,92 +497,64 @@ func (s *RewardsTestSuite) TestMultipleEpochsWeightAndStdNormEvolution() {
 
 	// Initial setup
 	block := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(block)
+	s.WithBlockHeight(block)
 
-	alphaRegret := alloraMath.MustNewDecFromString("0.1")
 	s.SetParamsForTest()
-
-	// Set up single topic with workers and reputers
-	workerIndexes := s.returnIndexes(0, 3)
-	reputerIndexes := s.returnIndexes(3, 3)
-
-	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
 
 	// Create topic with shorter epoch length for testing multiple epochs
 	epochLength := int64(5)
-	topicId := s.setUpTopicWithEpochLength(block, workerIndexes, reputerIndexes, stake, alphaRegret, epochLength)
-
-	// Initial worker and reputer values
-	workerValues := []TestWorkerValue{
-		{Index: workerIndexes[0], Value: "0.1"},
-		{Index: workerIndexes[1], Value: "0.2"},
-		{Index: workerIndexes[2], Value: "0.3"},
-	}
-
-	reputerValues := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.1"},
-		{Index: reputerIndexes[1], Value: "0.2"},
-		{Index: reputerIndexes[2], Value: "0.3"},
-	}
-
-	// Fund topic
-	initialStake := cosmosMath.NewInt(1000)
-	s.MintTokensToAddress(s.addrs[reputerIndexes[0]], initialStake)
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  initialStake,
-	}
-	_, err := s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	require.NoError(err)
+	groundTruthLag := int64(5)
+	workerIndexes := testutil.ReturnIndexes(0, 3)
+	reputerIndexes := testutil.ReturnIndexes(3, 3)
+	topicId, _ := s.FullTopicPass(
+		workerIndexes,
+		reputerIndexes,
+		testutil.WithBlock(block),
+		testutil.WithAlphaRegret(alloraMath.MustNewDecFromString("0.1")),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithGroundTruthLag(groundTruthLag),
+	)
 
 	// Track weights and stdnorm over epochs
-	var workerWeights = make(map[string][]alloraMath.Dec)
-	var stdNorms []alloraMath.Dec
+	var (
+		workerWeights = make(map[string][]alloraMath.Dec)
+		stdNorms      []alloraMath.Dec
+	)
 
-	numEpochs := 5
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), topicId)
+	s.Require().NoError(err)
+
+	const numEpochs = 10
 	// Run multiple epochs
-	for epoch := 0; epoch < numEpochs; epoch++ {
+	for range numEpochs {
+		baseOptions := []testutil.Option{
+			testutil.WithAlphaRegret(alloraMath.MustNewDecFromString("0.1")),
+			testutil.WithBlock(block + epochLength + topic.GroundTruthLag),
+			testutil.WithTopicID(topicId),
+		}
+
+		topicId, block = s.FullTopicPass(workerIndexes, reputerIndexes, baseOptions...)
+
 		// Get current weight and stdnorm before processing
-		stdNorm, err := s.emissionsKeeper.GetLatestRegretStdNorm(s.ctx, topicId)
+		stdNorm, err := s.EmissionsKeeper().GetLatestRegretStdNorm(s.Ctx(), topicId)
 		require.NoError(err)
 		stdNorms = append(stdNorms, stdNorm)
-
-		// Process worker submissions
-		s.getRewardsDistribution(
-			topicId,
-			workerValues,
-			reputerValues,
-			s.addrs[workerIndexes[0]],
-			fmt.Sprintf("0.%d", epoch+1), // Varying predictions
-			fmt.Sprintf("0.%d", epoch+1), // Varying ground truth
-		)
-
-		for _, index := range workerIndexes {
-			weight, err := s.emissionsKeeper.GetLatestInfererWeight(s.ctx, topicId, s.addrsStr[index])
-			s.Require().NoError(err)
-			workerWeights[s.addrsStr[index]] = append(workerWeights[s.addrsStr[index]], weight)
-		}
 
 		// Mint rewards
 		s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
 
-		// Move to next epoch
-		block += epochLength
-		s.ctx = s.ctx.WithBlockHeight(block)
-
-		// Distribute rewards
-		err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-		require.NoError(err)
-		err = s.emissionsAppModule.EndBlock(s.ctx)
-		require.NoError(err)
+		for _, index := range workerIndexes {
+			weight, err := s.EmissionsKeeper().GetLatestInfererWeight(s.Ctx(), topicId, s.AddrsStr(index))
+			s.Require().NoError(err)
+			workerWeights[s.AddrsStr(index)] = append(workerWeights[s.AddrsStr(index)], weight)
+		}
 	}
 
 	// Verify weight evolution
 	require.Len(workerWeights, 3) // one entry per worker
-	for i := 1; i < len(workerWeights); i++ {
+	for i := 0; i < len(workerWeights); i++ {
 		// Weight for the same worker should change between epochs
-		currentWorker := s.addrsStr[i]
+		currentWorker := s.AddrsStr(i)
 		currentWorkerWeights := workerWeights[currentWorker]
 		// check weights are different from diff actors
 		for j := 1; j < len(currentWorkerWeights); j++ {
@@ -1709,7 +564,7 @@ func (s *RewardsTestSuite) TestMultipleEpochsWeightAndStdNormEvolution() {
 				"Weight should change between epochs %d and %d", j-1, j,
 			)
 		}
-		s.T().Logf("Worker %d , %s Weight: %v", i, s.addrsStr[i], currentWorkerWeights)
+		s.T().Logf("Worker %d , %s Weight: %v", i, s.AddrsStr(i), currentWorkerWeights)
 	}
 
 	// Verify stdnorm evolution
@@ -1723,1357 +578,99 @@ func (s *RewardsTestSuite) TestMultipleEpochsWeightAndStdNormEvolution() {
 		)
 		s.T().Logf("StdNorm: %v", stdNorms[i].String())
 	}
-
 }
 
 func (s *RewardsTestSuite) TestRewardsIncreasesBalance() {
-	block := int64(600)
-	s.ctx = s.ctx.WithBlockHeight(block)
-	epochLength := int64(10800)
 	s.MintTokensToModule(types.AlloraStakingAccountName, cosmosMath.NewInt(10000000000))
 
-	// Reputer Addresses
-	reputerIndexes := s.returnIndexes(0, 5)
-	// Worker Addresses
-	workerIndexes := s.returnIndexes(5, 5)
+	workerIndexes := testutil.ReturnIndexes(5, 5)
+	reputerIndexes := testutil.ReturnIndexes(0, 5)
+	// TOPIC 1 - PRE PASS
+	topicId, _ := s.FullTopicPass(workerIndexes, reputerIndexes)
 
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              epochLength,
-		AllowNegative:            false,
-		GroundTruthLag:           epochLength,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-
-	// Get Topic Id
-	topicId := res.TopicId
-
-	// Register 5 workers
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 5 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
-
-	// Add Stake for reputers
-	var stakes = []cosmosMath.Int{
-		cosmosMath.NewInt(1176644).Mul(cosmosOneE18),
-		cosmosMath.NewInt(984623).Mul(cosmosOneE18),
-		cosmosMath.NewInt(994676).Mul(cosmosOneE18),
-		cosmosMath.NewInt(907999).Mul(cosmosOneE18),
-		cosmosMath.NewInt(868582).Mul(cosmosOneE18),
-	}
-	for _, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[index])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[index],
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	initialStake := cosmosMath.NewInt(1000)
-	s.MintTokensToAddress(s.addrs[reputerIndexes[0]], initialStake)
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  initialStake,
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	// Insert unfullfiled nonces
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-
-	reputerBalances := make([]sdk.Coin, 5)
+	var err error
 	reputerStake := make([]cosmosMath.Int, 5)
 	for _, index := range reputerIndexes {
-		reputerBalances[index] = s.bankKeeper.GetBalance(s.ctx, s.addrs[index], params.DefaultBondDenom)
-		reputerStake[index], err = s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId, s.addrsStr[index])
+		reputerStake[index], err = s.EmissionsKeeper().GetStakeReputerAuthority(s.Ctx(), topicId, s.AddrsStr(index))
 		s.Require().NoError(err)
 	}
 
 	workerBalances := make(map[int]sdk.Coin)
 	for _, index := range workerIndexes {
-		workerBalances[index] = s.bankKeeper.GetBalance(s.ctx, s.addrs[index], params.DefaultBondDenom)
+		workerBalances[index] = s.BankKeeper().GetBalance(s.Ctx(), s.Addrs(index), params.DefaultBondDenom)
 	}
 
-	// Insert inference from workers
-	inferenceBundles := generateWorkerDataBundles(s, block, topicId)
-	for _, payload := range inferenceBundles {
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	// Move to end of worker submission window
-	s.ctx = s.ctx.WithBlockHeight(block + topic.WorkerSubmissionWindow)
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
-	s.Require().NoError(err)
-
-	newBlockheight := block + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-
-	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-
-	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	err = actorutils.CloseReputerNonce(&s.emissionsKeeper, s.ctx, topic, *lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce)
-	s.Require().NoError(err)
-
-	// mint some rewards to give out
-	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
-
-	// Trigger end block - rewards distribution
-	newBlockheight += epochLength
-	s.ctx = s.ctx.WithBlockHeight(newBlockheight)
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
+	// TOPIC 1 - FIRST PASS
+	s.FullTopicPass(workerIndexes, reputerIndexes, testutil.WithTopicID(topicId))
 
 	for i, index := range reputerIndexes {
-		reputerStakeCurrent, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId, s.addrsStr[index])
+		reputerStakeCurrent, err := s.EmissionsKeeper().GetStakeReputerAuthority(s.Ctx(), topicId, s.AddrsStr(index))
 		s.Require().NoError(err)
 		s.Require().True(
 			reputerStakeCurrent.GT(reputerStake[i]),
 			"Reputer %s stake did not increase: %s | %s",
-			s.addrsStr[index],
+			s.AddrsStr(index),
 			reputerStakeCurrent.String(),
 			reputerStake[i].String(),
 		)
 	}
 
 	for _, index := range workerIndexes {
-		s.Require().True(s.bankKeeper.GetBalance(s.ctx, s.addrs[index], params.DefaultBondDenom).Amount.GT(workerBalances[index].Amount))
+		s.Require().True(s.BankKeeper().GetBalance(s.Ctx(), s.Addrs(index), params.DefaultBondDenom).Amount.GT(workerBalances[index].Amount))
 	}
-}
-
-func (s *RewardsTestSuite) TestRewardsHandleStandardDeviationOfZero() {
-	block := int64(600)
-	s.ctx = s.ctx.WithBlockHeight(block)
-	epochLength := int64(10800)
-
-	// Reputer Addresses
-	reputerIndexes := s.returnIndexes(0, 5)
-	// Worker Addresses
-	workerIndexes := s.returnIndexes(5, 5)
-
-	// Create first topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              epochLength,
-		AllowNegative:            false,
-		GroundTruthLag:           epochLength,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	// Get Topic Id for first topic
-	topicId1 := res.TopicId
-	res, err = s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId2 := res.TopicId
-
-	// Register 5 workers, first 3 for topic 1 and last 2 for topic 2
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId1,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		// Full registration of all workers in both topics.
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-
-		workerRegMsg.TopicId = topicId2
-		_, err = s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 5 reputers, first 3 for topic 1 and last 2 for topic 2
-	for i, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			Owner:     s.addrsStr[index],
-			TopicId:   topicId1,
-			IsReputer: true,
-		}
-		if i > 2 {
-			reputerRegMsg.TopicId = topicId2
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
-
-	// Add Stake for reputers
-	var stakes = []cosmosMath.Int{
-		cosmosMath.NewInt(1176644).Mul(cosmosOneE18),
-		cosmosMath.NewInt(384623).Mul(cosmosOneE18),
-		cosmosMath.NewInt(394676).Mul(cosmosOneE18),
-		cosmosMath.NewInt(207999).Mul(cosmosOneE18),
-		cosmosMath.NewInt(368582).Mul(cosmosOneE18),
-	}
-	for i, index := range reputerIndexes {
-		addStakeMsg := &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId1,
-		}
-		if i > 2 {
-			addStakeMsg.TopicId = topicId2
-		}
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, addStakeMsg)
-		s.Require().NoError(err)
-	}
-
-	// fund topic 1
-	var initialStake int64 = 1000
-	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake)))
-	err = s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, s.addrs[reputerIndexes[0]], initialStakeCoins)
-	s.Require().NoError(err)
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId1,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	// fund topic 2
-	err = s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, s.addrs[reputerIndexes[0]], initialStakeCoins)
-	s.Require().NoError(err)
-	fundTopicMessage.TopicId = topicId2
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	// Insert unfullfiled nonces
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId1, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId1, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId2, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId2, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-
-	reputerBalances := make([]sdk.Coin, 5)
-	reputerStake := make([]cosmosMath.Int, 5)
-	for i, index := range reputerIndexes {
-		reputerBalances[i] = s.bankKeeper.GetBalance(s.ctx, s.addrs[index], params.DefaultBondDenom)
-		if i > 2 {
-			reputerStake[i], err = s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId2, s.addrsStr[index])
-			s.Require().NoError(err)
-		} else {
-			reputerStake[i], err = s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[index])
-			s.Require().NoError(err)
-		}
-	}
-
-	workerBalances := make([]sdk.Coin, 5)
-	for i, index := range workerIndexes {
-		workerBalances[i] = s.bankKeeper.GetBalance(s.ctx, s.addrs[index], params.DefaultBondDenom)
-	}
-
-	// Insert inference from workers
-	inferenceBundles := generateWorkerDataBundles(s, block, topicId1)
-	for _, payload := range inferenceBundles {
-		s.RegisterAllWorkersOfPayload(topicId1, payload)
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	inferenceBundles2 := generateWorkerDataBundles(s, block, topicId2)
-	for _, payload := range inferenceBundles2 {
-		s.RegisterAllWorkersOfPayload(topicId2, payload)
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId1)
-	s.Require().NoError(err)
-
-	newBlockheight := block + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-
-	// Insert loss bundle from reputers
-	lossBundles := generateLossBundles(s, block, topicId1, reputerIndexes, workerIndexes)
-	for i, payload := range lossBundles.ReputerValueBundles {
-		s.RegisterAllReputersOfPayload(topicId1, payload)
-		if i <= 2 {
-			_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId1, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-			_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId1, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-			_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-				Sender:             payload.ValueBundle.Reputer,
-				ReputerValueBundle: payload,
-			})
-			s.Require().NoError(err)
-		}
-	}
-
-	topic2, err := s.emissionsKeeper.GetTopic(s.ctx, topicId2)
-	s.Require().NoError(err)
-
-	newBlockheight = block + topic2.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-
-	lossBundles2 := generateLossBundles(s, block, topicId2, reputerIndexes, workerIndexes)
-	for i, payload := range lossBundles2.ReputerValueBundles {
-		s.RegisterAllReputersOfPayload(topicId2, payload)
-		if i > 2 {
-			_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId2, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-			_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId2, payload.ValueBundle.ReputerRequestNonce.ReputerNonce)
-			_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-				Sender:             payload.ValueBundle.Reputer,
-				ReputerValueBundle: payload,
-			})
-			s.Require().NoError(err)
-		}
-	}
-
-	block += epochLength * 3
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	// mint some rewards to give out
-	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(10000000000))
-
-	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
 }
 
 func (s *RewardsTestSuite) TestStandardRewardEmissionWithOneInfererAndOneReputer() {
-	blockHeight := int64(600)
-	s.ctx = s.ctx.WithBlockHeight(blockHeight)
 	epochLength := int64(10800)
 
-	// Reputer Addresses
-	reputer := 0
-	// Worker Addresses
-	worker := 5
-
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputer],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              epochLength,
-		GroundTruthLag:           epochLength,
-		AllowNegative:            false,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	// Get Topic Id
-	topicId := res.TopicId
-
-	// Register 1 worker
-	workerRegMsg := &types.RegisterRequest{
-		Sender:    s.addrsStr[worker],
-		TopicId:   topicId,
-		IsReputer: false,
-		Owner:     s.addrsStr[worker],
-	}
-	_, err = s.msgServer.Register(s.ctx, workerRegMsg)
-	s.Require().NoError(err)
-
-	// Register 1 reputer
-	reputerRegMsg := &types.RegisterRequest{
-		Sender:    s.addrsStr[reputer],
-		TopicId:   topicId,
-		IsReputer: true,
-		Owner:     s.addrsStr[reputer],
-	}
-	_, err = s.msgServer.Register(s.ctx, reputerRegMsg)
-	s.Require().NoError(err)
-
-	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
-
-	s.MintTokensToAddress(s.addrs[reputer], cosmosMath.NewInt(1176644).Mul(cosmosOneE18))
-	// Add Stake for reputer
-	_, err = s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-		Sender:  s.addrsStr[reputer],
-		Amount:  cosmosMath.NewInt(1176644).Mul(cosmosOneE18),
-		TopicId: topicId,
-	})
-	s.Require().NoError(err)
-
-	var initialStake int64 = 1000
-	initialStakeCoins := sdk.NewCoins(sdk.NewCoin(params.DefaultBondDenom, cosmosMath.NewInt(initialStake)))
-	err = s.bankKeeper.MintCoins(s.ctx, types.AlloraStakingAccountName, initialStakeCoins)
-	s.Require().NoError(err)
-	err = s.bankKeeper.SendCoinsFromModuleToAccount(s.ctx, types.AlloraStakingAccountName, s.addrs[reputer], initialStakeCoins)
-	s.Require().NoError(err)
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[reputer],
-		TopicId: topicId,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-	// Insert unfullfiled nonces
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: blockHeight,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: blockHeight,
-	})
-	s.Require().NoError(err)
-
-	// Insert inference from worker
-	worker1InferenceForecastBundle := &types.InputInferenceForecastBundle{
-		Inference: &types.InputInference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker],
-			Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01127")),
-			ExtraData:   []byte("extra data"),
-			Proof:       "",
-		},
-		Forecast: nil,
-	}
-	worker1Sig, err := signInputInferenceForecastBundle(worker1InferenceForecastBundle, s.privKeys[worker])
-	s.Require().NoError(err)
-	worker1Bundle := &types.InputWorkerDataBundle{
-		Worker:                             s.addrsStr[worker],
-		TopicId:                            topicId,
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		InferenceForecastsBundle:           worker1InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker1Sig,
-		Pubkey:                             s.pubKeyHexStr[worker],
-	}
-	_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-		Sender:           s.addrsStr[worker],
-		WorkerDataBundle: worker1Bundle,
-	})
-	s.Require().NoError(err)
-
-	// Insert loss bundle from reputer
-	valueBundle := &types.InputValueBundle{
-		TopicId: topicId,
-		ReputerRequestNonce: &types.ReputerRequestNonce{
-			ReputerNonce: &types.Nonce{
-				BlockHeight: blockHeight,
-			},
-		},
-		ExtraData:                     nil,
-		Reputer:                       s.addrsStr[reputer],
-		CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01127")),
-		NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0116")),
-		InfererValues:                 []*types.InputWorkerAttributedValue{{Worker: s.addrsStr[worker], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0112"))}},
-		ForecasterValues:              []*types.InputWorkerAttributedValue{},
-		OneOutInfererValues:           []*types.InputWithheldWorkerAttributedValue{},
-		OneOutForecasterValues:        []*types.InputWithheldWorkerAttributedValue{},
-		OneInForecasterValues:         []*types.InputWorkerAttributedValue{},
-		OneOutInfererForecasterValues: nil,
-	}
-	sig, err := signInputValueBundle(valueBundle, s.privKeys[reputer])
-	s.Require().NoError(err)
-	reputerBundle := &types.InputReputerValueBundle{
-		Pubkey:      s.pubKeyHexStr[reputer],
-		Signature:   sig,
-		ValueBundle: valueBundle,
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	newBlockheight := blockHeight + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-
-	_, _ = s.emissionsKeeper.FulfillWorkerNonce(s.ctx, topicId, reputerBundle.ValueBundle.ReputerRequestNonce.ReputerNonce)
-	_ = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, reputerBundle.ValueBundle.ReputerRequestNonce.ReputerNonce)
-
-	_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-		Sender:             s.addrsStr[reputer],
-		ReputerValueBundle: reputerBundle,
-	})
-	s.Require().NoError(err)
+	_, blockHeight := s.FullTopicPass([]int{0}, []int{5}, testutil.WithEpochLength(epochLength))
 
 	blockHeight += epochLength * 3
-	s.ctx = s.ctx.WithBlockHeight(blockHeight)
+	s.WithBlockHeight(blockHeight)
 
 	// mint some rewards to give out
 	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(10000000000))
 
 	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-}
-
-func (s *RewardsTestSuite) SetParamsForTest() {
-	// Setup a sender address
-	adminPrivateKey := secp256k1.GenPrivKey()
-	adminAddr := sdk.AccAddress(adminPrivateKey.PubKey().Address())
-	err := s.emissionsKeeper.AddWhitelistAdmin(s.ctx, adminAddr.String())
-	s.Require().NoError(err)
-
-	newParams := &types.OptionalParams{
-		MaxTopInferersToReward:  []uint64{24},
-		MinEpochLength:          []int64{1},
-		RegistrationFee:         []cosmosMath.Int{cosmosMath.NewInt(6)},
-		MaxActiveTopicsPerBlock: []uint64{2},
-		BlocksPerMonth:          []uint64{864000},
-		// Exaggerated TopicRewardAlpha to compensate the effect of latest topic reward alpha vs
-		// the dripping effect and separate epochs running multiple topics.
-		TopicRewardAlpha: []alloraMath.Dec{alloraMath.MustNewDecFromString("0.999375")},
-		// the following fields are not set
-		Version:                             nil,
-		MaxSerializedMsgLength:              nil,
-		MinTopicWeight:                      nil,
-		RequiredMinimumStake:                nil,
-		RemoveStakeDelayWindow:              nil,
-		BetaEntropy:                         nil,
-		LearningRate:                        nil,
-		MaxGradientThreshold:                nil,
-		MinStakeFraction:                    nil,
-		MaxUnfulfilledWorkerRequests:        nil,
-		MaxUnfulfilledReputerRequests:       nil,
-		TopicRewardStakeImportance:          nil,
-		TopicRewardFeeRevenueImportance:     nil,
-		TaskRewardAlpha:                     nil,
-		ValidatorsVsAlloraPercentReward:     nil,
-		MaxSamplesToScaleScores:             nil,
-		MaxTopForecastersToReward:           nil,
-		MaxTopReputersToReward:              nil,
-		CreateTopicFee:                      nil,
-		GradientDescentMaxIters:             nil,
-		DefaultPageLimit:                    nil,
-		MaxPageLimit:                        nil,
-		MinEpochLengthRecordLimit:           nil,
-		PRewardInference:                    nil,
-		PRewardForecast:                     nil,
-		PRewardReputer:                      nil,
-		CRewardInference:                    nil,
-		CRewardForecast:                     nil,
-		CNorm:                               nil,
-		EpsilonReputer:                      nil,
-		HalfMaxProcessStakeRemovalsEndBlock: nil,
-		DataSendingFee:                      nil,
-		EpsilonSafeDiv:                      nil,
-		MaxElementsPerForecast:              nil,
-		MaxStringLength:                     nil,
-		InitialRegretQuantile:               nil,
-		PNormSafeDiv:                        nil,
-		GlobalWhitelistEnabled:              nil,
-		TopicCreatorWhitelistEnabled:        nil,
-		MinExperiencedWorkerRegrets:         nil,
-		InferenceOutlierDetectionThreshold:  nil,
-		InferenceOutlierDetectionAlpha:      nil,
-		LambdaInitialScore:                  nil,
-		GlobalWorkerWhitelistEnabled:        nil,
-		GlobalReputerWhitelistEnabled:       nil,
-		GlobalAdminWhitelistAppended:        nil,
-		MaxWhitelistInputArrayLength:        nil,
-		MinWeightThresholdForStdnorm:        nil,
-	}
-
-	updateMsg := &types.UpdateParamsRequest{
-		Sender: adminAddr.String(),
-		Params: newParams,
-	}
-
-	response, err := s.msgServer.UpdateParams(s.ctx, updateMsg)
-	s.Require().NoError(err)
-	s.Require().NotNil(response)
+	s.EndBlock()
 }
 
 func (s *RewardsTestSuite) TestOnlyFewTopActorsGetReward() {
-	block := int64(600)
-	s.ctx = s.ctx.WithBlockHeight(block)
-	epochLength := int64(10800)
-
-	// Reputer Addresses
-	var reputerIndexes = make([]int, 0)
-	var workerIndexes = make([]int, 0)
-	var stakes = make([]cosmosMath.Int, 0)
-	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
-
 	s.SetParamsForTest()
 
-	for i := 0; i < 25; i++ {
-		reputerIndexes = append(reputerIndexes, i)
-		workerIndexes = append(workerIndexes, i+25)
-		stakes = append(stakes, cosmosMath.NewInt(int64(1000*(i+1))).Mul(cosmosOneE18))
-	}
+	// Reputer Addresses
+	reputerIndexes := testutil.ReturnIndexes(0, 25)
+	workerIndexes := testutil.ReturnIndexes(25, 25)
 
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		AllowNegative:            false,
-		EpochLength:              epochLength,
-		GroundTruthLag:           epochLength,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
+	topicId, _ := s.FullTopicPass(workerIndexes, reputerIndexes)
+	_, block := s.FullTopicPass(workerIndexes, reputerIndexes, testutil.WithTopicID(topicId))
 
-	// Get Topic Id
-	topicId := res.TopicId
-
-	// Register 25 workers
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 25 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	for i, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	var initialStake int64 = 1000
-	s.FundAccount(initialStake, s.addrs[reputerIndexes[0]])
-
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	// Insert unfullfiled nonces
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-
-	// Insert inference from workers
-	inferenceBundles := generateHugeWorkerDataBundles(s, block, topicId, workerIndexes)
-	for _, payload := range inferenceBundles {
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	// Move to end of worker submission window
-	s.ctx = s.ctx.WithBlockHeight(block + topic.WorkerSubmissionWindow)
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
-	s.Require().NoError(err)
-
-	newBlockheight := block + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(newBlockheight)
-
-	// Insert loss bundle from reputers
-	lossBundles := generateHugeLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             s.addrsStr[reputerIndexes[0]],
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-	err = actorutils.CloseReputerNonce(&s.emissionsKeeper, s.ctx, topic, *lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce)
-	s.Require().NoError(err)
-
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
-	s.Require().NoError(err)
-
-	//scoresAtBlock, err := s.emissionsKeeper.GetReputersScoresAtBlock(s.ctx, topicId, block)
-	//s.Require().Equal(len(scoresAtBlock.Scores), int(params.GetMaxTopReputersToReward()), "Only few Top reputers can get reward")
-
-	networkLossBundles, err := s.emissionsKeeper.GetNetworkLossBundleAtBlock(s.ctx, topicId, block)
+	networkLossBundles, err := s.EmissionsKeeper().GetNetworkLossBundleAtBlock(s.Ctx(), topicId, block)
 	s.Require().NoError(err)
 	s.Require().NotNil(networkLossBundles)
 
 	infererScores, err := rewards.GenerateInferenceScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block,
 		*networkLossBundles)
 	s.Require().NoError(err)
 
 	forecasterScores, err := rewards.GenerateForecastScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block,
 		*networkLossBundles)
 	s.Require().NoError(err)
 
-	s.Require().Equal(uint64(len(infererScores)), params.GetMaxTopInferersToReward(), "Only few Top inferers can get reward")
-	s.Require().Equal(uint64(len(forecasterScores)), params.GetMaxTopForecastersToReward(), "Only few Top forecasters can get reward")
+	p, err := s.EmissionsKeeper().GetParams(s.Ctx())
+	s.Require().NoError(err)
+
+	s.Require().Equal(p.GetMaxTopInferersToReward(), uint64(len(infererScores)), "Only few Top inferers can get reward")
+	s.Require().Equal(p.GetMaxTopForecastersToReward(), uint64(len(forecasterScores)), "Only few Top forecasters can get reward")
 }
-
-/* to be rewritten in PROTO-3088
-func (s *RewardsTestSuite) TestTotalInferersRewardFractionGrowsWithMoreInferers() {
-	block := int64(100)
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	reputerIndexes := s.returnIndexes(0, 3)
-	workerIndexes := s.returnIndexes(5, 5)
-
-	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
-
-	stakes := []cosmosMath.Int{
-		cosmosMath.NewInt(1000000000000000000).Mul(cosmosOneE18),
-		cosmosMath.NewInt(1000000000000000000).Mul(cosmosOneE18),
-		cosmosMath.NewInt(1000000000000000000).Mul(cosmosOneE18),
-	}
-
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		AllowNegative:            false,
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-
-	// Get Topic Id
-	topicId := res.TopicId
-
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-
-	// Register 5 workers
-	for _, index := range workerIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 3 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-	// Add Stake for reputers
-	for i, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	var initialStake int64 = 1000
-	s.FundAccount(initialStake, s.addrs[reputerIndexes[0]])
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-
-	// Insert inference from workers
-	inferenceBundles := generateHugeWorkerDataBundles(s, block, topicId, workerIndexes)
-	for _, payload := range inferenceBundles {
-		s.RegisterAllWorkersOfPayload(topicId, payload)
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
-	s.Require().NoError(err)
-
-	// Insert loss bundle from reputers
-	lossBundles := generateHugeLossBundles(s, block, topicId, reputerIndexes, workerIndexes)
-
-	block = block + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
-
-	// Trigger end block - rewards distribution
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	err = actorutils.CloseReputerNonce(&s.emissionsKeeper, s.ctx, topic,
-		*lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce)
-	s.Require().NoError(err)
-
-	topicTotalRewards := alloraMath.NewDecFromInt64(1000000)
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
-	s.Require().NoError(err)
-
-	firstRewardsDistribution, _, err := rewards.GenerateRewardsDistributionByTopicParticipant(
-		rewards.GenerateRewardsDistributionByTopicParticipantArgs{
-			Ctx:          s.ctx,
-			K:            s.emissionsKeeper,
-			TopicId:      topicId,
-			TopicReward:  &topicTotalRewards,
-			BlockHeight:  lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce.BlockHeight,
-			ModuleParams: params,
-		})
-	s.Require().NoError(err)
-
-	totalInferersReward := alloraMath.ZeroDec()
-	totalForecastersReward := alloraMath.ZeroDec()
-	totalReputersReward := alloraMath.ZeroDec()
-	countInferencesAccepted := 0
-	countForecastersAccepted := 0
-	countReputersAccepted := 0
-	for _, reward := range firstRewardsDistribution {
-		if reward.Type == types.WorkerInferenceRewardType {
-			totalInferersReward, err = totalInferersReward.Add(reward.Reward)
-			s.Require().NoError(err)
-			countInferencesAccepted++
-		} else if reward.Type == types.WorkerForecastRewardType {
-			totalForecastersReward, err = totalForecastersReward.Add(reward.Reward)
-			s.Require().NoError(err)
-			countForecastersAccepted++
-		} else if reward.Type == types.ReputerAndDelegatorRewardType {
-			totalReputersReward, err = totalReputersReward.Add(reward.Reward)
-			s.Require().NoError(err)
-			countReputersAccepted++
-		}
-	}
-	s.Require().Equal(len(inferenceBundles), countInferencesAccepted)
-	// because the GenerateHugeWorkerDataBundles does not generate forecasts
-	// that are accepted, the forecast elements are for inferers that don't exist
-	s.Require().Zero(countForecastersAccepted)
-	s.Require().Equal(len(lossBundles.ReputerValueBundles), countReputersAccepted)
-	totalNonInfererReward, err := totalForecastersReward.Add(totalReputersReward)
-	s.Require().NoError(err)
-	totalReward, err := totalNonInfererReward.Add(totalInferersReward)
-	s.Require().NoError(err)
-
-	firstInfererFraction, err := totalInferersReward.Quo(totalReward)
-	s.Require().NoError(err)
-
-	block += 1
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	// Add new worker(inferer) and stakes
-	newSecondWorkersIndexes := []int{
-		10,
-		11,
-		12,
-	}
-	newSecondWorkersIndexes = append(workerIndexes, newSecondWorkersIndexes...)
-
-	// Create new topic
-	newTopicMsg = &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		AllowNegative:            false,
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err = s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-
-	// Get Topic Id
-	topicId = res.TopicId
-
-	// Register 7 workers with 2 new inferers
-	for _, index := range newSecondWorkersIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 3 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-	// Add Stake for reputers
-	for i, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	s.FundAccount(initialStake, s.addrs[reputerIndexes[0]])
-
-	fundTopicMessage = types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	block += newTopicMsg.EpochLength
-	s.ctx = s.ctx.WithBlockHeight(block)
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-
-	block += 1
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	err = s.emissionsKeeper.AddWorkerNonce(
-		s.ctx,
-		topicId,
-		&types.Nonce{BlockHeight: block},
-	)
-	s.Require().NoError(err)
-	// Insert inference from workers
-	inferenceBundles = generateHugeWorkerDataBundles(s, block, topicId, newSecondWorkersIndexes)
-	// Add more inferer
-	newInferenceBundles := generateMoreInferencesDataBundles(s, block, topicId)
-	inferenceBundles = append(inferenceBundles, newInferenceBundles...)
-
-	for _, payload := range inferenceBundles {
-		s.RegisterAllWorkersOfPayload(topicId, payload)
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-
-	topic, err = s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
-	s.Require().NoError(err)
-
-	lossBundles = generateHugeLossBundles(s, block, topicId, reputerIndexes, newSecondWorkersIndexes)
-
-	block = block + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
-
-	// Insert loss bundle from reputers
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-	err = actorutils.CloseReputerNonce(&s.emissionsKeeper, s.ctx, topic,
-		*lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce)
-	s.Require().NoError(err)
-
-	topicTotalRewards = alloraMath.NewDecFromInt64(1000000)
-	secondRewardsDistribution, _, err := rewards.GenerateRewardsDistributionByTopicParticipant(
-		rewards.GenerateRewardsDistributionByTopicParticipantArgs{
-			Ctx:          s.ctx,
-			K:            s.emissionsKeeper,
-			TopicId:      topicId,
-			TopicReward:  &topicTotalRewards,
-			BlockHeight:  lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce.BlockHeight,
-			ModuleParams: params,
-		})
-	s.Require().NoError(err)
-
-	totalInferersReward = alloraMath.ZeroDec()
-	totalReward = alloraMath.ZeroDec()
-	for _, reward := range secondRewardsDistribution {
-		if reward.Type == types.WorkerInferenceRewardType {
-			totalInferersReward, err = totalInferersReward.Add(reward.Reward)
-			s.Require().NoError(err)
-		}
-		totalReward, err = totalReward.Add(reward.Reward)
-		s.Require().NoError(err)
-	}
-	secondInfererFraction, err := totalInferersReward.Quo(totalReward)
-	s.Require().NoError(err)
-	s.Require().True(
-		firstInfererFraction.Lt(secondInfererFraction),
-		"Second inference fraction must be bigger than first fraction %s < %s",
-		firstInfererFraction,
-		secondInfererFraction,
-	)
-
-	// Add new worker(forecaster) and stakes
-	newThirdWorkersIndexes := []int{
-		10,
-		11,
-	}
-	newThirdWorkersIndexes = append(workerIndexes, newThirdWorkersIndexes...)
-
-	// Create new topic
-	newTopicMsg = &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[reputerIndexes[0]],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		AllowNegative:            false,
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err = s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-
-	// Get Topic Id
-	topicId = res.TopicId
-
-	// Register 7 workers with 2 new forecasters
-	for _, index := range newThirdWorkersIndexes {
-		workerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: false,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, workerRegMsg)
-		s.Require().NoError(err)
-	}
-
-	// Register 3 reputers
-	for _, index := range reputerIndexes {
-		reputerRegMsg := &types.RegisterRequest{
-			Sender:    s.addrsStr[index],
-			TopicId:   topicId,
-			IsReputer: true,
-			Owner:     s.addrsStr[index],
-		}
-		_, err := s.msgServer.Register(s.ctx, reputerRegMsg)
-		s.Require().NoError(err)
-	}
-	// Add Stake for reputers
-	for i, index := range reputerIndexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrsStr[index],
-			Amount:  stakes[i],
-			TopicId: topicId,
-		})
-		s.Require().NoError(err)
-	}
-
-	s.FundAccount(initialStake, s.addrs[reputerIndexes[0]])
-
-	fundTopicMessage = types.FundTopicRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
-		TopicId: topicId,
-		Amount:  cosmosMath.NewInt(initialStake),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	s.Require().NoError(err)
-
-	block += newTopicMsg.EpochLength
-	s.ctx = s.ctx.WithBlockHeight(block)
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-
-	block++
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	err = s.emissionsKeeper.AddWorkerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-	err = s.emissionsKeeper.AddReputerNonce(s.ctx, topicId, &types.Nonce{
-		BlockHeight: block,
-	})
-	s.Require().NoError(err)
-
-	// Insert inference from workers
-	inferenceBundles = generateHugeWorkerDataBundles(s, block, topicId, newThirdWorkersIndexes)
-	// Add more inferer
-	newInferenceBundles = generateMoreForecastersDataBundles(s, block, topicId)
-	inferenceBundles = append(inferenceBundles, newInferenceBundles...)
-	for _, payload := range inferenceBundles {
-		s.RegisterAllWorkersOfPayload(topicId, payload)
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-
-	topic, err = s.emissionsKeeper.GetTopic(s.ctx, topicId)
-	s.Require().NoError(err)
-
-	err = actorutils.CloseWorkerNonce(&s.emissionsKeeper, s.ctx, topic, *inferenceBundles[0].Nonce)
-	s.Require().NoError(err)
-
-	lossBundles = generateHugeLossBundles(s, block, topicId, reputerIndexes, newThirdWorkersIndexes)
-	block = block + topic.GroundTruthLag
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
-
-	// Insert loss bundle from reputers
-	for _, payload := range lossBundles.ReputerValueBundles {
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
-	err = actorutils.CloseReputerNonce(&s.emissionsKeeper, s.ctx, topic,
-		*lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce)
-	s.Require().NoError(err)
-
-	topicTotalRewards = alloraMath.NewDecFromInt64(1000000)
-	thirdRewardsDistribution, _, err := rewards.GenerateRewardsDistributionByTopicParticipant(
-		rewards.GenerateRewardsDistributionByTopicParticipantArgs{
-			Ctx:          s.ctx,
-			K:            s.emissionsKeeper,
-			TopicId:      topicId,
-			TopicReward:  &topicTotalRewards,
-			BlockHeight:  lossBundles.ReputerValueBundles[0].ValueBundle.ReputerRequestNonce.ReputerNonce.BlockHeight,
-			ModuleParams: params,
-		})
-	s.Require().NoError(err)
-
-	totalInferersReward = alloraMath.ZeroDec()
-	totalReward = alloraMath.ZeroDec()
-	for _, reward := range thirdRewardsDistribution {
-		if reward.Type == types.WorkerInferenceRewardType {
-			totalInferersReward, err = totalInferersReward.Add(reward.Reward)
-			s.Require().NoError(err)
-		}
-		totalReward, err = totalReward.Add(reward.Reward)
-		s.Require().NoError(err)
-	}
-	thirdInfererFraction, err := totalInferersReward.Quo(totalReward)
-	s.Require().NoError(err)
-	s.Require().True(
-		firstInfererFraction.Lt(thirdInfererFraction),
-		"Third forecaster fraction must be bigger than first fraction %s > %s",
-		firstInfererFraction.String(),
-		thirdInfererFraction.String(),
-	)
-}
-*/
 
 // TestRewardForTopicGoesUpWhenRelativeStakeGoesUp tests that the reward for a topic increases
 // when its relative stake compared to other topics increases.
@@ -3094,765 +691,481 @@ func (s *RewardsTestSuite) TestTotalInferersRewardFractionGrowsWithMoreInferers(
 // This test demonstrates that the reward distribution mechanism correctly
 // adjusts rewards based on the relative stakes of topics in the network.
 func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
-	// setup
 	require := s.Require()
 
+	const (
+		epochLength    = int64(100)
+		groundTruthLag = int64(100)
+		numTopics      = 2
+		numReputers    = 3
+		numEpochs      = 2
+		fundAmount     = 1000
+	)
+
 	alphaRegret := alloraMath.MustNewDecFromString("0.1")
-
-	block := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	s.SetParamsForTest()
-	reputerIndexes := s.returnIndexes(0, 3)
-	workerIndexes := s.returnIndexes(3, 3)
-
-	// setup topics
 	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
 
-	epochLength := int64(100)
-	topicId0 := s.setUpTopicWithEpochLength(block, workerIndexes, reputerIndexes, stake, alphaRegret, epochLength)
-	topicId1 := s.setUpTopicWithEpochLength(block, workerIndexes, reputerIndexes, stake, alphaRegret, epochLength)
-	// setup values to be identical for both topics
-	reputerValues := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.2"},
-		{Index: reputerIndexes[1], Value: "0.2"},
-		{Index: reputerIndexes[2], Value: "0.2"},
+	s.WithBlockHeight(1)
+	s.SetParamsForTest()
+
+	reputerIndexes := testutil.ReturnIndexes(0, numReputers)
+	workerIndexes := testutil.ReturnIndexes(3, numReputers)
+
+	opts := []testutil.Option{
+		testutil.WithEpochLength(epochLength),
+		testutil.WithGroundTruthLag(groundTruthLag),
+		testutil.WithAlphaRegret(alphaRegret),
+		testutil.WithWorkerValues(testutil.GetWorkerValuesFromIndexes(workerIndexes, "0.2")),
+		testutil.WithReputerStake(&stake),
+		testutil.WithReputerValues(s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.2")),
 	}
 
-	workerValues := []TestWorkerValue{
-		{Index: workerIndexes[0], Value: "0.2"},
-		{Index: workerIndexes[1], Value: "0.2"},
-		{Index: workerIndexes[2], Value: "0.2"},
-	}
+	// pre-emptive passes for topics
+	var topicIDs [numTopics]uint64
+	topicIDs[0], _ = s.FullTopicPass(workerIndexes, reputerIndexes, opts...)
+	topicIDs[1], _ = s.FullTopicPass(workerIndexes, reputerIndexes, opts...)
 
-	// record the stakes on each topic so we can see the reward differences
-	reputer0_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrsStr[reputerIndexes[0]])
-	require.NoError(err)
-	reputer1_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrsStr[reputerIndexes[1]])
-	require.NoError(err)
-	reputer2_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrsStr[reputerIndexes[2]])
-	require.NoError(err)
+	// validate topic weights consistency
+	s.validateTopicWeightsConsistency(topicIDs)
 
-	reputer3_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[0]])
-	require.NoError(err)
-	reputer4_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[1]])
-	require.NoError(err)
-	reputer5_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[2]])
-	require.NoError(err)
+	// first phase: equal rewards
+	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(fundAmount))
 
-	// do work on the topics to earn rewards. Beware: there are moving of blocks, so it's different epochs where
-	// topicId0 and topicId1 get their action done.
-	s.getRewardsDistribution(
-		topicId0,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	s.getRewardsDistribution(
-		topicId1,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	// force rewards to be distributed
-	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
-
-	nextBlock, _, err := s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId0)
-
-	s.T().Logf("Next block: %v", nextBlock)
-	s.Require().NoError(err)
-	s.ctx = s.ctx.WithBlockHeight(nextBlock)
-
-	// Check that the total sum of previous topic weights is equal to the sum of the weights of the two topics
-	topic1Weight0, _, err := s.emissionsKeeper.GetPreviousTopicWeight(s.ctx, topicId0)
-	s.Require().NoError(err)
-	topic0Weight1, _, err := s.emissionsKeeper.GetPreviousTopicWeight(s.ctx, topicId1)
-	s.Require().NoError(err)
-	totalSumPreviousTopicWeights, err := s.emissionsKeeper.GetTotalSumPreviousTopicWeights(s.ctx)
-	s.Require().NoError(err)
-	sumWeights, err := topic0Weight1.Add(topic1Weight0)
-	s.Require().NoError(err)
-	inDelta, err := alloraMath.InDelta(totalSumPreviousTopicWeights, sumWeights, alloraMath.MustNewDecFromString("0.0001"))
-	s.Require().NoError(err)
-	s.Require().True(inDelta, "Total sum of previous topic weights %s + %s = %s is not equal to the sum of the weights of the two topics %s", topic0Weight1, topic1Weight0, totalSumPreviousTopicWeights, sumWeights)
-
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-
-	require.NoError(err)
-
-	worker1InclusionNum, err := s.emissionsKeeper.GetCountInfererInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[0]])
-	require.NoError(err)
-	require.Equal(uint64(1), worker1InclusionNum)
-	worker2InclusionNum, err := s.emissionsKeeper.GetCountInfererInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[1]])
-	require.NoError(err)
-	require.Equal(uint64(1), worker2InclusionNum)
-	worker3InclusionNum, err := s.emissionsKeeper.GetCountInfererInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[2]])
-	require.Equal(uint64(1), worker3InclusionNum)
-	require.NoError(err)
-
-	worker1InclusionNum, err = s.emissionsKeeper.GetCountForecasterInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[0]])
-	require.NoError(err)
-	require.Equal(uint64(1), worker1InclusionNum)
-	worker2InclusionNum, err = s.emissionsKeeper.GetCountForecasterInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[1]])
-	require.NoError(err)
-	require.Equal(uint64(1), worker2InclusionNum)
-	worker3InclusionNum, err = s.emissionsKeeper.GetCountForecasterInclusionsInTopic(s.ctx, topicId0, s.addrsStr[workerIndexes[2]])
-	require.Equal(uint64(1), worker3InclusionNum)
-	require.NoError(err)
-	const topicFundAmount int64 = 1000
-
-	fundTopic := func(topicId uint64, funderAddr sdk.AccAddress, amount int64) {
-		s.MintTokensToAddress(funderAddr, cosmosMath.NewInt(amount))
-		fundTopicMessage := types.FundTopicRequest{
-			Sender:  funderAddr.String(),
-			TopicId: topicId,
-			Amount:  cosmosMath.NewInt(amount),
+	recordStakes := func() [numTopics][numReputers]cosmosMath.Int {
+		var stakes [numTopics][numReputers]cosmosMath.Int
+		for i, topicID := range topicIDs {
+			for j, reputerIdx := range reputerIndexes {
+				var err error
+				stakes[i][j], err = s.EmissionsKeeper().GetStakeReputerAuthority(s.Ctx(), topicID, s.AddrsStr(reputerIdx))
+				require.NoError(err)
+			}
 		}
-		_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-		require.NoError(err)
+		return stakes
 	}
 
-	fundTopic(topicId0, s.addrs[0], topicFundAmount)
-	fundTopic(topicId1, s.addrs[3], topicFundAmount)
+	// record stakes before pass
+	stakes0 := recordStakes()
 
-	reputer0_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrsStr[reputerIndexes[0]])
-	require.NoError(err)
-	reputer1_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrsStr[reputerIndexes[1]])
-	require.NoError(err)
-	reputer2_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrsStr[reputerIndexes[2]])
-	require.NoError(err)
+	s.FullTopicPass(workerIndexes, reputerIndexes, append(opts, testutil.WithTopicID(topicIDs[0]))...)
+	s.FullTopicPass(workerIndexes, reputerIndexes, append(opts, testutil.WithTopicID(topicIDs[1]))...)
 
-	reputer3_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[0]])
-	require.NoError(err)
-	reputer4_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[1]])
-	require.NoError(err)
-	reputer5_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[2]])
-	require.NoError(err)
+	s.validateWorkerInclusions(topicIDs[0], workerIndexes)
 
-	reputer0_Reward0 := reputer0_Stake1.Sub(reputer0_Stake0)
-	reputer1_Reward0 := reputer1_Stake1.Sub(reputer1_Stake0)
-	reputer2_Reward0 := reputer2_Stake1.Sub(reputer2_Stake0)
-	reputer3_Reward0 := reputer3_Stake1.Sub(reputer3_Stake0)
-	reputer4_Reward0 := reputer4_Stake1.Sub(reputer4_Stake0)
-	reputer5_Reward0 := reputer5_Stake1.Sub(reputer5_Stake0)
+	s.FundTopic(topicIDs[0], s.Addrs(0), cosmosMath.NewInt(fundAmount))
+	s.FundTopic(topicIDs[1], s.Addrs(3), cosmosMath.NewInt(fundAmount))
 
-	topic0RewardTotal0 := reputer0_Reward0.Add(reputer1_Reward0).Add(reputer2_Reward0)
-	topic1RewardTotal0 := reputer3_Reward0.Add(reputer4_Reward0).Add(reputer5_Reward0)
+	stakes1 := recordStakes()
 
-	require.Equal(topic0RewardTotal0, topic1RewardTotal0)
+	var topicRewardsTotal [numEpochs][numTopics]alloraMath.Dec
 
-	// Now, in second trial, significantly increase stake for first reputer in topic1
+	rewardsFromStakes := func(phase int, stakesCurrent, stakesPrevious [2][3]cosmosMath.Int) {
+		for i := range stakesCurrent {
+			for j := range stakesCurrent[i] {
+				currentRewards, err := alloraMath.NewDecFromSdkInt(stakesCurrent[i][j].Sub(stakesPrevious[i][j]))
+				require.NoError(err)
+				topicRewardsTotal[phase][i], err = topicRewardsTotal[phase][i].Add(currentRewards)
+				require.NoError(err)
+			}
+		}
+	}
+
+	// calculate rewards for first epoch
+	rewardsFromStakes(0, stakes1, stakes0)
+
+	require.Equal(topicRewardsTotal[0][0], topicRewardsTotal[0][1])
+
+	// second phase: increase stake for first reputer in topic1
 	stakeIncrease := cosmosMath.NewInt(1000).Mul(stake)
-	s.MintTokensToAddress(s.addrs[reputerIndexes[0]], stakeIncrease)
-	_, err = s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-		Sender:  s.addrsStr[reputerIndexes[0]],
+	s.MintTokensToAddress(s.Addrs(reputerIndexes[0]), stakeIncrease)
+	_, err := s.EmissionsMsgServer().AddStake(s.Ctx(), &types.AddStakeRequest{
+		Sender:  s.AddrsStr(reputerIndexes[0]),
 		Amount:  stakeIncrease,
-		TopicId: topicId1,
+		TopicId: topicIDs[1],
 	})
 	require.NoError(err)
 
-	// record the updated stakes
-	reputer3_Stake1, err = s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[0]])
+	// update stakes and run second epoch
+	stakes1[1][0], err = s.EmissionsKeeper().GetStakeReputerAuthority(s.Ctx(), topicIDs[1], s.AddrsStr(reputerIndexes[0]))
 	require.NoError(err)
 
-	// force rewards to be distributed
-	block = s.ctx.BlockHeight()
-	block++
-	s.ctx = s.ctx.WithBlockHeight(block)
+	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(fundAmount))
 
-	// do work on the topics to earn rewards. Beware: there are moving of blocks, so it's different epochs where
-	// topicId0 and topicId1 get their action done.
-	s.getRewardsDistribution(
-		topicId0,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-	taskRewards1 := s.getRewardsDistribution(
-		topicId1,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
+	s.FullTopicPass(workerIndexes, reputerIndexes, append(opts, testutil.WithTopicID(topicIDs[0]))...)
+	_, block := s.FullTopicPass(workerIndexes, reputerIndexes, append(opts, testutil.WithTopicID(topicIDs[1]))...)
 
-	// Get and check the rewards for the reputer after the stake increase
-	var taskRewardsReputer3AfterStakeIncrease,
-		taskRewardsReputer4AfterStakeIncrease,
-		taskRewardsReputer5AfterStakeIncrease types.TaskReward
+	s.validateStakeIncreaseRewards(topicIDs[1], block, reputerIndexes)
 
-	for _, reward := range taskRewards1 {
-		if reward.Type == types.ReputerAndDelegatorRewardType {
-			if reward.Address == s.addrsStr[reputerIndexes[0]] {
-				taskRewardsReputer3AfterStakeIncrease = reward
-			}
-			if reward.Address == s.addrsStr[reputerIndexes[1]] {
-				taskRewardsReputer4AfterStakeIncrease = reward
-			}
-			if reward.Address == s.addrsStr[reputerIndexes[2]] {
-				taskRewardsReputer5AfterStakeIncrease = reward
-			}
-		}
-	}
-	require.True(taskRewardsReputer3AfterStakeIncrease.Reward.Gt(taskRewardsReputer4AfterStakeIncrease.Reward))
-	require.True(taskRewardsReputer3AfterStakeIncrease.Reward.Gt(taskRewardsReputer5AfterStakeIncrease.Reward))
+	stakes2 := recordStakes()
 
-	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
+	// calculate rewards for second epoch
+	rewardsFromStakes(1, stakes2, stakes1)
 
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	require.NoError(err)
-
-	// record the stakes after
-	reputer0_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrsStr[reputerIndexes[0]])
-	require.NoError(err)
-	reputer1_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrsStr[reputerIndexes[1]])
-	require.NoError(err)
-	reputer2_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrsStr[reputerIndexes[2]])
-	require.NoError(err)
-
-	reputer3_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[0]])
-	require.NoError(err)
-	reputer4_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[1]])
-	require.NoError(err)
-	reputer5_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId1, s.addrsStr[reputerIndexes[2]])
-	require.NoError(err)
-
-	// calculate rewards (topic 0)
-	reputer0_Reward1 := reputer0_Stake2.Sub(reputer0_Stake1)
-	reputer1_Reward1 := reputer1_Stake2.Sub(reputer1_Stake1)
-	reputer2_Reward1 := reputer2_Stake2.Sub(reputer2_Stake1)
-	// calculate rewards (topic 1)
-	reputer3_Reward1 := reputer3_Stake2.Sub(reputer3_Stake1)
-	reputer4_Reward1 := reputer4_Stake2.Sub(reputer4_Stake1)
-	reputer5_Reward1 := reputer5_Stake2.Sub(reputer5_Stake1)
-
-	// calculate total rewards for each topic
-	topic0RewardTotal1 := reputer0_Reward1.Add(reputer1_Reward1).Add(reputer2_Reward1)
-	topic1RewardTotal1 := reputer3_Reward1.Add(reputer4_Reward1).Add(reputer5_Reward1)
-
-	topic0Total0Dec, err := alloraMath.NewDecFromSdkInt(topic0RewardTotal0)
-	require.NoError(err)
-	topic1Total0Dec, err := alloraMath.NewDecFromSdkInt(topic1RewardTotal0)
-	require.NoError(err)
-	topic0Total1Dec, err := alloraMath.NewDecFromSdkInt(topic0RewardTotal1)
-	require.NoError(err)
-	topic1Total1Dec, err := alloraMath.NewDecFromSdkInt(topic1RewardTotal1)
-	require.NoError(err)
-
-	// Normalize to the amount of rewards given in each cycle and check the ratios of the whole rewards,
-	// instead of absolute values (since rewards amount is different in each cycle).
-	totalRewardsEpoch0, err := topic0Total0Dec.Add(topic1Total0Dec)
-	require.NoError(err)
-	totalRewardsEpoch1, err := topic0Total1Dec.Add(topic1Total1Dec)
-	require.NoError(err)
-
-	topic0RewardTotal0Normalized, err := topic0Total0Dec.Quo(totalRewardsEpoch0)
-	require.NoError(err)
-	topic1RewardTotal0Normalized, err := topic1Total0Dec.Quo(totalRewardsEpoch0)
-	require.NoError(err)
-	topic0RewardTotal1Normalized, err := topic0Total1Dec.Quo(totalRewardsEpoch1)
-	require.NoError(err)
-	topic1RewardTotal1Normalized, err := topic1Total1Dec.Quo(totalRewardsEpoch1)
-
-	// in the first round, the rewards should be equal for each topic
-	require.True(topic0RewardTotal0Normalized.Equal(topic1RewardTotal0Normalized), "%s != %s", topic0RewardTotal0Normalized, topic1RewardTotal0Normalized)
-	// for topic 0, the rewards should be less in the second round
-	require.True(topic0RewardTotal0Normalized.Gte(topic1RewardTotal0Normalized), "%s <= %s", topic0RewardTotal0Normalized, topic1RewardTotal0Normalized)
-	// in the second round, the rewards should be greater for topic 1
-	require.True(topic0RewardTotal1Normalized.Lte(topic1RewardTotal1Normalized), "%s >= %s", topic0RewardTotal1Normalized, topic1RewardTotal1Normalized)
-	// the rewards for topic 1 should be greater in the second round
-	require.True(topic1RewardTotal0Normalized.Lt(topic1RewardTotal1Normalized), "%s >= %s", topic1RewardTotal0Normalized, topic1RewardTotal1Normalized)
-}
-
-func (s *RewardsTestSuite) TestReputerAboveConsensusGetsLessRewards() {
-	require := s.Require()
-
-	block := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	alphaRegret := alloraMath.MustNewDecFromString("0.1")
-
-	s.SetParamsForTest()
-
-	reputerIndexes := s.returnIndexes(0, 6)
-	workerIndexes := s.returnIndexes(6, 3)
-
-	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
-
-	topicId0 := s.setUpTopicWithEpochLength(block, workerIndexes, reputerIndexes, stake, alphaRegret, 5)
-	s.T().Logf("TopicId: %v", topicId0)
-	err := s.emissionsKeeper.SetPreviousTopicWeight(s.ctx, topicId0, alloraMath.MustNewDecFromString("100"))
-	require.NoError(err)
-
-	reputerValues := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.1"},
-		{Index: reputerIndexes[1], Value: "0.1"},
-		{Index: reputerIndexes[2], Value: "0.1"},
-		{Index: reputerIndexes[3], Value: "0.1"},
-		{Index: reputerIndexes[4], Value: "0.1"},
-		{Index: reputerIndexes[5], Value: "0.9"},
-	}
-
-	workerValues := []TestWorkerValue{
-		{Index: workerIndexes[0], Value: "0.1"},
-		{Index: workerIndexes[1], Value: "0.1"},
-		{Index: workerIndexes[2], Value: "0.1"},
-	}
-
-	reputer0_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[0].String())
-	require.NoError(err)
-	reputer1_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[1].String())
-	require.NoError(err)
-	reputer2_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[2].String())
-	require.NoError(err)
-	reputer3_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[3].String())
-	require.NoError(err)
-	reputer4_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[4].String())
-	require.NoError(err)
-	reputer5_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[5].String())
-	require.NoError(err)
-
-	s.getRewardsDistribution(
-		topicId0,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
-
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	require.NoError(err)
-
-	reputer0_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[0].String())
-	require.NoError(err)
-	reputer1_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[1].String())
-	require.NoError(err)
-	reputer2_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[2].String())
-	require.NoError(err)
-	reputer3_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[3].String())
-	require.NoError(err)
-	reputer4_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[4].String())
-	require.NoError(err)
-	reputer5_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[5].String())
-	require.NoError(err)
-
-	reputer0Reward := reputer0_Stake1.Sub(reputer0_Stake0)
-	reputer1Reward := reputer1_Stake1.Sub(reputer1_Stake0)
-	reputer2Reward := reputer2_Stake1.Sub(reputer2_Stake0)
-	reputer3Reward := reputer3_Stake1.Sub(reputer3_Stake0)
-	reputer4Reward := reputer4_Stake1.Sub(reputer4_Stake0)
-	reputer5Reward := reputer5_Stake1.Sub(reputer5_Stake0)
-
-	require.True(reputer0Reward.Equal(reputer1Reward))
-	require.True(reputer1Reward.Equal(reputer2Reward))
-	require.True(reputer2Reward.Equal(reputer3Reward))
-	require.True(reputer3Reward.Equal(reputer4Reward))
-	require.True(reputer5Reward.LT(reputer1Reward))
-}
-
-func (s *RewardsTestSuite) TestReputerBelowConsensusGetsLessRewards() {
-	require := s.Require()
-
-	block := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	alphaRegret := alloraMath.MustNewDecFromString("0.1")
-
-	s.SetParamsForTest()
-
-	reputerIndexes := s.returnIndexes(0, 6)
-	workerIndexes := s.returnIndexes(6, 3)
-
-	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
-
-	topicId0 := s.setUpTopicWithEpochLength(block, workerIndexes, reputerIndexes, stake, alphaRegret, 5)
-
-	reputerValues := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.9"},
-		{Index: reputerIndexes[1], Value: "0.9"},
-		{Index: reputerIndexes[2], Value: "0.9"},
-		{Index: reputerIndexes[3], Value: "0.9"},
-		{Index: reputerIndexes[4], Value: "0.9"},
-		{Index: reputerIndexes[5], Value: "0.1"},
-	}
-
-	workerValues := []TestWorkerValue{
-		{Index: workerIndexes[0], Value: "0.9"},
-		{Index: workerIndexes[1], Value: "0.9"},
-		{Index: workerIndexes[2], Value: "0.9"},
-	}
-
-	reputer0_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[0].String())
-	require.NoError(err)
-	reputer1_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[1].String())
-	require.NoError(err)
-	reputer2_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[2].String())
-	require.NoError(err)
-	reputer3_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[3].String())
-	require.NoError(err)
-	reputer4_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[4].String())
-	require.NoError(err)
-	reputer5_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[5].String())
-	require.NoError(err)
-
-	s.getRewardsDistribution(
-		topicId0,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.9",
-		"0.9",
-	)
-
-	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
-
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	require.NoError(err)
-
-	reputer0_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[0].String())
-	require.NoError(err)
-	reputer1_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[1].String())
-	require.NoError(err)
-	reputer2_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[2].String())
-	require.NoError(err)
-	reputer3_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[3].String())
-	require.NoError(err)
-	reputer4_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[4].String())
-	require.NoError(err)
-	reputer5_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[5].String())
-	require.NoError(err)
-
-	reputer0Reward := reputer0_Stake1.Sub(reputer0_Stake0)
-	reputer1Reward := reputer1_Stake1.Sub(reputer1_Stake0)
-	reputer2Reward := reputer2_Stake1.Sub(reputer2_Stake0)
-	reputer3Reward := reputer3_Stake1.Sub(reputer3_Stake0)
-	reputer4Reward := reputer4_Stake1.Sub(reputer4_Stake0)
-	reputer5Reward := reputer5_Stake1.Sub(reputer5_Stake0)
-
-	require.True(reputer0Reward.Equal(reputer1Reward))
-	require.True(reputer1Reward.Equal(reputer2Reward))
-	require.True(reputer2Reward.Equal(reputer3Reward))
-	require.True(reputer3Reward.Equal(reputer4Reward))
-	require.True(reputer5Reward.LT(reputer1Reward))
-}
-
-func (s *RewardsTestSuite) TestRewardForRemainingParticipantsGoUpWhenParticipantDropsOut() {
-	// SETUP
-	require := s.Require()
-
-	block := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	alphaRegret := alloraMath.MustNewDecFromString("0.1")
-
-	s.SetParamsForTest()
-
-	reputerIndexes := s.returnIndexes(0, 3)
-	workerIndexes := s.returnIndexes(3, 3)
-
-	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
-
-	topicId0 := s.setUpTopicWithEpochLength(block, workerIndexes, reputerIndexes, stake, alphaRegret, 30)
-
-	// Define values to test
-	reputer0Values := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.2"},
-		{Index: reputerIndexes[1], Value: "0.2"},
-		{Index: reputerIndexes[2], Value: "0.2"},
-	}
-
-	workerValues := []TestWorkerValue{
-		{Index: workerIndexes[0], Value: "0.2"},
-		{Index: workerIndexes[1], Value: "0.2"},
-		{Index: workerIndexes[2], Value: "0.2"},
-	}
-
-	// Define second round values to test with one less reputer
-	reputer1Values := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.2"},
-		{Index: reputerIndexes[1], Value: "0.2"},
-	}
-
-	// record the stakes before rewards
-	reputer0_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[0].String())
-	require.NoError(err)
-	reputer1_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[1].String())
-	require.NoError(err)
-	reputer2_Stake0, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[2].String())
-	require.NoError(err)
-
-	// do work on the current block
-	s.getRewardsDistribution(
-		topicId0,
-		workerValues,
-		reputer0Values,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	// create tokens to reward with
-	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
-
-	nextBlock, _, err := s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId0)
-	s.Require().NoError(err)
-	s.ctx = s.ctx.WithBlockHeight(nextBlock)
-	// force rewards to be distributed
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	require.NoError(err)
-
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId0)
-	s.Require().NoError(err)
-	// record the updated stakes after rewards
-	reputer0_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[0].String())
-	require.NoError(err)
-	reputer1_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[1].String())
-	require.NoError(err)
-	reputer2_Stake1, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[2].String())
-	require.NoError(err)
-
-	// calculate the rewards for each reputer
-	reputer0_Reward0 := reputer0_Stake1.Sub(reputer0_Stake0)
-	reputer1_Reward0 := reputer1_Stake1.Sub(reputer1_Stake0)
-	reputer2_Reward0 := reputer2_Stake1.Sub(reputer2_Stake0)
-
-	// fund the topic again for future rewards
-	const topicFundAmount int64 = 1000
-
-	fundTopic := func(topicId uint64, funderAddr sdk.AccAddress, amount int64) {
-		s.MintTokensToAddress(funderAddr, cosmosMath.NewInt(amount))
-		fundTopicMessage := types.FundTopicRequest{
-			Sender:  funderAddr.String(),
-			TopicId: topicId,
-			Amount:  cosmosMath.NewInt(amount),
-		}
-		_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
+	// normalize rewards
+	var totalRewardsEpoch [numEpochs]alloraMath.Dec
+	for i, topicRewards := range topicRewardsTotal {
+		totalRewardsEpoch[i], err = topicRewards[0].Add(topicRewards[1])
 		require.NoError(err)
 	}
 
-	fundTopic(topicId0, s.addrs[0], topicFundAmount)
+	var topicRewardTotalNormalized [numTopics][numEpochs]alloraMath.Dec // [topic][epoch]
+	for i, phaseTopicRewards := range topicRewardsTotal {
+		for j, topicReward := range phaseTopicRewards {
+			topicRewardTotalNormalized[j][i], err = topicReward.Quo(totalRewardsEpoch[i])
+			require.NoError(err)
+		}
+	}
 
-	// do work on the current block, but with one less reputer
-	s.getRewardsDistribution(
-		topic.Id,
-		workerValues,
-		reputer1Values,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-
-	// create tokens to reward with
-	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
-
-	nextBlock, _, err = s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId0)
-	s.Require().NoError(err)
-	s.ctx = s.ctx.WithBlockHeight(nextBlock)
-	// force rewards to be distributed
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	require.NoError(err)
-
-	// check the updated stakes after rewards
-	reputer0_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[0].String())
-	require.NoError(err)
-	reputer1_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[1].String())
-	require.NoError(err)
-	reputer2_Stake2, err := s.emissionsKeeper.GetStakeReputerAuthority(s.ctx, topicId0, s.addrs[2].String())
-	require.NoError(err)
-
-	// calculate the rewards for each reputer
-	reputer0_Reward1 := reputer0_Stake2.Sub(reputer0_Stake1)
-	reputer1_Reward1 := reputer1_Stake2.Sub(reputer1_Stake1)
-	reputer2_Reward1 := reputer2_Stake2.Sub(reputer2_Stake1)
-
-	// sanity check that participating reputer rewards went up, but non participating reputer
-	// rewards went to zero
-	require.True(reputer0_Reward1.GT(reputer0_Reward0))
-	require.True(reputer1_Reward1.GT(reputer1_Reward0))
-	require.True(reputer2_Reward0.GT(cosmosMath.ZeroInt()))
-	require.True(reputer2_Reward1.Equal(cosmosMath.ZeroInt()))
+	// in the first round, the rewards should be equal for each topic
+	require.True(topicRewardTotalNormalized[0][0].Equal(topicRewardTotalNormalized[1][0]), "%s != %s", topicRewardTotalNormalized[0][0], topicRewardTotalNormalized[1][0])
+	// for topic 0, the rewards should be less in the second round
+	require.True(topicRewardTotalNormalized[0][0].Gte(topicRewardTotalNormalized[0][1]), "%s <= %s", topicRewardTotalNormalized[0][0], topicRewardTotalNormalized[0][1])
+	// in the second round, the rewards should be greater for topic 1
+	require.True(topicRewardTotalNormalized[1][0].Lte(topicRewardTotalNormalized[1][1]), "%s >= %s", topicRewardTotalNormalized[1][0], topicRewardTotalNormalized[1][1])
+	// the rewards for topic 1 should be greater in the second round
+	require.True(topicRewardTotalNormalized[1][0].Lt(topicRewardTotalNormalized[1][1]), "%s >= %s", topicRewardTotalNormalized[1][0], topicRewardTotalNormalized[1][1])
 }
 
-func (s *RewardsTestSuite) TestRewardIncreaseContiouslyAfterTopicReactivated() {
-	// SETUP
+// Helper methods (same as before)
+func (s *RewardsTestSuite) validateTopicWeightsConsistency(topicIDs [2]uint64) {
+	var topicWeights [2]alloraMath.Dec
+	var err error
+	for i, topicID := range topicIDs {
+		topicWeights[i], _, err = s.EmissionsKeeper().GetPreviousTopicWeight(s.Ctx(), topicID)
+		s.Require().NoError(err)
+	}
+
+	sumWeights, err := topicWeights[0].Add(topicWeights[1])
+	s.Require().NoError(err)
+
+	totalSum, err := s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
+	s.Require().NoError(err)
+
+	inDelta, err := alloraMath.InDelta(totalSum, sumWeights, alloraMath.MustNewDecFromString("0.0001"))
+	s.Require().NoError(err)
+	s.Require().True(inDelta, "Topic weights sum mismatch: %s vs %s", totalSum, sumWeights)
+}
+
+func (s *RewardsTestSuite) validateWorkerInclusions(topicID uint64, workerIndexes []int) {
+	for _, workerIndex := range workerIndexes {
+		infererCount, _ := s.EmissionsKeeper().GetCountInfererInclusionsInTopic(s.Ctx(), topicID, s.AddrsStr(workerIndex))
+		s.Require().Equal(uint64(1), infererCount)
+
+		forecasterCount, _ := s.EmissionsKeeper().GetCountForecasterInclusionsInTopic(s.Ctx(), topicID, s.AddrsStr(workerIndex))
+		s.Require().Equal(uint64(1), forecasterCount)
+	}
+}
+
+func (s *RewardsTestSuite) validateStakeIncreaseRewards(topicID uint64, block int64, reputerIndexes []int) {
+	taskRewards, _ := s.GenerateRewards(topicID, block)
+	var reputerRewards [3]types.TaskReward
+	for i, reputerIdx := range reputerIndexes {
+		for _, reward := range taskRewards {
+			if reward.Type == types.ReputerAndDelegatorRewardType && reward.Address == s.AddrsStr(reputerIdx) {
+				reputerRewards[i] = reward
+				break
+			}
+		}
+	}
+	s.Require().True(reputerRewards[0].Reward.Gt(reputerRewards[1].Reward))
+	s.Require().True(reputerRewards[0].Reward.Gt(reputerRewards[2].Reward))
+}
+
+func (s *RewardsTestSuite) TestReputerDeviatingFromConsensusGetsLessRewards() {
+	testCases := []struct {
+		name        string
+		baseValue   string
+		deltaValue  string // Value for a reputer that deviates from consensus
+		description string
+	}{
+		{
+			name:        "Reputer above consensus gets less rewards",
+			baseValue:   "0.1",
+			deltaValue:  "-0.8",
+			description: "Higher than consensus value should result in lower rewards",
+		},
+		{
+			name:        "Reputer below consensus gets less rewards",
+			baseValue:   "0.9",
+			deltaValue:  "0.8",
+			description: "Lower than consensus value should result in lower rewards",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			require := s.Require()
+			epochLength := int64(5)
+			groundTruthLag := int64(5)
+			alphaRegret := alloraMath.MustNewDecFromString("0.1")
+
+			s.SetParamsForTest()
+
+			reputerIndexes := testutil.ReturnIndexes(0, 6)
+			workerIndexes := testutil.ReturnIndexes(6, 3)
+			stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
+
+			// PRE RUN
+			topicId, _ := s.FullTopicPass(
+				workerIndexes,
+				reputerIndexes,
+				testutil.WithEpochLength(epochLength),
+				testutil.WithGroundTruthLag(groundTruthLag),
+				testutil.WithAlphaRegret(alphaRegret),
+				testutil.WithReputerStake(&stake),
+			)
+
+			var err error
+			reputerStakes0 := make([]cosmosMath.Int, len(reputerIndexes))
+			for i, index := range reputerIndexes {
+				reputerStakes0[i], err = s.EmissionsKeeper().GetStakeReputerAuthority(s.Ctx(), topicId, s.AddrsStr(index))
+				require.NoError(err)
+			}
+
+			err = s.EmissionsKeeper().SetPreviousTopicWeight(s.Ctx(), topicId, alloraMath.MustNewDecFromString("100"))
+			require.NoError(err)
+
+			reputerValues := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, tc.baseValue)
+			exceptionReputerIdx := 5
+			reputerValues[exceptionReputerIdx].WorkerValues[s.AddrsStr(6)] = tc.deltaValue // used as delta
+			workerValues := testutil.GetWorkerValuesFromIndexes(workerIndexes, tc.baseValue)
+
+			s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
+
+			s.FullTopicPass(
+				workerIndexes,
+				reputerIndexes,
+				testutil.WithWorkerValues(workerValues),
+				testutil.WithReputerValues(reputerValues),
+				testutil.WithReputerStake(&stake),
+				testutil.WithTopicID(topicId),
+			)
+
+			reputerStakes1 := make([]cosmosMath.Int, len(reputerIndexes))
+			for i, index := range reputerIndexes {
+				reputerStakes1[i], err = s.EmissionsKeeper().GetStakeReputerAuthority(s.Ctx(), topicId, s.AddrsStr(index))
+				require.NoError(err)
+			}
+
+			reputerRewards := make([]cosmosMath.Int, len(reputerStakes0))
+			for i := range reputerStakes1 {
+				reputerRewards[i] = reputerStakes1[i].Sub(reputerStakes0[i])
+			}
+
+			for i := 0; i < len(reputerRewards)-2; i++ {
+				require.False(reputerRewards[i].IsZero())
+				require.True(reputerRewards[i].Equal(reputerRewards[i+1]))
+			}
+
+			require.Truef(reputerRewards[exceptionReputerIdx].LT(reputerRewards[0]), "%s < %s", reputerRewards[exceptionReputerIdx], reputerRewards[0])
+		})
+	}
+}
+
+func (s *RewardsTestSuite) TestRewardForRemainingParticipantsGoUpWhenParticipantDropsOut() {
 	require := s.Require()
 
-	block := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(block)
-
-	alphaRegret := alloraMath.MustNewDecFromString("0.1")
-
+	s.WithBlockHeight(1)
 	s.SetParamsForTest()
 
-	reputer0Indexes := s.returnIndexes(0, 3)
-	worker0Indexes := s.returnIndexes(3, 3)
-
-	reputer1Indexes := s.returnIndexes(6, 3)
-	worker1Indexes := s.returnIndexes(9, 3)
-
+	// Constants
+	alphaRegret := alloraMath.MustNewDecFromString("0.1")
+	epochLength := int64(30)
+	groundTruthLag := int64(30)
 	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
 
-	topicId0 := s.setUpTopicWithEpochLength(block, worker0Indexes, reputer0Indexes, stake, alphaRegret, 30)
-	topicId1 := s.setUpTopicWithEpochLength(block, worker1Indexes, reputer1Indexes, stake, alphaRegret, 60)
+	// Participant configs
+	reputerIndexes := testutil.ReturnIndexes(0, 3)
+	workerIndexes := testutil.ReturnIndexes(3, 3)
+	workerValues := testutil.GetWorkerValuesFromIndexes(workerIndexes, "0.2")
+
+	// Test scenarios
+	scenarios := []struct {
+		name          string
+		reputerIdxs   []int
+		reputerValues []testutil.TestReputerValue
+	}{
+		{
+			name:          "setup",
+			reputerIdxs:   reputerIndexes,
+			reputerValues: s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.2"),
+		},
+		{
+			name:          "all_reputers",
+			reputerIdxs:   reputerIndexes,
+			reputerValues: s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.2"),
+		},
+		{
+			name:          "reduced_reputers",
+			reputerIdxs:   reputerIndexes[:2],
+			reputerValues: s.GetReputerValuesFromIndexes(reputerIndexes[:2], workerIndexes, "0.2"),
+		},
+	}
+
+	var topicId uint64
+	reputerStakeSnapshots := make([][]cosmosMath.Int, len(scenarios))
+
+	// Combined setup and execution function
+	runScenario := func(scenarioIdx int) {
+		// Prepare rewards for scenario
+		s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
+
+		opts := []testutil.Option{
+			testutil.WithTopicID(topicId),
+			testutil.WithEpochLength(epochLength),
+			testutil.WithGroundTruthLag(groundTruthLag),
+			testutil.WithAlphaRegret(alphaRegret),
+			testutil.WithWorkerValues(workerValues),
+			testutil.WithReputerStake(&stake),
+			testutil.WithReputerValues(scenarios[scenarioIdx].reputerValues),
+		}
+
+		// Execute the pass
+		topicId, _ = s.FullTopicPass(workerIndexes, scenarios[scenarioIdx].reputerIdxs, opts...)
+
+		// Record stakes
+		reputerStakeSnapshots[scenarioIdx] = make([]cosmosMath.Int, len(reputerIndexes))
+		for i, idx := range reputerIndexes {
+			var err error
+			reputerStakeSnapshots[scenarioIdx][i], err = s.EmissionsKeeper().GetStakeReputerAuthority(s.Ctx(), topicId, s.AddrsStr(idx))
+			require.NoError(err)
+		}
+
+		// Fund topic for next scenario if not the last one
+		topicFundAmount := cosmosMath.NewInt(1000)
+		s.FundTopic(topicId, s.Addrs(0), topicFundAmount)
+	}
+
+	// Execute scenarios
+	for i := range scenarios {
+		runScenario(i)
+	}
+
+	// Calculate rewards for each scenario
+	calculateRewards := func(beforeIdx, afterIdx int) []cosmosMath.Int {
+		reputerRewards := make([]cosmosMath.Int, len(reputerIndexes))
+		for i := range reputerRewards {
+			reputerRewards[i] = reputerStakeSnapshots[afterIdx][i].Sub(reputerStakeSnapshots[beforeIdx][i])
+		}
+		return reputerRewards
+	}
+
+	reputerRewards0 := calculateRewards(0, 1) // Initial to after first scenario
+	reputerRewards1 := calculateRewards(1, 2) // After first to after second scenario
+
+	// Assertions: verify behavior when participant drops out
+	require.True(reputerRewards1[2].IsZero(), "Dropped reputer should get zero rewards")
+	require.True(reputerRewards0[2].IsPositive(), "Dropped reputer should have gotten rewards in first round")
+	require.True(reputerRewards1[0].GT(reputerRewards0[0]), "Remaining reputer 0 rewards should increase")
+	require.True(reputerRewards1[1].GT(reputerRewards0[1]), "Remaining reputer 1 rewards should increase")
+}
+
+func (s *RewardsTestSuite) TestRewardIncreaseContinuouslyAfterTopicReactivated() {
+	require := s.Require()
+
+	s.WithBlockHeight(1)
+	s.SetParamsForTest()
+
+	alphaRegret := alloraMath.MustNewDecFromString("0.1")
 	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
-	// Add Stake for reputers
-	var stakes = []cosmosMath.Int{
+	initialStake := cosmosMath.NewInt(1000)
+	baseStake := cosmosMath.NewInt(1000).Mul(cosmosOneE18)
+
+	// Predefined stakes
+	stakes := []cosmosMath.Int{
 		cosmosMath.NewInt(1176644).Mul(cosmosOneE18),
 		cosmosMath.NewInt(384623).Mul(cosmosOneE18),
 		cosmosMath.NewInt(394676).Mul(cosmosOneE18),
 		cosmosMath.NewInt(207999).Mul(cosmosOneE18),
 		cosmosMath.NewInt(368582).Mul(cosmosOneE18),
 	}
-	for i, index := range reputer0Indexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i])
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrs[index].String(),
-			Amount:  stakes[i],
-			TopicId: topicId0,
-		})
-		s.Require().NoError(err)
-	}
-	for i, index := range reputer1Indexes {
-		s.MintTokensToAddress(s.addrs[index], stakes[i].MulRaw(2))
-		_, err := s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-			Sender:  s.addrs[index].String(),
-			Amount:  stakes[i].MulRaw(2),
-			TopicId: topicId1,
-		})
-		s.Require().NoError(err)
+
+	// Topic configs
+	topicConfigs := []struct {
+		rIdx, wIdx       []int
+		epoch, gtl, mult int64
+		values           []string
+	}{
+		{testutil.ReturnIndexes(0, 3), testutil.ReturnIndexes(3, 3), 30, 30, 1, []string{"0.1", "0.2", "0.3"}},
+		{testutil.ReturnIndexes(6, 3), testutil.ReturnIndexes(9, 3), 60, 60, 2, []string{"0.4", "0.5", "0.6"}},
 	}
 
-	initialStake := cosmosMath.NewInt(1000)
-	s.MintTokensToAddress(s.addrs[reputer0Indexes[0]], initialStake)
-	fundTopic0Message := types.FundTopicRequest{
-		Sender:  s.addrs[reputer0Indexes[0]].String(),
-		TopicId: topicId0,
-		Amount:  initialStake,
-	}
-	_, err := s.msgServer.FundTopic(s.ctx, &fundTopic0Message)
-	s.Require().NoError(err)
+	var topicIDs []uint64
 
-	s.MintTokensToAddress(s.addrs[reputer1Indexes[0]], initialStake.MulRaw(2))
-	fundTopic1Message := types.FundTopicRequest{
-		Sender:  s.addrs[reputer1Indexes[0]].String(),
-		TopicId: topicId1,
-		Amount:  initialStake.MulRaw(2),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopic1Message)
-	s.Require().NoError(err)
+	// Combined setup and pass function
+	runPassWithSetup := func(topicIdx int, isSetup bool) []types.TaskReward {
+		cfg := topicConfigs[topicIdx]
+		workerValues := testutil.GetWorkerValuesFromIndexes(cfg.wIdx, cfg.values...)
+		reputerValues := s.GetReputerValuesFromIndexes(cfg.rIdx, cfg.wIdx, cfg.values...)
 
-	topic0, err := s.emissionsKeeper.GetTopic(s.ctx, topicId0)
+		addrs := make([]string, len(cfg.wIdx))
+		for i, idx := range cfg.wIdx {
+			addrs[i] = s.AddrsStr(idx)
+		}
+		slices.Sort(addrs)
+		reputerValues[0].OneOutInfValues = map[string]string{addrs[0]: "0.1"}
+		// Apply special values based on topic index
+		if topicIdx != 0 {
+			reputerValues[0].WorkerValues[addrs[0]] = "0.2"
+			reputerValues[0].OneOutInfValues = map[string]string{addrs[0]: "0.2"}
+		}
+
+		// Build common options
+		opts := []testutil.Option{
+			testutil.WithAlphaRegret(alphaRegret),
+			testutil.WithReputerStake(&baseStake),
+			testutil.WithEpochLength(cfg.epoch),
+			testutil.WithGroundTruthLag(cfg.gtl),
+			testutil.WithWorkerValues(workerValues),
+			testutil.WithReputerValues(reputerValues),
+		}
+
+		if !isSetup {
+			// Add topic ID for existing topic
+			opts = append(opts, testutil.WithTopicID(topicIDs[topicIdx]))
+		}
+
+		topicID, block := s.FullTopicPass(cfg.wIdx, cfg.rIdx, opts...)
+
+		if isSetup {
+			topicIDs = append(topicIDs, topicID)
+			// Add stakes for reputers
+			for j, rIdx := range cfg.rIdx {
+				stakeAmount := stakes[j].MulRaw(cfg.mult)
+				s.MintTokensToAddress(s.Addrs(rIdx), stakeAmount)
+				_, err := s.EmissionsMsgServer().AddStake(s.Ctx(), &types.AddStakeRequest{
+					Sender: s.AddrsStr(rIdx), Amount: stakeAmount, TopicId: topicID})
+				require.NoError(err)
+			}
+			// Fund topic
+			fundAmount := initialStake.MulRaw(cfg.mult)
+			s.FundTopic(topicID, s.Addrs(cfg.rIdx[0]), fundAmount)
+			return nil // No rewards on setup pass
+		}
+		rews, _ := s.GenerateRewards(topicIDs[topicIdx], block)
+		return rews
+	}
+
+	// Setup both topics
+	runPassWithSetup(0, true)
+	runPassWithSetup(1, true)
+
+	// Execute actual test passes
+	rewards0_0 := runPassWithSetup(0, false)
+	runPassWithSetup(1, false)
+
+	// Check topic 0 is inactive, reactivate, and verify rewards
+	isActive, err := s.EmissionsKeeper().IsTopicActive(s.Ctx(), topicIDs[0])
 	require.NoError(err)
-	blocklHeight := topic0.EpochLength
-	s.ctx = s.ctx.WithBlockHeight(blocklHeight)
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(100))
-	s.Require().NoError(err)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	s.Require().NoError(err)
-	worker0Values := []TestWorkerValue{
-		{Index: worker0Indexes[0], Value: "0.1"},
-		{Index: worker0Indexes[1], Value: "0.2"},
-		{Index: worker0Indexes[2], Value: "0.3"},
-	}
-	reputer0Values := []TestWorkerValue{
-		{Index: reputer0Indexes[0], Value: "0.1"},
-		{Index: reputer0Indexes[1], Value: "0.2"},
-		{Index: reputer0Indexes[2], Value: "0.3"},
-	}
-	worker1Values := []TestWorkerValue{
-		{Index: worker1Indexes[0], Value: "0.4"},
-		{Index: worker1Indexes[1], Value: "0.5"},
-		{Index: worker1Indexes[2], Value: "0.6"},
-	}
-	reputer1Values := []TestWorkerValue{
-		{Index: reputer1Indexes[0], Value: "0.4"},
-		{Index: reputer1Indexes[1], Value: "0.5"},
-		{Index: reputer1Indexes[2], Value: "0.6"},
-	}
-	rewardsDistribution0_0 := s.getRewardsDistribution(
-		topicId0,
-		worker0Values,
-		reputer0Values,
-		s.addrs[worker0Indexes[0]],
-		"0.1",
-		"0.1",
-	)
+	require.False(isActive)
 
-	_ = s.getRewardsDistribution(
-		topicId1,
-		worker1Values,
-		reputer1Values,
-		s.addrs[worker1Indexes[0]],
-		"0.2",
-		"0.2",
-	)
+	s.FundTopic(topicIDs[0], s.Addrs(topicConfigs[0].rIdx[0]), initialStake.MulRaw(3))
 
-	// Check if first topic is inactivated due to low weight
-	isActivated, err := s.emissionsKeeper.IsTopicActive(s.ctx, topicId0)
+	isActive, err = s.EmissionsKeeper().IsTopicActive(s.Ctx(), topicIDs[0])
 	require.NoError(err)
-	require.False(isActivated)
+	require.True(isActive)
 
-	// Activate first topic
-	s.MintTokensToAddress(s.addrs[reputer0Indexes[0]], initialStake)
-	fundTopic0Message = types.FundTopicRequest{
-		Sender:  s.addrs[reputer0Indexes[0]].String(),
-		TopicId: topicId0,
-		Amount:  initialStake.MulRaw(3),
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopic0Message)
-	s.Require().NoError(err)
-
-	isActivated, err = s.emissionsKeeper.IsTopicActive(s.ctx, topicId0)
-	require.NoError(err)
-	require.True(isActivated)
-
-	rewardsDistribution0_1 := s.getRewardsDistribution(
-		topicId0,
-		worker0Values,
-		reputer0Values,
-		s.addrs[worker0Indexes[0]],
-		"0.1",
-		"0.1",
-	)
-	require.Equal(len(rewardsDistribution0_1), len(rewardsDistribution0_0))
-}
-
-// Generates slice of consecutive numbers
-func (s *RewardsTestSuite) returnIndexes(start, count int) []int {
-	res := make([]int, count)
-	for ind := start; ind < start+count; ind++ {
-		res[ind-start] = ind
-	}
-	return res
-}
-
-func decPtr(s string) *alloraMath.Dec {
-	d := alloraMath.MustNewDecFromString(s)
-	return &d
+	rewards0_1 := runPassWithSetup(0, false)
+	require.Equal(len(rewards0_1), len(rewards0_0))
 }
 
 func (s *RewardsTestSuite) TestCalcTopicRewards() {
@@ -3871,9 +1184,9 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 				map[uint64]int64,
 				alloraMath.Dec) {
 				weights := map[uint64]*alloraMath.Dec{
-					1: decPtr("0.5"),
-					2: decPtr("0.3"),
-					3: decPtr("0.2"),
+					1: testutil.DecPtr("0.5"),
+					2: testutil.DecPtr("0.3"),
+					3: testutil.DecPtr("0.2"),
 				}
 				sortedTopics := []uint64{1, 2, 3}
 				sumWeight := alloraMath.MustNewDecFromString("1.0")
@@ -3888,9 +1201,9 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			},
 			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
-					1: decPtr("500.0"),
-					2: decPtr("300.0"),
-					3: decPtr("200.0"),
+					1: testutil.DecPtr("500.0"),
+					2: testutil.DecPtr("300.0"),
+					3: testutil.DecPtr("200.0"),
 				}
 				return s.compareRewards(rewards, expected)
 			},
@@ -3900,7 +1213,7 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			name: "Single topic",
 			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
 				weights := map[uint64]*alloraMath.Dec{
-					1: decPtr("1.0"),
+					1: testutil.DecPtr("1.0"),
 				}
 				sortedTopics := []uint64{1}
 				sumWeight := alloraMath.MustNewDecFromString("1.0")
@@ -3913,7 +1226,7 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			},
 			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
-					1: decPtr("1000.0"),
+					1: testutil.DecPtr("1000.0"),
 				}
 				return s.compareRewards(rewards, expected)
 			},
@@ -3923,8 +1236,8 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			name: "Zero total reward",
 			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
 				weights := map[uint64]*alloraMath.Dec{
-					1: decPtr("0.5"),
-					2: decPtr("0.5"),
+					1: testutil.DecPtr("0.5"),
+					2: testutil.DecPtr("0.5"),
 				}
 				sortedTopics := []uint64{1, 2}
 				sumWeight := alloraMath.MustNewDecFromString("1.0")
@@ -3938,8 +1251,8 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			},
 			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
-					1: decPtr("0"),
-					2: decPtr("0"),
+					1: testutil.DecPtr("0"),
+					2: testutil.DecPtr("0"),
 				}
 				return s.compareRewards(rewards, expected)
 			},
@@ -3949,8 +1262,8 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			name: "Different epoch lengths",
 			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
 				weights := map[uint64]*alloraMath.Dec{
-					1: decPtr("0.75"),
-					2: decPtr("0.25"),
+					1: testutil.DecPtr("0.75"),
+					2: testutil.DecPtr("0.25"),
 				}
 				sortedTopics := []uint64{1, 2}
 				sumWeight := alloraMath.MustNewDecFromString("1")
@@ -3964,8 +1277,8 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			},
 			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
-					1: decPtr("75"),
-					2: decPtr("50"),
+					1: testutil.DecPtr("75"),
+					2: testutil.DecPtr("50"),
 				}
 				return s.compareRewards(rewards, expected)
 			},
@@ -3975,8 +1288,8 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			name: "Very small weights",
 			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
 				weights := map[uint64]*alloraMath.Dec{
-					1: decPtr("0.000000000000000001"),
-					2: decPtr("0.000000000000000002"),
+					1: testutil.DecPtr("0.000000000000000001"),
+					2: testutil.DecPtr("0.000000000000000002"),
 				}
 				sortedTopics := []uint64{1, 2}
 				sumWeight := alloraMath.MustNewDecFromString("0.000000000000000003")
@@ -3990,8 +1303,8 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			},
 			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
-					1: decPtr("333.333333333333333333"),
-					2: decPtr("666.666666666666666667"),
+					1: testutil.DecPtr("333.333333333333333333"),
+					2: testutil.DecPtr("666.666666666666666667"),
 				}
 				return s.compareRewards(rewards, expected)
 			},
@@ -4001,8 +1314,8 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			name: "Mismatched weights and sorted topics",
 			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
 				weights := map[uint64]*alloraMath.Dec{
-					1: decPtr("0.5"),
-					2: decPtr("0.5"),
+					1: testutil.DecPtr("0.5"),
+					2: testutil.DecPtr("0.5"),
 				}
 				sortedTopics := []uint64{1, 2, 3}
 				sumWeight := alloraMath.MustNewDecFromString("1.0")
@@ -4023,9 +1336,9 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			name: "Treasury lower than rewards",
 			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
 				weights := map[uint64]*alloraMath.Dec{
-					1: decPtr("0.5"),
-					2: decPtr("0.3"),
-					3: decPtr("0.2"),
+					1: testutil.DecPtr("0.5"),
+					2: testutil.DecPtr("0.3"),
+					3: testutil.DecPtr("0.2"),
 				}
 				sortedTopics := []uint64{1, 2, 3}
 				sumWeight := alloraMath.MustNewDecFromString("1.0")
@@ -4040,9 +1353,9 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 			},
 			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
-					1: decPtr("25.0"),
-					2: decPtr("15.0"),
-					3: decPtr("10.0"),
+					1: testutil.DecPtr("25.0"),
+					2: testutil.DecPtr("15.0"),
+					3: testutil.DecPtr("10.0"),
 				}
 				return s.compareRewards(rewards, expected)
 			},
@@ -4054,7 +1367,7 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 		s.Run(tc.name, func() {
 			weights, sortedTopics, sumWeight, totalReward, epochLengths, currentBlockEmission := tc.setupFunc()
 			args := rewards.CalcTopicRewardsArgs{
-				Ctx:                             s.ctx,
+				Ctx:                             s.Ctx(),
 				Weights:                         weights,
 				SortedTopics:                    sortedTopics,
 				SumTopicWeights:                 sumWeight,
@@ -4098,11 +1411,11 @@ func (s *RewardsTestSuite) compareRewards(actual, expected map[uint64]*alloraMat
 
 func (s *RewardsTestSuite) TestMonthlyPercentageRewardCalculation() {
 	// 1. Setup Params
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	blocksPerMonth := int64(10)
 	params.BlocksPerMonth = uint64(blocksPerMonth)
-	err = s.emissionsKeeper.SetParams(s.ctx, params)
+	err = s.EmissionsKeeper().SetParams(s.Ctx(), params)
 	s.Require().NoError(err)
 
 	// 2. Fund Rewards Module (required for EndBlocker checks)
@@ -4115,13 +1428,13 @@ func (s *RewardsTestSuite) TestMonthlyPercentageRewardCalculation() {
 
 	// 4. Simulate Block Progression and Reward Accumulation
 	for i := int64(1); i < blocksPerMonth; i++ {
-		loopCtx := s.ctx.WithBlockHeight(i)
+		loopCtx := s.Ctx().WithBlockHeight(i)
 		// Run EndBlocker (simulates standard block processing)
-		err = module.EndBlocker(loopCtx, s.emissionsAppModule)
+		err = module.EndBlocker(loopCtx, s.EmissionsAppModule())
 		s.Require().NoError(err, "EndBlocker failed during block %d", i)
 
 		// Manually add rewards to simulate accumulation during the month
-		err = s.emissionsKeeper.AddMonthlyRewards(loopCtx, reputerIncrement, topicIncrement)
+		err = s.EmissionsKeeper().AddMonthlyRewards(loopCtx, reputerIncrement, topicIncrement)
 		s.Require().NoError(err, "Failed to add rewards at block %d", i)
 	}
 
@@ -4140,43 +1453,42 @@ func (s *RewardsTestSuite) TestMonthlyPercentageRewardCalculation() {
 	}
 
 	// Sanity check the accumulated values before the final EndBlocker call
-	reputerRewardsBeforeFinal, err := s.emissionsKeeper.GetMonthlyReputerRewards(s.ctx)
+	reputerRewardsBeforeFinal, err := s.EmissionsKeeper().GetMonthlyReputerRewards(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(totalReputerRewards.Equal(reputerRewardsBeforeFinal), "Mismatch in accumulated reputer rewards before reset")
-	topicRewardsBeforeFinal, err := s.emissionsKeeper.GetMonthlyTopicRewards(s.ctx)
+	topicRewardsBeforeFinal, err := s.EmissionsKeeper().GetMonthlyTopicRewards(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(totalTopicRewards.Equal(topicRewardsBeforeFinal), "Mismatch in accumulated topic rewards before reset")
 
 	// 6. Trigger End Blocker execution at the end of the month
-	endOfMonthCtx := s.ctx.WithBlockHeight(blocksPerMonth)
-	err = module.EndBlocker(endOfMonthCtx, s.emissionsAppModule)
+	endOfMonthCtx := s.Ctx().WithBlockHeight(blocksPerMonth)
+	err = module.EndBlocker(endOfMonthCtx, s.EmissionsAppModule())
 	s.Require().NoError(err, "EndBlocker execution failed at month boundary %d", blocksPerMonth)
 
 	// 7. Verify State After End Blocker
 	// Verify percentage calculated and stored by EndBlocker
-	actualPercentageAfter, err := s.emissionsKeeper.GetPreviousPercentageRewardToStakedReputers(s.ctx)
+	actualPercentageAfter, err := s.EmissionsKeeper().GetPreviousPercentageRewardToStakedReputers(s.Ctx())
 	s.Require().NoError(err)
 	s.T().Logf("Expected percentage %s, got %s", expectedPercentage.String(), actualPercentageAfter.String())
 	s.Require().True(expectedPercentage.Equal(actualPercentageAfter), "Expected percentage %s, got %s", expectedPercentage.String(), actualPercentageAfter.String())
 
 	// Verify counters reset by EndBlocker
-	reputerRewardsAfter, err := s.emissionsKeeper.GetMonthlyReputerRewards(s.ctx)
+	reputerRewardsAfter, err := s.EmissionsKeeper().GetMonthlyReputerRewards(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(reputerRewardsAfter.IsZero(), "Monthly reputer rewards not reset by EndBlocker")
 
-	topicRewardsAfter, err := s.emissionsKeeper.GetMonthlyTopicRewards(s.ctx)
+	topicRewardsAfter, err := s.EmissionsKeeper().GetMonthlyTopicRewards(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(topicRewardsAfter.IsZero(), "Monthly topic rewards not reset by EndBlocker")
 }
 
 func (s *RewardsTestSuite) TestMonthlyPercentageRewardCalculation_ZeroTopicRewards() {
-
 	// 1. Setup Params
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	blocksPerMonth := int64(10)
 	params.BlocksPerMonth = uint64(blocksPerMonth)
-	err = s.emissionsKeeper.SetParams(s.ctx, params)
+	err = s.EmissionsKeeper().SetParams(s.Ctx(), params)
 	s.Require().NoError(err)
 
 	// 2. Fund Rewards Module (required for EndBlocker checks)
@@ -4189,34 +1501,34 @@ func (s *RewardsTestSuite) TestMonthlyPercentageRewardCalculation_ZeroTopicRewar
 
 	// 4. Simulate Block Progression up to the Monthly Boundary
 	for i := int64(1); i < blocksPerMonth; i++ {
-		loopCtx := s.ctx.WithBlockHeight(i)
-		err = module.EndBlocker(loopCtx, s.emissionsAppModule)
+		loopCtx := s.Ctx().WithBlockHeight(i)
+		err = module.EndBlocker(loopCtx, s.EmissionsAppModule())
 		s.Require().NoError(err, "EndBlocker failed during block %d", i)
 
 		// Sanity check: Verify topic rewards remain zero during the month
-		topicRewards, err := s.emissionsKeeper.GetMonthlyTopicRewards(loopCtx)
+		topicRewards, err := s.EmissionsKeeper().GetMonthlyTopicRewards(loopCtx)
 		s.Require().NoError(err)
 		s.Require().True(topicRewards.IsZero(), "Topic rewards became non-zero before month end at block %d", i)
 	}
 
 	// 5. Trigger End Blocker execution at the end of the month
-	endOfMonthCtx := s.ctx.WithBlockHeight(blocksPerMonth)
-	err = module.EndBlocker(endOfMonthCtx, s.emissionsAppModule)
+	endOfMonthCtx := s.Ctx().WithBlockHeight(blocksPerMonth)
+	err = module.EndBlocker(endOfMonthCtx, s.EmissionsAppModule())
 	s.Require().NoError(err, "EndBlocker execution failed at month boundary %d", blocksPerMonth)
 
 	// 6. Verify State After End Blocker
 	// Verify percentage is zero due to zero topic rewards
 	expectedPercentage := alloraMath.ZeroDec()
-	actualPercentageAfter, err := s.emissionsKeeper.GetPreviousPercentageRewardToStakedReputers(s.ctx)
+	actualPercentageAfter, err := s.EmissionsKeeper().GetPreviousPercentageRewardToStakedReputers(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(expectedPercentage.Equal(actualPercentageAfter), "Expected percentage %s, got %s", expectedPercentage.String(), actualPercentageAfter.String())
 
 	// Verify counters reset by EndBlocker
-	reputerRewardsAfter, err := s.emissionsKeeper.GetMonthlyReputerRewards(s.ctx)
+	reputerRewardsAfter, err := s.EmissionsKeeper().GetMonthlyReputerRewards(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(reputerRewardsAfter.IsZero(), "Monthly reputer rewards not reset by EndBlocker")
 
-	topicRewardsAfter, err := s.emissionsKeeper.GetMonthlyTopicRewards(s.ctx)
+	topicRewardsAfter, err := s.EmissionsKeeper().GetMonthlyTopicRewards(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(topicRewardsAfter.IsZero(), "Monthly topic rewards not reset by EndBlocker")
 }
@@ -4225,103 +1537,85 @@ func (s *RewardsTestSuite) TestNoActiveParticipantsNoRewardsForTopic() {
 	require := s.Require()
 
 	block := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(block)
+	s.WithBlockHeight(block)
 
 	s.SetParamsForTest()
 
 	creatorIndex := 40
 	reputerIndex := 41
 
-	// Create topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrsStr[creatorIndex],
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              100,
-		AllowNegative:            false,
-		GroundTruthLag:           100,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	require.NoError(err)
-	topicId := res.TopicId
-
-	// Register the single reputer
-	// But it will not be actively participating in the topic
-	reputerRegMsg := &types.RegisterRequest{
-		Sender:    s.addrsStr[reputerIndex],
-		TopicId:   topicId,
-		IsReputer: true,
-		Owner:     s.addrsStr[reputerIndex],
-	}
-	_, err = s.msgServer.Register(s.ctx, reputerRegMsg)
-	require.NoError(err)
-
-	// Add stake for the reputer
-	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
-	s.MintTokensToAddress(s.addrs[reputerIndex], stake)
-	_, err = s.msgServer.AddStake(s.ctx, &types.AddStakeRequest{
-		Sender:  s.addrsStr[reputerIndex],
-		Amount:  stake,
-		TopicId: topicId,
-	})
-	require.NoError(err)
-
-	// Fund the topic
-	s.MintTokensToAddress(s.addrs[creatorIndex], stake)
-	fundTopicMessage := types.FundTopicRequest{
-		Sender:  s.addrsStr[creatorIndex],
-		TopicId: topicId,
-		Amount:  stake,
-	}
-	_, err = s.msgServer.FundTopic(s.ctx, &fundTopicMessage)
-	require.NoError(err)
+	topicId := s.SetupTopic(s.Addrs(creatorIndex))
+	s.SetupParticipants(topicId, []int{reputerIndex}, true)
 
 	// Record initial balance of the rewards module account
-	rewardsModuleAddr := s.accountKeeper.GetModuleAddress(types.AlloraRewardsAccountName)
-	initialRewardsBalance := s.bankKeeper.GetBalance(s.ctx, rewardsModuleAddr, params.DefaultBondDenom)
+	rewardsModuleAddr := s.AccountKeeper().GetModuleAddress(types.AlloraRewardsAccountName)
+	initialRewardsBalance := s.BankKeeper().GetBalance(s.Ctx(), rewardsModuleAddr, params.DefaultBondDenom)
 
 	// Record initial balance of the ecosystem account
-	ecosystemAddr := s.accountKeeper.GetModuleAddress(minttypes.EcosystemModuleName)
-	initialEcosystemBalance := s.bankKeeper.GetBalance(s.ctx, ecosystemAddr, params.DefaultBondDenom)
+	ecosystemAddr := s.AccountKeeper().GetModuleAddress(minttypes.EcosystemModuleName)
+	initialEcosystemBalance := s.BankKeeper().GetBalance(s.Ctx(), ecosystemAddr, params.DefaultBondDenom)
 
 	// Simulate moving to the end of the first epoch
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
+	topic, err := s.EmissionsKeeper().GetTopic(s.Ctx(), topicId)
 	require.NoError(err)
 	nextBlock := block + topic.EpochLength
-	s.ctx = s.ctx.WithBlockHeight(nextBlock)
-
-	// Set some block emission (even though it shouldn't be used for this topic)
-	err = s.emissionsKeeper.SetRewardCurrentBlockEmission(s.ctx, cosmosMath.NewInt(1000))
-	require.NoError(err)
+	s.WithBlockHeight(nextBlock)
 
 	// Trigger EndBlocker to process potential rewards
-	err = s.emissionsAppModule.EndBlock(s.ctx)
-	require.NoError(err)
+	s.EndBlock()
 
 	// Check topic weight after funding and epoch end
-	topicWeight, _, err := s.emissionsKeeper.GetPreviousTopicWeight(s.ctx, topicId)
+	topicWeight, _, err := s.EmissionsKeeper().GetPreviousTopicWeight(s.Ctx(), topicId)
 	require.NoError(err)
 	require.True(topicWeight.Gt(alloraMath.ZeroDec()), "Topic weight should be greater than zero after funding")
 
 	// Verify no rewards were distributed for this topic (moved to ecosystem account)
-	finalRewardsBalance := s.bankKeeper.GetBalance(s.ctx, rewardsModuleAddr, params.DefaultBondDenom)
+	finalRewardsBalance := s.BankKeeper().GetBalance(s.Ctx(), rewardsModuleAddr, params.DefaultBondDenom)
 	require.True(initialRewardsBalance.Amount.GT(finalRewardsBalance.Amount),
 		"Rewards module - topic %d: Initial: %s, Final: %s",
 		topicId, initialRewardsBalance.String(), finalRewardsBalance.String())
 
 	// Verify if rewards were moved to the ecosystem account
-	ecosystemBalance := s.bankKeeper.GetBalance(s.ctx, ecosystemAddr, params.DefaultBondDenom)
+	ecosystemBalance := s.BankKeeper().GetBalance(s.Ctx(), ecosystemAddr, params.DefaultBondDenom)
 	require.True(ecosystemBalance.Amount.GT(initialEcosystemBalance.Amount),
 		"Ecosystem account - topic %d: Initial: %s, Final: %s",
 		topicId, initialEcosystemBalance.String(), ecosystemBalance.String())
+}
+
+func areTaskRewardsEqualIgnoringTopicId(s *RewardsTestSuite, A []types.TaskReward, B []types.TaskReward) bool {
+	if len(A) != len(B) {
+		s.Fail("Lengths are different")
+	}
+
+	for _, taskRewardA := range A {
+		found := false
+		for _, taskRewardB := range B {
+			if taskRewardA.Address == taskRewardB.Address && taskRewardA.Type == taskRewardB.Type {
+				if found {
+					s.Fail("Worker %v found twice", taskRewardA.Address)
+				}
+				found = true
+				inDelta, err := alloraMath.InDelta(
+					taskRewardA.Reward,
+					taskRewardB.Reward,
+					alloraMath.MustNewDecFromString("0.00001"),
+				)
+				if err != nil {
+					s.Fail("Error finding out if taskRewardA in delta with taskRewardB",
+						taskRewardA.Reward.String(),
+						taskRewardB.Reward.String(),
+					)
+				}
+				if !inDelta {
+					return false
+				}
+			}
+		}
+		if !found {
+			s.T().Logf("Worker %v not found", taskRewardA.Address)
+			return false
+		}
+	}
+
+	return true
 }

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -52,40 +52,24 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionShouldRewardTopicsWithFulfi
 
 	reputerIndexes := testutil.ReturnIndexes(0, 5)
 	workerIndexes := testutil.ReturnIndexes(5, 5)
+	reputerIndexes2 := testutil.ReturnIndexes(10, 5)
+	workerIndexes2 := testutil.ReturnIndexes(15, 5)
 
 	// TOPIC 1 - PRE PASS
 	topicId, newBlockheight := s.FullTopicPass(workerIndexes, reputerIndexes)
 
-	// TOPIC 1 - FIRST PASS
-	s.FullTopicPass(workerIndexes, reputerIndexes, testutil.WithTopicID(topicId))
+	// TOPIC 2 - SETUP
+	// Do not send bundles for topic 2 yet
+	topic2 := s.FullTopicSetup(workerIndexes2, reputerIndexes2)
 
 	beforeRewardsTopic1FeeRevenue, err := s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
-	reputerIndexes2 := testutil.ReturnIndexes(10, 5)
-	workerIndexes2 := testutil.ReturnIndexes(15, 5)
-
-	// TOPIC 2 - PRE PASS
-	topic2 := s.FullTopicSetup(workerIndexes2, reputerIndexes2)
-
-	afterRewardsTopic1FeeRevenue, err := s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topicId)
-	s.Require().NoError(err)
-
-	// Topic 1 should have less revenue after rewards distribution -> rewards distributed
-	s.Require().True(
-		beforeRewardsTopic1FeeRevenue.Equal(afterRewardsTopic1FeeRevenue),
-		"Topic 1 should not lose influence of their fee revenue yet: %s = %s",
-		beforeRewardsTopic1FeeRevenue.String(),
-		afterRewardsTopic1FeeRevenue.String(),
-	)
-
-	// Do not send bundles for topic 2 yet
-
 	beforeRewardsTopic2FeeRevenue, err := s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topic2.GetId())
 	s.Require().NoError(err)
 
-	// TOPIC 2 - FIRST PASS
-	s.FullTopicPass(workerIndexes2, reputerIndexes2, testutil.WithTopicID(topic2.GetId()))
+	// TOPIC 1 - FIRST PASS
+	s.FullTopicPass(workerIndexes, reputerIndexes, testutil.WithTopicID(topicId))
 
 	// mint some rewards to give out
 	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(1000))
@@ -96,7 +80,7 @@ func (s *RewardsTestSuite) TestStandardRewardEmissionShouldRewardTopicsWithFulfi
 	// Trigger end block - rewards distribution
 	s.EndBlock()
 
-	afterRewardsTopic1FeeRevenue, err = s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topicId)
+	afterRewardsTopic1FeeRevenue, err := s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	afterRewardsTopic2FeeRevenue, err := s.EmissionsKeeper().GetTopicFeeRevenue(s.Ctx(), topic2.GetId())
 	s.Require().NoError(err)

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -1,17 +1,16 @@
 package rewards_test
 
 import (
-	"math/rand"
-	"strconv"
+	"fmt"
 
 	cosmosMath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/test/testutil"
 	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (s *RewardsTestSuite) TestGetReputersScoresFromCsv() {
@@ -19,126 +18,58 @@ func (s *RewardsTestSuite) TestGetReputersScoresFromCsv() {
 	epoch300Get := epochGet[300]
 	epoch301Get := epochGet[301]
 	block := int64(1003)
+	topicId := uint64(1)
 
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
+	reputerAddresses := make([]string, 5)
+	for i := range len(reputerAddresses) {
+		reputerAddresses[i] = s.AddrsStr(13 + i)
 	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
-
-	reputer0 := s.addrsStr[13]
-	reputer1 := s.addrsStr[14]
-	reputer2 := s.addrsStr[15]
-	reputer3 := s.addrsStr[16]
-	reputer4 := s.addrsStr[17]
-	reputerAddresses := []string{reputer0, reputer1, reputer2, reputer3, reputer4}
-
-	inferer0 := s.addrsStr[5]
-	inferer1 := s.addrsStr[6]
-	inferer2 := s.addrsStr[7]
-	inferer3 := s.addrsStr[8]
-	inferer4 := s.addrsStr[9]
-	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
-
-	forecaster0 := s.addrsStr[10]
-	forecaster1 := s.addrsStr[11]
-	forecaster2 := s.addrsStr[12]
-	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
-
-	reputers := []testutil.ReputerKey{
-		{
-			Address:    s.addrsStr[13],
-			PrivateKey: s.privKeys[13],
-			PubKeyHex:  s.pubKeyHexStr[13],
-		},
-		{
-			Address:    s.addrsStr[14],
-			PrivateKey: s.privKeys[14],
-			PubKeyHex:  s.pubKeyHexStr[14],
-		},
-		{
-			Address:    s.addrsStr[15],
-			PrivateKey: s.privKeys[15],
-			PubKeyHex:  s.pubKeyHexStr[15],
-		},
-		{
-			Address:    s.addrsStr[16],
-			PrivateKey: s.privKeys[16],
-			PubKeyHex:  s.pubKeyHexStr[16],
-		},
-		{
-			Address:    s.addrsStr[17],
-			PrivateKey: s.privKeys[17],
-			PubKeyHex:  s.pubKeyHexStr[17],
-		},
+	infererAddresses := make([]string, 5)
+	for i := range len(infererAddresses) {
+		infererAddresses[i] = s.AddrsStr(5 + i)
+	}
+	forecasterAddresses := make([]string, 3)
+	for i := range len(forecasterAddresses) {
+		forecasterAddresses[i] = s.AddrsStr(10 + i)
+	}
+	reputers := make([]testutil.ReputerKey, 5)
+	for i := range len(reputers) {
+		reputers[i] = testutil.ReputerKey{
+			Address:    s.AddrsStr(13 + i),
+			PrivateKey: s.PrivKeys(13 + i),
+			PubKeyHex:  s.PubKeyHexStr(13 + i),
+		}
 	}
 
 	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
 	cosmosOneE18Dec, err := alloraMath.NewDecFromSdkInt(cosmosOneE18)
 	s.Require().NoError(err)
 
-	reputer0Stake, err := epoch301Get("reputer_stake_0").Mul(cosmosOneE18Dec)
-	s.Require().NoError(err)
-	reputer0StakeInt, err := reputer0Stake.BigInt()
-	s.Require().NoError(err)
-	reputer1Stake, err := epoch301Get("reputer_stake_1").Mul(cosmosOneE18Dec)
-	s.Require().NoError(err)
-	reputer1StakeInt, err := reputer1Stake.BigInt()
-	s.Require().NoError(err)
-	reputer2Stake, err := epoch301Get("reputer_stake_2").Mul(cosmosOneE18Dec)
-	s.Require().NoError(err)
-	reputer2StakeInt, err := reputer2Stake.BigInt()
-	s.Require().NoError(err)
-	reputer3Stake, err := epoch301Get("reputer_stake_3").Mul(cosmosOneE18Dec)
-	s.Require().NoError(err)
-	reputer3StakeInt, err := reputer3Stake.BigInt()
-	s.Require().NoError(err)
-	reputer4Stake, err := epoch301Get("reputer_stake_4").Mul(cosmosOneE18Dec)
-	s.Require().NoError(err)
-	reputer4StakeInt, err := reputer4Stake.BigInt()
-	s.Require().NoError(err)
+	stakes := make([]cosmosMath.Int, 5)
+	for i := range len(stakes) {
+		reputerStake, err := epoch301Get(fmt.Sprintf("reputer_stake_%d", i)).Mul(cosmosOneE18Dec)
+		s.Require().NoError(err)
+		reputerStakeInt, err := reputerStake.BigInt()
+		s.Require().NoError(err)
+		stakes[i] = cosmosMath.NewIntFromBigInt(reputerStakeInt)
+	}
 
-	var stakes = []cosmosMath.Int{
-		cosmosMath.NewIntFromBigInt(reputer0StakeInt),
-		cosmosMath.NewIntFromBigInt(reputer1StakeInt),
-		cosmosMath.NewIntFromBigInt(reputer2StakeInt),
-		cosmosMath.NewIntFromBigInt(reputer3StakeInt),
-		cosmosMath.NewIntFromBigInt(reputer4StakeInt),
+	coefficients := make([]alloraMath.Dec, 5)
+	for i := range len(coefficients) {
+		coefficients[i] = epoch300Get(fmt.Sprintf("reputer_listening_coefficient_%d", i))
 	}
-	var coefficients = []alloraMath.Dec{
-		epoch300Get("reputer_listening_coefficient_0"),
-		epoch300Get("reputer_listening_coefficient_1"),
-		epoch300Get("reputer_listening_coefficient_2"),
-		epoch300Get("reputer_listening_coefficient_3"),
-		epoch300Get("reputer_listening_coefficient_4"),
-	}
+
 	for i, addr := range reputerAddresses {
 		addrBech, err := sdk.AccAddressFromBech32(addr)
 		s.Require().NoError(err)
 
 		s.MintTokensToAddress(addrBech, stakes[i])
 
-		err = s.emissionsKeeper.AddReputerStake(s.ctx, topicId, addr, stakes[i])
+		err = s.EmissionsKeeper().AddReputerStake(s.Ctx(), topicId, addr, stakes[i])
 		s.Require().NoError(err)
 
-		err = s.emissionsKeeper.SetListeningCoefficient(
-			s.ctx,
+		err = s.EmissionsKeeper().SetListeningCoefficient(
+			s.Ctx(),
 			topicId,
 			addr,
 			types.ListeningCoefficient{Coefficient: coefficients[i]},
@@ -156,50 +87,27 @@ func (s *RewardsTestSuite) TestGetReputersScoresFromCsv() {
 	)
 	s.Require().NoError(err)
 
-	// Generate new reputer scores
 	scores, err := rewards.GenerateReputerScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block,
 		reportedLosses,
 	)
 	s.Require().NoError(err)
 
-	expectedScores := []alloraMath.Dec{
-		epoch301Get("reputer_score_0"),
-		epoch301Get("reputer_score_1"),
-		epoch301Get("reputer_score_2"),
-		epoch301Get("reputer_score_3"),
-		epoch301Get("reputer_score_4"),
+	expectedScores := make([]alloraMath.Dec, 5)
+	for i := range len(expectedScores) {
+		expectedScores[i] = epoch301Get(fmt.Sprintf("reputer_score_%d", i))
 	}
+
 	for i, reputerScore := range scores {
 		testutil.InEpsilon5(s.T(), reputerScore.Score, expectedScores[i].String())
 	}
 }
 
 func (s *RewardsTestSuite) TestGetInferenceScores() {
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
+	topicId := uint64(1)
 	block := int64(1003)
 
 	// Generate workers data for tests
@@ -208,8 +116,8 @@ func (s *RewardsTestSuite) TestGetInferenceScores() {
 
 	// Get inference scores
 	scores, err := rewards.GenerateInferenceScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block,
 		reportedLosses,
@@ -237,27 +145,7 @@ func (s *RewardsTestSuite) TestGetInferenceScores() {
 }
 
 func (s *RewardsTestSuite) TestGenerateInferenceScores_AllNilOneOutAndOneIn() {
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
+	topicId := uint64(1)
 	block := int64(2001)
 
 	// Generate normal network losses, then set all one-out/one-in fields to nil
@@ -269,8 +157,8 @@ func (s *RewardsTestSuite) TestGenerateInferenceScores_AllNilOneOutAndOneIn() {
 	reportedLosses.OneInForecasterValues = nil
 
 	scores, err := rewards.GenerateInferenceScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block,
 		reportedLosses,
@@ -283,42 +171,18 @@ func (s *RewardsTestSuite) TestGenerateInferenceScores_AllNilOneOutAndOneIn() {
 func (s *RewardsTestSuite) TestGetInferenceScoresFromCsv() {
 	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
 	epoch3Get := epochGet[300]
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
+	topicId := uint64(1)
 	block := int64(1003)
 
-	inferer0 := s.addrs[5].String()
-	inferer1 := s.addrs[6].String()
-	inferer2 := s.addrs[7].String()
-	inferer3 := s.addrs[8].String()
-	inferer4 := s.addrs[9].String()
-	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
-
-	forecaster0 := s.addrs[10].String()
-	forecaster1 := s.addrs[11].String()
-	forecaster2 := s.addrs[12].String()
-	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
-
-	reputer0 := s.addrs[13].String()
+	infererAddresses := make([]string, 5)
+	for i := range infererAddresses {
+		infererAddresses[i] = s.AddrsStr(i + 5)
+	}
+	forecasterAddresses := make([]string, 3)
+	for i := range forecasterAddresses {
+		forecasterAddresses[i] = s.AddrsStr(i + 10)
+	}
+	reputer0 := s.AddrsStr(13)
 
 	reportedLosses, err := testutil.GetNetworkLossFromCsv(
 		topicId,
@@ -331,21 +195,19 @@ func (s *RewardsTestSuite) TestGetInferenceScoresFromCsv() {
 	s.Require().NoError(err)
 
 	scores, err := rewards.GenerateInferenceScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block,
 		reportedLosses,
 	)
 	s.Require().NoError(err)
 
-	expectedScores := []alloraMath.Dec{
-		epoch3Get("inferer_score_0"),
-		epoch3Get("inferer_score_1"),
-		epoch3Get("inferer_score_2"),
-		epoch3Get("inferer_score_3"),
-		epoch3Get("inferer_score_4"),
+	expectedScores := make([]alloraMath.Dec, 5)
+	for i := range expectedScores {
+		expectedScores[i] = epoch3Get(fmt.Sprintf("inferer_score_%d", i))
 	}
+
 	for i, infererScore := range scores {
 		testutil.InEpsilon5(s.T(), infererScore.Score, expectedScores[i].String())
 	}
@@ -355,27 +217,7 @@ func (s *RewardsTestSuite) TestGetInferenceScoresFromCsv() {
 // and the second with higher one out losses.
 // We then compare the resulting scores and check that the higher one out losses result in higher scores.
 func (s *RewardsTestSuite) TestHigherOneOutLossesHigherInferenceScore() {
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
+	topicId := uint64(1)
 	block0 := int64(1003)
 	require := s.Require()
 
@@ -383,8 +225,8 @@ func (s *RewardsTestSuite) TestHigherOneOutLossesHigherInferenceScore() {
 	require.NoError(err)
 
 	scores0, err := rewards.GenerateInferenceScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block0,
 		networkLosses0,
@@ -397,8 +239,8 @@ func (s *RewardsTestSuite) TestHigherOneOutLossesHigherInferenceScore() {
 	require.NoError(err)
 
 	scores1, err := rewards.GenerateInferenceScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block1,
 		networkLosses1,
@@ -410,35 +252,15 @@ func (s *RewardsTestSuite) TestHigherOneOutLossesHigherInferenceScore() {
 
 func (s *RewardsTestSuite) TestGetForecastScores() {
 	block := int64(1003)
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
+	topicId := uint64(1)
 
 	// Generate workers data for tests
 	reportedLosses, err := mockNetworkLosses(s, topicId, block)
 	s.Require().NoError(err)
 
 	scores, err := rewards.GenerateForecastScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block,
 		reportedLosses,
@@ -467,42 +289,18 @@ func (s *RewardsTestSuite) TestGetForecastScores() {
 func (s *RewardsTestSuite) TestGetForecasterScoresFromCsv() {
 	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
 	epoch3Get := epochGet[300]
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
+	topicId := uint64(1)
 	block := int64(1003)
 
-	inferer0 := s.addrs[5].String()
-	inferer1 := s.addrs[6].String()
-	inferer2 := s.addrs[7].String()
-	inferer3 := s.addrs[8].String()
-	inferer4 := s.addrs[9].String()
-	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
-
-	forecaster0 := s.addrs[10].String()
-	forecaster1 := s.addrs[11].String()
-	forecaster2 := s.addrs[12].String()
-	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
-
-	reputer0 := s.addrsStr[13]
+	infererAddresses := make([]string, 5)
+	for i := range infererAddresses {
+		infererAddresses[i] = s.AddrsStr(i + 5)
+	}
+	forecasterAddresses := make([]string, 3)
+	for i := range forecasterAddresses {
+		forecasterAddresses[i] = s.AddrsStr(i + 10)
+	}
+	reputer0 := s.AddrsStr(13)
 
 	reportedLosses, err := testutil.GetNetworkLossFromCsv(
 		topicId,
@@ -515,19 +313,19 @@ func (s *RewardsTestSuite) TestGetForecasterScoresFromCsv() {
 	s.Require().NoError(err)
 
 	scores, err := rewards.GenerateForecastScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block,
 		reportedLosses,
 	)
 	s.Require().NoError(err)
 
-	expectedScores := []alloraMath.Dec{
-		epoch3Get("forecaster_score_0"),
-		epoch3Get("forecaster_score_1"),
-		epoch3Get("forecaster_score_2"),
+	expectedScores := make([]alloraMath.Dec, 3)
+	for i := range expectedScores {
+		expectedScores[i] = epoch3Get(fmt.Sprintf("forecaster_score_%d", i))
 	}
+
 	for i, forecasterScore := range scores {
 		testutil.InEpsilon5(s.T(), forecasterScore.Score, expectedScores[i].String())
 	}
@@ -538,27 +336,7 @@ func (s *RewardsTestSuite) TestGetForecasterScoresFromCsv() {
 // We then compare the resulting forecaster scores and check that the higher one out losses result
 // in higher scores.
 func (s *RewardsTestSuite) TestHigherOneOutLossesHigherForecastScore() {
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
+	topicId := uint64(1)
 	block0 := int64(1003)
 	require := s.Require()
 
@@ -566,8 +344,8 @@ func (s *RewardsTestSuite) TestHigherOneOutLossesHigherForecastScore() {
 	require.NoError(err)
 
 	scores0, err := rewards.GenerateForecastScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block0,
 		networkLosses0,
@@ -581,8 +359,8 @@ func (s *RewardsTestSuite) TestHigherOneOutLossesHigherForecastScore() {
 
 	// Get inference scores
 	scores1, err := rewards.GenerateForecastScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block1,
 		networkLosses1,
@@ -595,20 +373,20 @@ func (s *RewardsTestSuite) TestHigherOneOutLossesHigherForecastScore() {
 func (s *RewardsTestSuite) TestEnsureAllWorkersPresent() {
 	// Setup
 	allWorkers := map[string]struct{}{
-		s.addrsStr[1]: {},
-		s.addrsStr[2]: {},
+		s.AddrsStr(1): {},
+		s.AddrsStr(2): {},
 		"worker3":     {},
 		"worker4":     {},
 	}
 
 	values := []*types.WorkerAttributedValue{
-		{Worker: s.addrsStr[1], Value: alloraMath.NewDecFromInt64(100)},
+		{Worker: s.AddrsStr(1), Value: alloraMath.NewDecFromInt64(100)},
 		{Worker: "worker3", Value: alloraMath.NewDecFromInt64(300)},
 	}
 
 	expectedValues := map[string]string{
-		s.addrsStr[1]: "100",
-		s.addrsStr[2]: "NaN",
+		s.AddrsStr(1): "100",
+		s.AddrsStr(2): "NaN",
 		"worker3":     "300",
 		"worker4":     "NaN",
 	}
@@ -640,20 +418,20 @@ func (s *RewardsTestSuite) TestEnsureAllWorkersPresent() {
 func (s *RewardsTestSuite) TestEnsureAllWorkersPresentWithheld() {
 	// Setup
 	allWorkers := map[string]struct{}{
-		s.addrsStr[1]: {},
-		s.addrsStr[2]: {},
+		s.AddrsStr(1): {},
+		s.AddrsStr(2): {},
 		"worker3":     {},
 		"worker4":     {},
 	}
 
 	values := []*types.WithheldWorkerAttributedValue{
-		{Worker: s.addrsStr[1], Value: alloraMath.NewDecFromInt64(100)},
+		{Worker: s.AddrsStr(1), Value: alloraMath.NewDecFromInt64(100)},
 		{Worker: "worker3", Value: alloraMath.NewDecFromInt64(300)},
 	}
 
 	expectedValues := map[string]string{
-		s.addrsStr[1]: "100",
-		s.addrsStr[2]: "NaN",
+		s.AddrsStr(1): "100",
+		s.AddrsStr(2): "NaN",
 		"worker3":     "300",
 		"worker4":     "NaN",
 	}
@@ -698,27 +476,27 @@ func (s *RewardsTestSuite) TestEnsureWorkerPresenceConsistency() {
 					CombinedValue: alloraMath.NewDecFromInt64(100),
 					NaiveValue:    alloraMath.NewDecFromInt64(100),
 					InfererValues: []*types.WorkerAttributedValue{
-						{Worker: s.addrsStr[1], Value: alloraMath.NewDecFromInt64(100)},
-						{Worker: s.addrsStr[2], Value: alloraMath.NewDecFromInt64(200)},
+						{Worker: s.AddrsStr(1), Value: alloraMath.NewDecFromInt64(100)},
+						{Worker: s.AddrsStr(2), Value: alloraMath.NewDecFromInt64(200)},
 					},
 					ForecasterValues: []*types.WorkerAttributedValue{
-						{Worker: s.addrsStr[1], Value: alloraMath.NewDecFromInt64(300)},
+						{Worker: s.AddrsStr(1), Value: alloraMath.NewDecFromInt64(300)},
 					},
 					OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
-						{Worker: s.addrsStr[1], Value: alloraMath.NewDecFromInt64(100)},
-						{Worker: s.addrsStr[2], Value: alloraMath.NewDecFromInt64(200)},
+						{Worker: s.AddrsStr(1), Value: alloraMath.NewDecFromInt64(100)},
+						{Worker: s.AddrsStr(2), Value: alloraMath.NewDecFromInt64(200)},
 					},
 					OneOutForecasterValues: []*types.WithheldWorkerAttributedValue{
-						{Worker: s.addrsStr[1], Value: alloraMath.NewDecFromInt64(300)},
+						{Worker: s.AddrsStr(1), Value: alloraMath.NewDecFromInt64(300)},
 					},
 					OneInForecasterValues: []*types.WorkerAttributedValue{
-						{Worker: s.addrsStr[2], Value: alloraMath.NewDecFromInt64(400)},
+						{Worker: s.AddrsStr(2), Value: alloraMath.NewDecFromInt64(400)},
 					},
 					OneOutInfererForecasterValues: []*types.OneOutInfererForecasterValues{
 						{
 							Forecaster: "allo13kenskkx7e0v253m3kcgwfc67cmx00fgwpgj6h",
 							OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
-								{Worker: s.addrsStr[1], Value: alloraMath.NewDecFromInt64(500)},
+								{Worker: s.AddrsStr(1), Value: alloraMath.NewDecFromInt64(500)},
 							},
 						},
 					},
@@ -740,17 +518,17 @@ func (s *RewardsTestSuite) TestEnsureWorkerPresenceConsistency() {
 					},
 					ForecasterValues: nil,
 					OneOutInfererValues: []*types.WithheldWorkerAttributedValue{
-						{Worker: s.addrsStr[1], Value: alloraMath.NewDecFromInt64(100)},
-						{Worker: s.addrsStr[2], Value: alloraMath.NewDecFromInt64(200)},
+						{Worker: s.AddrsStr(1), Value: alloraMath.NewDecFromInt64(100)},
+						{Worker: s.AddrsStr(2), Value: alloraMath.NewDecFromInt64(200)},
 						{Worker: "worker3", Value: alloraMath.NewDecFromInt64(300)},
 						{Worker: "worker4", Value: alloraMath.NewDecFromInt64(400)},
 					},
 					OneOutForecasterValues: []*types.WithheldWorkerAttributedValue{
-						{Worker: s.addrsStr[1], Value: alloraMath.NewDecFromInt64(500)},
+						{Worker: s.AddrsStr(1), Value: alloraMath.NewDecFromInt64(500)},
 						{Worker: "worker3", Value: alloraMath.NewDecFromInt64(600)},
 					},
 					OneInForecasterValues: []*types.WorkerAttributedValue{
-						{Worker: s.addrsStr[2], Value: alloraMath.NewDecFromInt64(700)},
+						{Worker: s.AddrsStr(2), Value: alloraMath.NewDecFromInt64(700)},
 						{Worker: "worker4", Value: alloraMath.NewDecFromInt64(800)},
 					},
 					OneOutInfererForecasterValues: []*types.OneOutInfererForecasterValues{
@@ -789,1021 +567,24 @@ func (s *RewardsTestSuite) TestEnsureWorkerPresenceConsistency() {
 	s.Require().Equal(len(reputer1Losses), len(reputer2Losses), "Lengths should be equal after processing")
 }
 
-func prepareMockLosses(reputersCount int, workersCount int) (
-	reputersLosses []alloraMath.Dec,
-	reputersInfererLosses [][]alloraMath.Dec,
-	reputersForecasterLosses [][]alloraMath.Dec,
-	reputersNaiveLosses []alloraMath.Dec,
-	reputersInfererOneOutLosses [][]alloraMath.Dec,
-	reputersForecasterOneOutLosses [][]alloraMath.Dec,
-	reputersOneInNaiveLosses [][]alloraMath.Dec,
-) {
-	rnd := rand.New(rand.NewSource(20))
-	for i := 0; i < reputersCount; i++ {
-		reputersLosses = append(reputersLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-		reputersNaiveLosses = append(reputersNaiveLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-		var infererLosses = make([]alloraMath.Dec, 0)
-		var forecasterLosses = make([]alloraMath.Dec, 0)
-		var infererOneOutLosses = make([]alloraMath.Dec, 0)
-		var forecasterOneOutLosses = make([]alloraMath.Dec, 0)
-		var oneInNaiveLosses = make([]alloraMath.Dec, 0)
-		for j := 0; j < workersCount; j++ {
-			infererLosses = append(infererLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-			forecasterLosses = append(forecasterLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-			infererOneOutLosses = append(infererOneOutLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-			forecasterOneOutLosses = append(forecasterOneOutLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-			oneInNaiveLosses = append(oneInNaiveLosses, alloraMath.MustNewDecFromString(strconv.FormatFloat(float64(rnd.Intn(1000)+1), 'f', -1, 64)))
-		}
-		reputersInfererLosses = append(reputersInfererLosses, infererLosses)
-		reputersForecasterLosses = append(reputersForecasterLosses, forecasterLosses)
-		reputersInfererOneOutLosses = append(reputersInfererOneOutLosses, infererOneOutLosses)
-		reputersForecasterOneOutLosses = append(reputersForecasterOneOutLosses, forecasterOneOutLosses)
-		reputersOneInNaiveLosses = append(reputersOneInNaiveLosses, oneInNaiveLosses)
-	}
-	return reputersLosses,
-		reputersInfererLosses,
-		reputersForecasterLosses,
-		reputersNaiveLosses,
-		reputersInfererOneOutLosses,
-		reputersForecasterOneOutLosses,
-		reputersOneInNaiveLosses
-}
-
-func generateLossBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64, reputerIndexes []int, workerIndexes []int) types.InputReputerValueBundles {
-	if len(workerIndexes) != 5 {
-		panic("workerIndexes length must be 5")
-	}
-	workers := []sdk.AccAddress{
-		s.addrs[workerIndexes[0]],
-		s.addrs[workerIndexes[1]],
-		s.addrs[workerIndexes[2]],
-		s.addrs[workerIndexes[3]],
-		s.addrs[workerIndexes[4]],
-	}
-	reputersLosses := []alloraMath.BoundedExp40Dec{
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01127")),
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01791")),
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01404")),
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02318")),
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01251")),
-	}
-	reputersInfererLosses := [][]alloraMath.BoundedExp40Dec{
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0112")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.00231")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02274")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01299")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02515")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01635")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.00179")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.03396")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0153")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01988")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01345")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.00209")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.03249")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01688")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02126")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01675")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.00318")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02623")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02734")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.03526")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02093")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.00213")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02462")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0203")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.03115")),
-		},
-	}
-	reputersForecasterLosses := [][]alloraMath.BoundedExp40Dec{
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0185")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01018")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02105")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01041")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0183")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.00962")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01191")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01616")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01417")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01216")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01338")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0116")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01605")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0133")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01407")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02733")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01697")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01619")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01925")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02018")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01545")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01785")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01662")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01156")),
-		},
-	}
-	reputersNaiveLosses := []alloraMath.BoundedExp40Dec{
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0116")),
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01428")),
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01441")),
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01594")),
-		alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01705")),
-	}
-	reputersInfererOneOutLosses := [][]alloraMath.BoundedExp40Dec{
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0148")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01046")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01192")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01381")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01687")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01043")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01308")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01455")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01607")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01205")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01339")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01053")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01424")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01428")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01446")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01674")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02944")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01796")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02187")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01895")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01049")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02068")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01573")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01487")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02639")),
-		},
-	}
-	reputersForecasterOneOutLosses := [][]alloraMath.BoundedExp40Dec{
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01136")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01185")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01568")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.00949")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01339")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01357")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01108")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01633")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01208")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01278")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01805")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01229")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01586")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01234")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01513")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01637")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01594")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01608")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02203")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01486")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01981")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02123")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02134")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0217")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01177")),
-		},
-	}
-	reputersOneInNaiveLosses := [][]alloraMath.BoundedExp40Dec{
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01588")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01012")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01467")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0128")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01234")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01239")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01023")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01712")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0116")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01639")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01419")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01497")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01629")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01514")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01133")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01936")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01518")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.018")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02212")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02259")),
-		},
-		{
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01602")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01194")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0153")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.0199")),
-			alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01673")),
-		},
-	}
-
-	var reputerValueBundles types.InputReputerValueBundles
-	for i, reputerIndex := range reputerIndexes {
-		valueBundle := &types.InputValueBundle{
-			TopicId: topicId,
-			ReputerRequestNonce: &types.ReputerRequestNonce{
-				ReputerNonce: &types.Nonce{
-					BlockHeight: blockHeight,
-				},
-			},
-			Reputer:                       s.addrsStr[reputerIndex],
-			ExtraData:                     nil,
-			CombinedValue:                 reputersLosses[i],
-			NaiveValue:                    reputersNaiveLosses[i],
-			InfererValues:                 make([]*types.InputWorkerAttributedValue, len(workers)),
-			ForecasterValues:              make([]*types.InputWorkerAttributedValue, len(workers)),
-			OneOutInfererValues:           make([]*types.InputWithheldWorkerAttributedValue, len(workers)),
-			OneOutForecasterValues:        make([]*types.InputWithheldWorkerAttributedValue, len(workers)),
-			OneInForecasterValues:         make([]*types.InputWorkerAttributedValue, len(workers)),
-			OneOutInfererForecasterValues: nil,
-		}
-
-		for j, worker := range workers {
-			valueBundle.InfererValues[j] = &types.InputWorkerAttributedValue{Worker: worker.String(), Value: reputersInfererLosses[i][j]}
-			valueBundle.ForecasterValues[j] = &types.InputWorkerAttributedValue{Worker: worker.String(), Value: reputersForecasterLosses[i][j]}
-			valueBundle.OneOutInfererValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: worker.String(), Value: reputersInfererOneOutLosses[i][j]}
-			valueBundle.OneOutForecasterValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: worker.String(), Value: reputersForecasterOneOutLosses[i][j]}
-			valueBundle.OneInForecasterValues[j] = &types.InputWorkerAttributedValue{Worker: worker.String(), Value: reputersOneInNaiveLosses[i][j]}
-		}
-
-		sig, err := signInputValueBundle(valueBundle, s.privKeys[reputerIndex])
-		s.Require().NoError(err)
-
-		bundle := &types.InputReputerValueBundle{
-			Pubkey:      s.pubKeyHexStr[reputerIndex],
-			Signature:   sig,
-			ValueBundle: valueBundle,
-		}
-		reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, bundle)
-	}
-
-	return reputerValueBundles
-}
-
-func generateHugeLossBundles(
-	s *RewardsTestSuite,
-	blockHeight int64,
-	topicId uint64,
-	reputerIndexes []int,
-	workerIndexes []int,
-) types.InputReputerValueBundles {
-	var (
-		reputersLosses,
-		reputersInfererLosses,
-		reputersForecasterLosses,
-		reputersNaiveLosses,
-		reputersInfererOneOutLosses,
-		reputersForecasterOneOutLosses,
-		reputersOneInNaiveLosses = prepareMockLosses(len(reputerIndexes), len(workerIndexes))
-	)
-
-	var reputerValueBundles types.InputReputerValueBundles
-	for i, reputerIndex := range reputerIndexes {
-		valueBundle := &types.InputValueBundle{
-			TopicId: topicId,
-			ReputerRequestNonce: &types.ReputerRequestNonce{
-				ReputerNonce: &types.Nonce{
-					BlockHeight: blockHeight,
-				},
-			},
-			ExtraData:                     nil,
-			Reputer:                       s.addrsStr[reputerIndex],
-			CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(reputersLosses[i]),
-			NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(reputersNaiveLosses[i]),
-			InfererValues:                 make([]*types.InputWorkerAttributedValue, len(workerIndexes)),
-			ForecasterValues:              make([]*types.InputWorkerAttributedValue, len(workerIndexes)),
-			OneOutInfererValues:           make([]*types.InputWithheldWorkerAttributedValue, len(workerIndexes)),
-			OneOutForecasterValues:        make([]*types.InputWithheldWorkerAttributedValue, len(workerIndexes)),
-			OneInForecasterValues:         make([]*types.InputWorkerAttributedValue, len(workerIndexes)),
-			OneOutInfererForecasterValues: nil,
-		}
-
-		for j, workerIndex := range workerIndexes {
-			valueBundle.InfererValues[j] = &types.InputWorkerAttributedValue{Worker: s.addrsStr[workerIndex], Value: alloraMath.MustNewBoundedExp40Dec(reputersInfererLosses[i][j])}
-			valueBundle.ForecasterValues[j] = &types.InputWorkerAttributedValue{Worker: s.addrsStr[workerIndex], Value: alloraMath.MustNewBoundedExp40Dec(reputersForecasterLosses[i][j])}
-			valueBundle.OneOutInfererValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: s.addrsStr[workerIndex], Value: alloraMath.MustNewBoundedExp40Dec(reputersInfererOneOutLosses[i][j])}
-			valueBundle.OneOutForecasterValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: s.addrsStr[workerIndex], Value: alloraMath.MustNewBoundedExp40Dec(reputersForecasterOneOutLosses[i][j])}
-			valueBundle.OneInForecasterValues[j] = &types.InputWorkerAttributedValue{Worker: s.addrsStr[workerIndex], Value: alloraMath.MustNewBoundedExp40Dec(reputersOneInNaiveLosses[i][j])}
-		}
-
-		sig, err := signInputValueBundle(valueBundle, s.privKeys[reputerIndex])
-		s.Require().NoError(err)
-
-		bundle := &types.InputReputerValueBundle{
-			Pubkey:      s.pubKeyHexStr[reputerIndex],
-			Signature:   sig,
-			ValueBundle: valueBundle,
-		}
-		reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, bundle)
-	}
-
-	return reputerValueBundles
-}
-
-func generateHugeWorkerDataBundles(
-	s *RewardsTestSuite,
-	blockHeight int64,
-	topicId uint64,
-	workerIndexes []int,
-) []*types.InputWorkerDataBundle {
-	var inferences []*types.InputWorkerDataBundle
-	for _, workerIndex := range workerIndexes {
-		workerInferenceForecastBundle := &types.InputInferenceForecastBundle{
-			Inference: &types.InputInference{
-				TopicId:     topicId,
-				BlockHeight: blockHeight,
-				Inferer:     s.addrsStr[workerIndex],
-				Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(strconv.FormatInt(int64(rand.Intn(1000)+1), 10))),
-				ExtraData:   nil,
-				Proof:       "",
-			},
-			Forecast: &types.InputForecast{
-				TopicId:     topicId,
-				BlockHeight: blockHeight,
-				Forecaster:  s.addrsStr[workerIndex],
-				ForecastElements: []*types.InputForecastElement{
-					{
-						Inferer: s.addrs[26].String(),
-						Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(strconv.FormatInt(int64(rand.Intn(1000)+1), 10))),
-					},
-					{
-						Inferer: s.addrs[27].String(),
-						Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(strconv.FormatInt(int64(rand.Intn(1000)+1), 10))),
-					},
-				},
-				ExtraData: nil,
-			},
-		}
-		workerSig, err := signInputInferenceForecastBundle(workerInferenceForecastBundle, s.privKeys[workerIndex])
-		s.Require().NoError(err)
-		workerBundle := &types.InputWorkerDataBundle{
-			Worker:                             s.addrsStr[workerIndex],
-			TopicId:                            topicId,
-			Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-			InferenceForecastsBundle:           workerInferenceForecastBundle,
-			InferencesForecastsBundleSignature: workerSig,
-			Pubkey:                             s.pubKeyHexStr[workerIndex],
-		}
-		inferences = append(inferences, workerBundle)
-	}
-	return inferences
-}
-
-func signValueBundle(valueBundle *types.ValueBundle, privateKey secp256k1.PrivKey) ([]byte, error) {
-	src := make([]byte, 0)
-	src, err := valueBundle.XXX_Marshal(src, true)
-	if err != nil {
-		return nil, err
-	}
-
-	valueBundleSignature, err := privateKey.Sign(src)
-	if err != nil {
-		return nil, err
-	}
-
-	return valueBundleSignature, nil
-}
-
-func signInputValueBundle(InputValueBundle *types.InputValueBundle, privateKey secp256k1.PrivKey) ([]byte, error) {
-	valueBundle, err := types.NewValueBundleFromInput(InputValueBundle)
-	if err != nil {
-		return nil, err
-	}
-	return signValueBundle(valueBundle, privateKey)
-}
-
-func signInferenceForecastBundle(
-	inferenceForecastBundle *types.InferenceForecastBundle,
-	privateKey secp256k1.PrivKey,
-) ([]byte, error) {
-	src := make([]byte, 0)
-	src, err := inferenceForecastBundle.XXX_Marshal(src, true)
-	if err != nil {
-		return nil, err
-	}
-
-	sig, err := privateKey.Sign(src)
-	if err != nil {
-		return nil, err
-	}
-
-	return sig, nil
-}
-
-func signInputInferenceForecastBundle(
-	InputInferenceForecastBundle *types.InputInferenceForecastBundle,
-	privateKey secp256k1.PrivKey,
-) ([]byte, error) {
-	bundle, err := types.NewInferenceForecastBundleFromInput(InputInferenceForecastBundle)
-	if err != nil {
-		return nil, err
-	}
-	return signInferenceForecastBundle(bundle, privateKey)
-}
-
-func generateWorkerDataBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64) []*types.InputWorkerDataBundle {
-	var inferences []*types.InputWorkerDataBundle
-	worker1 := 5
-	worker2 := 6
-	worker3 := 7
-	worker4 := 8
-	worker5 := 9
-
-	// inference and forecast data - worker 1
-	worker1InferenceForecastBundle := &types.InputInferenceForecastBundle{
-		Inference: &types.InputInference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker1],
-			Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01127")),
-			ExtraData:   nil,
-			Proof:       "",
-		},
-		Forecast: &types.InputForecast{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Forecaster:  s.addrsStr[worker1],
-			ForecastElements: []*types.InputForecastElement{
-				{
-					Inferer: s.addrs[6].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01127")),
-				},
-				{
-					Inferer: s.addrs[7].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01127")),
-				},
-			},
-			ExtraData: nil,
-		},
-	}
-	worker1Sig, err := signInputInferenceForecastBundle(worker1InferenceForecastBundle, s.privKeys[worker1])
-	s.Require().NoError(err)
-	worker1Bundle := &types.InputWorkerDataBundle{
-		Worker:                             s.addrsStr[worker1],
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		TopicId:                            topicId,
-		InferenceForecastsBundle:           worker1InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker1Sig,
-		Pubkey:                             s.pubKeyHexStr[worker1],
-	}
-	inferences = append(inferences, worker1Bundle)
-	// inference and forecast data - worker 2
-	worker2InferenceForecastBundle := &types.InputInferenceForecastBundle{
-		Inference: &types.InputInference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker2],
-			Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01791")),
-			ExtraData:   nil,
-			Proof:       "",
-		},
-		Forecast: &types.InputForecast{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Forecaster:  s.addrsStr[worker2],
-			ForecastElements: []*types.InputForecastElement{
-				{
-					Inferer: s.addrs[7].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01791")),
-				},
-				{
-					Inferer: s.addrs[8].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01791")),
-				},
-			},
-			ExtraData: nil,
-		},
-	}
-	worker2Sig, err := signInputInferenceForecastBundle(worker2InferenceForecastBundle, s.privKeys[worker2])
-	s.Require().NoError(err)
-	worker2Bundle := &types.InputWorkerDataBundle{
-		Worker:                             s.addrsStr[worker2],
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		TopicId:                            topicId,
-		InferenceForecastsBundle:           worker2InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker2Sig,
-		Pubkey:                             s.pubKeyHexStr[worker2],
-	}
-	inferences = append(inferences, worker2Bundle)
-	// inference and forecast data - worker 3
-	worker3InferenceForecastBundle := &types.InputInferenceForecastBundle{
-		Inference: &types.InputInference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker3],
-			Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01404")),
-			ExtraData:   nil,
-			Proof:       "",
-		},
-		Forecast: &types.InputForecast{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Forecaster:  s.addrsStr[worker3],
-			ForecastElements: []*types.InputForecastElement{
-				{
-					Inferer: s.addrs[8].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01404")),
-				},
-				{
-					Inferer: s.addrs[9].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01404")),
-				},
-			},
-			ExtraData: nil,
-		},
-	}
-	worker3Sig, err := signInputInferenceForecastBundle(worker3InferenceForecastBundle, s.privKeys[worker3])
-	s.Require().NoError(err)
-	worker3Bundle := &types.InputWorkerDataBundle{
-		Worker:                             s.addrsStr[worker3],
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		TopicId:                            topicId,
-		InferenceForecastsBundle:           worker3InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker3Sig,
-		Pubkey:                             s.pubKeyHexStr[worker3],
-	}
-	inferences = append(inferences, worker3Bundle)
-	// inference and forecast data - worker 4
-	worker4InferenceForecastBundle := &types.InputInferenceForecastBundle{
-		Inference: &types.InputInference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker4],
-			Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02318")),
-			ExtraData:   nil,
-			Proof:       "",
-		},
-		Forecast: &types.InputForecast{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Forecaster:  s.addrsStr[worker4],
-			ForecastElements: []*types.InputForecastElement{
-				{
-					Inferer: s.addrs[9].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02318")),
-				},
-				{
-					Inferer: s.addrs[0].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.02318")),
-				},
-			},
-			ExtraData: nil,
-		},
-	}
-	worker4Sig, err := signInputInferenceForecastBundle(worker4InferenceForecastBundle, s.privKeys[worker4])
-	s.Require().NoError(err)
-	worker4Bundle := &types.InputWorkerDataBundle{
-		Worker:                             s.addrsStr[worker4],
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		TopicId:                            topicId,
-		InferenceForecastsBundle:           worker4InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker4Sig,
-		Pubkey:                             s.pubKeyHexStr[worker4],
-	}
-	inferences = append(inferences, worker4Bundle)
-	// inference and forecast data - worker 5
-	worker5InferenceForecastBundle := &types.InputInferenceForecastBundle{
-		Inference: &types.InputInference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker5],
-			Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01251")),
-			ExtraData:   nil,
-			Proof:       "",
-		},
-		Forecast: &types.InputForecast{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Forecaster:  s.addrsStr[worker5],
-			ForecastElements: []*types.InputForecastElement{
-				{
-					Inferer: s.addrs[0].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01251")),
-				},
-				{
-					Inferer: s.addrs[1].String(),
-					Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString("0.01251")),
-				},
-			},
-			ExtraData: nil,
-		},
-	}
-	worker5Sig, err := signInputInferenceForecastBundle(worker5InferenceForecastBundle, s.privKeys[worker5])
-	s.Require().NoError(err)
-	worker5Bundle := &types.InputWorkerDataBundle{
-		Worker:                             s.addrsStr[worker5],
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		TopicId:                            topicId,
-		InferenceForecastsBundle:           worker5InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker5Sig,
-		Pubkey:                             s.pubKeyHexStr[worker5],
-	}
-	inferences = append(inferences, worker5Bundle)
-
-	return inferences
-}
-
-/* to be rewritten in PROTO-3088
-func generateMoreInferencesDataBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64) []*types.WorkerDataBundle {
-	var newInferences []*types.WorkerDataBundle
-	worker1 := 13
-	worker2 := 14
-
-	worker1InferenceForecastBundle := &types.InferenceForecastBundle{
-		Inference: &types.Inference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker1],
-			Value:       alloraMath.MustNewDecFromString("0.01251"),
-			ExtraData:   nil,
-			Proof:       "",
-		},
-		Forecast: &types.Forecast{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Forecaster:  s.addrsStr[worker1],
-			ForecastElements: []*types.ForecastElement{
-				{
-					Inferer: s.addrs[7].String(),
-					Value:   alloraMath.MustNewDecFromString("0.01251"),
-				},
-				{
-					Inferer: s.addrs[8].String(),
-					Value:   alloraMath.MustNewDecFromString("0.01251"),
-				},
-			},
-			ExtraData: nil,
-		},
-	}
-	worker1Sig, err := signInferenceForecastBundle(worker1InferenceForecastBundle, s.privKeys[worker1])
-	s.Require().NoError(err)
-	worker1Bundle := &types.WorkerDataBundle{
-		Worker:                             s.addrsStr[worker1],
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		TopicId:                            topicId,
-		InferenceForecastsBundle:           worker1InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker1Sig,
-		Pubkey:                             s.pubKeyHexStr[worker1],
-	}
-	newInferences = append(newInferences, worker1Bundle)
-
-	worker2InferenceForecastBundle := &types.InferenceForecastBundle{
-		Inference: &types.Inference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker2],
-			Value:       alloraMath.MustNewDecFromString("10000"),
-			ExtraData:   nil,
-			Proof:       "",
-		},
-		Forecast: &types.Forecast{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Forecaster:  s.addrsStr[worker2],
-			ForecastElements: []*types.ForecastElement{
-				{
-					Inferer: s.addrs[5].String(),
-					Value:   alloraMath.MustNewDecFromString("0.01251"),
-				},
-				{
-					Inferer: s.addrs[6].String(),
-					Value:   alloraMath.MustNewDecFromString("0.01251"),
-				},
-			},
-			ExtraData: nil,
-		},
-	}
-	worker2Sig, err := signInferenceForecastBundle(worker2InferenceForecastBundle, s.privKeys[worker2])
-	s.Require().NoError(err)
-	worker2Bundle := &types.WorkerDataBundle{
-		Worker:                             s.addrsStr[worker2],
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		TopicId:                            topicId,
-		InferenceForecastsBundle:           worker2InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker2Sig,
-		Pubkey:                             s.pubKeyHexStr[worker2],
-	}
-	newInferences = append(newInferences, worker2Bundle)
-
-	return newInferences
-}
-*/
-
-/* to be rewritten in PROTO-3088
-func generateMoreForecastersDataBundles(s *RewardsTestSuite, blockHeight int64, topicId uint64) []*types.WorkerDataBundle {
-	var newForecasts []*types.WorkerDataBundle
-	worker1 := 13
-	worker2 := 14
-
-	worker1InferenceForecastBundle := &types.InferenceForecastBundle{
-		Inference: &types.Inference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker1],
-			Value:       alloraMath.MustNewDecFromString("0.01251"),
-			ExtraData:   nil,
-			Proof:       "",
-		},
-		Forecast: &types.Forecast{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Forecaster:  s.addrsStr[worker1],
-			ForecastElements: []*types.ForecastElement{
-				{
-					Inferer: s.addrs[7].String(),
-					Value:   alloraMath.MustNewDecFromString("0.01251"),
-				},
-				{
-					Inferer: s.addrs[8].String(),
-					Value:   alloraMath.MustNewDecFromString("0.01251"),
-				},
-			},
-			ExtraData: nil,
-		},
-	}
-	worker1Sig, err := signInferenceForecastBundle(worker1InferenceForecastBundle, s.privKeys[worker1])
-	s.Require().NoError(err)
-	worker1Bundle := &types.WorkerDataBundle{
-		Worker:                             s.addrsStr[worker1],
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		TopicId:                            topicId,
-		InferenceForecastsBundle:           worker1InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker1Sig,
-		Pubkey:                             s.pubKeyHexStr[worker1],
-	}
-	newForecasts = append(newForecasts, worker1Bundle)
-
-	worker2InferenceForecastBundle := &types.InferenceForecastBundle{
-		Inference: &types.Inference{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Inferer:     s.addrsStr[worker2],
-			Value:       alloraMath.MustNewDecFromString("0.01251"),
-			ExtraData:   nil,
-			Proof:       "",
-		},
-		Forecast: &types.Forecast{
-			TopicId:     topicId,
-			BlockHeight: blockHeight,
-			Forecaster:  s.addrsStr[worker2],
-			ForecastElements: []*types.ForecastElement{
-				{
-					Inferer: s.addrs[5].String(),
-					Value:   alloraMath.MustNewDecFromString("0.01251"),
-				},
-				{
-					Inferer: s.addrs[6].String(),
-					Value:   alloraMath.MustNewDecFromString("0.01251"),
-				},
-			},
-			ExtraData: nil,
-		},
-	}
-	worker2Sig, err := signInferenceForecastBundle(worker2InferenceForecastBundle, s.privKeys[worker2])
-	s.Require().NoError(err)
-	worker2Bundle := &types.WorkerDataBundle{
-		Worker:                             s.addrsStr[worker2],
-		Nonce:                              &types.Nonce{BlockHeight: blockHeight},
-		TopicId:                            topicId,
-		InferenceForecastsBundle:           worker2InferenceForecastBundle,
-		InferencesForecastsBundleSignature: worker2Sig,
-		Pubkey:                             s.pubKeyHexStr[worker2],
-	}
-	newForecasts = append(newForecasts, worker2Bundle)
-
-	return newForecasts
-}
-*/
-
-type TestWorkerValue struct {
-	Index int
-	Value string
-}
-
-func generateSimpleWorkerDataBundles(
-	s *RewardsTestSuite,
-	topicId uint64,
-	nonce int64,
-	blockHeight int64,
-	workerValues []TestWorkerValue,
-	infererIndexes []int,
-) []*types.InputWorkerDataBundle {
-	require := s.Require()
-	if len(workerValues) < 2 {
-		require.Fail("workerValues must have at least 2 elements")
-	}
-	if len(infererIndexes) < 2 {
-		require.Fail("infererIndexes must have at least 2 elements")
-	}
-
-	var inferences []*types.InputWorkerDataBundle
-
-	infererIndex := 0
-
-	getInfererIndex := func() int {
-		if infererIndex >= len(infererIndexes) {
-			infererIndex = 0
-		}
-		currentInfererIndex := infererIndex
-		infererIndex++
-		return currentInfererIndex
-	}
-
-	for _, workerValue := range workerValues {
-		newWorkerInferenceForecastBundle := &types.InputInferenceForecastBundle{
-			Inference: &types.InputInference{
-				TopicId:     topicId,
-				BlockHeight: blockHeight,
-				Inferer:     s.addrsStr[workerValue.Index],
-				Value:       alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(workerValue.Value)),
-				ExtraData:   nil,
-				Proof:       "",
-			},
-			Forecast: &types.InputForecast{
-				TopicId:     topicId,
-				BlockHeight: blockHeight,
-				Forecaster:  s.addrsStr[workerValue.Index],
-				ForecastElements: []*types.InputForecastElement{
-					{
-						Inferer: s.addrsStr[infererIndexes[getInfererIndex()]],
-						Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(workerValue.Value)),
-					},
-					{
-						Inferer: s.addrsStr[infererIndexes[getInfererIndex()]],
-						Value:   alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(workerValue.Value)),
-					},
-				},
-				ExtraData: nil,
-			},
-		}
-		workerSig, err := signInputInferenceForecastBundle(newWorkerInferenceForecastBundle, s.privKeys[workerValue.Index])
-		s.Require().NoError(err)
-		workerBundle := &types.InputWorkerDataBundle{
-			Worker:                             s.addrsStr[workerValue.Index],
-			Nonce:                              &types.Nonce{BlockHeight: nonce},
-			TopicId:                            topicId,
-			InferenceForecastsBundle:           newWorkerInferenceForecastBundle,
-			InferencesForecastsBundleSignature: workerSig,
-			Pubkey:                             s.pubKeyHexStr[workerValue.Index],
-		}
-		inferences = append(inferences, workerBundle)
-	}
-
-	return inferences
-}
-
-func generateSimpleLossBundles(
-	s *RewardsTestSuite,
-	topicId uint64,
-	nonce int64,
-	workerValues []TestWorkerValue,
-	reputerValues []TestWorkerValue,
-	workerZeroAddress sdk.AccAddress,
-	workerZeroOneOutInfererValue string,
-	workerZeroInfererValue string,
-) types.InputReputerValueBundles {
-	var reputerValueBundles types.InputReputerValueBundles
-	for _, reputer := range reputerValues {
-		var countValues int
-		if len(workerValues) < len(reputerValues) {
-			countValues = len(workerValues)
-		} else {
-			countValues = len(reputerValues)
-		}
-
-		valueBundle := &types.InputValueBundle{
-			TopicId: topicId,
-			ReputerRequestNonce: &types.ReputerRequestNonce{
-				ReputerNonce: &types.Nonce{
-					BlockHeight: nonce,
-				},
-			},
-			Reputer:                       s.addrsStr[reputer.Index],
-			ExtraData:                     nil,
-			CombinedValue:                 alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputer.Value)),
-			NaiveValue:                    alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputer.Value)),
-			InfererValues:                 make([]*types.InputWorkerAttributedValue, countValues),
-			ForecasterValues:              make([]*types.InputWorkerAttributedValue, countValues),
-			OneOutInfererValues:           make([]*types.InputWithheldWorkerAttributedValue, countValues),
-			OneOutForecasterValues:        make([]*types.InputWithheldWorkerAttributedValue, countValues),
-			OneInForecasterValues:         make([]*types.InputWorkerAttributedValue, countValues),
-			OneOutInfererForecasterValues: nil,
-		}
-
-		for j, worker := range workerValues {
-			if j < len(reputerValues) {
-				if s.addrs[worker.Index].Equals(workerZeroAddress) {
-					valueBundle.InfererValues[j] = &types.InputWorkerAttributedValue{Worker: s.addrsStr[worker.Index], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(workerZeroInfererValue))}
-				} else {
-					valueBundle.InfererValues[j] = &types.InputWorkerAttributedValue{Worker: s.addrsStr[worker.Index], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputerValues[j].Value))}
-				}
-				valueBundle.ForecasterValues[j] = &types.InputWorkerAttributedValue{Worker: s.addrsStr[worker.Index], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputerValues[j].Value))}
-				if s.addrs[worker.Index].Equals(workerZeroAddress) {
-					valueBundle.OneOutInfererValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: s.addrsStr[worker.Index], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(workerZeroOneOutInfererValue))}
-				} else {
-					valueBundle.OneOutInfererValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: s.addrsStr[worker.Index], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputerValues[j].Value))}
-				}
-				valueBundle.OneOutForecasterValues[j] = &types.InputWithheldWorkerAttributedValue{Worker: s.addrsStr[worker.Index], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputerValues[j].Value))}
-				valueBundle.OneInForecasterValues[j] = &types.InputWorkerAttributedValue{Worker: s.addrsStr[worker.Index], Value: alloraMath.MustNewBoundedExp40Dec(alloraMath.MustNewDecFromString(reputerValues[j].Value))}
-			}
-		}
-
-		sig, err := signInputValueBundle(valueBundle, s.privKeys[reputer.Index])
-		s.Require().NoError(err)
-
-		bundle := &types.InputReputerValueBundle{
-			Pubkey:      s.pubKeyHexStr[reputer.Index],
-			Signature:   sig,
-			ValueBundle: valueBundle,
-		}
-		reputerValueBundles.ReputerValueBundles = append(reputerValueBundles.ReputerValueBundles, bundle)
-	}
-
-	return reputerValueBundles
-}
-
 func (s *RewardsTestSuite) TestGenerateReputerScoresWithZeroListeningCoefficients() {
-	// Create a new topic
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[0].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
-		AllowNegative:            true,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	topicId := res.TopicId
+	topicId := uint64(1)
 	block := int64(1003)
 
 	// Set up reputer with zero listening coefficient
-	reputer := s.addrsStr[13]
+	reputer := s.AddrsStr(13)
 	stake := cosmosMath.NewInt(1000000000)
 
 	// Mint tokens and add stake
 	addrBech, err := sdk.AccAddressFromBech32(reputer)
 	s.Require().NoError(err)
 	s.MintTokensToAddress(addrBech, stake)
-	err = s.emissionsKeeper.AddReputerStake(s.ctx, topicId, reputer, stake)
+	err = s.EmissionsKeeper().AddReputerStake(s.Ctx(), topicId, reputer, stake)
 	s.Require().NoError(err)
 
 	// Set zero listening coefficient
-	err = s.emissionsKeeper.SetListeningCoefficient(
-		s.ctx,
+	err = s.EmissionsKeeper().SetListeningCoefficient(
+		s.Ctx(),
 		topicId,
 		reputer,
 		types.ListeningCoefficient{Coefficient: alloraMath.ZeroDec()},
@@ -1811,10 +592,11 @@ func (s *RewardsTestSuite) TestGenerateReputerScoresWithZeroListeningCoefficient
 	s.Require().NoError(err)
 
 	// Create reported losses
+	//nolint:exhaustruct
 	reportedLosses := types.ReputerValueBundles{
 		ReputerValueBundles: []*types.ReputerValueBundle{
 			{
-				Pubkey: s.pubKeyHexStr[13],
+				Pubkey: s.PubKeyHexStr(13),
 				ValueBundle: &types.ValueBundle{
 					TopicId: topicId,
 					ReputerRequestNonce: &types.ReputerRequestNonce{
@@ -1825,40 +607,34 @@ func (s *RewardsTestSuite) TestGenerateReputerScoresWithZeroListeningCoefficient
 					NaiveValue:    alloraMath.MustNewDecFromString("3.8"),
 					InfererValues: []*types.WorkerAttributedValue{
 						{
-							Worker: s.addrsStr[5],
+							Worker: s.AddrsStr(5),
 							Value:  alloraMath.MustNewDecFromString("3.81"),
 						},
 						{
-							Worker: s.addrsStr[6],
+							Worker: s.AddrsStr(6),
 							Value:  alloraMath.MustNewDecFromString("3.82"),
 						},
 					},
-					ForecasterValues:              nil,
-					OneOutInfererValues:           nil,
-					OneOutForecasterValues:        nil,
-					OneInForecasterValues:         nil,
-					OneOutInfererForecasterValues: nil,
-					ExtraData:                     nil,
 				},
 			},
 		},
 	}
 
 	// Sign the value bundle
-	sig, err := signValueBundle(reportedLosses.ReputerValueBundles[0].ValueBundle, s.privKeys[13])
+	sig := s.SignValueBundle(reportedLosses.ReputerValueBundles[0].ValueBundle, s.PrivKeys(13))
 	s.Require().NoError(err)
 	reportedLosses.ReputerValueBundles[0].Signature = sig
 
 	// Get params and set epsilon reputer
 	params := types.DefaultParams()
 	params.EpsilonReputer = alloraMath.MustNewDecFromString("0.1")
-	err = s.emissionsKeeper.SetParams(s.ctx, params)
+	err = s.EmissionsKeeper().SetParams(s.Ctx(), params)
 	s.Require().NoError(err)
 
 	// Generate scores
 	scores, err := rewards.GenerateReputerScores(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		block,
 		reportedLosses,
@@ -1867,7 +643,7 @@ func (s *RewardsTestSuite) TestGenerateReputerScoresWithZeroListeningCoefficient
 	s.Require().Len(scores, 1)
 
 	// Verify that the listening coefficient was updated to epsilon reputer value
-	coefficient, err := s.emissionsKeeper.GetListeningCoefficient(s.ctx, topicId, reputer)
+	coefficient, err := s.EmissionsKeeper().GetListeningCoefficient(s.Ctx(), topicId, reputer)
 	s.Require().NoError(err)
 	s.Require().True(coefficient.Coefficient.Equal(params.EpsilonReputer))
 }
@@ -1878,41 +654,41 @@ func (s *RewardsTestSuite) TestCalculateTopicInitialEmaScore() {
 		{
 			TopicId:     1,
 			BlockHeight: 1000,
-			Address:     s.addrs[0].String(),
+			Address:     s.AddrsStr(0),
 			Score:       alloraMath.MustNewDecFromString("0.5"),
 		},
 		{
 			TopicId:     1,
 			BlockHeight: 1000,
-			Address:     s.addrs[1].String(),
+			Address:     s.AddrsStr(1),
 			Score:       alloraMath.MustNewDecFromString("0.3"),
 		},
 		{
 			TopicId:     1,
 			BlockHeight: 1000,
-			Address:     s.addrs[2].String(),
+			Address:     s.AddrsStr(2),
 			Score:       alloraMath.MustNewDecFromString("0.1"),
 		},
 		{
 			TopicId:     1,
 			BlockHeight: 1000,
-			Address:     s.addrs[3].String(),
+			Address:     s.AddrsStr(3),
 			Score:       alloraMath.MustNewDecFromString("0.4"),
 		},
 		{
 			TopicId:     1,
 			BlockHeight: 1000,
-			Address:     s.addrs[4].String(),
+			Address:     s.AddrsStr(4),
 			Score:       alloraMath.MustNewDecFromString("0.2"),
 		},
 	}
 
 	// Calculate initial EMA score
-	initialScore, err := rewards.CalculateTopicInitialEmaScore(s.ctx, s.emissionsKeeper, scores)
+	initialScore, err := rewards.CalculateTopicInitialEmaScore(s.Ctx(), *s.EmissionsKeeper(), scores)
 	s.Require().NoError(err)
 
 	// Get lambda from params
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	lambda := params.LambdaInitialScore
 
@@ -1960,7 +736,7 @@ func (s *RewardsTestSuite) TestCalculateTopicInitialEmaScoreEdgeCases() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			initialScore, err := rewards.CalculateTopicInitialEmaScore(s.ctx, s.emissionsKeeper, tc.scores)
+			initialScore, err := rewards.CalculateTopicInitialEmaScore(s.Ctx(), *s.EmissionsKeeper(), tc.scores)
 
 			if tc.expectedError {
 				s.Require().Error(err)

--- a/x/emissions/module/rewards/topic_rewards_test.go
+++ b/x/emissions/module/rewards/topic_rewards_test.go
@@ -4,8 +4,8 @@ import (
 	cosmosMath "cosmossdk.io/math"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
-	"github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 

--- a/x/emissions/module/rewards/topic_rewards_test.go
+++ b/x/emissions/module/rewards/topic_rewards_test.go
@@ -2,40 +2,17 @@ package rewards_test
 
 import (
 	cosmosMath "cosmossdk.io/math"
+
 	alloraMath "github.com/allora-network/allora-chain/math"
-	inferencesynthesis "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
+	"github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
-
-func mockTopic(s *RewardsTestSuite) types.Topic {
-	return types.Topic{
-		Id:                       1,
-		Creator:                  s.addrs[5].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		EpochLastEnded:           0,
-		GroundTruthLag:           10800,
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		InitialRegret:            alloraMath.ZeroDec(),
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		AllowNegative:            false,
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		WorkerSubmissionWindow:   10,
-	}
-}
 
 // Forces dripping of two topics, which initially has two active topics, but next round
 // leads to one of them not reaching the MinTopicWeight thus being inactivated.
 func (s *RewardsTestSuite) TestGetAndUpdateActiveTopicWeights() {
-	ctx := s.ctx
-	maxActiveTopicsNum := uint64(2)
+	maxActiveTopicsNum := uint64(3)
 	params := types.DefaultParams()
 	params.BlocksPerMonth = 864000
 	params.MaxActiveTopicsPerBlock = maxActiveTopicsNum
@@ -44,194 +21,163 @@ func (s *RewardsTestSuite) TestGetAndUpdateActiveTopicWeights() {
 	params.TopicRewardAlpha = alloraMath.MustNewDecFromString("0.5")
 	params.TopicRewardStakeImportance = alloraMath.OneDec()
 	params.TopicRewardFeeRevenueImportance = alloraMath.OneDec()
-	err := s.emissionsKeeper.SetParams(ctx, params)
+	err := s.EmissionsKeeper().SetParams(s.Ctx(), params)
 	s.Require().NoError(err, "Setting parameters should not fail")
 
 	setTopicWeight := func(topicId uint64, revenue, stake int64) {
-		err = s.emissionsKeeper.AddTopicFeeRevenue(ctx, topicId, cosmosMath.NewInt(revenue))
+		err = s.EmissionsKeeper().AddTopicFeeRevenue(s.Ctx(), topicId, cosmosMath.NewInt(revenue))
 		s.Require().NoError(err)
-		err = s.emissionsKeeper.SetTopicStake(ctx, topicId, cosmosMath.NewInt(stake))
+		err = s.EmissionsKeeper().SetTopicStake(s.Ctx(), topicId, cosmosMath.NewInt(stake))
 		s.Require().NoError(err)
 	}
 
-	ctx = s.ctx.WithBlockHeight(1)
+	s.WithBlockHeight(1)
 	// Assume topic initially active
-	topic1 := mockTopic(s)
-	topic1.Id = 1
+	topic1 := s.MockTopic()
+	topic1.Id = 2
 	topic1.EpochLength = 15
 	topic1.GroundTruthLag = topic1.EpochLength
 	topic1.WorkerSubmissionWindow = topic1.EpochLength
-	topic2 := mockTopic(s)
-	topic2.Id = 2
+	topic2 := s.MockTopic()
+	topic2.Id = 3
 	topic2.EpochLength = 15
 	topic2.GroundTruthLag = topic2.EpochLength
 	topic2.WorkerSubmissionWindow = topic2.EpochLength
 
-	totalSumPreviousTopicWeights, err := s.emissionsKeeper.GetTotalSumPreviousTopicWeights(ctx)
+	totalSumPreviousTopicWeights, err := s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(totalSumPreviousTopicWeights, alloraMath.ZeroDec(), "Total sum of previous topic weights at start should be zero")
 	setTopicWeight(topic1.Id, 10, 10)
-	err = s.emissionsKeeper.SetTopic(ctx, topic1.Id, topic1)
+	err = s.EmissionsKeeper().SetTopic(s.Ctx(), topic1.Id, topic1)
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.ActivateTopic(ctx, topic1.Id)
+	err = s.EmissionsKeeper().ActivateTopic(s.Ctx(), topic1.Id)
 	s.Require().NoError(err, "Activating topic should not fail")
 
-	totalSumPreviousTopicWeights, err = s.emissionsKeeper.GetTotalSumPreviousTopicWeights(ctx)
+	totalSumPreviousTopicWeights, err = s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(totalSumPreviousTopicWeights, alloraMath.ZeroDec(), "Total sum of previous topic weights should still be 0 bc previous topic weight is not set")
 
 	setTopicWeight(topic2.Id, 30, 10)
-	err = s.emissionsKeeper.SetTopic(ctx, topic2.Id, topic2)
+	err = s.EmissionsKeeper().SetTopic(s.Ctx(), topic2.Id, topic2)
 	s.Require().NoError(err)
-	err = s.emissionsKeeper.ActivateTopic(ctx, topic2.Id)
+	err = s.EmissionsKeeper().ActivateTopic(s.Ctx(), topic2.Id)
 	s.Require().NoError(err, "Activating topic should not fail")
 
 	block := 10
-	ctx = s.ctx.WithBlockHeight(int64(block))
-	_, _, _, err = rewards.GetAndUpdateActiveTopicWeights(ctx, s.emissionsKeeper, int64(block))
+	s.WithBlockHeight(int64(block))
+	_, _, _, err = rewards.GetAndUpdateActiveTopicWeights(s.Ctx(), *s.EmissionsKeeper(), int64(block))
 	s.Require().NoError(err, "Activating topic should not fail")
 
 	// Previous weights still not moved
-	totalSumPreviousTopicWeights, err = s.emissionsKeeper.GetTotalSumPreviousTopicWeights(ctx)
+	totalSumPreviousTopicWeights, err = s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
 	s.T().Logf("totalSumPreviousTopicWeights: %v", totalSumPreviousTopicWeights)
 	s.Require().NoError(err)
 	s.Require().Equal(totalSumPreviousTopicWeights, alloraMath.ZeroDec(), "Total sum of previous topic weights should not be 0 after settings topic weights")
 
-	previousTopicWeights, _, err := s.emissionsKeeper.GetPreviousTopicWeight(ctx, topic1.Id)
+	previousTopicWeights, _, err := s.EmissionsKeeper().GetPreviousTopicWeight(s.Ctx(), topic1.Id)
 	s.T().Logf("topic1 previousTopicWeights: %v", previousTopicWeights)
 	s.Require().NoError(err)
 	s.Require().Equal(previousTopicWeights, alloraMath.ZeroDec(), "Previous topic weights should still be 0 after settings topic weights")
 
 	block = 16
-	ctx = s.ctx.WithBlockHeight(int64(block))
-	_, _, _, err = rewards.GetAndUpdateActiveTopicWeights(ctx, s.emissionsKeeper, int64(block))
+	s.WithBlockHeight(int64(block))
+	_, _, _, err = rewards.GetAndUpdateActiveTopicWeights(s.Ctx(), *s.EmissionsKeeper(), int64(block))
 	s.Require().NoError(err, "Activating topic should not fail")
 
-	activeTopics, err := s.emissionsKeeper.GetActiveTopicIdsAtBlock(ctx, 31)
+	activeTopics, err := s.EmissionsKeeper().GetActiveTopicIdsAtBlock(s.Ctx(), 31)
 	s.Require().NoError(err, "Fetching active topics should not produce an error")
 	s.Require().Equal(2, len(activeTopics.TopicIds), "Should retrieve exactly two active topics")
 
-	err = s.emissionsKeeper.SetParams(ctx, params)
+	err = s.EmissionsKeeper().SetParams(s.Ctx(), params)
 	s.Require().NoError(err)
 
 	block = 31
-	ctx = s.ctx.WithBlockHeight(int64(block))
-	_, _, _, err = rewards.GetAndUpdateActiveTopicWeights(ctx, s.emissionsKeeper, int64(block))
+	s.WithBlockHeight(int64(block))
+	_, _, _, err = rewards.GetAndUpdateActiveTopicWeights(s.Ctx(), *s.EmissionsKeeper(), int64(block))
 	s.Require().NoError(err, "Activating topic should not fail")
 
-	activeTopics, err = s.emissionsKeeper.GetActiveTopicIdsAtBlock(ctx, 46)
+	activeTopics, err = s.EmissionsKeeper().GetActiveTopicIdsAtBlock(s.Ctx(), 46)
 	s.Require().NoError(err, "Fetching active topics should not produce an error")
 	s.Require().Equal(1, len(activeTopics.TopicIds), "Should retrieve exactly one active topics")
 }
 
 func (s *RewardsTestSuite) TestGetRewardAndRemovedRewardableTopics() {
 	block := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(block)
+	s.WithBlockHeight(block)
 
 	s.SetParamsForTest()
 
-	reputerIndexes := s.returnIndexes(0, 3)
-	workerIndexes := s.returnIndexes(3, 3)
-	// setup topics
-	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
+	reputerIndexes := testutil.ReturnIndexes(0, 3)
+	workerIndexes := testutil.ReturnIndexes(3, 3)
 
+	// setup topic
 	alphaRegret := alloraMath.MustNewDecFromString("0.1")
 	epochLength := int64(100)
-	topicId0 := s.setUpTopicWithEpochLength(block, workerIndexes, reputerIndexes, stake, alphaRegret, epochLength)
-	//topicId1 := s.setUpTopicWithEpochLength(block, workerAddrs, reputerAddrs, stake, alphaRegret, epochLength)
-	//
-	// setup values to be identical for both topics
-	reputerValues := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.2"},
-		{Index: reputerIndexes[1], Value: "0.2"},
-		{Index: reputerIndexes[2], Value: "0.2"},
-	}
-
-	workerValues := []TestWorkerValue{
-		{Index: workerIndexes[0], Value: "0.2"},
-		{Index: workerIndexes[1], Value: "0.2"},
-		{Index: workerIndexes[2], Value: "0.2"},
-	}
+	topic := s.FullTopicSetup(workerIndexes, reputerIndexes, testutil.WithAlphaRegret(alphaRegret), testutil.WithEpochLength(epochLength))
+	topicId := topic.Id
 
 	// mint some rewards to give out
 	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(100000))
 
 	// Move to end of this epoch block
-	nextBlock, _, err := s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId0)
+	nextBlock, _, err := s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	block = nextBlock
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
+	s.WithBlockHeight(block)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	s.Require().NoError(err)
 
-	topic0, err := s.emissionsKeeper.GetTopic(s.ctx, topicId0)
+	topic, err = s.EmissionsKeeper().GetTopic(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
 	// Insert inference
-	inferenceBundles := generateSimpleWorkerDataBundles(s, topicId0, topic0.EpochLastEnded, block, workerValues, workerIndexes)
-	for _, payload := range inferenceBundles {
-		s.RegisterAllWorkersOfPayload(topicId0, payload)
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
+	s.SetupInferences(topicId, topic.EpochLastEnded, workerIndexes)
 
 	// Advance to close the window
-	block = block + topic0.WorkerSubmissionWindow
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	block = block + topic.WorkerSubmissionWindow
+	s.WithBlockHeight(block)
 
 	// EndBlock closes the  worker nonce
-	err = s.emissionsAppModule.EndBlock(s.ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	s.Require().NoError(err)
 
-	// Generate loss data
-	lossBundles := generateSimpleLossBundles(
-		s,
-		topicId0,
-		topic0.EpochLastEnded,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
+	// Advance to close the window
+	block = block + topic.WorkerSubmissionWindow
+	s.WithBlockHeight(block)
+
+	// EndBlock closes the  worker nonce
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
+	s.Require().NoError(err)
 
 	// Run endBlock at 201, epoch end block - important bc of the topic in/activation
-	block = block + (topic0.GroundTruthLag - topic0.WorkerSubmissionWindow)
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	block = block + (topic.GroundTruthLag - topic.WorkerSubmissionWindow)
+	s.WithBlockHeight(block)
 	s.T().Logf("****  Moved to next block %d", block)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	s.Require().NoError(err)
 
 	// Insert reputation
 	block = block + 1
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		s.RegisterAllReputersOfPayload(topicId0, payload)
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
+	s.WithBlockHeight(block)
+
+	err = s.InsertReputerLossBundle(topicId, topic.EpochLastEnded, reputerIndexes)
+	s.Require().NoError(err)
 
 	block = block + 1
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
+	s.WithBlockHeight(block)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	s.Require().NoError(err)
 
 	// Move to next end of epoch
-	nextBlock, _, err = s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId0)
+	nextBlock, _, err = s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	block = nextBlock
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	s.WithBlockHeight(block)
 	// EndBlock for closes the reputer nonce & add rewardable nonce
-	err = s.emissionsAppModule.EndBlock(s.ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	s.Require().NoError(err)
 
-	totalSumPreviousTopicWeights, err := s.emissionsKeeper.GetTotalSumPreviousTopicWeights(s.ctx)
+	totalSumPreviousTopicWeights, err := s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
 	s.T().Logf("totalSumPreviousTopicWeights: %v", totalSumPreviousTopicWeights)
 	s.Require().NoError(err)
 	s.Require().NotEqual(totalSumPreviousTopicWeights, alloraMath.MustNewDecFromString("0"), "Total sum of previous topic weights should not be 0 after endBlocker topic weights")
@@ -239,153 +185,127 @@ func (s *RewardsTestSuite) TestGetRewardAndRemovedRewardableTopics() {
 
 func (s *RewardsTestSuite) TestPreviousTopicWeightsAfterInactivation() {
 	block := int64(1)
-	s.ctx = s.ctx.WithBlockHeight(block)
+	s.WithBlockHeight(block)
 
 	s.SetParamsForTest()
 
-	reputerIndexes := s.returnIndexes(0, 3)
-	workerIndexes := s.returnIndexes(3, 3)
-	stake := cosmosMath.NewInt(1000).Mul(inferencesynthesis.CosmosIntOneE18())
+	reputerIndexes := testutil.ReturnIndexes(0, 3)
+	workerIndexes := testutil.ReturnIndexes(3, 3)
 
 	alphaRegret := alloraMath.MustNewDecFromString("0.1")
 	epochLength := int64(100)
-	topicId := s.setUpTopicWithEpochLength(block, workerIndexes, reputerIndexes, stake, alphaRegret, epochLength)
+	groundTruthLag := int64(100)
+	topic := s.FullTopicSetup(
+		workerIndexes,
+		reputerIndexes,
+		testutil.WithAlphaRegret(alphaRegret),
+		testutil.WithEpochLength(epochLength),
+		testutil.WithGroundTruthLag(groundTruthLag),
+	)
+	topicId := topic.Id
 
-	reputerValues := []TestWorkerValue{
-		{Index: reputerIndexes[0], Value: "0.2"},
-		{Index: reputerIndexes[1], Value: "0.2"},
-		{Index: reputerIndexes[2], Value: "0.2"},
-	}
-
-	workerValues := []TestWorkerValue{
-		{Index: workerIndexes[0], Value: "0.2"},
-		{Index: workerIndexes[1], Value: "0.2"},
-		{Index: workerIndexes[2], Value: "0.2"},
-	}
+	reputerValues := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.2")
+	workerValues := testutil.GetWorkerValuesFromIndexes(workerIndexes, "0.2")
 
 	s.MintTokensToModule(types.AlloraRewardsAccountName, cosmosMath.NewInt(100000))
-	totalSumPreviousTopicWeights, err := s.emissionsKeeper.GetTotalSumPreviousTopicWeights(s.ctx)
+	totalSumPreviousTopicWeights, err := s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().Equal(totalSumPreviousTopicWeights.String(), alloraMath.ZeroDec().String(), "Total sum of previous topic weights should be zero on start")
 
 	// Move to end of this epoch block
-	nextBlock, _, err := s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId)
+	nextBlock, _, err := s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	block = nextBlock
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	s.WithBlockHeight(block)
 	s.T().Logf("****  Moved to next block %d", block)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	s.Require().NoError(err)
 
-	topicPreviousWeight, noPrior, err := s.emissionsKeeper.GetPreviousTopicWeight(s.ctx, topicId)
+	topicPreviousWeight, noPrior, err := s.EmissionsKeeper().GetPreviousTopicWeight(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	s.Require().False(topicPreviousWeight.Equal(alloraMath.ZeroDec()), "Previous topic weight should be zero after endBlocker")
 	s.Require().Equal(noPrior, false, "A prior weight should have been set")
 
-	totalSumPreviousTopicWeights, err = s.emissionsKeeper.GetTotalSumPreviousTopicWeights(s.ctx)
+	totalSumPreviousTopicWeights, err = s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
 	s.T().Logf("totalSumPreviousTopicWeights: %v", totalSumPreviousTopicWeights)
 	s.Require().NoError(err)
 	s.Require().NotEqual(totalSumPreviousTopicWeights.String(), alloraMath.ZeroDec().String(), "Total sum of previous topic weights should be zero after endBlocker")
 	// At this point, topic total weight should be equal to the topic's previous weight
 	s.Require().True(topicPreviousWeight.Equal(totalSumPreviousTopicWeights), "Topic total weight should be equal to the topic's previous weight")
 
-	topic, err := s.emissionsKeeper.GetTopic(s.ctx, topicId)
+	topic, err = s.EmissionsKeeper().GetTopic(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
 	// Insert inference
-	inferenceBundles := generateSimpleWorkerDataBundles(s, topicId, topic.EpochLastEnded, block, workerValues, workerIndexes)
-	for _, payload := range inferenceBundles {
-		s.RegisterAllWorkersOfPayload(topicId, payload)
-		_, err = s.msgServer.InsertWorkerPayload(s.ctx, &types.InsertWorkerPayloadRequest{
-			Sender:           payload.Worker,
-			WorkerDataBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
+	s.SetupInferences(topicId, topic.EpochLastEnded, workerIndexes, workerValues...)
 
 	// Advance to close the worker window
 	block = block + topic.WorkerSubmissionWindow
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	s.WithBlockHeight(block)
 	s.T().Logf("****  Moved to next block %d", block)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	s.Require().NoError(err)
 
 	// Run endBlock at 201, epoch end block - important bc of the topic in/activation
 	block = block + (topic.GroundTruthLag - topic.WorkerSubmissionWindow)
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	s.WithBlockHeight(block)
 	s.T().Logf("****  Moved to next block %d", block)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	s.Require().NoError(err)
 
 	// Run block at 202, epoch end block
 	block = block + 1
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	s.WithBlockHeight(block)
 	s.T().Logf("****  Moved to next block %d", block)
 
 	// Generate and insert loss data
-	lossBundles := generateSimpleLossBundles(
-		s,
-		topicId,
-		topic.EpochLastEnded,
-		workerValues,
-		reputerValues,
-		s.addrs[workerIndexes[0]],
-		"0.1",
-		"0.1",
-	)
-	for _, payload := range lossBundles.ReputerValueBundles {
-		s.RegisterAllReputersOfPayload(topicId, payload)
-		_, err = s.msgServer.InsertReputerPayload(s.ctx, &types.InsertReputerPayloadRequest{
-			Sender:             payload.ValueBundle.Reputer,
-			ReputerValueBundle: payload,
-		})
-		s.Require().NoError(err)
-	}
+	err = s.InsertReputerLossBundle(topicId, topic.EpochLastEnded, reputerIndexes, testutil.WithReputerValues(reputerValues))
+	s.Require().NoError(err)
 	s.T().Logf("Inserted loss data for topic %d at block %d", topicId, block)
 
 	// Move to next end of epoch
-	nextBlock, _, err = s.emissionsKeeper.GetNextPossibleChurningBlockByTopicId(s.ctx, topicId)
+	nextBlock, _, err = s.EmissionsKeeper().GetNextPossibleChurningBlockByTopicId(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	block = nextBlock
-	s.ctx = sdk.UnwrapSDKContext(s.ctx).WithBlockHeight(block)
+	s.WithBlockHeight(block)
 	s.T().Logf("****  Moved to next block %d", block)
-	err = s.emissionsAppModule.EndBlock(s.ctx)
+	err = s.EmissionsAppModule().EndBlock(s.Ctx())
 	s.Require().NoError(err)
 
 	// Check previousTopicWeights and totalPreviousTopicWeights
-	previousTopicWeight, _, err := s.emissionsKeeper.GetPreviousTopicWeight(s.ctx, topicId)
+	previousTopicWeight, _, err := s.EmissionsKeeper().GetPreviousTopicWeight(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	s.Require().False(alloraMath.ZeroDec().Equal(previousTopicWeight), "Previous topic weight should not be zero after endBlocker")
 
-	totalSumPreviousTopicWeights, err = s.emissionsKeeper.GetTotalSumPreviousTopicWeights(s.ctx)
+	totalSumPreviousTopicWeights, err = s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(previousTopicWeight.Equal(totalSumPreviousTopicWeights), "Total sum of previous topic weights should not be zero after endBlocker")
 
 	// Inactivate the topic
-	err = s.emissionsKeeper.InactivateTopic(s.ctx, topicId)
+	err = s.EmissionsKeeper().InactivateTopic(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
 	// Check previousTopicWeights and totalPreviousTopicWeights after inactivation
-	inactivePreviousTopicWeight, _, err := s.emissionsKeeper.GetPreviousTopicWeight(s.ctx, topicId)
+	inactivePreviousTopicWeight, _, err := s.EmissionsKeeper().GetPreviousTopicWeight(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(previousTopicWeight, inactivePreviousTopicWeight, "Previous topic weight should remain unchanged after inactivation")
 	s.Require().False(alloraMath.ZeroDec().Equal(inactivePreviousTopicWeight), "Previous topic weight should not be zero after inactivation")
 
-	inactiveTotalSumPreviousTopicWeights, err := s.emissionsKeeper.GetTotalSumPreviousTopicWeights(s.ctx)
+	inactiveTotalSumPreviousTopicWeights, err := s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(alloraMath.ZeroDec().Equal(inactiveTotalSumPreviousTopicWeights), "Total sum of previous topic weights should be zero after inactivation")
 
 	// Reactivate the topic
-	err = s.emissionsKeeper.ActivateTopic(s.ctx, topicId)
+	err = s.EmissionsKeeper().ActivateTopic(s.Ctx(), topicId)
 	s.Require().NoError(err)
 
 	// Check previousTopicWeights and totalPreviousTopicWeights after reactivation
-	reactivePreviousTopicWeight, _, err := s.emissionsKeeper.GetPreviousTopicWeight(s.ctx, topicId)
+	reactivePreviousTopicWeight, _, err := s.EmissionsKeeper().GetPreviousTopicWeight(s.Ctx(), topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(previousTopicWeight, reactivePreviousTopicWeight, "Previous topic weight should remain unchanged after reactivation")
 	s.Require().False(alloraMath.ZeroDec().Equal(reactivePreviousTopicWeight), "Previous topic weight should not be zero after reactivation")
 
-	reactiveTotalSumPreviousTopicWeights, err := s.emissionsKeeper.GetTotalSumPreviousTopicWeights(s.ctx)
+	reactiveTotalSumPreviousTopicWeights, err := s.EmissionsKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
 	s.Require().NoError(err)
 	s.Require().True(previousTopicWeight.Equal(reactiveTotalSumPreviousTopicWeights), "Total sum of previous topic weights should be equal to previous topic weight after reactivation")
 }

--- a/x/emissions/module/rewards/topic_skimming_test.go
+++ b/x/emissions/module/rewards/topic_skimming_test.go
@@ -16,7 +16,7 @@ func (s *RewardsTestSuite) TestSkimTopTopicsByWeightDescSimple() {
 		weights[topicId] = &weight
 	}
 	N := uint64(3)
-	mapOfTopN, listOfTopN, err := rewards.SkimTopTopicsByWeightDesc(s.ctx, weights, N)
+	mapOfTopN, listOfTopN, err := rewards.SkimTopTopicsByWeightDesc(s.Ctx(), weights, N)
 	s.Require().NoError(err)
 
 	// Check that mapOfTopN has the expected keys

--- a/x/emissions/module/rewards/worker_rewards_test.go
+++ b/x/emissions/module/rewards/worker_rewards_test.go
@@ -9,40 +9,16 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-func createNewTopic(s *RewardsTestSuite) uint64 {
-	newTopicMsg := &types.CreateNewTopicRequest{
-		Creator:                  s.addrs[5].String(),
-		Metadata:                 "test",
-		LossMethod:               "mse",
-		EpochLength:              10800,
-		GroundTruthLag:           10800,
-		WorkerSubmissionWindow:   10,
-		AlphaRegret:              alloraMath.NewDecFromInt64(1),
-		PNorm:                    alloraMath.NewDecFromInt64(3),
-		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
-		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
-		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
-		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
-		AllowNegative:            false,
-		EnableWorkerWhitelist:    true,
-		EnableReputerWhitelist:   true,
-	}
-	res, err := s.msgServer.CreateNewTopic(s.ctx, newTopicMsg)
-	s.Require().NoError(err)
-	return res.TopicId
-}
-
 func (s *RewardsTestSuite) TestGetReputersRewardFractionsSimpleShouldOutputSameFractionsForEqualZeroScores() {
-	topicId := createNewTopic(s)
+	topicId := uint64(1)
 	blockHeight := int64(1003)
 
 	workerAddrs := []sdk.AccAddress{
-		s.addrs[0],
-		s.addrs[1],
-		s.addrs[2],
-		s.addrs[3],
-		s.addrs[4],
+		s.Addrs(0),
+		s.Addrs(1),
+		s.Addrs(2),
+		s.Addrs(3),
+		s.Addrs(4),
 	}
 
 	// Check with all scores being 0
@@ -58,11 +34,11 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsSimpleShouldOutputSameF
 			}
 
 			// Persist worker inference score
-			err := s.emissionsKeeper.InsertWorkerInferenceScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err := s.EmissionsKeeper().InsertWorkerInferenceScore(s.Ctx(), topicId, blockHeight, scoreToAdd)
 			s.Require().NoError(err)
 
 			// Persist worker forecast score
-			err = s.emissionsKeeper.InsertWorkerForecastScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err = s.EmissionsKeeper().InsertWorkerForecastScore(s.Ctx(), topicId, blockHeight, scoreToAdd)
 			s.Require().NoError(err)
 		}
 
@@ -76,8 +52,8 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsSimpleShouldOutputSameF
 
 	// Get worker rewards
 	inferers, inferersRewardFractions, err := rewards.GetInferenceTaskRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		blockHeight,
 		alloraMath.MustNewDecFromString("1.5"),
@@ -88,8 +64,8 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsSimpleShouldOutputSameF
 	s.Require().Equal(5, len(inferersRewardFractions))
 
 	forecasters, forecastersRewardFractions, err := rewards.GetForecastingTaskRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		blockHeight,
 		alloraMath.MustNewDecFromString("1.5"),
@@ -121,15 +97,15 @@ func (s *RewardsTestSuite) TestGetReputersRewardFractionsSimpleShouldOutputSameF
 }
 
 func (s *RewardsTestSuite) TestGetWorkersRewardFractionsShouldOutputSameFractionsForEqualScores() {
-	topicId := createNewTopic(s)
+	topicId := uint64(1)
 	blockHeight := int64(1003)
 
 	workerAddrs := []sdk.AccAddress{
-		s.addrs[0],
-		s.addrs[1],
-		s.addrs[2],
-		s.addrs[3],
-		s.addrs[4],
+		s.Addrs(0),
+		s.Addrs(1),
+		s.Addrs(2),
+		s.Addrs(3),
+		s.Addrs(4),
 	}
 
 	// Generate old scores - 3 equal past scores per worker
@@ -145,11 +121,11 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsShouldOutputSameFraction
 			}
 
 			// Persist worker inference score
-			err := s.emissionsKeeper.InsertWorkerInferenceScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err := s.EmissionsKeeper().InsertWorkerInferenceScore(s.Ctx(), topicId, blockHeight, scoreToAdd)
 			s.Require().NoError(err)
 
 			// Persist worker forecast score
-			err = s.emissionsKeeper.InsertWorkerForecastScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err = s.EmissionsKeeper().InsertWorkerForecastScore(s.Ctx(), topicId, blockHeight, scoreToAdd)
 			s.Require().NoError(err)
 		}
 
@@ -163,8 +139,8 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsShouldOutputSameFraction
 
 	// Get worker rewards
 	inferers, inferersRewardFractions, err := rewards.GetInferenceTaskRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		blockHeight,
 		alloraMath.MustNewDecFromString("1.5"),
@@ -174,8 +150,8 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsShouldOutputSameFraction
 	s.Require().NoError(err)
 	s.Require().Equal(5, len(inferersRewardFractions))
 	forecasters, forecastersRewardFractions, err := rewards.GetForecastingTaskRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		blockHeight,
 		alloraMath.MustNewDecFromString("1.5"),
@@ -207,7 +183,7 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsShouldOutputSameFraction
 }
 
 func (s *RewardsTestSuite) TestGetWorkersRewardFractionsFromCsv() {
-	topicId := createNewTopic(s)
+	topicId := uint64(1)
 	blockHeight := int64(4)
 
 	finalEpoch := 304
@@ -215,25 +191,25 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsFromCsv() {
 	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
 	epoch4Get := epochGet[finalEpoch]
 
-	inferer0 := s.addrsStr[0]
-	inferer1 := s.addrsStr[1]
-	inferer2 := s.addrsStr[2]
-	inferer3 := s.addrsStr[3]
-	inferer4 := s.addrsStr[4]
+	inferer0 := s.AddrsStr(0)
+	inferer1 := s.AddrsStr(1)
+	inferer2 := s.AddrsStr(2)
+	inferer3 := s.AddrsStr(3)
+	inferer4 := s.AddrsStr(4)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
-	forecaster0 := s.addrsStr[5]
-	forecaster1 := s.addrsStr[6]
-	forecaster2 := s.addrsStr[7]
+	forecaster0 := s.AddrsStr(5)
+	forecaster1 := s.AddrsStr(6)
+	forecaster2 := s.AddrsStr(7)
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
 	// CSV values were generated considering just max scores = 10
 	// The actual implementation considers max scores = 10 * max actors to reward
-	params, err := s.emissionsKeeper.GetParams(s.ctx)
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
 	s.Require().NoError(err)
 	params.MaxTopInferersToReward = 1
 	params.MaxTopForecastersToReward = 1
-	err = s.emissionsKeeper.SetParams(s.ctx, params)
+	err = s.EmissionsKeeper().SetParams(s.Ctx(), params)
 	s.Require().NoError(err)
 
 	// Add scores from previous epochs
@@ -264,7 +240,7 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsFromCsv() {
 			}
 
 			// Persist worker inference score
-			err := s.emissionsKeeper.InsertWorkerInferenceScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err := s.EmissionsKeeper().InsertWorkerInferenceScore(s.Ctx(), topicId, blockHeight, scoreToAdd)
 			s.Require().NoError(err)
 
 			if j == 3 {
@@ -281,7 +257,7 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsFromCsv() {
 			}
 
 			// Persist worker forecast score
-			err := s.emissionsKeeper.InsertWorkerForecastScore(s.ctx, topicId, blockHeight, scoreToAdd)
+			err := s.EmissionsKeeper().InsertWorkerForecastScore(s.Ctx(), topicId, blockHeight, scoreToAdd)
 			s.Require().NoError(err)
 
 			if j == 3 {
@@ -292,8 +268,8 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsFromCsv() {
 
 	// Get worker rewards
 	inferers, inferersRewardFractions, err := rewards.GetInferenceTaskRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		blockHeight,
 		alloraMath.MustNewDecFromString("3"),
@@ -314,8 +290,8 @@ func (s *RewardsTestSuite) TestGetWorkersRewardFractionsFromCsv() {
 	}
 
 	forecasters, forecastersRewardFractions, err := rewards.GetForecastingTaskRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		blockHeight,
 		alloraMath.MustNewDecFromString("3"),
@@ -343,11 +319,11 @@ func (s *RewardsTestSuite) TestGetInferenceTaskEntropyFromCsv() {
 	taskRewardAlpha := alloraMath.MustNewDecFromString("0.1")
 	betaEntropy := alloraMath.MustNewDecFromString("0.25")
 
-	inferer0 := s.addrs[5].String()
-	inferer1 := s.addrs[6].String()
-	inferer2 := s.addrs[7].String()
-	inferer3 := s.addrs[8].String()
-	inferer4 := s.addrs[9].String()
+	inferer0 := s.AddrsStr(5)
+	inferer1 := s.AddrsStr(6)
+	inferer2 := s.AddrsStr(7)
+	inferer3 := s.AddrsStr(8)
+	inferer4 := s.AddrsStr(9)
 	infererAddresses := []string{inferer0, inferer1, inferer2, inferer3, inferer4}
 
 	infererPreviousFractions := []alloraMath.Dec{
@@ -360,7 +336,7 @@ func (s *RewardsTestSuite) TestGetInferenceTaskEntropyFromCsv() {
 
 	// Add previous reward fractions
 	for i, infererAddr := range infererAddresses {
-		err := s.emissionsKeeper.SetPreviousInferenceRewardFraction(s.ctx, topicId, infererAddr, infererPreviousFractions[i])
+		err := s.EmissionsKeeper().SetPreviousInferenceRewardFraction(s.Ctx(), topicId, infererAddr, infererPreviousFractions[i])
 		s.Require().NoError(err)
 	}
 
@@ -373,8 +349,8 @@ func (s *RewardsTestSuite) TestGetInferenceTaskEntropyFromCsv() {
 	}
 
 	inferenceEntropy, err := rewards.GetInferenceTaskEntropy(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		taskRewardAlpha,
 		betaEntropy,
@@ -388,7 +364,7 @@ func (s *RewardsTestSuite) TestGetInferenceTaskEntropyFromCsv() {
 }
 
 func (s *RewardsTestSuite) TestGetForecastTaskEntropyFromCsv() {
-	topicId := createNewTopic(s)
+	topicId := s.CreateTopic()
 	taskRewardAlpha := alloraMath.MustNewDecFromString("0.1")
 	betaEntropy := alloraMath.MustNewDecFromString("0.25")
 
@@ -396,9 +372,9 @@ func (s *RewardsTestSuite) TestGetForecastTaskEntropyFromCsv() {
 	epoch1Get := epochGet[301]
 	epoch2Get := epochGet[302]
 
-	forecaster0 := s.addrs[10].String()
-	forecaster1 := s.addrs[11].String()
-	forecaster2 := s.addrs[12].String()
+	forecaster0 := s.AddrsStr(10)
+	forecaster1 := s.AddrsStr(11)
+	forecaster2 := s.AddrsStr(12)
 	forecasterAddresses := []string{forecaster0, forecaster1, forecaster2}
 
 	forecasterPreviousFractions := []alloraMath.Dec{
@@ -409,7 +385,7 @@ func (s *RewardsTestSuite) TestGetForecastTaskEntropyFromCsv() {
 
 	// Add previous reward fractions
 	for i, forecasterAddr := range forecasterAddresses {
-		err := s.emissionsKeeper.SetPreviousForecastRewardFraction(s.ctx, topicId, forecasterAddr, forecasterPreviousFractions[i])
+		err := s.EmissionsKeeper().SetPreviousForecastRewardFraction(s.Ctx(), topicId, forecasterAddr, forecasterPreviousFractions[i])
 		s.Require().NoError(err)
 	}
 
@@ -420,8 +396,8 @@ func (s *RewardsTestSuite) TestGetForecastTaskEntropyFromCsv() {
 	}
 
 	forecastEntropy, err := rewards.GetForecastTaskEntropy(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		taskRewardAlpha,
 		betaEntropy,
@@ -435,7 +411,7 @@ func (s *RewardsTestSuite) TestGetForecastTaskEntropyFromCsv() {
 }
 
 func (s *RewardsTestSuite) TestGetWorkersRewardsInferenceTask() {
-	topicId := createNewTopic(s)
+	topicId := s.CreateTopic()
 	blockHeight := int64(1003)
 
 	// Generate old scores
@@ -444,8 +420,8 @@ func (s *RewardsTestSuite) TestGetWorkersRewardsInferenceTask() {
 
 	// Get worker rewards
 	inferers, inferersRewardFractions, err := rewards.GetInferenceTaskRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		blockHeight,
 		alloraMath.MustNewDecFromString("1.5"),
@@ -465,7 +441,7 @@ func (s *RewardsTestSuite) TestGetWorkersRewardsInferenceTask() {
 }
 
 func (s *RewardsTestSuite) TestGetWorkersRewardsForecastTask() {
-	topicId := createNewTopic(s)
+	topicId := s.CreateTopic()
 	blockHeight := int64(1003)
 
 	// Generate old scores
@@ -474,8 +450,8 @@ func (s *RewardsTestSuite) TestGetWorkersRewardsForecastTask() {
 
 	// Get worker rewards
 	forecasters, forecastersRewardFractions, err := rewards.GetForecastingTaskRewardFractions(
-		s.ctx,
-		s.emissionsKeeper,
+		s.Ctx(),
+		*s.EmissionsKeeper(),
 		topicId,
 		blockHeight,
 		alloraMath.MustNewDecFromString("1.5"),
@@ -501,11 +477,11 @@ func (s *RewardsTestSuite) TestInferenceRewardsFromCsv() {
 	totalReward, err := testutil.GetTotalRewardForTopicInEpoch(epoch3Get)
 	s.Require().NoError(err)
 	infererScores := []types.Score{
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[0], Score: epoch3Get("inferer_score_0")},
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[1], Score: epoch3Get("inferer_score_1")},
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[2], Score: epoch3Get("inferer_score_2")},
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[3], Score: epoch3Get("inferer_score_3")},
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[4], Score: epoch3Get("inferer_score_4")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(0), Score: epoch3Get("inferer_score_0")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(1), Score: epoch3Get("inferer_score_1")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(2), Score: epoch3Get("inferer_score_2")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(3), Score: epoch3Get("inferer_score_3")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(4), Score: epoch3Get("inferer_score_4")},
 	}
 	chi, gamma, _, _, err := rewards.GetChiAndGamma(
 		epoch3Get("network_naive_loss"),
@@ -539,11 +515,11 @@ func (s *RewardsTestSuite) TestForecastRewardsFromCsv() {
 	totalReward, err := testutil.GetTotalRewardForTopicInEpoch(epoch3Get)
 	s.Require().NoError(err)
 	infererScores := []types.Score{
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[0], Score: epoch3Get("inferer_score_0")},
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[1], Score: epoch3Get("inferer_score_1")},
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[2], Score: epoch3Get("inferer_score_2")},
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[3], Score: epoch3Get("inferer_score_3")},
-		{TopicId: 1, BlockHeight: 300, Address: s.addrsStr[4], Score: epoch3Get("inferer_score_4")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(0), Score: epoch3Get("inferer_score_0")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(1), Score: epoch3Get("inferer_score_1")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(2), Score: epoch3Get("inferer_score_2")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(3), Score: epoch3Get("inferer_score_3")},
+		{TopicId: 1, BlockHeight: 300, Address: s.AddrsStr(4), Score: epoch3Get("inferer_score_4")},
 	}
 	chi, gamma, _, _, err := rewards.GetChiAndGamma(
 		epoch3Get("network_naive_loss"),
@@ -573,92 +549,92 @@ func (s *RewardsTestSuite) TestForecastRewardsFromCsv() {
 func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.ValueBundle, error) {
 	infererValues := []*types.WorkerAttributedValue{
 		{
-			Worker: s.addrs[0].String(),
+			Worker: s.AddrsStr(0),
 			Value:  alloraMath.MustNewDecFromString("0.01327"),
 		},
 		{
-			Worker: s.addrs[1].String(),
+			Worker: s.AddrsStr(1),
 			Value:  alloraMath.MustNewDecFromString("0.01302"),
 		},
 		{
-			Worker: s.addrs[2].String(),
+			Worker: s.AddrsStr(2),
 			Value:  alloraMath.MustNewDecFromString("0.0136"),
 		},
 		{
-			Worker: s.addrs[3].String(),
+			Worker: s.AddrsStr(3),
 			Value:  alloraMath.MustNewDecFromString("0.01491"),
 		},
 		{
-			Worker: s.addrs[4].String(),
+			Worker: s.AddrsStr(4),
 			Value:  alloraMath.MustNewDecFromString("0.01686"),
 		},
 	}
 
 	oneOutInfererLosses := []*types.WithheldWorkerAttributedValue{
 		{
-			Worker: s.addrs[0].String(),
+			Worker: s.AddrsStr(0),
 			Value:  alloraMath.MustNewDecFromString("0.01327"),
 		},
 		{
-			Worker: s.addrs[1].String(),
+			Worker: s.AddrsStr(1),
 			Value:  alloraMath.MustNewDecFromString("0.01302"),
 		},
 		{
-			Worker: s.addrs[2].String(),
+			Worker: s.AddrsStr(2),
 			Value:  alloraMath.MustNewDecFromString("0.0136"),
 		},
 		{
-			Worker: s.addrs[3].String(),
+			Worker: s.AddrsStr(3),
 			Value:  alloraMath.MustNewDecFromString("0.01491"),
 		},
 		{
-			Worker: s.addrs[4].String(),
+			Worker: s.AddrsStr(4),
 			Value:  alloraMath.MustNewDecFromString("0.01686"),
 		},
 	}
 
 	oneOutForecasterLosses := []*types.WithheldWorkerAttributedValue{
 		{
-			Worker: s.addrs[0].String(),
+			Worker: s.AddrsStr(0),
 			Value:  alloraMath.MustNewDecFromString("0.01402"),
 		},
 		{
-			Worker: s.addrs[1].String(),
+			Worker: s.AddrsStr(1),
 			Value:  alloraMath.MustNewDecFromString("0.01316"),
 		},
 		{
-			Worker: s.addrs[2].String(),
+			Worker: s.AddrsStr(2),
 			Value:  alloraMath.MustNewDecFromString("0.01657"),
 		},
 		{
-			Worker: s.addrs[3].String(),
+			Worker: s.AddrsStr(3),
 			Value:  alloraMath.MustNewDecFromString("0.0124"),
 		},
 		{
-			Worker: s.addrs[4].String(),
+			Worker: s.AddrsStr(4),
 			Value:  alloraMath.MustNewDecFromString("0.01341"),
 		},
 	}
 
 	oneInNaiveLosses := []*types.WorkerAttributedValue{
 		{
-			Worker: s.addrs[0].String(),
+			Worker: s.AddrsStr(0),
 			Value:  alloraMath.MustNewDecFromString("0.01529"),
 		},
 		{
-			Worker: s.addrs[1].String(),
+			Worker: s.AddrsStr(1),
 			Value:  alloraMath.MustNewDecFromString("0.01141"),
 		},
 		{
-			Worker: s.addrs[2].String(),
+			Worker: s.AddrsStr(2),
 			Value:  alloraMath.MustNewDecFromString("0.01562"),
 		},
 		{
-			Worker: s.addrs[3].String(),
+			Worker: s.AddrsStr(3),
 			Value:  alloraMath.MustNewDecFromString("0.01444"),
 		},
 		{
-			Worker: s.addrs[4].String(),
+			Worker: s.AddrsStr(4),
 			Value:  alloraMath.MustNewDecFromString("0.01396"),
 		},
 	}
@@ -666,7 +642,7 @@ func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.
 	networkLosses := types.ValueBundle{
 		TopicId:                       topicId,
 		ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
-		Reputer:                       s.addrsStr[9],
+		Reputer:                       s.AddrsStr(9),
 		ExtraData:                     nil,
 		CombinedValue:                 alloraMath.MustNewDecFromString("0.013481256018186383"),
 		InfererValues:                 infererValues,
@@ -679,7 +655,7 @@ func mockNetworkLosses(s *RewardsTestSuite, topicId uint64, block int64) (types.
 	}
 
 	// Persist network losses
-	err := s.emissionsKeeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, block, networkLosses)
+	err := s.EmissionsKeeper().InsertNetworkLossBundleAtBlock(s.Ctx(), topicId, block, networkLosses)
 	if err != nil {
 		return types.ValueBundle{}, err
 	}
@@ -695,45 +671,45 @@ func mockSimpleNetworkLosses(
 ) (types.ValueBundle, error) {
 	infererValues := []*types.WorkerAttributedValue{
 		{
-			Worker: s.addrs[0].String(),
+			Worker: s.AddrsStr(0),
 			Value:  alloraMath.MustNewDecFromString(worker0Value),
 		},
 		{
-			Worker: s.addrs[1].String(),
+			Worker: s.AddrsStr(1),
 			Value:  alloraMath.MustNewDecFromString("0.3"),
 		},
 		{
-			Worker: s.addrs[2].String(),
+			Worker: s.AddrsStr(2),
 			Value:  alloraMath.MustNewDecFromString("0.4"),
 		},
 	}
 
 	genericLossesWithheld := []*types.WithheldWorkerAttributedValue{
 		{
-			Worker: s.addrs[0].String(),
+			Worker: s.AddrsStr(0),
 			Value:  alloraMath.MustNewDecFromString(worker0Value),
 		},
 		{
-			Worker: s.addrs[1].String(),
+			Worker: s.AddrsStr(1),
 			Value:  alloraMath.MustNewDecFromString("0.3"),
 		},
 		{
-			Worker: s.addrs[2].String(),
+			Worker: s.AddrsStr(2),
 			Value:  alloraMath.MustNewDecFromString("0.4"),
 		},
 	}
 
 	genericLosses := []*types.WorkerAttributedValue{
 		{
-			Worker: s.addrs[0].String(),
+			Worker: s.AddrsStr(0),
 			Value:  alloraMath.MustNewDecFromString(worker0Value),
 		},
 		{
-			Worker: s.addrs[1].String(),
+			Worker: s.AddrsStr(1),
 			Value:  alloraMath.MustNewDecFromString("0.3"),
 		},
 		{
-			Worker: s.addrs[2].String(),
+			Worker: s.AddrsStr(2),
 			Value:  alloraMath.MustNewDecFromString("0.4"),
 		},
 	}
@@ -741,7 +717,7 @@ func mockSimpleNetworkLosses(
 	networkLosses := types.ValueBundle{
 		TopicId:                       topicId,
 		ReputerRequestNonce:           &types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: block}},
-		Reputer:                       s.addrsStr[9],
+		Reputer:                       s.AddrsStr(9),
 		ExtraData:                     nil,
 		CombinedValue:                 alloraMath.MustNewDecFromString("0.05"),
 		InfererValues:                 infererValues,
@@ -753,7 +729,7 @@ func mockSimpleNetworkLosses(
 		OneOutInfererForecasterValues: nil,
 	}
 
-	err := s.emissionsKeeper.InsertNetworkLossBundleAtBlock(s.ctx, topicId, block, networkLosses)
+	err := s.EmissionsKeeper().InsertNetworkLossBundleAtBlock(s.Ctx(), topicId, block, networkLosses)
 	if err != nil {
 		return types.ValueBundle{}, err
 	}
@@ -763,11 +739,11 @@ func mockSimpleNetworkLosses(
 
 func mockWorkerLastScores(s *RewardsTestSuite, topicId uint64) ([]types.Score, error) {
 	workerAddrs := []sdk.AccAddress{
-		s.addrs[0],
-		s.addrs[1],
-		s.addrs[2],
-		s.addrs[3],
-		s.addrs[4],
+		s.Addrs(0),
+		s.Addrs(1),
+		s.Addrs(2),
+		s.Addrs(3),
+		s.Addrs(4),
 	}
 
 	var blocks = []int64{
@@ -794,13 +770,13 @@ func mockWorkerLastScores(s *RewardsTestSuite, topicId uint64) ([]types.Score, e
 			}
 
 			// Persist worker inference score
-			err := s.emissionsKeeper.InsertWorkerInferenceScore(s.ctx, topicId, blocks[j], scoreToAdd)
+			err := s.EmissionsKeeper().InsertWorkerInferenceScore(s.Ctx(), topicId, blocks[j], scoreToAdd)
 			if err != nil {
 				return nil, err
 			}
 
 			// Persist worker forecast score
-			err = s.emissionsKeeper.InsertWorkerForecastScore(s.ctx, topicId, blocks[j], scoreToAdd)
+			err = s.EmissionsKeeper().InsertWorkerForecastScore(s.Ctx(), topicId, blocks[j], scoreToAdd)
 			if err != nil {
 				return nil, err
 			}

--- a/x/emissions/module/stake_removals_test.go
+++ b/x/emissions/module/stake_removals_test.go
@@ -5,13 +5,14 @@ import (
 
 	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
-	"github.com/allora-network/allora-chain/x/emissions/module"
-	emissionstestutil "github.com/allora-network/allora-chain/x/emissions/testutil"
-	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+
+	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/module"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 // nolint: exhaustruct
@@ -110,7 +111,7 @@ func TestRemoveStakes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			kMock := emissionstestutil.NewMockEmissionsKeeper(ctrl)
+			kMock := alloratestutil.NewMockEmissionsKeeper(ctrl)
 			kMock.EXPECT().GetStakeRemovalsUpUntilBlock(gomock.Any(), tc.currentBlock, uint64(2)).Return(tc.stakeRemovals, tc.limitHit, nil)
 			for _, removal := range tc.stakeRemovals {
 				kMock.EXPECT().RemoveReputerStake(gomock.Any(), removal.BlockRemovalCompleted, removal.TopicId, removal.Reputer, removal.Amount).Return(nil)
@@ -225,7 +226,7 @@ func TestRemoveDelegateStakes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			kMock := emissionstestutil.NewMockEmissionsKeeper(ctrl)
+			kMock := alloratestutil.NewMockEmissionsKeeper(ctrl)
 			kMock.EXPECT().GetDelegateStakeRemovalsUpUntilBlock(gomock.Any(), tc.currentBlock, uint64(2)).Return(tc.stakeRemovals, tc.limitHit, nil)
 			for _, removal := range tc.stakeRemovals {
 				kMock.EXPECT().RemoveDelegateStake(gomock.Any(), removal.BlockRemovalCompleted, removal.TopicId, removal.Delegator, removal.Reputer, removal.Amount).Return(nil)

--- a/x/emissions/testutil/test_utils.go
+++ b/x/emissions/testutil/test_utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/allora-network/allora-chain/app/params"
 	alloralog "github.com/allora-network/allora-chain/log"
 	alloraMath "github.com/allora-network/allora-chain/math"
+	alloratestutil "github.com/allora-network/allora-chain/test/testutil"
 	"github.com/allora-network/allora-chain/utils/fn"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
@@ -358,7 +359,7 @@ func (s *TestSuite) SetupTest() {
 	// Fund the rewards account generously
 	s.FundAccount(10000000000, s.accountKeeper.GetModuleAddress(types.AlloraRewardsAccountName))
 
-	s.privKeys, s.pubKeyHexStr, s.addrs, s.addrsStr = GenerateTestAccounts(50)
+	s.privKeys, s.pubKeyHexStr, s.addrs, s.addrsStr = alloratestutil.GenerateTestAccounts(50)
 	for _, addr := range s.addrs {
 		s.FundAccount(10000000000, addr)
 	}
@@ -936,7 +937,7 @@ func (s *TestSuite) SetupParticipants(topicID uint64, indexes []int, isReputer b
 	}
 
 	// Add Stake for reputers
-	stakes := GenerateTestStakes(len(addresses))
+	stakes := alloratestutil.GenerateTestStakes(len(addresses))
 	for i, addr := range addresses {
 		stake := stakes[i]
 		if p.reputerStake != nil {
@@ -1033,17 +1034,18 @@ func (s *TestSuite) FullTopicSetup(workerIndexes, reputerIndexes []int, options 
 }
 
 // FullTopicPass runs a full pass for a topic. It:
-// 	- takes the option and sets up the topic
-// 	- in case topicID is provided, it assumes that topic exists so it skips creating it,
-// 	- finds the next churning block for the topic and uses it as the nonce,
-// 	- submits inferences for the unfulfilled worker nonce,
-// 	- forwards the chain to the end of the epoch,
-// 	- submits reputer loss bundles for the unfulfilled reputer nonce,
-// 	- forwards the chain to the rewards end blocker,
-// 	- runs the end blocker for closing the reputer nonce and calculating and distributing rewards (when appropriate),
-// 	- when running on a newly created topic, there will be no losses, so no rewards will be distributed.
+//   - takes the option and sets up the topic
+//   - in case topicID is provided, it assumes that topic exists so it skips creating it,
+//   - finds the next churning block for the topic and uses it as the nonce,
+//   - submits inferences for the unfulfilled worker nonce,
+//   - forwards the chain to the end of the epoch,
+//   - submits reputer loss bundles for the unfulfilled reputer nonce,
+//   - forwards the chain to the rewards end blocker,
+//   - runs the end blocker for closing the reputer nonce and calculating and distributing rewards (when appropriate),
+//   - when running on a newly created topic, there will be no losses, so no rewards will be distributed.
+//
 // Limitations:
-// 	- with the current design, `ground_truth_lag` needs to be the same as `epoch_length`.
+//   - with the current design, `ground_truth_lag` needs to be the same as `epoch_length`.
 func (s *TestSuite) FullTopicPass(workerIndexes, reputerIndexes []int, options ...Option) (uint64, int64) {
 	p := new(customParams)
 	for _, opt := range options {

--- a/x/emissions/types/inputreputer.go
+++ b/x/emissions/types/inputreputer.go
@@ -1,0 +1,19 @@
+package types
+
+import alloramath "github.com/allora-network/allora-chain/math"
+
+func (m *InputWorkerAttributedValue) SetWorker(s string) {
+	m.Worker = s
+}
+
+func (m *InputWorkerAttributedValue) SetValue(val alloramath.Dec) {
+	m.Value = alloramath.MustNewBoundedExp40Dec(val)
+}
+
+func (m *InputWithheldWorkerAttributedValue) SetWorker(worker string) {
+	m.Worker = worker
+}
+
+func (m *InputWithheldWorkerAttributedValue) SetValue(val alloramath.Dec) {
+	m.Value = alloramath.MustNewBoundedExp40Dec(val)
+}

--- a/x/emissions/types/inputreputer.go
+++ b/x/emissions/types/inputreputer.go
@@ -6,6 +6,7 @@ func (m *InputWorkerAttributedValue) SetWorker(s string) {
 	m.Worker = s
 }
 
+//nolint:stylecheck
 func (m *InputWorkerAttributedValue) SetValue(val alloramath.Dec) {
 	m.Value = alloramath.MustNewBoundedExp40Dec(val)
 }
@@ -14,6 +15,7 @@ func (m *InputWithheldWorkerAttributedValue) SetWorker(worker string) {
 	m.Worker = worker
 }
 
+//nolint:stylecheck
 func (m *InputWithheldWorkerAttributedValue) SetValue(val alloramath.Dec) {
 	m.Value = alloramath.MustNewBoundedExp40Dec(val)
 }

--- a/x/emissions/types/reputer.go
+++ b/x/emissions/types/reputer.go
@@ -1,0 +1,11 @@
+package types
+
+import alloramath "github.com/allora-network/allora-chain/math"
+
+func (workerValue *WorkerAttributedValue) GetValue() alloramath.Dec {
+	return workerValue.Value
+}
+
+func (withheldWorkerValue *WithheldWorkerAttributedValue) GetValue() alloramath.Dec {
+	return withheldWorkerValue.Value
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

The unit tests in the `x/emissions` module needed refactoring to make them compatible with the way natural topic flow would happen, and to accommodate the changes to be done in https://github.com/allora-network/allora-chain/pull/812.

- The helper function `getRewardsDistribution` is removed
- A new set of configurable helper functions is added for simulating a full topic pass
- Large tests were reduced in size
- Code repetition is reduced
- `TestSuite` is centralized and shared by most testing packages
- Some bugs were addressed

This is only the first such iteration of refactoring, it does not address every issue, so there should be more fixes in the future.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
