### PR TITLE
fix typo Update keepers.go

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -71,7 +71,7 @@ func (r *DefaultFeemarketDenomResolver) ConvertToDenom(_ sdk.Context, coin sdk.D
 		return coin, nil
 	}
 
-	return sdk.DecCoin{}, fmt.Errorf("error resolving denom: the only denom supported is %s", coin.Denom)
+	return sdk.DecCoin{}, fmt.Errorf("error resolving denom: the only denom supported is %s", denom)
 }
 
 func (r *DefaultFeemarketDenomResolver) ExtraDenoms(_ sdk.Context) ([]string, error) {


### PR DESCRIPTION
This PR corrects a misleading error message in the DefaultFeemarketDenomResolver.ConvertToDenom method.

Previously, when coin.Denom != denom, the error message would state:

the only denom supported is <coin.Denom>

This was confusing, since coin.Denom is the invalid denom passed in, not the expected one. The correct behavior is to indicate that only the target denom (the denom argument) is supported.

This fix improves clarity in logs and error handling for clients or developers interacting with the fee market denom resolver. The corrected message now properly reflects which denom is allowed.

