### PR TITLE
fix typo Update ante.go

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -44,7 +44,7 @@ func NewAnteHandler(options AnteHandlerOptions) (sdk.AnteHandler, error) {
 	}
 
 	if options.BankKeeper == nil {
-		return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "bank keeper keeper is required for ante builder")
+		return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "bank keeper is required for ante builder")
 	}
 
 	anteDecorators := []sdk.AnteDecorator{


### PR DESCRIPTION
This PR introduces the following improvements to the NewAnteHandler function:

Fixes a typo in an error message:

"bank keeper keeper is required for ante builder" → "bank keeper is required for ante builder"


