### PR TITLE
fix error in  testnet.go

### DIFF
--- a/cmd/allorad/cmd/testnet.go
+++ b/cmd/allorad/cmd/testnet.go
@@ -144,7 +144,7 @@ func initAppForTestnet(app *app.AlloraApp, args valArgs) *app.AlloraApp {
 	}
 	validatorsPowerStoreIterator.Close()
 
-	// Remove all valdiators from last validators store
+	// Remove all validators from last validators store
 	lastValidatorsIterator, err := app.StakingKeeper.LastValidatorsIterator(ctx)
 	if err != nil {
 		tmos.Exit(errors.Wrap(err, "initAppForTestnet(): failed to get last validators iterator").Error())


### PR DESCRIPTION
Hey team, found and fixed simple error in `cmd/allorad/cmd/testnet.go`

`valdiators` - `validators`