### PR TITLE
fix: replace formatted error string with predefined error constant in…

### DIFF
--- a/x/emissions/types/params.go
+++ b/x/emissions/types/params.go
@@ -577,7 +577,7 @@ func validateMaxSerializedMsgLength(i int64) error {
 // should be a number on the order of 525,960
 func ValidateBlocksPerMonth(i uint64) error {
 	if i == 0 {
-		return fmt.Errorf("blocks per month must be positive: %d", i)
+		return ErrValidationMustBeGreaterthanZero
 	}
 	return nil
 }


### PR DESCRIPTION
This change replaces a custom formatted error message with the predefined error constant ErrValidationMustBeGreaterthanZero in the ValidateBlocksPerMonth function. This improves code consistency as all other similar validation functions use the same error constant pattern, making error handling more uniform throughout the codebase.