### PR TITLE
fix typo in Update ante.go

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -44,7 +44,7 @@ func NewAnteHandler(options AnteHandlerOptions) (sdk.AnteHandler, error) {
 	}
 
 	if options.BankKeeper == nil {
-		return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "bank keeper keeper is required for ante builder")
+		return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "bank keeper is required for ante builder")
 	}
 
 	anteDecorators := []sdk.AnteDecorator{


### PR DESCRIPTION
This pull request fixes a small typo in the error message returned when the BankKeeper is nil in the NewAnteHandler function.

Although the typo doesn't affect functionality, it may cause confusion during debugging or reading logs. This change improves clarity and consistency.


