### PR TITLE
feat: enforce consensus settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* [#851](https://github.com/allora-network/allora-chain/pull/851) Enforce recommended settings
+
 ### Changed
 
 ### Deprecated
@@ -87,7 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Released]
 
-# v0.12.4
+# v0.12.4
 
 ### Added
 
@@ -113,7 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 
-# v0.12.3
+# v0.12.3
 
 ### Added
 

--- a/cmd/allorad/cmd/commands.go
+++ b/cmd/allorad/cmd/commands.go
@@ -28,6 +28,11 @@ import (
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 )
 
+const (
+	// FlagOverrideRecommendedConfig allows overriding recommended configuration settings.
+	FlagOverrideRecommendedConfig = "insecure-override-recommended-config"
+)
+
 func initRootCmd(rootCmd *cobra.Command, txConfig client.TxConfig, basicManager module.BasicManager) {
 	// Seal the config to prevent further modifications
 	cfg := sdk.GetConfig()
@@ -42,7 +47,35 @@ func initRootCmd(rootCmd *cobra.Command, txConfig client.TxConfig, basicManager 
 		NewInPlaceTestnetCmd(addModuleInitFlags),
 	)
 
-	server.AddCommands(rootCmd, app.DefaultNodeHome, newApp, appExport, func(startCmd *cobra.Command) {})
+	server.AddCommands(rootCmd, app.DefaultNodeHome, newApp, appExport, func(startCmd *cobra.Command) {
+		startCmd.Flags().Bool(FlagOverrideRecommendedConfig, false, "Override some recommended settings by using values provided in the config.toml and app.toml")
+	})
+
+	// update the start cmd to include config enforcement logic
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "start" {
+			runStart := cmd.RunE
+
+			cmd.RunE = func(cmd *cobra.Command, args []string) error {
+				serverCtx := server.GetServerContextFromCmd(cmd)
+
+				if serverCtx.Viper.GetBool(FlagOverrideRecommendedConfig) {
+					serverCtx.Logger.Warn("Overriding recommended settings with value provided in config.toml and app.toml")
+				} else {
+					// enforce the recommended settings
+					if err := overrideCometConfig(serverCtx.Config); err != nil {
+						return errors.New("failed to enforce comet settings: " + err.Error())
+					}
+
+					overrideViperConfig(serverCtx.Viper)
+				}
+
+				// run the original start cmd logic
+				return runStart(cmd, args)
+			}
+			break
+		}
+	}
 
 	// add keybase, auxiliary RPC, query, genesis, and tx child commands
 	rootCmd.AddCommand(

--- a/cmd/allorad/cmd/commands.go
+++ b/cmd/allorad/cmd/commands.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// FlagOverrideRecommendedConfig allows overriding recommended configuration settings.
-	FlagOverrideRecommendedConfig = "insecure-override-recommended-config"
+	FlagOverrideRecommendedConfig = "unsafe-override-recommended-settings"
 )
 
 func initRootCmd(rootCmd *cobra.Command, txConfig client.TxConfig, basicManager module.BasicManager) {
@@ -48,7 +48,7 @@ func initRootCmd(rootCmd *cobra.Command, txConfig client.TxConfig, basicManager 
 	)
 
 	server.AddCommands(rootCmd, app.DefaultNodeHome, newApp, appExport, func(startCmd *cobra.Command) {
-		startCmd.Flags().Bool(FlagOverrideRecommendedConfig, false, "Override some recommended settings by using values provided in the config.toml and app.toml")
+		startCmd.Flags().Bool(FlagOverrideRecommendedConfig, false, "Allow to override recommended settings by using values provided in the config.toml and app.toml configuration files")
 	})
 
 	// update the start cmd to include config enforcement logic

--- a/cmd/allorad/cmd/config.go
+++ b/cmd/allorad/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"time"
 
 	cmtcfg "github.com/cometbft/cometbft/config"
@@ -46,10 +47,13 @@ var (
 
 type settings []setting
 
-func (s settings) setInMap(cfg map[string]interface{}) {
+func (s settings) setInMap(cfg map[string]interface{}) error {
 	for _, setting := range s {
-		setting.setInMap(cfg)
+		if err := setting.setInMap(cfg); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (s settings) setInViper(v *viper.Viper) {
@@ -64,11 +68,17 @@ type setting struct {
 	value   interface{}
 }
 
-func (s setting) setInMap(cfg map[string]interface{}) {
+func (s setting) setInMap(cfg map[string]interface{}) error {
 	if _, ok := cfg[s.section]; !ok {
 		cfg[s.section] = make(map[string]interface{})
 	}
-	cfg[s.section].(map[string]interface{})[s.key] = s.value
+	cfgSection, ok := cfg[s.section].(map[string]interface{})
+	if !ok {
+		return errors.New("section '" + s.section + "' is not a map[string]interface{}")
+	}
+
+	cfgSection[s.key] = s.value
+	return nil
 }
 
 func (s setting) setInViper(v *viper.Viper) {
@@ -116,7 +126,9 @@ func overrideStructConfig(config interface{}, enforcedSettings settings) error {
 		return err
 	}
 
-	enforcedSettings.setInMap(cfg)
+	if err := enforcedSettings.setInMap(cfg); err != nil {
+		return err
+	}
 
 	return mapstructure.Decode(cfg, config)
 }

--- a/cmd/allorad/cmd/config.go
+++ b/cmd/allorad/cmd/config.go
@@ -87,7 +87,6 @@ func (s setting) setInViper(v *viper.Viper) {
 
 func mustGetDefaultConfigs() (*serverconfig.Config, *cmtcfg.Config) {
 	srvCfg := serverconfig.DefaultConfig()
-	srvCfg.MinGasPrices = "10uallo"
 
 	cmtCfg := cmtcfg.DefaultConfig()
 	cmtCfg.LogLevel = "*:error,p2p:info,state:info"

--- a/cmd/allorad/cmd/config.go
+++ b/cmd/allorad/cmd/config.go
@@ -10,17 +10,70 @@ import (
 )
 
 var (
-	recommendedAppSettings   = map[string]interface{}{}
-	recommendedCometSettings = map[string]interface{}{
-		"consensus.timeout_propose":         time.Second * 5,
-		"consensus.timeout_propose_delta":   time.Millisecond * 500,
-		"consensus.timeout_prevote":         time.Second * 3,
-		"consensus.timeout_prevote_delta":   time.Millisecond * 500,
-		"consensus.timeout_precommit":       time.Second * 3,
-		"consensus.timeout_precommit_delta": time.Millisecond * 500,
-		"consensus.timeout_commit":          time.Second * 5,
+	recommendedAppSettings   settings
+	recommendedCometSettings = settings{
+		{
+			section: "consensus",
+			key:     "timeout_propose",
+			value:   time.Second * 5,
+		}, {
+			section: "consensus",
+			key:     "timeout_propose_delta",
+			value:   time.Millisecond * 500,
+		}, {
+			section: "consensus",
+			key:     "timeout_prevote",
+			value:   time.Second * 3,
+		}, {
+			section: "consensus",
+			key:     "timeout_prevote_delta",
+			value:   time.Millisecond * 500,
+		}, {
+			section: "consensus",
+			key:     "timeout_precommit",
+			value:   time.Second * 3,
+		}, {
+			section: "consensus",
+			key:     "timeout_precommit_delta",
+			value:   time.Millisecond * 500,
+		}, {
+			section: "consensus",
+			key:     "timeout_commit",
+			value:   time.Second * 5,
+		},
 	}
 )
+
+type settings []setting
+
+func (s settings) setInMap(cfg map[string]interface{}) {
+	for _, setting := range s {
+		setting.setInMap(cfg)
+	}
+}
+
+func (s settings) setInViper(v *viper.Viper) {
+	for _, setting := range s {
+		setting.setInViper(v)
+	}
+}
+
+type setting struct {
+	section string
+	key     string
+	value   interface{}
+}
+
+func (s setting) setInMap(cfg map[string]interface{}) {
+	if _, ok := cfg[s.section]; !ok {
+		cfg[s.section] = make(map[string]interface{})
+	}
+	cfg[s.section].(map[string]interface{})[s.key] = s.value
+}
+
+func (s setting) setInViper(v *viper.Viper) {
+	v.Set(s.section+"."+s.key, s.value)
+}
 
 func mustGetDefaultConfigs() (*serverconfig.Config, *cmtcfg.Config) {
 	srvCfg := serverconfig.DefaultConfig()
@@ -37,13 +90,8 @@ func mustGetDefaultConfigs() (*serverconfig.Config, *cmtcfg.Config) {
 }
 
 func overrideViperConfig(v *viper.Viper) {
-	for key, value := range recommendedAppSettings {
-		v.Set(key, value)
-	}
-
-	for key, value := range recommendedCometSettings {
-		v.Set(key, value)
-	}
+	recommendedAppSettings.setInViper(v)
+	recommendedCometSettings.setInViper(v)
 }
 
 func overrideConfigs(srvCfg *serverconfig.Config, cmtCfg *cmtcfg.Config) error {
@@ -55,22 +103,20 @@ func overrideConfigs(srvCfg *serverconfig.Config, cmtCfg *cmtcfg.Config) error {
 }
 
 func overrideCometConfig(cmtCfg *cmtcfg.Config) error {
-	return overrideStructSettings(cmtCfg, recommendedCometSettings)
+	return overrideStructConfig(cmtCfg, recommendedCometSettings)
 }
 
 func overrideAppConfig(srvCfg *serverconfig.Config) error {
-	return overrideStructSettings(srvCfg, recommendedAppSettings)
+	return overrideStructConfig(srvCfg, recommendedAppSettings)
 }
 
-func overrideStructSettings(config interface{}, enforcedSettings map[string]interface{}) error {
+func overrideStructConfig(config interface{}, enforcedSettings settings) error {
 	var cfg map[string]interface{}
-	if err := mapstructure.Decode(config, cfg); err != nil {
+	if err := mapstructure.Decode(config, &cfg); err != nil {
 		return err
 	}
 
-	for key, value := range enforcedSettings {
-		cfg[key] = value
-	}
+	enforcedSettings.setInMap(cfg)
 
 	return mapstructure.Decode(cfg, config)
 }

--- a/cmd/allorad/cmd/config.go
+++ b/cmd/allorad/cmd/config.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"time"
+
+	cmtcfg "github.com/cometbft/cometbft/config"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+)
+
+var (
+	recommendedAppSettings   = map[string]interface{}{}
+	recommendedCometSettings = map[string]interface{}{
+		"consensus.timeout_propose":         time.Second * 5,
+		"consensus.timeout_propose_delta":   time.Millisecond * 500,
+		"consensus.timeout_prevote":         time.Second * 3,
+		"consensus.timeout_prevote_delta":   time.Millisecond * 500,
+		"consensus.timeout_precommit":       time.Second * 3,
+		"consensus.timeout_precommit_delta": time.Millisecond * 500,
+		"consensus.timeout_commit":          time.Second * 5,
+	}
+)
+
+func mustGetDefaultConfigs() (*serverconfig.Config, *cmtcfg.Config) {
+	srvCfg := serverconfig.DefaultConfig()
+	srvCfg.MinGasPrices = "10uallo"
+
+	cmtCfg := cmtcfg.DefaultConfig()
+	cmtCfg.LogLevel = "*:error,p2p:info,state:info"
+
+	if err := overrideConfigs(srvCfg, cmtCfg); err != nil {
+		panic("failed to enforce settings: " + err.Error())
+	}
+
+	return srvCfg, cmtCfg
+}
+
+func overrideViperConfig(v *viper.Viper) {
+	for key, value := range recommendedAppSettings {
+		v.Set(key, value)
+	}
+
+	for key, value := range recommendedCometSettings {
+		v.Set(key, value)
+	}
+}
+
+func overrideConfigs(srvCfg *serverconfig.Config, cmtCfg *cmtcfg.Config) error {
+	if err := overrideAppConfig(srvCfg); err != nil {
+		return err
+	}
+
+	return overrideCometConfig(cmtCfg)
+}
+
+func overrideCometConfig(cmtCfg *cmtcfg.Config) error {
+	return overrideStructSettings(cmtCfg, recommendedCometSettings)
+}
+
+func overrideAppConfig(srvCfg *serverconfig.Config) error {
+	return overrideStructSettings(srvCfg, recommendedAppSettings)
+}
+
+func overrideStructSettings(config interface{}, enforcedSettings map[string]interface{}) error {
+	var cfg map[string]interface{}
+	if err := mapstructure.Decode(config, cfg); err != nil {
+		return err
+	}
+
+	for key, value := range enforcedSettings {
+		cfg[key] = value
+	}
+
+	return mapstructure.Decode(cfg, config)
+}

--- a/cmd/allorad/cmd/config_test.go
+++ b/cmd/allorad/cmd/config_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	cmtcfg "github.com/cometbft/cometbft/config"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverrideStructConfig(t *testing.T) {
+	overrides := settings{
+		{
+			section: "consensus",
+			key:     "timeout_propose",
+			value:   time.Second * 15,
+		},
+		{
+			section: "consensus",
+			key:     "timeout_propose_delta",
+			value:   time.Millisecond * 2000,
+		},
+	}
+
+	cmtCfg := cmtcfg.DefaultConfig()
+	require.NoError(t, overrideStructConfig(cmtCfg, overrides))
+	require.Equal(t, time.Second*15, cmtCfg.Consensus.TimeoutPropose)
+	require.Equal(t, time.Millisecond*2000, cmtCfg.Consensus.TimeoutProposeDelta)
+}
+
+func TestSetInViper(t *testing.T) {
+	overrides := settings{
+		{
+			section: "consensus",
+			key:     "timeout_propose",
+			value:   time.Second * 15,
+		},
+		{
+			section: "consensus",
+			key:     "timeout_propose_delta",
+			value:   time.Millisecond * 2000,
+		},
+	}
+
+	v := viper.New()
+	v.Set("consensus.timeout_propose", time.Second*2)
+	v.Set("consensus.timeout_propose_delta", time.Second*6)
+
+	overrides.setInViper(v)
+
+	require.Equal(t, time.Second*15, v.Get("consensus.timeout_propose"))
+	require.Equal(t, time.Millisecond*2000, v.Get("consensus.timeout_propose_delta"))
+}

--- a/cmd/allorad/cmd/root.go
+++ b/cmd/allorad/cmd/root.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"os"
-	"time"
 
-	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/spf13/cobra"
 
 	"cosmossdk.io/client/v2/autocli"
@@ -94,14 +92,7 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			// overwrite the minimum gas price from the app configuration
-			srvCfg := serverconfig.DefaultConfig()
-			srvCfg.MinGasPrices = "0uallo"
-
-			// overwrite the block timeout
-			cmtCfg := cmtcfg.DefaultConfig()
-			cmtCfg.Consensus.TimeoutCommit = 3 * time.Second
-			cmtCfg.LogLevel = "*:error,p2p:info,state:info" // better default logging
+			srvCfg, cmtCfg := mustGetDefaultConfigs()
 
 			return server.InterceptConfigsPreRunHandler(cmd, serverconfig.DefaultConfigTemplate, srvCfg, cmtCfg)
 		},
@@ -133,14 +124,14 @@ func ProvideClientContext(
 	legacyAmino *codec.LegacyAmino,
 ) client.Context {
 	clientCtx := client.Context{}. // nolint: exhaustruct // dependency code don't want to change the way it works
-					WithCodec(appCodec).
-					WithInterfaceRegistry(interfaceRegistry).
-					WithTxConfig(txConfig).
-					WithLegacyAmino(legacyAmino).
-					WithInput(os.Stdin).
-					WithAccountRetriever(types.AccountRetriever{}).
-					WithHomeDir(app.DefaultNodeHome).
-					WithViper("ALLORA") // env variable prefix
+		WithCodec(appCodec).
+		WithInterfaceRegistry(interfaceRegistry).
+		WithTxConfig(txConfig).
+		WithLegacyAmino(legacyAmino).
+		WithInput(os.Stdin).
+		WithAccountRetriever(types.AccountRetriever{}).
+		WithHomeDir(app.DefaultNodeHome).
+		WithViper("ALLORA") // env variable prefix
 
 	// Read the config again to overwrite the default values with the values from the config file
 	clientCtx, _ = config.ReadFromClientConfig(clientCtx)

--- a/cmd/allorad/cmd/root.go
+++ b/cmd/allorad/cmd/root.go
@@ -124,14 +124,14 @@ func ProvideClientContext(
 	legacyAmino *codec.LegacyAmino,
 ) client.Context {
 	clientCtx := client.Context{}. // nolint: exhaustruct // dependency code don't want to change the way it works
-		WithCodec(appCodec).
-		WithInterfaceRegistry(interfaceRegistry).
-		WithTxConfig(txConfig).
-		WithLegacyAmino(legacyAmino).
-		WithInput(os.Stdin).
-		WithAccountRetriever(types.AccountRetriever{}).
-		WithHomeDir(app.DefaultNodeHome).
-		WithViper("ALLORA") // env variable prefix
+					WithCodec(appCodec).
+					WithInterfaceRegistry(interfaceRegistry).
+					WithTxConfig(txConfig).
+					WithLegacyAmino(legacyAmino).
+					WithInput(os.Stdin).
+					WithAccountRetriever(types.AccountRetriever{}).
+					WithHomeDir(app.DefaultNodeHome).
+					WithViper("ALLORA") // env variable prefix
 
 	// Read the config again to overwrite the default values with the values from the config file
 	clientCtx, _ = config.ReadFromClientConfig(clientCtx)


### PR DESCRIPTION
## Purpose of Changes and their Description

Define a bunch of recommended settings for both `app.toml` and `config.toml` and enforce them upon start-up.

These settings are automatically set as default when using the `init` command, and if changed they are overridden before loading the application.

In order to still allow their modification a `--unsafe-override-recommended-settings` flag has been added to the `start` command to bypass the enforcing logic and let the values provided in the `config.toml` and `app.toml` files.

The recommended settings to enforce that are set through this PR are the following:
- `consensus.timeout_propose`: 5s
- `consensus.timeout_propose_delta`: 500ms
- `consensus.timeout_prevote`: 3s
- `consensus.timeout_prevote_delta`:  500ms
- `consensus.timeout_precommit`: 3s
- `consensus.timeout_precommit_delta`: 500ms
- `consensus.timeout_commit`: 5s

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
