### PR TITLE
Apply an upper boundary to open reputer submission window event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+### API Breaking Changes
+
+#### Removed
+
+#### Added 
+
+#### Changed
+
+# [Released]
+
+# v0.12.3
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+* [#857](https://github.com/allora-network/allora-chain/pull/857) Apply an upper boundary to open reputer submission window event
+
+### Security
+
+### API Breaking Changes
+
+#### Removed
+
+#### Added 
+
+#### Changed
+
+# v0.12.2
+
+### Added
+
 * [#823](https://github.com/allora-network/allora-chain/pull/823) Pruning metric and event
 * [#834](https://github.com/allora-network/allora-chain/pull/834) Add outlier resistant network inferences event
 * [#854](https://github.com/allora-network/allora-chain/pull/854) Add EmissionInfo event
@@ -93,7 +141,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-# [Released]
 
 # v0.12.1
 

--- a/x/emissions/module/rewards/nonce_management.go
+++ b/x/emissions/module/rewards/nonce_management.go
@@ -14,9 +14,13 @@ func UpdateReputerNonce(ctx sdk.Context, k keeper.Keeper, topic types.Topic, blo
 		ctx.Logger().Warn("Error getting unfulfilled worker nonces", "error", err)
 		return err
 	}
+	extraLag := topic.GroundTruthLag % topic.EpochLength
+	if extraLag != 0 {
+		extraLag = topic.EpochLength - extraLag
+	}
 	for _, nonce := range nonces.Nonces {
-		if block >= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag {
-			windowEndBlock := block + topic.EpochLength
+		if block >= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag && block <= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag+extraLag {
+			windowEndBlock := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag + extraLag + topic.EpochLength
 			types.EmitNewReputerSubmissionWindowOpenedEvent(ctx, topic.Id, nonce.ReputerNonce.BlockHeight, windowEndBlock)
 		}
 		// Check if current blockheight has reached the blockheight of the nonce + groundTruthLag + epochLength


### PR DESCRIPTION
## Purpose of Changes and their Description
Apply an upper boundary to avoid re-sending of open reputer submission event on closing of epoch end.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- testing
- [x] If documented, please describe where. If not, describe why docs are not needed. -- just a fix. 
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

