### PR TITLE
Adapter/api worker reputer/utils.go

### DIFF
--- a/interact.py
+++ b/interact.py
@@ -1,0 +1,4 @@
+import os
+from allora import AlloraAPIClient, ChainSlug
+
+client = AlloraAPIClient(chain_slug=ChainSlug.TESTNET, api_key=os.environ.get("ALLORA_API_KEY"))

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,12 @@
+// File: adapter/api-worker-reputer/utils.go
+
+package api_worker_reputer
+
+import (
+    "log"
+)
+
+// LogStartup logs a startup message for the worker/reputer node.
+func LogStartup(nodeType string) {
+    log.Printf("Starting %s node for Allora Network...\n", nodeType)
+}


### PR DESCRIPTION
This PR adds a simple LogStartup function to log the startup of worker/reputer nodes, improving debuggability


