### PR TITLE
scores take 2 gtlags to appear on topic start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [#868](https://github.com/allora-network/allora-chain/pull/868) Scores take 2 gtlags to appear on topic start
+
 ### Security
 
 ### API Breaking Changes

--- a/math/utils.go
+++ b/math/utils.go
@@ -248,6 +248,45 @@ func Median(data []Dec) (Dec, error) {
 	return sum.Quo(NewDecFromInt64(2))
 }
 
+// Average calculates the arithmetic mean of a slice of `Dec` values.
+// For empty slices, returns ZeroDec().
+// For single-element slices, returns that element.
+func Average(data []Dec) (Dec, error) {
+	// Check for NaN values first, consistent with other functions
+	for _, v := range data {
+		if v.isNaN {
+			return Dec{}, errorsmod.Wrap(ErrNaN, "average input data contains NaN values")
+		}
+	}
+
+	if len(data) == 0 {
+		return ZeroDec(), nil
+	}
+
+	if len(data) == 1 {
+		return data[0], nil
+	}
+
+	// Calculate the sum
+	sum := ZeroDec()
+	var err error
+	for _, v := range data {
+		sum, err = sum.Add(v)
+		if err != nil {
+			return Dec{}, err
+		}
+	}
+
+	// Calculate the average by dividing sum by length
+	length := NewDecFromInt64(int64(len(data)))
+	average, err := sum.Quo(length)
+	if err != nil {
+		return Dec{}, err
+	}
+
+	return average, nil
+}
+
 // Implements the new gradient function phi prime
 // φ'_p(x) = p / (exp(p * (c - x)) + 1)
 func Gradient(p, c, x Dec) (Dec, error) {

--- a/math/utils_test.go
+++ b/math/utils_test.go
@@ -1030,3 +1030,278 @@ func TestGetSmoothedAlpha(t *testing.T) {
 		})
 	}
 }
+
+func TestAverage(t *testing.T) {
+	testCases := []struct {
+		name        string
+		data        []alloraMath.Dec
+		expected    alloraMath.Dec
+		expectError bool
+		epsilon     alloraMath.Dec
+	}{
+		{
+			name:        "Empty slice",
+			data:        []alloraMath.Dec{},
+			expected:    alloraMath.ZeroDec(),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name:        "Single element",
+			data:        []alloraMath.Dec{alloraMath.MustNewDecFromString("5.5")},
+			expected:    alloraMath.MustNewDecFromString("5.5"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "Two elements",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("10"),
+				alloraMath.MustNewDecFromString("20"),
+			},
+			expected:    alloraMath.MustNewDecFromString("15"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "Three elements",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("1"),
+				alloraMath.MustNewDecFromString("2"),
+				alloraMath.MustNewDecFromString("3"),
+			},
+			expected:    alloraMath.MustNewDecFromString("2"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "Four elements with decimals",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("1.5"),
+				alloraMath.MustNewDecFromString("2.5"),
+				alloraMath.MustNewDecFromString("3.5"),
+				alloraMath.MustNewDecFromString("4.5"),
+			},
+			expected:    alloraMath.MustNewDecFromString("3"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "Negative numbers balanced",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("-10"),
+				alloraMath.MustNewDecFromString("-5"),
+				alloraMath.MustNewDecFromString("0"),
+				alloraMath.MustNewDecFromString("5"),
+				alloraMath.MustNewDecFromString("10"),
+			},
+			expected:    alloraMath.ZeroDec(),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "All negative numbers",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("-3"),
+				alloraMath.MustNewDecFromString("-2"),
+				alloraMath.MustNewDecFromString("-1"),
+			},
+			expected:    alloraMath.MustNewDecFromString("-2"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "Mixed positive and negative",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("-2.5"),
+				alloraMath.MustNewDecFromString("1.5"),
+				alloraMath.MustNewDecFromString("3.5"),
+			},
+			expected:    alloraMath.MustNewDecFromString("0.833333333333333333333333333333"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "Large numbers",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("1000000"),
+				alloraMath.MustNewDecFromString("2000000"),
+				alloraMath.MustNewDecFromString("3000000"),
+			},
+			expected:    alloraMath.MustNewDecFromString("2000000"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "Very small numbers",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("0.0001"),
+				alloraMath.MustNewDecFromString("0.0002"),
+				alloraMath.MustNewDecFromString("0.0003"),
+			},
+			expected:    alloraMath.MustNewDecFromString("0.0002"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0000001"),
+		},
+		{
+			name: "All zeros",
+			data: []alloraMath.Dec{
+				alloraMath.ZeroDec(),
+				alloraMath.ZeroDec(),
+				alloraMath.ZeroDec(),
+			},
+			expected:    alloraMath.ZeroDec(),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "All same values",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("7.5"),
+				alloraMath.MustNewDecFromString("7.5"),
+				alloraMath.MustNewDecFromString("7.5"),
+				alloraMath.MustNewDecFromString("7.5"),
+			},
+			expected:    alloraMath.MustNewDecFromString("7.5"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "Large dataset",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("1"),
+				alloraMath.MustNewDecFromString("2"),
+				alloraMath.MustNewDecFromString("3"),
+				alloraMath.MustNewDecFromString("4"),
+				alloraMath.MustNewDecFromString("5"),
+				alloraMath.MustNewDecFromString("6"),
+				alloraMath.MustNewDecFromString("7"),
+				alloraMath.MustNewDecFromString("8"),
+				alloraMath.MustNewDecFromString("9"),
+				alloraMath.MustNewDecFromString("10"),
+			},
+			expected:    alloraMath.MustNewDecFromString("5.5"),
+			expectError: false,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "NaN in data",
+			data: []alloraMath.Dec{
+				alloraMath.MustNewDecFromString("1"),
+				alloraMath.NewNaN(),
+				alloraMath.MustNewDecFromString("3"),
+			},
+			expected:    alloraMath.ZeroDec(),
+			expectError: true,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name: "All NaN values",
+			data: []alloraMath.Dec{
+				alloraMath.NewNaN(),
+				alloraMath.NewNaN(),
+				alloraMath.NewNaN(),
+			},
+			expected:    alloraMath.ZeroDec(),
+			expectError: true,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+		{
+			name:        "Single NaN",
+			data:        []alloraMath.Dec{alloraMath.NewNaN()},
+			expected:    alloraMath.ZeroDec(),
+			expectError: true,
+			epsilon:     alloraMath.MustNewDecFromString("0.0001"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := alloraMath.Average(tc.data)
+			if tc.expectError {
+				require.Error(t, err, "Expected an error but got none")
+				require.ErrorIs(t, err, alloraMath.ErrNaN, "Expected ErrNaN error")
+			} else {
+				require.NoError(t, err, "Unexpected error: %v", err)
+				inDelta, err := alloraMath.InDelta(tc.expected, result, tc.epsilon)
+				require.NoError(t, err)
+				require.True(t, inDelta,
+					"Unexpected result for %s: got %s, want %s", tc.name, result.String(), tc.expected.String())
+			}
+		})
+	}
+}
+
+// TestAverageDeterministic tests that the Average function is deterministic
+// by running the same data multiple times and ensuring consistent results
+func TestAverageDeterministic(t *testing.T) {
+	data := []alloraMath.Dec{
+		alloraMath.MustNewDecFromString("0.123456789012345678901234567890"), // Very long decimal
+		alloraMath.MustNewDecFromString("42"),                               // Integer without decimals
+		alloraMath.MustNewDecFromString("999999999999999999.5"),             // Very big number
+		alloraMath.MustNewDecFromString("0.0000000001"),                     // Very small number
+		alloraMath.MustNewDecFromString("1234.567890123"),                   // Medium number with many decimals
+	}
+
+	// Expected average: sum / 5 = (0.123456789012345678901234567890 + 42 + 999999999999999999.5 + 0.0000000001 + 1234.567890123) / 5
+	// = 1000000000000001276.191347012312345678901234567890 / 5
+	// = 200000000000000255.2382694024624691357802469136
+	expected := alloraMath.MustNewDecFromString("200000000000000255.2382694024624691357802469136")
+	epsilon := alloraMath.MustNewDecFromString("0.0001")
+
+	// Run the test multiple times to ensure deterministic behavior
+	for i := 0; i < 10; i++ {
+		result, err := alloraMath.Average(data)
+		require.NoError(t, err, "Unexpected error on iteration %d: %v", i, err)
+
+		inDelta, err := alloraMath.InDelta(expected, result, epsilon)
+		require.NoError(t, err)
+		require.True(t, inDelta,
+			"Non-deterministic result on iteration %d: got %s, want %s", i, result.String(), expected.String())
+	}
+}
+
+// TestAverageOrderIndependent tests that the Average function is order-independent
+// by testing the same values in different orders
+func TestAverageOrderIndependent(t *testing.T) {
+	// Test data in different orders
+	testData := [][]alloraMath.Dec{
+		{
+			alloraMath.MustNewDecFromString("1"),
+			alloraMath.MustNewDecFromString("2"),
+			alloraMath.MustNewDecFromString("3"),
+			alloraMath.MustNewDecFromString("4"),
+		},
+		{
+			alloraMath.MustNewDecFromString("4"),
+			alloraMath.MustNewDecFromString("3"),
+			alloraMath.MustNewDecFromString("2"),
+			alloraMath.MustNewDecFromString("1"),
+		},
+		{
+			alloraMath.MustNewDecFromString("2"),
+			alloraMath.MustNewDecFromString("4"),
+			alloraMath.MustNewDecFromString("1"),
+			alloraMath.MustNewDecFromString("3"),
+		},
+		{
+			alloraMath.MustNewDecFromString("3"),
+			alloraMath.MustNewDecFromString("1"),
+			alloraMath.MustNewDecFromString("4"),
+			alloraMath.MustNewDecFromString("2"),
+		},
+	}
+
+	expected := alloraMath.MustNewDecFromString("2.5")
+	epsilon := alloraMath.MustNewDecFromString("0.0001")
+
+	for i, data := range testData {
+		result, err := alloraMath.Average(data)
+		require.NoError(t, err, "Unexpected error for order %d: %v", i, err)
+
+		inDelta, err := alloraMath.InDelta(expected, result, epsilon)
+		require.NoError(t, err)
+		require.True(t, inDelta,
+			"Order-dependent result for order %d: got %s, want %s", i, result.String(), expected.String())
+	}
+}

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -78,7 +78,7 @@ func calcNetworkInferencesMultipleByMedian(
 		return nil, errorsmod.Wrap(err, "while calculating median")
 	}
 
-	// Compute one-out median for each inferer
+	// Compute one-out average for each inferer
 	oneOutInfererValues := make([]*emissions.WithheldWorkerAttributedValue, 0, len(inferences.Inferences))
 	for i, inf := range inferences.Inferences {
 		// Build slice without the current inference
@@ -89,15 +89,15 @@ func calcNetworkInferencesMultipleByMedian(
 			}
 		}
 
-		// Calculate one-out median
-		oneOutMedian, err := alloraMath.Median(without)
+		// Calculate one-out average
+		oneOutAverage, err := alloraMath.Average(without)
 		if err != nil {
 			return nil, errorsmod.Wrapf(err, "while calculating one-out median for inferer %s", inf.Inferer)
 		}
 
 		oneOutInfererValues = append(oneOutInfererValues, &emissions.WithheldWorkerAttributedValue{
 			Worker: inf.Inferer,
-			Value:  oneOutMedian,
+			Value:  oneOutAverage,
 		})
 	}
 

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -78,6 +78,29 @@ func calcNetworkInferencesMultipleByMedian(
 		return nil, errorsmod.Wrap(err, "while calculating median")
 	}
 
+	// Compute one-out median for each inferer
+	oneOutInfererValues := make([]*emissions.WithheldWorkerAttributedValue, 0, len(inferences.Inferences))
+	for i, inf := range inferences.Inferences {
+		// Build slice without the current inference
+		without := make([]alloraMath.Dec, 0, len(inferenceValues)-1)
+		for j, val := range inferenceValues {
+			if i != j {
+				without = append(without, val)
+			}
+		}
+
+		// Calculate one-out median
+		oneOutMedian, err := alloraMath.Median(without)
+		if err != nil {
+			return nil, errorsmod.Wrapf(err, "while calculating one-out median for inferer %s", inf.Inferer)
+		}
+
+		oneOutInfererValues = append(oneOutInfererValues, &emissions.WithheldWorkerAttributedValue{
+			Worker: inf.Inferer,
+			Value:  oneOutMedian,
+		})
+	}
+
 	networkInferences := &emissions.ValueBundle{
 		TopicId:   topicId,
 		ExtraData: nil,
@@ -89,13 +112,14 @@ func calcNetworkInferencesMultipleByMedian(
 		InfererValues: fn.Map(inferences.Inferences, func(inf *emissions.Inference) *emissions.WorkerAttributedValue {
 			return &emissions.WorkerAttributedValue{Worker: inf.Inferer, Value: inf.Value}
 		}),
-		ForecasterValues:              nil,
 		NaiveValue:                    alloraMath.ZeroDec(),
-		OneOutInfererValues:           nil,
+		ForecasterValues:              nil,
+		OneOutInfererValues:           oneOutInfererValues,
 		OneOutForecasterValues:        nil,
 		OneInForecasterValues:         nil,
 		OneOutInfererForecasterValues: nil,
 	}
+
 	return &GetNetworkInferencesResult{
 		NetworkInferences:    networkInferences,
 		InfererToWeight:      nil,

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -286,6 +286,7 @@ func (s *RewardsTestSuite) TestIncreasingAlphaRegretIncreasesPresentEffectOnRegr
 	stake := cosmosMath.NewInt(1000000000000000000).Mul(cosmosMath.NewInt(1000000000000000000))
 	epochLength := int64(60)
 	groundTruthLag := int64(60)
+	deltaRegret := alloraMath.MustNewDecFromString("0.000000000001")
 
 	// Alpha values for the two trials
 	alphaValues := []string{"0.1", "0.2"}
@@ -388,7 +389,7 @@ func (s *RewardsTestSuite) TestIncreasingAlphaRegretIncreasesPresentEffectOnRegr
 		delta, err := alloraMath.InDelta(
 			trial.decreaseRate,
 			trial.alphaRegret,
-			alloraMath.MustNewDecFromString("0.000000000001"))
+			deltaRegret)
 		require.NoError(err)
 		require.True(delta, "Regret decrease rate should equal alpha (within a delta): got %s, expected %s",
 			trial.decreaseRate.String(), trial.alphaRegret.String())

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -164,6 +164,9 @@ func (s *RewardsTestSuite) TestFixingTaskRewardAlphaDoesNotChangePerformanceImpo
 // due to a worse one out inferer value, indicating that the network is better off with the worker.
 // We increase TaskRewardAlpha between the trials to show that weighting current performance more heavily
 // means that the worker is rewarded more for their better performance in the 2nd epoch of the 2nd trial.
+// Note this test contains noise in the second phase, as in the second run there is a competing topic already created.
+// For absolutely equal conditions, it should be two different clean chains with one topic only and different alpha.
+// However this test is enough to prove the point
 func (s *RewardsTestSuite) TestIncreasingTaskRewardAlphaIncreasesImportanceOfPresentPerformance() {
 	require := s.Require()
 	k := s.EmissionsKeeper()
@@ -175,8 +178,7 @@ func (s *RewardsTestSuite) TestIncreasingTaskRewardAlphaIncreasesImportanceOfPre
 	workerValues := testutil.GetWorkerValuesFromIndexes(workerIndexes, "0.1", "0.2", "0.3")
 	// define the different reputer performance values for each test phase
 	normalPerformance := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.1", "0.2", "0.3")
-	improvedPerformance := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.1", "0.2", "0.3")
-	improvedPerformance[0].OneOutInfValues = map[string]string{s.AddrsStr(workerIndexes[0]): "0.2"} // first worker performs better
+	improvedPerformance := s.GetReputerValuesFromIndexes(reputerIndexes, workerIndexes, "0.1", "0.01", "0.01") // first worker performs better
 	alphaValues := []string{"0.1", "0.2"}
 
 	var rewardsDistributions [2][2][]types.TaskReward // [alphaIndex][testPhase]

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -1,7 +1,9 @@
 package rewards_test
 
 import (
+	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	cosmosMath "cosmossdk.io/math"
@@ -229,6 +231,8 @@ func (s *RewardsTestSuite) TestIncreasingTaskRewardAlphaIncreasesImportanceOfPre
 	require.False(areTaskRewardsEqualIgnoringTopicId(s, rewardsDistributions[0][1], rewardsDistributions[1][1]),
 		"Rewards in the second phase should differ between alphas")
 
+	// Print the rewards distribution table
+	s.printRewardsDistributionTable(rewardsDistributions)
 	// Extract worker[0] rewards for comparing phase 1 improvements
 	var workerReward_0_1_Reward, workerReward_1_1_Reward alloraMath.Dec
 
@@ -265,7 +269,7 @@ func (s *RewardsTestSuite) TestIncreasingTaskRewardAlphaIncreasesImportanceOfPre
 // We have 2 trials with 2 epochs each, and the reputer does worse in 2nd epoch in both trials,
 // enacted by their increasing loss between epochs.
 // We increase alpha between the trials to prove that their worsening performance decreases regret.
-// This is somewhat counterintuitive, but can be explained by the following passage from the litepaper:
+// This is somewhat counterintuitive, but can be explained by the following passage from the whitepaper:
 // "A positive regret implies that the inference of worker j is expected by worker k to outperform
 // the network's previously reported accuracy, whereas a negative regret indicates that the network
 // is expected to be more accurate."
@@ -381,9 +385,12 @@ func (s *RewardsTestSuite) TestIncreasingAlphaRegretIncreasesPresentEffectOnRegr
 		trial.decreaseRate, err = trial.decrease.Quo(trial.firstRegret)
 		require.NoError(err)
 
-		// Verify the decrease rate equals the alpha
-		require.True(trial.decreaseRate.Equal(trial.alphaRegret),
-			"Regret decrease rate should equal alpha: got %s, expected %s",
+		delta, err := alloraMath.InDelta(
+			trial.decreaseRate,
+			trial.alphaRegret,
+			alloraMath.MustNewDecFromString("0.000000000001"))
+		require.NoError(err)
+		require.True(delta, "Regret decrease rate should equal alpha (within a delta): got %s, expected %s",
 			trial.decreaseRate.String(), trial.alphaRegret.String())
 	}
 
@@ -755,7 +762,6 @@ func (s *RewardsTestSuite) TestRewardForTopicGoesUpWhenRelativeStakeGoesUp() {
 
 	// calculate rewards for first epoch
 	rewardsFromStakes(0, stakes1, stakes0)
-
 	require.Equal(topicRewardsTotal[0][0], topicRewardsTotal[0][1])
 
 	// second phase: increase stake for first reputer in topic1
@@ -832,10 +838,10 @@ func (s *RewardsTestSuite) validateTopicWeightsConsistency(topicIDs [2]uint64) {
 func (s *RewardsTestSuite) validateWorkerInclusions(topicID uint64, workerIndexes []int) {
 	for _, workerIndex := range workerIndexes {
 		infererCount, _ := s.EmissionsKeeper().GetCountInfererInclusionsInTopic(s.Ctx(), topicID, s.AddrsStr(workerIndex))
-		s.Require().Equal(uint64(1), infererCount)
+		s.Require().GreaterOrEqual(infererCount, uint64(2))
 
 		forecasterCount, _ := s.EmissionsKeeper().GetCountForecasterInclusionsInTopic(s.Ctx(), topicID, s.AddrsStr(workerIndex))
-		s.Require().Equal(uint64(1), forecasterCount)
+		s.Require().GreaterOrEqual(forecasterCount, uint64(1))
 	}
 }
 
@@ -1602,4 +1608,44 @@ func areTaskRewardsEqualIgnoringTopicId(s *RewardsTestSuite, A []types.TaskRewar
 	}
 
 	return true
+}
+
+// printRewardsDistributionTable formats and prints the rewards distribution in a readable table format
+func (s *RewardsTestSuite) printRewardsDistributionTable(rewardsDistributions [2][2][]types.TaskReward) {
+	var sb strings.Builder
+	sb.WriteString("\n\nREWARDS DISTRIBUTIONS TABLE\n")
+	sb.WriteString("================================================================================\n")
+
+	alphaValues := []string{"0.1", "0.2"}
+
+	for alphaIndex := 0; alphaIndex < 2; alphaIndex++ {
+		sb.WriteString(fmt.Sprintf("\n[ALPHA INDEX %d] TaskRewardAlpha = %s\n", alphaIndex, alphaValues[alphaIndex]))
+		sb.WriteString("--------------------------------------------------------------------------------\n")
+
+		for phase := 0; phase < 2; phase++ {
+			phaseName := "Normal Performance"
+			if phase == 1 {
+				phaseName = "Improved Performance"
+			}
+			sb.WriteString(fmt.Sprintf("\n  [PHASE %d] %s - Total Rewards: %d\n", phase, phaseName, len(rewardsDistributions[alphaIndex][phase])))
+			sb.WriteString("  ----------------------------------------------------------------------------\n")
+			sb.WriteString(fmt.Sprintf("  %-4s | %-42s | %-20s | %-8s | %-20s\n", "Idx", "Address", "Type", "TopicId", "Reward"))
+			sb.WriteString("  ----------------------------------------------------------------------------\n")
+
+			for i, reward := range rewardsDistributions[alphaIndex][phase] {
+				sb.WriteString(fmt.Sprintf("  %-4d | %-42s | %-20s | %-8d | %s\n",
+					i,
+					reward.Address,
+					reward.Type,
+					reward.TopicId,
+					reward.Reward.String()))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("================================================================================\n")
+
+	// Log the entire table in one statement to preserve formatting
+	s.Ctx().Logger().Info(sb.String())
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Generation of oneOutInfererValues in the network inference generation, in the case where there are no network losses (in which case a median of the combined value is applied). 
This in turn makes the scoring process to be activated on that epoch, otherwise there is no scoring on those epochs until there are actually network losses.
This will reduce the warm-up time until rewards can be given, from 2 GTLags, to 1 GTLag + 1 EpochLength.   
* Added `Average` function over a vector of `Dec`

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. Added unit tests over the `Average`function and 
- [x] If documented, please describe where. If not, describe why docs are not needed. -- a bugfix, affects starting time of a topic, but it does not affect documentation.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?
