### PR TITLE
refactor(keeper): optimize validation and remove redundant checks

### DIFF
--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -726,10 +726,7 @@ func (k *Keeper) AddWorkerNonce(ctx context.Context, topicId TopicId, nonce *typ
 
 	lenNonces := uint64(len(nonces.Nonces))
 	if lenNonces > maxUnfulfilledRequests {
-		diff := uint64(len(nonces.Nonces)) - maxUnfulfilledRequests
-		if diff > 0 {
-			nonces.Nonces = nonces.Nonces[:maxUnfulfilledRequests]
-		}
+		nonces.Nonces = nonces.Nonces[:maxUnfulfilledRequests]
 	}
 
 	if err := nonces.Validate(); err != nil {
@@ -775,10 +772,7 @@ func (k *Keeper) AddReputerNonce(ctx context.Context, topicId TopicId, nonce *ty
 	maxUnfulfilledRequests := moduleParams.MaxUnfulfilledReputerRequests
 	lenNonces := uint64(len(nonces.Nonces))
 	if lenNonces > maxUnfulfilledRequests {
-		diff := uint64(len(nonces.Nonces)) - maxUnfulfilledRequests
-		if diff > 0 {
-			nonces.Nonces = nonces.Nonces[:maxUnfulfilledRequests]
-		}
+		nonces.Nonces = nonces.Nonces[:maxUnfulfilledRequests]
 	}
 	if err := nonces.Validate(); err != nil {
 		return errorsmod.Wrap(err, "error validating unfulfilled reputer nonces")
@@ -2702,9 +2696,6 @@ func (k *Keeper) SetDelegateRewardPerShare(ctx context.Context, topicId TopicId,
 		return errorsmod.Wrap(err, "share is not valid")
 	}
 	key := collections.Join(topicId, reputer)
-	if err := types.ValidateDec(share); err != nil { // Added error check
-		return errorsmod.Wrapf(err, "SetDelegateRewardPerShare: invalid share")
-	}
 	return k.delegateRewardPerShare.Set(ctx, key, share)
 }
 
@@ -2859,9 +2850,6 @@ func (k *Keeper) GetStakeRemovalForReputerAndTopicId(
 			BlockRemovalCompleted: 0,
 		}, false, nil
 	}
-	if keysLen < 0 {
-		return types.StakeRemovalInfo{}, false, errorsmod.Wrapf(types.ErrInvariantFailure, "Why is golang len function returning negative values?")
-	}
 	key := keys[0]
 	byBlockKey := collections.Join3(key.K3(), topicId, reputer)
 	ret, err := k.stakeRemovalsByBlock.Get(ctx, byBlockKey)
@@ -2998,9 +2986,6 @@ func (k *Keeper) GetDelegateStakeRemovalForDelegatorReputerAndTopicId(
 			Amount:                cosmosMath.ZeroInt(),
 			BlockRemovalCompleted: 0,
 		}, false, nil
-	}
-	if keysLen < 0 {
-		return types.DelegateStakeRemovalInfo{}, false, errorsmod.Wrapf(types.ErrInvariantFailure, "Why is golang len function returning negative values?")
 	}
 	key := keys[0]
 	byBlockKey := Join4(key.K4(), topicId, delegator, reputer)
@@ -3790,10 +3775,7 @@ func (k *Keeper) InsertReputerScore(ctx context.Context, topicId TopicId, blockH
 	maxNumScores := moduleParams.MaxSamplesToScaleScores
 	lenScores := uint64(len(scores.Scores))
 	if lenScores > maxNumScores {
-		diff := lenScores - maxNumScores
-		if diff > 0 {
-			scores.Scores = scores.Scores[diff:]
-		}
+		scores.Scores = scores.Scores[lenScores-maxNumScores:]
 	}
 	key := collections.Join(topicId, blockHeight)
 	if err := scores.Validate(); err != nil {


### PR DESCRIPTION
## Purpose of Changes and their Description
This PR refactors the `x/emissions/keeper/keeper.go` file to remove redundant code and improve performance. The changes eliminate unnecessary validation checks, remove impossible conditions, and optimize repeated function calls.

1. Remove Duplicate Validation in `SetDelegateRewardPerShare`
The `share` parameter was being validated 3 times in the same function:
```go
if err := types.ValidateDec(share); err != nil {
    return errorsmod.Wrap(err, "share is not valid")
}
// ... 
if err := types.ValidateDec(share); err != nil {  // Duplicate 
    return errorsmod.Wrapf(err, "SetDelegateRewardPerShare: invalid share")
}
```
Removed the duplicate validation calls, keeping only the first one.

2. Remove Impossible Negative Length Check
Code was checking if `len()` returns a negative value, which is impossible in Go:
```go
keysLen := len(keys)
if keysLen == 0 {
    return types.StakeRemovalInfo{...}, false, nil
}
if keysLen < 0 {  // This condition can NEVER be true
    return types.StakeRemovalInfo{}, false, 
        errorsmod.Wrapf(types.ErrInvariantFailure, 
            "Why is golang len function returning negative values?")
}
```
The Go language specification and runtime guarantee that `len()` will never return a negative value. 

3. Optimize Repeated `len()` Calls and Remove Redundant Conditions
Code was calling `len()` multiple times on the same slice and had redundant conditions:
```go
lenNonces := uint64(len(nonces.Nonces))  // First call
if lenNonces > maxUnfulfilledRequests {
    diff := uint64(len(nonces.Nonces)) - maxUnfulfilledRequests  // Second call!
    if diff > 0 {  // Always true when we reach here!
        nonces.Nonces = nonces.Nonces[:maxUnfulfilledRequests]
    }
}
```

Use the already computed length value and remove redundant conditions:

```go
lenNonces := uint64(len(nonces.Nonces))
if lenNonces > maxUnfulfilledRequests {
    nonces.Nonces = nonces.Nonces[:maxUnfulfilledRequests]
}
```


## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
