### PR TITLE
fix(keeper): prevent clearing all active topics when removing non-existent topic

### DIFF
--- a/x/emissions/keeper/topic_activation.go
+++ b/x/emissions/keeper/topic_activation.go
@@ -133,7 +133,7 @@ func (k *Keeper) inactivateTopicWithoutMinWeightReset(ctx context.Context, topic
 	}
 	// Remove the topic from the active topics at the block
 	// If the topic is not found in the active topics at the block, no op
-	newActiveTopicIds := []TopicId{}
+	newActiveTopicIds := topicIdsActiveAtBlock.TopicIds 
 	for i, id := range topicIdsActiveAtBlock.TopicIds {
 		if id == topicId {
 			newActiveTopicIds = append(topicIdsActiveAtBlock.TopicIds[:i], topicIdsActiveAtBlock.TopicIds[i+1:]...)


### PR DESCRIPTION
## Purpose of Changes and their Description

Fix a bug in `inactivateTopicWithoutMinWeightReset` function that could cause **all active topics to be inadvertently cleared** when attempting to remove a topic that doesn't exist in the active topics list.

```go
// Remove the topic from the active topics at the block
// If the topic is not found in the active topics at the block, no op
newActiveTopicIds := []TopicId{}  // Empty slice initialization
for i, id := range topicIdsActiveAtBlock.TopicIds {
    if id == topicId {
        newActiveTopicIds = append(topicIdsActiveAtBlock.TopicIds[:i], topicIdsActiveAtBlock.TopicIds[i+1:]...)
        break
    }
}
err = k.SetBlockToActiveTopics(ctx, block, types.TopicIds{TopicIds: newActiveTopicIds})
```

If `topicId` is not found in the loop (due to state inconsistency), `newActiveTopicIds` remains empty, and `SetBlockToActiveTopics` will clear all active topics for that block.


## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
