### PR TITLE
Turn math cache into its own object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [#851](https://github.com/allora-network/allora-chain/pull/851) Enforce recommended settings
-* [#835](https://github.com/allora-network/allora-chain/pull/835): Introduce the `x/scheduler` module to manage tasks scheduling
+* [#835](https://github.com/allora-network/allora-chain/pull/835) Introduce the `x/scheduler` module to manage tasks scheduling
+* [#897](https://github.com/allora-network/allora-chain/pull/897) Turn math cache into its own object + use in closing reputer window
 
 ### Changed
 

--- a/x/emissions/keeper/actor_utils/losses.go
+++ b/x/emissions/keeper/actor_utils/losses.go
@@ -28,6 +28,17 @@ func CloseReputerNonce(
 ) (err error) {
 	blockHeight := ctx.BlockHeight()
 
+	// Create and enable math helper cache for this function's scope
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	// Disable math helper cache and clear cache when function exits
+	defer func() {
+		cache.Disable()
+		cache.Clear()
+		ctx.Logger().Debug("Math helper cache cleared after CloseReputerNonce")
+	}()
+
 	// All filters should be done in order of increasing computational complexity
 	// Check if the worker nonce is unfulfilled
 	workerNonceUnfulfilled, err := k.IsWorkerNonceUnfulfilled(ctx, topic.Id, &nonce)
@@ -250,6 +261,7 @@ func CloseReputerNonce(
 			PNorm:              topic.PNorm,
 			CNorm:              params.CNorm,
 			StdDevPlusEpsilon:  stdDevPlusEpsilon,
+			Cache:              cache,
 		},
 	)
 	if err != nil {

--- a/x/emissions/keeper/inference_synthesis/cache_test.go
+++ b/x/emissions/keeper/inference_synthesis/cache_test.go
@@ -1,0 +1,614 @@
+package inferencesynthesis_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	synth "github.com/allora-network/allora-chain/x/emissions/keeper/inference_synthesis"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
+)
+
+type CacheTestSuite struct {
+	testutil.TestSuite
+}
+
+func TestCacheTestSuite(t *testing.T) {
+	suite.Run(t, &CacheTestSuite{
+		testutil.NewTestSuite("inference_synthesis_cache"),
+	})
+}
+
+func (s *CacheTestSuite) TestNewMathHelperCache() {
+	cache := synth.NewMathHelperCache()
+	s.Require().NotNil(cache)
+
+	// Cache should be disabled by default
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// Should not be in cache (disabled)
+	s.Require().False(cache.IsInCache(a, b))
+
+	result1, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+
+	// Still should not be in cache (disabled)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Second call should work but not use cache (disabled)
+	result2, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result2))
+}
+
+func (s *CacheTestSuite) TestEnable() {
+	cache := synth.NewMathHelperCache()
+
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// Initially disabled - should not be in cache
+	s.Require().False(cache.IsInCache(a, b))
+
+	_, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+
+	// Still should not be in cache (disabled)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Enable cache
+	cache.Enable()
+
+	// Still not in cache yet (haven't called with cache enabled)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Now make a call - should cache
+	result1, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+
+	// Should now be in cache
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Second call with same inputs should return same result (cached)
+	result2, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result2))
+	s.Require().True(cache.IsInCache(a, b))
+}
+
+func (s *CacheTestSuite) TestDisable() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// Should not be in cache initially
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Make a call to populate cache
+	result1, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+
+	// Should now be in cache
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Verify it's cached by calling again
+	result2, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result2))
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Disable cache
+	cache.Disable()
+
+	// IsInCache should return false when disabled (even if entry exists)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Call again - should still work but not use cache
+	result3, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result3))
+
+	// Still should return false (disabled)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Re-enable cache
+	cache.Enable()
+
+	// Should still be in cache (Disable doesn't clear, just disables)
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Should return cached value
+	result4, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result4))
+}
+
+func (s *CacheTestSuite) TestClear() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	// Add some values to cache
+	a1 := alloraMath.MustNewDecFromString("1.0")
+	b1 := alloraMath.MustNewDecFromString("2.0")
+	result1, err := cache.Exp1DivExp1(a1, b1)
+	s.Require().NoError(err)
+	s.Require().True(cache.IsInCache(a1, b1))
+
+	a2 := alloraMath.MustNewDecFromString("3.0")
+	b2 := alloraMath.MustNewDecFromString("4.0")
+	_, err = cache.Exp1DivExp1(a2, b2)
+	s.Require().NoError(err)
+	s.Require().True(cache.IsInCache(a2, b2))
+
+	// Verify both are cached by calling again
+	result1Again, err := cache.Exp1DivExp1(a1, b1)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result1Again))
+
+	// Clear cache
+	cache.Clear()
+
+	// Both should no longer be in cache
+	s.Require().False(cache.IsInCache(a1, b1))
+	s.Require().False(cache.IsInCache(a2, b2))
+
+	// Cache should still be enabled after clear
+	// But entries should be cleared - verify by making new calls
+	// The results should still be correct, but cache was cleared
+	result1AfterClear, err := cache.Exp1DivExp1(a1, b1)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result1AfterClear))
+
+	// Now it should be cached again
+	s.Require().True(cache.IsInCache(a1, b1))
+	result1AgainAfterClear, err := cache.Exp1DivExp1(a1, b1)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result1AgainAfterClear))
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_DisabledCache() {
+	cache := synth.NewMathHelperCache()
+	// Don't enable cache
+
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// Should not be in cache (disabled)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// First call
+	result1, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.IsFinite())
+	s.Require().True(result1.IsPositive())
+
+	// Still should not be in cache (disabled)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Second call with same inputs - should recalculate (no cache)
+	result2, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+
+	// Results should be equal (same calculation)
+	s.Require().True(result1.Equal(result2))
+	s.Require().False(cache.IsInCache(a, b))
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_EnabledCache_CacheHit() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// Should not be in cache initially
+	s.Require().False(cache.IsInCache(a, b))
+
+	// First call - should calculate and cache
+	result1, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.IsFinite())
+	s.Require().True(result1.IsPositive())
+
+	// Should now be in cache
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Second call with same inputs - should return cached value
+	result2, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+
+	// Results should be identical (from cache)
+	s.Require().True(result1.Equal(result2))
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Third call - should also use cache
+	result3, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result3))
+	s.Require().True(cache.IsInCache(a, b))
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_EnabledCache_DifferentInputs() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	// First call
+	a1 := alloraMath.MustNewDecFromString("1.0")
+	b1 := alloraMath.MustNewDecFromString("2.0")
+	s.Require().False(cache.IsInCache(a1, b1))
+	result1, err := cache.Exp1DivExp1(a1, b1)
+	s.Require().NoError(err)
+	s.Require().True(cache.IsInCache(a1, b1))
+
+	// Second call with different inputs - should calculate new value
+	a2 := alloraMath.MustNewDecFromString("3.0")
+	b2 := alloraMath.MustNewDecFromString("4.0")
+	s.Require().False(cache.IsInCache(a2, b2))
+	result2, err := cache.Exp1DivExp1(a2, b2)
+	s.Require().NoError(err)
+	s.Require().True(cache.IsInCache(a2, b2))
+
+	// Results should be different
+	s.Require().False(result1.Equal(result2))
+
+	// Verify both are cached by calling again
+	result1Again, err := cache.Exp1DivExp1(a1, b1)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result1Again))
+	s.Require().True(cache.IsInCache(a1, b1))
+
+	result2Again, err := cache.Exp1DivExp1(a2, b2)
+	s.Require().NoError(err)
+	s.Require().True(result2.Equal(result2Again))
+	s.Require().True(cache.IsInCache(a2, b2))
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_CacheKeyGeneration() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	// Test that cache keys are based on string representation
+	// Same numeric value should produce same cache key
+	a1 := alloraMath.MustNewDecFromString("1.0")
+	b1 := alloraMath.MustNewDecFromString("2.0")
+
+	a2 := alloraMath.MustNewDecFromString("1.0")
+	b2 := alloraMath.MustNewDecFromString("2.0")
+
+	// First call
+	result1, err := cache.Exp1DivExp1(a1, b1)
+	s.Require().NoError(err)
+
+	// Second call with same values (even if different Dec instances)
+	result2, err := cache.Exp1DivExp1(a2, b2)
+	s.Require().NoError(err)
+
+	// Results should be mathematically equal
+	s.Require().True(result1.Equal(result2))
+
+	// And should use same cache entry (verify by calling first again)
+	result1Again, err := cache.Exp1DivExp1(a1, b1)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result1Again))
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_CacheAfterClear() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// First call - cache it
+	result1, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Verify it's cached
+	result1Again, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result1Again))
+
+	// Clear cache
+	cache.Clear()
+
+	// Should no longer be in cache
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Call again - should recalculate (not cached)
+	result2, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+
+	// Results should be equal (same calculation)
+	s.Require().True(result1.Equal(result2))
+
+	// But now it should be cached again
+	s.Require().True(cache.IsInCache(a, b))
+	result2Again, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result2.Equal(result2Again))
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_EnableAfterUse() {
+	cache := synth.NewMathHelperCache()
+	// Start with cache disabled
+
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// Should not be in cache (disabled)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Call with cache disabled
+	result1, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Enable cache
+	cache.Enable()
+
+	// Still not in cache (wasn't cached when disabled)
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Call again - should calculate and cache this time
+	result2, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result2))
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Third call - should use cache
+	result3, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result2.Equal(result3))
+	s.Require().True(cache.IsInCache(a, b))
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_DisableAfterUse() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// Call with cache enabled - should cache
+	result1, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Verify it's cached
+	result1Again, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result1Again))
+
+	// Disable cache
+	cache.Disable()
+
+	// IsInCache should return false when disabled
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Call again - should recalculate (cache disabled)
+	result2, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result2))
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Re-enable cache
+	cache.Enable()
+
+	// Should still be in cache (Disable doesn't clear)
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Call again - should use cached value
+	result3, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result3))
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Should still be cached
+	result3Again, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result3.Equal(result3Again))
+}
+
+func (s *CacheTestSuite) TestCacheIsolation() {
+	// Test that different cache instances don't interfere
+	cache1 := synth.NewMathHelperCache()
+	cache1.Enable()
+
+	cache2 := synth.NewMathHelperCache()
+	cache2.Enable()
+
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// Use cache1
+	s.Require().False(cache1.IsInCache(a, b))
+	result1, err := cache1.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(cache1.IsInCache(a, b))
+
+	// cache2 should not have it
+	s.Require().False(cache2.IsInCache(a, b))
+
+	// Verify cache1 has it cached
+	result1Again, err := cache1.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result1Again))
+
+	// Use cache2 - should calculate independently
+	result2, err := cache2.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result2))
+	s.Require().True(cache2.IsInCache(a, b))
+
+	// Verify cache2 now has it cached
+	result2Again, err := cache2.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result2.Equal(result2Again))
+
+	// Clear cache1 - cache2 should be unaffected
+	cache1.Clear()
+	s.Require().False(cache1.IsInCache(a, b))
+	s.Require().True(cache2.IsInCache(a, b))
+
+	// cache1 should recalculate
+	result1AfterClear, err := cache1.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result1AfterClear))
+	s.Require().True(cache1.IsInCache(a, b))
+
+	// cache2 should still use cache
+	result2AfterClear, err := cache2.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result2.Equal(result2AfterClear))
+	s.Require().True(cache2.IsInCache(a, b))
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_ErrorPropagation() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	// Test with NaN - should return error and not cache
+	nan := alloraMath.NewNaN()
+	valid := alloraMath.MustNewDecFromString("1.0")
+
+	_, err := cache.Exp1DivExp1(nan, valid)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "NaN")
+
+	// Should not be cached (errors aren't cached)
+	s.Require().False(cache.IsInCache(nan, valid))
+
+	// Try again - should still error (not cached)
+	_, err = cache.Exp1DivExp1(nan, valid)
+	s.Require().Error(err)
+	s.Require().False(cache.IsInCache(nan, valid))
+
+	// Valid call should still work
+	result, err := cache.Exp1DivExp1(valid, valid)
+	s.Require().NoError(err)
+	s.Require().True(result.IsFinite())
+	s.Require().True(cache.IsInCache(valid, valid))
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_MultipleCalls_Performance() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	// Test with multiple different inputs
+	inputs := []struct {
+		a, b string
+	}{
+		{"1.0", "2.0"},
+		{"3.0", "4.0"},
+		{"5.0", "6.0"},
+		{"1.0", "2.0"}, // Duplicate - should use cache
+		{"3.0", "4.0"}, // Duplicate - should use cache
+		{"7.0", "8.0"},
+		{"1.0", "2.0"}, // Another duplicate
+	}
+
+	results := make([]alloraMath.Dec, 0, len(inputs))
+	for i, input := range inputs {
+		a := alloraMath.MustNewDecFromString(input.a)
+		b := alloraMath.MustNewDecFromString(input.b)
+		result, err := cache.Exp1DivExp1(a, b)
+		s.Require().NoError(err, "Failed on input %d", i)
+		results = append(results, result)
+	}
+
+	// Verify duplicates return same results (cached)
+	s.Require().True(results[0].Equal(results[3]), "First and fourth should be equal (cached)")
+	s.Require().True(results[0].Equal(results[6]), "First and seventh should be equal (cached)")
+	s.Require().True(results[1].Equal(results[4]), "Second and fifth should be equal (cached)")
+
+	// Verify unique inputs produce different results
+	s.Require().False(results[0].Equal(results[1]), "Different inputs should produce different results")
+	s.Require().False(results[1].Equal(results[2]), "Different inputs should produce different results")
+	s.Require().False(results[2].Equal(results[5]), "Different inputs should produce different results")
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_EdgeCaseValues() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	testCases := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{"zero values", "0.0", "0.0"},
+		{"very small values", "0.0001", "0.0002"},
+		{"very large values", "100.0", "200.0"},
+		{"negative values", "-1.0", "-2.0"},
+		{"mixed signs", "-1.0", "1.0"},
+		{"equal values", "5.0", "5.0"},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			a := alloraMath.MustNewDecFromString(tc.a)
+			b := alloraMath.MustNewDecFromString(tc.b)
+
+			// Should not be in cache initially
+			s.Require().False(cache.IsInCache(a, b))
+
+			// First call
+			result1, err := cache.Exp1DivExp1(a, b)
+			s.Require().NoError(err)
+			s.Require().True(result1.IsFinite())
+			s.Require().True(cache.IsInCache(a, b))
+
+			// Second call - should use cache
+			result2, err := cache.Exp1DivExp1(a, b)
+			s.Require().NoError(err)
+			s.Require().True(result1.Equal(result2))
+			s.Require().True(cache.IsInCache(a, b))
+		})
+	}
+}
+
+func (s *CacheTestSuite) TestExp1DivExp1_ReEnableAfterDisable() {
+	cache := synth.NewMathHelperCache()
+	cache.Enable()
+
+	a := alloraMath.MustNewDecFromString("1.0")
+	b := alloraMath.MustNewDecFromString("2.0")
+
+	// Call with cache enabled
+	result1, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Disable
+	cache.Disable()
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Call while disabled
+	result2, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result2))
+	s.Require().False(cache.IsInCache(a, b))
+
+	// Re-enable
+	cache.Enable()
+
+	// Should still be in cache (Disable doesn't clear)
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Call again - should use cached value
+	result3, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result1.Equal(result3))
+	s.Require().True(cache.IsInCache(a, b))
+
+	// Should still be cached
+	result3Again, err := cache.Exp1DivExp1(a, b)
+	s.Require().NoError(err)
+	s.Require().True(result3.Equal(result3Again))
+	s.Require().True(cache.IsInCache(a, b))
+}

--- a/x/emissions/keeper/inference_synthesis/forecast_implied.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied.go
@@ -23,6 +23,7 @@ type CalcForecastImpliedInferencesArgs struct {
 	PNorm                alloraMath.Dec
 	CNorm                alloraMath.Dec
 	StdDevPlusEpsilon    alloraMath.Dec
+	Cache                *MathHelperCache
 }
 
 // Calculate the forecast-implied inferences I_ik given inferences, forecasts and network losses.
@@ -143,6 +144,7 @@ func CalcForecastImpliedInferences(args CalcForecastImpliedInferencesArgs) (
 							PNorm:              args.PNorm,
 							CNorm:              args.CNorm,
 							StdDevPlusEpsilon:  args.StdDevPlusEpsilon,
+							Cache:              args.Cache,
 						},
 					)
 					if err != nil {

--- a/x/emissions/keeper/inference_synthesis/forecast_implied_test.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied_test.go
@@ -43,7 +43,8 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromRegret_OLD_BOUNDS_ALGORI
 		regretFrac := alloraMath.MustNewDecFromString(tc.regretFrac)
 		maxRegret := alloraMath.MustNewDecFromString(tc.maxRegret)
 
-		weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm, cNorm)
+		cache := inferencesynthesis.NewMathHelperCache()
+		weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm, cNorm, cache)
 		s.Require().NoError(err)
 
 		testutil.InEpsilon5(s.T(), weight, tc.expectedWeight)
@@ -164,7 +165,8 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromNormalizedRegret_Exp1Div
 			regretFrac := alloraMath.MustNewDecFromString(tc.regretFrac)
 			maxRegret := alloraMath.MustNewDecFromString(tc.maxRegret)
 
-			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm, cNorm)
+			cache := inferencesynthesis.NewMathHelperCache()
+			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm, cNorm, cache)
 			s.Require().NoError(err, "Failed to calculate weight for case: %s", tc.name)
 
 			expected := alloraMath.MustNewDecFromString(tc.expectedWeight)
@@ -283,7 +285,8 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromNormalizedRegret_Exp1Div
 			regretFrac := alloraMath.MustNewDecFromString(tc.regretFrac)
 			maxRegret := alloraMath.MustNewDecFromString(tc.maxRegret)
 
-			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm, cNorm)
+			cache := inferencesynthesis.NewMathHelperCache()
+			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm, cNorm, cache)
 			s.Require().NoError(err, "Failed to calculate weight for case: %s", tc.name)
 
 			expected := alloraMath.MustNewDecFromString(tc.expectedWeight)
@@ -353,7 +356,8 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromNormalizedRegret_Exp1Div
 			regretFrac := alloraMath.MustNewDecFromString(tc.regretFrac)
 			maxRegret := alloraMath.MustNewDecFromString(tc.maxRegret)
 
-			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm, cNorm)
+			cache := inferencesynthesis.NewMathHelperCache()
+			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm, cNorm, cache)
 			s.Require().NoError(err, "Failed to calculate weight for case: %s", tc.name)
 
 			// For identity cases (regret == maxRegret), result should always be 1
@@ -375,9 +379,10 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromNormalizedRegret_Exp1Div
 
 	s.Run("Identity Property: regret == maxRegret => weight == 1", func() {
 		testValues := []string{"-10", "-1", "-0.5", "0", "0.5", "1", "5"}
+		cache := inferencesynthesis.NewMathHelperCache()
 		for _, val := range testValues {
 			regret := alloraMath.MustNewDecFromString(val)
-			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regret, regret, pNorm, cNorm)
+			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regret, regret, pNorm, cNorm, cache)
 			s.Require().NoError(err)
 
 			one := alloraMath.OneDec()
@@ -390,6 +395,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromNormalizedRegret_Exp1Div
 
 	s.Run("Monotonicity: better regret (closer to max) => higher weight", func() {
 		maxRegret := alloraMath.MustNewDecFromString("1.0")
+		cache := inferencesynthesis.NewMathHelperCache()
 
 		// Test points from worst to best regret
 		regrets := []string{"-5", "-2", "-1", "0", "0.5", "1.0"}
@@ -397,7 +403,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromNormalizedRegret_Exp1Div
 
 		for i, regretStr := range regrets {
 			regret := alloraMath.MustNewDecFromString(regretStr)
-			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regret, maxRegret, pNorm, cNorm)
+			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regret, maxRegret, pNorm, cNorm, cache)
 			s.Require().NoError(err)
 			weights[i] = weight
 		}
@@ -418,11 +424,12 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromNormalizedRegret_Exp1Div
 			{"1", "1"},
 			{"5", "-2"}, // Even when regret > max
 		}
+		cache := inferencesynthesis.NewMathHelperCache()
 
 		for _, tc := range testCases {
 			regret := alloraMath.MustNewDecFromString(tc.regret)
 			maxRegret := alloraMath.MustNewDecFromString(tc.maxRegret)
-			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regret, maxRegret, pNorm, cNorm)
+			weight, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regret, maxRegret, pNorm, cNorm, cache)
 			s.Require().NoError(err)
 			s.Require().True(weight.IsPositive(),
 				"Weight should be positive for regret=%s, maxRegret=%s, got %s",
@@ -441,22 +448,23 @@ func (s *InferenceSynthesisTestSuite) TestCalcWeightFromNormalizedRegret_Exp1Div
 		maxRegret := alloraMath.MustNewDecFromString("1.0")
 
 		// Test NaN regret
-		_, err := inferencesynthesis.CalcWeightFromNormalizedRegret(nan, maxRegret, pNorm, cNorm)
+		cache := inferencesynthesis.NewMathHelperCache()
+		_, err := inferencesynthesis.CalcWeightFromNormalizedRegret(nan, maxRegret, pNorm, cNorm, cache)
 		s.Require().Error(err)
 		s.Require().Contains(err.Error(), "NaN")
 
 		// Test NaN maxRegret
-		_, err = inferencesynthesis.CalcWeightFromNormalizedRegret(regret, nan, pNorm, cNorm)
+		_, err = inferencesynthesis.CalcWeightFromNormalizedRegret(regret, nan, pNorm, cNorm, cache)
 		s.Require().Error(err)
 		s.Require().Contains(err.Error(), "NaN")
 
 		// Test NaN pNorm
-		_, err = inferencesynthesis.CalcWeightFromNormalizedRegret(regret, maxRegret, nan, cNorm)
+		_, err = inferencesynthesis.CalcWeightFromNormalizedRegret(regret, maxRegret, nan, cNorm, cache)
 		s.Require().Error(err)
 		s.Require().Contains(err.Error(), "NaN")
 
 		// Test NaN cNorm
-		_, err = inferencesynthesis.CalcWeightFromNormalizedRegret(regret, maxRegret, pNorm, nan)
+		_, err = inferencesynthesis.CalcWeightFromNormalizedRegret(regret, maxRegret, pNorm, nan, cache)
 		s.Require().Error(err)
 		s.Require().Contains(err.Error(), "NaN")
 	})
@@ -493,13 +501,14 @@ func (s *InferenceSynthesisTestSuite) TestIncreasingPNormIncreasesRegretSpread()
 		pNorm2_point_5 := alloraMath.MustNewDecFromString("2.5")
 		pNorm4_point_5 := alloraMath.MustNewDecFromString("4.5")
 
-		weght2_point_5, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm2_point_5, cNorm)
+		cache := inferencesynthesis.NewMathHelperCache()
+		weight2_point_5, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm2_point_5, cNorm, cache)
 		s.Require().NoError(err)
-		weightWithPNorm2_point_5[i] = weght2_point_5
+		weightWithPNorm2_point_5[i] = weight2_point_5
 
-		weght4_point_5, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm4_point_5, cNorm)
+		weight4_point_5, err := inferencesynthesis.CalcWeightFromNormalizedRegret(regretFrac, maxRegret, pNorm4_point_5, cNorm, cache)
 		s.Require().NoError(err)
-		weightWithPNorm4_point_5[i] = weght4_point_5
+		weightWithPNorm4_point_5[i] = weight4_point_5
 	}
 
 	stdDev2_point_5, err := alloraMath.StdDev(weightWithPNorm2_point_5)
@@ -568,6 +577,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                inferencesynthesis.NewMathHelperCache(),
 		},
 	)
 	s.Require().NoError(err)
@@ -645,6 +655,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                inferencesynthesis.NewMathHelperCache(),
 		},
 	)
 	s.Require().NoError(err)
@@ -740,6 +751,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesThreeWork
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                inferencesynthesis.NewMathHelperCache(),
 		},
 	)
 	s.Require().NoError(err)
@@ -1007,6 +1019,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesForecaste
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                inferencesynthesis.NewMathHelperCache(),
 		},
 	)
 	s.Require().NoError(err)
@@ -1066,6 +1079,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesForecaste
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                inferencesynthesis.NewMathHelperCache(),
 		},
 	)
 	s.Require().NoError(err)
@@ -1164,6 +1178,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesMultipleF
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                inferencesynthesis.NewMathHelperCache(),
 		},
 	)
 	s.Require().NoError(err)

--- a/x/emissions/keeper/inference_synthesis/forecast_implied_test.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied_test.go
@@ -853,6 +853,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch2() {
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                nil,
 		})
 	s.Require().NoError(err)
 	for key, expectedValue := range expected {
@@ -946,6 +947,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch3() {
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                nil,
 		})
 	s.Require().NoError(err)
 	for key, expectedValue := range expected {

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder.go
@@ -27,6 +27,7 @@ type GetCombinedInferenceArgs struct {
 	PNorm                                alloraMath.Dec
 	CNorm                                alloraMath.Dec
 	StdDevPlusEpsilon                    alloraMath.Dec
+	Cache                                *MathHelperCache
 }
 
 // Calculates the network combined inference I_i, Equation 9
@@ -45,6 +46,7 @@ func GetCombinedInference(args GetCombinedInferenceArgs) (
 			PNorm:              args.PNorm,
 			CNorm:              args.CNorm,
 			StdDevPlusEpsilon:  args.StdDevPlusEpsilon,
+			Cache:              args.Cache,
 		},
 	)
 	if err != nil {
@@ -123,6 +125,7 @@ type GetOneOutInfererForecastImpliedInferencesArgs struct {
 	PNorm                alloraMath.Dec
 	CNorm                alloraMath.Dec
 	StdDevPlusEpsilon    alloraMath.Dec
+	Cache                *MathHelperCache
 }
 
 // GetOneOutInfererForecastImpliedInferences calculates what each forecaster's implied inference
@@ -220,6 +223,7 @@ func GetOneOutInfererForecastImpliedInferences(args GetOneOutInfererForecastImpl
 					PNorm:                args.PNorm,
 					CNorm:                args.CNorm,
 					StdDevPlusEpsilon:    args.StdDevPlusEpsilon,
+					Cache:                args.Cache,
 				},
 			)
 			if calcErr != nil {
@@ -272,6 +276,7 @@ type GetNaiveInferenceArgs struct {
 	PNorm                                alloraMath.Dec
 	CNorm                                alloraMath.Dec
 	StdDevPlusEpsilon                    alloraMath.Dec
+	Cache                                *MathHelperCache
 }
 
 // Calculates the network naive inference I^-_i
@@ -299,6 +304,7 @@ func GetNaiveInference(args GetNaiveInferenceArgs) (naiveInference alloraMath.De
 			PNorm:              args.PNorm,
 			CNorm:              args.CNorm,
 			StdDevPlusEpsilon:  args.StdDevPlusEpsilon,
+			Cache:              args.Cache,
 		},
 	)
 	if err != nil {
@@ -345,6 +351,7 @@ type CalcOneOutInfererInferenceArgs struct {
 	CNorm                alloraMath.Dec
 	WithheldInferer      Inferer
 	StdDevPlusEpsilon    alloraMath.Dec
+	Cache                *MathHelperCache
 }
 
 // Calculate the one-out inference given a withheld inferer
@@ -399,6 +406,7 @@ func calcOneOutInfererInference(args CalcOneOutInfererInferenceArgs) (
 				PNorm:                args.PNorm,
 				CNorm:                args.CNorm,
 				StdDevPlusEpsilon:    args.StdDevPlusEpsilon,
+				Cache:                args.Cache,
 			},
 		)
 		if err != nil {
@@ -425,6 +433,7 @@ func calcOneOutInfererInference(args CalcOneOutInfererInferenceArgs) (
 			PNorm:              args.PNorm,
 			CNorm:              args.CNorm,
 			StdDevPlusEpsilon:  args.StdDevPlusEpsilon,
+			Cache:              args.Cache,
 		},
 	)
 	if err != nil {
@@ -539,6 +548,7 @@ type CalcOneOutForecasterInferenceArgs struct {
 	CNorm                                alloraMath.Dec
 	WithheldForecaster                   Forecaster
 	StdDevPlusEpsilon                    alloraMath.Dec
+	Cache                                *MathHelperCache
 }
 
 // Calculate the one-out inference given a withheld forecaster
@@ -591,6 +601,7 @@ func calcOneOutForecasterInference(args CalcOneOutForecasterInferenceArgs) (
 			PNorm:              args.PNorm,
 			CNorm:              args.CNorm,
 			StdDevPlusEpsilon:  args.StdDevPlusEpsilon,
+			Cache:              args.Cache,
 		},
 	)
 	if err != nil {
@@ -701,6 +712,7 @@ type calcOneInValueArgs struct {
 	CNorm                                alloraMath.Dec
 	OneInForecaster                      Forecaster
 	StdDevPlusEpsilon                    alloraMath.Dec
+	Cache                                *MathHelperCache
 }
 
 // Calculate the one-in inference given a withheld forecaster
@@ -758,6 +770,7 @@ func calcOneInValue(args calcOneInValueArgs) (
 			PNorm:              args.PNorm,
 			CNorm:              args.CNorm,
 			StdDevPlusEpsilon:  args.StdDevPlusEpsilon,
+			Cache:              args.Cache,
 		},
 	)
 	if err != nil {
@@ -866,6 +879,7 @@ type CalcNetworkInferencesArgs struct {
 	CNorm                                alloraMath.Dec
 	StdDevPlusEpsilon                    alloraMath.Dec
 	InferenceBlockHeight                 BlockHeight
+	Cache                                *MathHelperCache
 }
 
 // Calculates all network inferences in the set I_i given historical state (e.g. regrets)
@@ -898,6 +912,7 @@ func CalcNetworkInferences(
 			PNorm:                                args.PNorm,
 			CNorm:                                args.CNorm,
 			StdDevPlusEpsilon:                    args.StdDevPlusEpsilon,
+			Cache:                                args.Cache,
 		})
 	if err != nil {
 		return &emissions.ValueBundle{}, RegretInformedWeights{}, errorsmod.Wrap(err, "CalcNetworkInferences() error calculating combined inference")

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder.go
@@ -479,6 +479,7 @@ type GetOneOutInfererInferencesArgs struct {
 	PNorm                alloraMath.Dec
 	CNorm                alloraMath.Dec
 	StdDevPlusEpsilon    alloraMath.Dec
+	Cache                *MathHelperCache
 }
 
 // Set all one-out-inferer inferences that are possible given the provided input
@@ -514,6 +515,7 @@ func GetOneOutInfererInferences(args GetOneOutInfererInferencesArgs) (
 				CNorm:                args.CNorm,
 				WithheldInferer:      worker,
 				StdDevPlusEpsilon:    args.StdDevPlusEpsilon,
+				Cache:                args.Cache,
 			})
 		if err != nil {
 			return []*emissions.WithheldWorkerAttributedValue{}, errorsmod.Wrapf(err, "GetOneOutInfererInferences() error calculating one-out inferer inferences")
@@ -647,6 +649,7 @@ type GetOneOutForecasterInferencesArgs struct {
 	PNorm                                alloraMath.Dec
 	CNorm                                alloraMath.Dec
 	StdDevPlusEpsilon                    alloraMath.Dec
+	Cache                                *MathHelperCache
 }
 
 // Set all one-out-forecaster inferences that are possible given the provided input
@@ -681,6 +684,7 @@ func GetOneOutForecasterInferences(args GetOneOutForecasterInferencesArgs) (
 					CNorm:                                args.CNorm,
 					WithheldForecaster:                   worker,
 					StdDevPlusEpsilon:                    args.StdDevPlusEpsilon,
+					Cache:                                args.Cache,
 				})
 			if err != nil {
 				return []*emissions.WithheldWorkerAttributedValue{}, errorsmod.Wrapf(err, "GetOneOutForecasterInferences() error calculating one-out forecaster inferences")
@@ -813,6 +817,7 @@ type GetOneInForecasterInferencesArgs struct {
 	PNorm                                alloraMath.Dec
 	CNorm                                alloraMath.Dec
 	StdDevPlusEpsilon                    alloraMath.Dec
+	Cache                                *MathHelperCache
 }
 
 // Set all one-in inferences that are possible given the provided input
@@ -845,6 +850,7 @@ func GetOneInForecasterInferences(args GetOneInForecasterInferencesArgs) (
 					CNorm:                                args.CNorm,
 					OneInForecaster:                      oneInForecaster,
 					StdDevPlusEpsilon:                    args.StdDevPlusEpsilon,
+					Cache:                                args.Cache,
 				})
 			if err != nil {
 				return []*emissions.WorkerAttributedValue{}, errorsmod.Wrapf(err, "GetOneInForecasterInferences() error calculating one-in inferences")
@@ -947,6 +953,7 @@ func CalcNetworkInferences(
 			PNorm:                                args.PNorm,
 			CNorm:                                args.CNorm,
 			StdDevPlusEpsilon:                    args.StdDevPlusEpsilon,
+			Cache:                                args.Cache,
 		})
 	if err != nil {
 		return &emissions.ValueBundle{}, RegretInformedWeights{}, errorsmod.Wrap(err, "CalcNetworkInferences() error calculating naive inference")
@@ -978,6 +985,7 @@ func CalcNetworkInferences(
 			PNorm:                args.PNorm,
 			CNorm:                args.CNorm,
 			StdDevPlusEpsilon:    args.StdDevPlusEpsilon,
+			Cache:                args.Cache,
 		})
 	if err != nil {
 		return &emissions.ValueBundle{}, RegretInformedWeights{}, errorsmod.Wrap(err, "CalcNetworkInferences() error calculating one-out inferer inferences")
@@ -1013,6 +1021,7 @@ func CalcNetworkInferences(
 				PNorm:                                args.PNorm,
 				CNorm:                                args.CNorm,
 				StdDevPlusEpsilon:                    args.StdDevPlusEpsilon,
+				Cache:                                args.Cache,
 			})
 		if err != nil {
 			return &emissions.ValueBundle{}, RegretInformedWeights{}, errorsmod.Wrap(err, "CalcNetworkInferences() error calculating one-out forecaster inferences")
@@ -1040,6 +1049,7 @@ func CalcNetworkInferences(
 				PNorm:                                args.PNorm,
 				CNorm:                                args.CNorm,
 				StdDevPlusEpsilon:                    args.StdDevPlusEpsilon,
+				Cache:                                args.Cache,
 			})
 		if err != nil {
 			return &emissions.ValueBundle{}, RegretInformedWeights{}, errorsmod.Wrap(err, "CalcNetworkInferences() error calculating one-in inferences")
@@ -1064,6 +1074,7 @@ func CalcNetworkInferences(
 				PNorm:                args.PNorm,
 				CNorm:                args.CNorm,
 				StdDevPlusEpsilon:    args.StdDevPlusEpsilon,
+				Cache:                args.Cache,
 			},
 		)
 		if err != nil {

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
@@ -494,6 +494,7 @@ func (s *InferenceSynthesisTestSuite) testCorrectCombinedInitialValueForEpoch(ep
 			PNorm:                                pNorm,
 			CNorm:                                cNorm,
 			StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
+			Cache:                                nil,
 		})
 	s.Require().NoError(err)
 	alloratestutil.InEpsilon5(s.T(), combinedValue, epochGet[epoch]("network_inference").String())
@@ -533,6 +534,7 @@ func (s *InferenceSynthesisTestSuite) testCorrectNaiveValueForEpoch(epoch int) {
 			PNorm:                                pNorm,
 			CNorm:                                cNorm,
 			StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
+			Cache:                                nil,
 		})
 	s.Require().NoError(err)
 	alloratestutil.InEpsilon5(s.T(), naiveValue, epochGet[epoch]("network_naive_inference").String())
@@ -585,6 +587,7 @@ func (s *InferenceSynthesisTestSuite) testCorrectOneOutInfererValuesForEpoch(epo
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                nil,
 		})
 	s.Require().NoError(err)
 
@@ -632,6 +635,7 @@ func (s *InferenceSynthesisTestSuite) testCorrectOneOutForecasterValuesForEpoch(
 			PNorm:                                pNorm,
 			CNorm:                                cNorm,
 			StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
+			Cache:                                nil,
 		})
 	s.Require().NoError(err)
 
@@ -691,6 +695,7 @@ func (s *InferenceSynthesisTestSuite) testCorrectOneInForecasterValuesForEpoch(e
 			PNorm:                                pNorm,
 			CNorm:                                cNorm,
 			StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
+			Cache:                                nil,
 		})
 	s.Require().NoError(err)
 
@@ -800,6 +805,7 @@ func (s *InferenceSynthesisTestSuite) TestBuildNetworkInferencesIncompleteData()
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
 		InferenceBlockHeight:                 blockHeightInferences,
+		Cache:                                nil,
 	}
 
 	valueBundle, _, err := inferencesynthesis.CalcNetworkInferences(calcArgs)
@@ -914,6 +920,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesTwoWorkerTwoForec
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
 		InferenceBlockHeight:                 blockHeight,
+		Cache:                                nil,
 	}
 	valueBundle, _, err := inferencesynthesis.CalcNetworkInferences(calcArgs)
 	s.Require().NoError(err)
@@ -1058,6 +1065,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesThreeWorkerThreeF
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
 		InferenceBlockHeight:                 blockHeight,
+		Cache:                                nil,
 	}
 
 	valueBundle, _, err := inferencesynthesis.CalcNetworkInferences(
@@ -1206,6 +1214,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcNetworkInferencesThreeWorkerTwoFor
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
 		InferenceBlockHeight:                 blockHeight,
+		Cache:                                nil,
 	}
 
 	valueBundle, weights, err := inferencesynthesis.CalcNetworkInferences(
@@ -1315,6 +1324,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcOneInInferencesTwoForecastersOldTw
 		CNorm:                                cNorm,
 		StdDevPlusEpsilon:                    alloraMath.ZeroDec(),
 		InferenceBlockHeight:                 blockHeight,
+		Cache:                                nil,
 	}
 
 	valueBundle, _, err := inferencesynthesis.CalcNetworkInferences(calcArgs)
@@ -1409,6 +1419,7 @@ func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences() {
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                nil,
 		})
 	s.Require().NoError(err)
 
@@ -1450,6 +1461,7 @@ func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences() {
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                nil,
 		})
 	s.Require().NoError(err)
 	s.Require().Empty(emptyResult)
@@ -1473,6 +1485,7 @@ func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences() {
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                nil,
 		})
 	s.Require().NoError(err)
 	s.Require().Empty(singleInfererResult)
@@ -1550,6 +1563,7 @@ func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences2infe
 			PNorm:                pNorm,
 			CNorm:                cNorm,
 			StdDevPlusEpsilon:    alloraMath.ZeroDec(),
+			Cache:                nil,
 		})
 	s.Require().NoError(err)
 

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
@@ -397,6 +397,7 @@ func (s *InferenceSynthesisTestSuite) getEpochValueBundleByEpoch(epochNumber int
 		&networkCombinedLoss,
 		moduleParams,
 		blockHeight,
+		inferencesynthesis.NewMathHelperCache(),
 	)
 	s.Require().NoError(err)
 	return ctx, k, ctx.Logger(), topicId, calcArgs.AllInferersAreNew,
@@ -447,6 +448,7 @@ func (s *InferenceSynthesisTestSuite) getNetworkCalcArgs(
 		&networkCombinedLoss,
 		moduleParams,
 		blockHeight,
+		inferencesynthesis.NewMathHelperCache(),
 	)
 	s.Require().NoError(err)
 	return calcArgs.Inferers, calcArgs.InfererToInference, calcArgs.InfererToRegret, calcArgs.AllInferersAreNew,

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -34,19 +34,20 @@ func GetNetworkInferences(
 		return nil, errors.Wrap(emissions.ErrNotFound, "no inferences found")
 	}
 
-	// Enable math helper cache for this function's scope
-	enableMathCache()
+	// Create and enable math helper cache for this function's scope
+	cache := NewMathHelperCache()
+	cache.Enable()
 
 	// Disable math helper cache and clear cache when function exits
 	defer func() {
-		disableMathCache()
-		clearMathCache()
+		cache.Disable()
+		cache.Clear()
 		ctx.Logger().Debug("Math helper cache cleared after network inference calculation")
 	}()
 
 	if len(inferences.Inferences) > 1 {
 		// If we have multiple inferences:
-		return calcNetworkInferencesMultiple(ctx, k, topicId, inferences, forecasts, *inferencesNonce)
+		return calcNetworkInferencesMultiple(ctx, k, topicId, inferences, forecasts, *inferencesNonce, cache)
 	} else if len(inferences.Inferences) == 1 {
 		// If we only have a single inference, simply return it as is.
 		return calcNetworkInferencesSingle(*inferencesNonce, topicId, inferences), nil
@@ -62,6 +63,7 @@ func calcNetworkInferencesMultiple(
 	inferences *emissions.Inferences,
 	forecasts *emissions.Forecasts,
 	inferenceBlockHeight BlockHeight,
+	cache *MathHelperCache,
 ) (*GetNetworkInferencesResult, error) {
 	// Set forecasts to nil if there are no forecasts
 	if forecasts == nil {
@@ -103,6 +105,7 @@ func calcNetworkInferencesMultiple(
 		previousNetworkCombinedLoss,
 		moduleParams,
 		inferenceBlockHeight,
+		cache,
 	)
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "while getting network inference args")
@@ -180,6 +183,7 @@ func GetCalcNetworkInferenceArgs(
 	previousLossesCombinedValue *alloraMath.Dec,
 	moduleParams emissions.Params,
 	inferenceBlockHeight BlockHeight,
+	cache *MathHelperCache,
 ) (
 	calcArgs CalcNetworkInferencesArgs,
 	err error,
@@ -235,6 +239,7 @@ func GetCalcNetworkInferenceArgs(
 		CNorm:                                moduleParams.CNorm,
 		StdDevPlusEpsilon:                    stdDevPlusEpsilon,
 		InferenceBlockHeight:                 inferenceBlockHeight,
+		Cache:                                cache,
 	}
 
 	if previousLossesCombinedValue != nil {
@@ -271,6 +276,7 @@ func GetCalcNetworkInferenceArgs(
 				PNorm:                topic.PNorm,
 				CNorm:                moduleParams.CNorm,
 				StdDevPlusEpsilon:    stdDevPlusEpsilon,
+				Cache:                cache,
 			},
 		)
 		if err != nil {

--- a/x/emissions/keeper/inference_synthesis/weight.go
+++ b/x/emissions/keeper/inference_synthesis/weight.go
@@ -24,6 +24,7 @@ type CalcWeightsGivenWorkersArgs struct {
 	PNorm              alloraMath.Dec
 	CNorm              alloraMath.Dec
 	StdDevPlusEpsilon  alloraMath.Dec
+	Cache              *MathHelperCache
 }
 
 type CalcRegretStdDevFilteredByWeightsArgs struct {
@@ -39,33 +40,44 @@ type CalcRegretStdDevFilteredByWeightsArgs struct {
 	EpsilonTopic        alloraMath.Dec
 }
 
-// Math helper cache implementation
-// Used to memoize expensive helper computations like Gradient and Exp1DivExp1.
-var (
-	mathHelperCache  = make(map[string]alloraMath.Dec)
-	mathCacheEnabled = false
-)
-
-func enableMathCache() {
-	mathCacheEnabled = true
+// MathHelperCache is used to memoize expensive helper computations like Gradient and Exp1DivExp1.
+type MathHelperCache struct {
+	cache   map[string]alloraMath.Dec
+	enabled bool
 }
 
-func disableMathCache() {
-	mathCacheEnabled = false
+// NewMathHelperCache creates a new MathHelperCache instance with cache disabled by default.
+func NewMathHelperCache() *MathHelperCache {
+	return &MathHelperCache{
+		cache:   make(map[string]alloraMath.Dec),
+		enabled: false,
+	}
 }
 
-func clearMathCache() {
-	mathHelperCache = make(map[string]alloraMath.Dec)
+// Enable enables the cache for this instance.
+func (c *MathHelperCache) Enable() {
+	c.enabled = true
 }
 
-func cachedExp1DivExp1(a, b alloraMath.Dec) (alloraMath.Dec, error) {
-	if !mathCacheEnabled {
+// Disable disables the cache for this instance.
+func (c *MathHelperCache) Disable() {
+	c.enabled = false
+}
+
+// Clear clears all cached values.
+func (c *MathHelperCache) Clear() {
+	c.cache = make(map[string]alloraMath.Dec)
+}
+
+// Exp1DivExp1 calculates Exp1DivExp1 with caching if enabled.
+func (c *MathHelperCache) Exp1DivExp1(a, b alloraMath.Dec) (alloraMath.Dec, error) {
+	if !c.enabled {
 		return alloraMath.Exp1DivExp1(a, b)
 	}
 
 	key := fmt.Sprintf("exp1divexp1:%s:%s", a.String(), b.String())
 
-	if cachedValue, exists := mathHelperCache[key]; exists {
+	if cachedValue, exists := c.cache[key]; exists {
 		return cachedValue, nil
 	}
 
@@ -74,7 +86,7 @@ func cachedExp1DivExp1(a, b alloraMath.Dec) (alloraMath.Dec, error) {
 		return alloraMath.Dec{}, errorsmod.Wrapf(err, "error calculating Exp1DivExp1")
 	}
 
-	mathHelperCache[key] = result
+	c.cache[key] = result
 	return result, nil
 }
 
@@ -250,7 +262,7 @@ func CalcWeightsGivenWorkers(args CalcWeightsGivenWorkersArgs) (RegretInformedWe
 	// Calculate the weights from the normalized regrets
 	for _, worker := range args.Inferers {
 		// If there is more than one not-new inferer, calculate the weight for the ones that are not new
-		infererWeight, err := CalcWeightFromNormalizedRegret(normalizedInfererRegrets[worker], maxRegret, args.PNorm, args.CNorm)
+		infererWeight, err := CalcWeightFromNormalizedRegret(normalizedInfererRegrets[worker], maxRegret, args.PNorm, args.CNorm, args.Cache)
 		if err != nil {
 			return RegretInformedWeights{}, errorsmod.Wrapf(err, "Error calculating inferer weight")
 		}
@@ -260,7 +272,7 @@ func CalcWeightsGivenWorkers(args CalcWeightsGivenWorkersArgs) (RegretInformedWe
 
 	if len(forecasterRegrets) > 0 {
 		for _, worker := range args.Forecasters {
-			forecasterWeight, err := CalcWeightFromNormalizedRegret(normalizedForecasterRegrets[worker], maxRegret, args.PNorm, args.CNorm)
+			forecasterWeight, err := CalcWeightFromNormalizedRegret(normalizedForecasterRegrets[worker], maxRegret, args.PNorm, args.CNorm, args.Cache)
 			if err != nil {
 				return RegretInformedWeights{}, errorsmod.Wrapf(err, "Error calculating forecaster weight")
 			}
@@ -476,6 +488,7 @@ func CalcWeightFromNormalizedRegret(
 	maxNormalizedRegret alloraMath.Dec,
 	pNorm alloraMath.Dec,
 	cNorm alloraMath.Dec,
+	cache *MathHelperCache,
 ) (alloraMath.Dec, error) {
 	// Calculate exponent_regret = -p_norm * (normalized_regret - c_norm)
 	regretMinusC, err := normalizedRegret.Sub(cNorm)
@@ -506,7 +519,10 @@ func CalcWeightFromNormalizedRegret(
 	}
 
 	// Calculate weight = exp1_div_exp1(exponent_max_regret, exponent_regret)
-	weight, err := cachedExp1DivExp1(exponentMaxRegret, exponentRegret)
+	if cache == nil {
+		cache = NewMathHelperCache()
+	}
+	weight, err := cache.Exp1DivExp1(exponentMaxRegret, exponentRegret)
 	if err != nil {
 		return alloraMath.ZeroDec(), errorsmod.Wrapf(err, "Error calculating Exp1DivExp1")
 	}

--- a/x/emissions/keeper/inference_synthesis/weight.go
+++ b/x/emissions/keeper/inference_synthesis/weight.go
@@ -69,6 +69,17 @@ func (c *MathHelperCache) Clear() {
 	c.cache = make(map[string]alloraMath.Dec)
 }
 
+// IsInCache checks if a specific Exp1DivExp1 result is cached.
+// This is useful for testing and debugging.
+func (c *MathHelperCache) IsInCache(a, b alloraMath.Dec) bool {
+	if !c.enabled {
+		return false
+	}
+	key := fmt.Sprintf("exp1divexp1:%s:%s", a.String(), b.String())
+	_, exists := c.cache[key]
+	return exists
+}
+
 // Exp1DivExp1 calculates Exp1DivExp1 with caching if enabled.
 func (c *MathHelperCache) Exp1DivExp1(a, b alloraMath.Dec) (alloraMath.Dec, error) {
 	if !c.enabled {

--- a/x/emissions/keeper/inference_synthesis/weights_test.go
+++ b/x/emissions/keeper/inference_synthesis/weights_test.go
@@ -397,7 +397,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
 				CNorm:             alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon: alloraMath.MustNewDecFromString("1.0"),
-				Cache:              nil,
+				Cache:             nil,
 			},
 			expectedError: false,
 			checkResult: func(result synth.RegretInformedWeights) {
@@ -422,7 +422,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
 				CNorm:             alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon: alloraMath.MustNewDecFromString("1.0"),
-				Cache:              nil,
+				Cache:             nil,
 			},
 			expectedError: false,
 			checkResult: func(result synth.RegretInformedWeights) {
@@ -448,7 +448,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
 				CNorm:             alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon: alloraMath.MustNewDecFromString("1.0"),
-				Cache:              nil,
+				Cache:             nil,
 			},
 			expectedError: false,
 			checkResult: func(result synth.RegretInformedWeights) {
@@ -475,7 +475,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
 				CNorm:             alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon: alloraMath.MustNewDecFromString("1.0"),
-				Cache:              nil,
+				Cache:             nil,
 			},
 			expectedError: false,
 			checkResult: func(result synth.RegretInformedWeights) {

--- a/x/emissions/keeper/inference_synthesis/weights_test.go
+++ b/x/emissions/keeper/inference_synthesis/weights_test.go
@@ -397,6 +397,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
 				CNorm:             alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon: alloraMath.MustNewDecFromString("1.0"),
+				Cache:              nil,
 			},
 			expectedError: false,
 			checkResult: func(result synth.RegretInformedWeights) {
@@ -421,6 +422,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
 				CNorm:             alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon: alloraMath.MustNewDecFromString("1.0"),
+				Cache:              nil,
 			},
 			expectedError: false,
 			checkResult: func(result synth.RegretInformedWeights) {
@@ -446,6 +448,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
 				CNorm:             alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon: alloraMath.MustNewDecFromString("1.0"),
+				Cache:              nil,
 			},
 			expectedError: false,
 			checkResult: func(result synth.RegretInformedWeights) {
@@ -472,6 +475,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:             alloraMath.MustNewDecFromString("3.0"),
 				CNorm:             alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon: alloraMath.MustNewDecFromString("1.0"),
+				Cache:              nil,
 			},
 			expectedError: false,
 			checkResult: func(result synth.RegretInformedWeights) {
@@ -499,6 +503,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:              alloraMath.MustNewDecFromString("3.0"),
 				CNorm:              alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon:  alloraMath.MustNewDecFromString("1.0"),
+				Cache:              nil,
 			},
 			expectedError: true,
 		},
@@ -514,6 +519,7 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 				PNorm:              alloraMath.MustNewDecFromString("3.0"),
 				CNorm:              alloraMath.MustNewDecFromString("0.75"),
 				StdDevPlusEpsilon:  alloraMath.MustNewDecFromString("1.0"),
+				Cache:              nil,
 			},
 			expectedError: true,
 		},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
Turning math cache into an object instead of using global vars.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- Added extensive unit tests, in both the cache and the usage.
- [x] If documented, please describe where. If not, describe why docs are not needed. -- It is a performance change, not a functionality change, so it should not need its own documentation.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

