### PR TITLE
fix: fix data cleanup before snapshot extraction

### DIFF
--- a/scripts/restore_snapshot.sh
+++ b/scripts/restore_snapshot.sh
@@ -27,7 +27,8 @@ if [ ! -f "$RESTORED_FLAG" ]; then
   #* Download the archive from S3 and extract it to the /data directory
   mkdir -p "${APP_HOME}/data"
   touch "$LOGFILE"
-  rm -rf "${APP_HOME}/data"/*
+  rm -rf "${APP_HOME}/data"
+  mkdir -p "${APP_HOME}/data"
   rclone -v cat "$RCLONE_S3_NAME:$S3_BUCKET/$LATEST_BACKUP_FILE" | tar --zstd -xvf - -C "${APP_HOME}/data" > "$LOGFILE" 2>&1
   tail -n 50 "$LOGFILE"
 

--- a/scripts/restore_snapshot.sh
+++ b/scripts/restore_snapshot.sh
@@ -27,7 +27,7 @@ if [ ! -f "$RESTORED_FLAG" ]; then
   #* Download the archive from S3 and extract it to the /data directory
   mkdir -p "${APP_HOME}/data"
   touch "$LOGFILE"
-  rm -rf "${APP_HOME}/data/*"
+  rm -rf "${APP_HOME}/data"/*
   rclone -v cat "$RCLONE_S3_NAME:$S3_BUCKET/$LATEST_BACKUP_FILE" | tar --zstd -xvf - -C "${APP_HOME}/data" > "$LOGFILE" 2>&1
   tail -n 50 "$LOGFILE"
 


### PR DESCRIPTION
Double quotes around "${APP_HOME}/data/*" prevented glob expansion, so old data was not removed before extracting snapshot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the whole data directory before extracting the snapshot, then recreates it. Prevents residual files and inconsistent restore state caused by the previous quoted glob.

<sup>Written for commit 27a4c3cffdd6361a7de84a9dc03f8c57ff9196e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

