### PR TITLE
fix: correct swapped error log messages in payload events

### DIFF
--- a/x/emissions/types/events_emitters.go
+++ b/x/emissions/types/events_emitters.go
@@ -67,7 +67,7 @@ func EmitNewInsertInfererPayloadEvent(ctx context.Context, bundle *WorkerDataBun
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	err := sdkCtx.EventManager().EmitTypedEvent(NewInsertInfererPayloadEventBase(bundle))
 	if err != nil {
-		sdkCtx.Logger().Warn("Error emitting NewForecasterPayloadEvent", "error", err)
+		sdkCtx.Logger().Warn("Error emitting NewInsertInfererPayloadEvent", "error", err)
 	}
 }
 
@@ -76,7 +76,7 @@ func EmitNewInsertForecasterPayloadEvent(ctx context.Context, bundle *WorkerData
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	err := sdkCtx.EventManager().EmitTypedEvent(NewInsertForecasterPayloadEventBase(bundle))
 	if err != nil {
-		sdkCtx.Logger().Warn("Error emitting NewInfererPayloadEvent", "error", err)
+		sdkCtx.Logger().Warn("Error emitting NewInsertForecasterPayloadEvent", "error", err)
 	}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Error log messages in `EmitNewInsertInfererPayloadEvent` and `EmitNewInsertForecasterPayloadEvent` were swapped — each function was logging the other's event name, making debugging confusing.
 
Fixed the log messages to correctly identify which event failed to emit.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

None

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.  - Not necessary to test, not a functional change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed swapped error log messages in EmitNewInsertInfererPayloadEvent and EmitNewInsertForecasterPayloadEvent so failures log the correct event name, improving debugging clarity.

<sup>Written for commit 5e23f84368c16abff15411955f9be7b7d589b7c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

