### PR TITLE
pag guard, nil-wrap notfound, error mgmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ allora.log
 
 **/.DS_Store
 
+.worktrees/
+

--- a/test/fuzz/invariants.patch
+++ b/test/fuzz/invariants.patch
@@ -1,19 +1,19 @@
 diff --git a/x/emissions/module/abci.go b/x/emissions/module/abci.go
-index e7fcf865..5bfb9d44 100644
 --- a/x/emissions/module/abci.go
 +++ b/x/emissions/module/abci.go
-@@ -3,7 +3,10 @@ package module
+@@ -3,8 +3,11 @@ package module
  import (
  	"context"
  
 +	"fmt"
 +
  	"cosmossdk.io/errors"
+ 	sdk "github.com/cosmos/cosmos-sdk/types"
+ 
 +	emissionskeeper "github.com/allora-network/allora-chain/x/emissions/keeper"
  	allorautils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
  	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
- 	sdk "github.com/cosmos/cosmos-sdk/types"
-@@ -11,6 +14,11 @@ import (
+@@ -13,6 +16,11 @@ import (
  
  func EndBlocker(ctx context.Context, am AppModule) error {
  	sdkCtx := sdk.UnwrapSDKContext(ctx)
@@ -26,7 +26,6 @@ index e7fcf865..5bfb9d44 100644
  	sdkCtx.Logger().Debug("---------------- Emissions EndBlock -------------------", "blockHeight", blockHeight)
  
 diff --git a/x/emissions/module/module.go b/x/emissions/module/module.go
-index 7cc8ee97..e99ddb32 100644
 --- a/x/emissions/module/module.go
 +++ b/x/emissions/module/module.go
 @@ -41,6 +41,7 @@ var (
@@ -37,7 +36,7 @@ index 7cc8ee97..e99ddb32 100644
  )
  
  // ConsensusVersion defines the current module consensus version.
-@@ -204,3 +205,8 @@ func (am AppModule) EndBlock(ctx context.Context) error {
+@@ -210,3 +211,8 @@ func (am AppModule) EndBlock(ctx context.Context) error {
  	}
  	return err
  }

--- a/x/emissions/keeper/params.go
+++ b/x/emissions/keeper/params.go
@@ -8,6 +8,7 @@ import (
 	"cosmossdk.io/collections"
 	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
@@ -51,6 +52,13 @@ func (k *ParamsKeeper) CalcAppropriatePaginationForUint64Cursor(ctx context.Cont
 
 	if pagination != nil {
 		if len(pagination.Key) > 0 {
+			if len(pagination.Key) != 8 {
+				return uint64(0), uint64(0), errorsmod.Wrapf(
+					sdkerrors.ErrInvalidRequest,
+					"invalid pagination key length %d, expected 8",
+					len(pagination.Key),
+				)
+			}
 			cursor = binary.BigEndian.Uint64(pagination.Key)
 		}
 		if pagination.Limit > 0 {

--- a/x/emissions/keeper/params_test.go
+++ b/x/emissions/keeper/params_test.go
@@ -342,4 +342,9 @@ func (s *KeeperTestSuite) TestCalcAppropriatePaginationForUint64Cursor() {
 	limit, _, err = k.CalcAppropriatePaginationForUint64Cursor(ctx, pagination)
 	s.Require().NoError(err, "Handling limit exceeding maximum should not fail")
 	s.Require().Equal(maxLimit, limit, "Limit should be capped at the maximum limit")
+
+	// Test 5: Invalid key length should return an error instead of panicking
+	invalidKeyPagination := &types.SimpleCursorPaginationRequest{Key: []byte{0x01}, Limit: 10}
+	_, _, err = k.CalcAppropriatePaginationForUint64Cursor(ctx, invalidKeyPagination)
+	s.Require().Error(err, "Should reject non-8-byte pagination keys")
 }

--- a/x/emissions/keeper/queryserver/query_server_score.go
+++ b/x/emissions/keeper/queryserver/query_server_score.go
@@ -104,7 +104,7 @@ func (qs queryServer) GetCurrentLowestInfererScore(ctx context.Context, req *typ
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "error getting lowest inferer score EMA")
 	} else if !found {
-		return nil, errorsmod.Wrap(err, "no lowest inferer score found for this topic")
+		return nil, status.Errorf(codes.NotFound, "no lowest inferer score found for topic %d", req.TopicId)
 	}
 
 	return &types.GetCurrentLowestInfererScoreResponse{Score: &lowestInfererScore}, nil
@@ -136,7 +136,7 @@ func (qs queryServer) GetCurrentLowestForecasterScore(ctx context.Context, req *
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "error getting lowest forecaster score EMA")
 	} else if !found {
-		return nil, errorsmod.Wrap(err, "no lowest forecaster score found for this topic")
+		return nil, status.Errorf(codes.NotFound, "no lowest forecaster score found for topic %d", req.TopicId)
 	}
 
 	return &types.GetCurrentLowestForecasterScoreResponse{Score: &lowestForecasterScore}, nil
@@ -158,7 +158,7 @@ func (qs queryServer) GetCurrentLowestReputerScore(ctx context.Context, req *typ
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "error getting lowest reputer score EMA")
 	} else if !found {
-		return nil, errorsmod.Wrap(err, "no lowest reputer score found for this topic")
+		return nil, status.Errorf(codes.NotFound, "no lowest reputer score found for topic %d", req.TopicId)
 	}
 
 	return &types.GetCurrentLowestReputerScoreResponse{Score: &lowestReputerScore}, nil
@@ -179,10 +179,10 @@ func (qs queryServer) GetTopicInitialInfererEmaScore(ctx context.Context, req *t
 	defer metrics.RecordMetrics("GetTopicInitialInfererEmaScore", time.Now(), &err)
 
 	topicExists, err := qs.tk.TopicExists(ctx, req.TopicId)
-	if !topicExists {
-		return nil, status.Errorf(codes.NotFound, "topic %v not found", req.TopicId)
-	} else if err != nil {
+	if err != nil {
 		return nil, err
+	} else if !topicExists {
+		return nil, status.Errorf(codes.NotFound, "topic %v not found", req.TopicId)
 	}
 
 	score, err := qs.sck.GetTopicInitialInfererEmaScore(ctx, req.TopicId)
@@ -197,10 +197,10 @@ func (qs queryServer) GetTopicInitialForecasterEmaScore(ctx context.Context, req
 	defer metrics.RecordMetrics("GetTopicInitialForecasterEmaScore", time.Now(), &err)
 
 	topicExists, err := qs.tk.TopicExists(ctx, req.TopicId)
-	if !topicExists {
-		return nil, status.Errorf(codes.NotFound, "topic %v not found", req.TopicId)
-	} else if err != nil {
+	if err != nil {
 		return nil, err
+	} else if !topicExists {
+		return nil, status.Errorf(codes.NotFound, "topic %v not found", req.TopicId)
 	}
 
 	score, err := qs.sck.GetTopicInitialForecasterEmaScore(ctx, req.TopicId)
@@ -215,10 +215,10 @@ func (qs queryServer) GetTopicInitialReputerEmaScore(ctx context.Context, req *t
 	defer metrics.RecordMetrics("GetTopicInitialReputerEmaScore", time.Now(), &err)
 
 	topicExists, err := qs.tk.TopicExists(ctx, req.TopicId)
-	if !topicExists {
-		return nil, status.Errorf(codes.NotFound, "topic %v not found", req.TopicId)
-	} else if err != nil {
+	if err != nil {
 		return nil, err
+	} else if !topicExists {
+		return nil, status.Errorf(codes.NotFound, "topic %v not found", req.TopicId)
 	}
 
 	score, err := qs.sck.GetTopicInitialReputerEmaScore(ctx, req.TopicId)

--- a/x/emissions/keeper/queryserver/query_server_score_test.go
+++ b/x/emissions/keeper/queryserver/query_server_score_test.go
@@ -299,6 +299,13 @@ func (s *QueryServerTestSuite) TestGetCurrentLowestInfererScore() {
 	)
 }
 
+func (s *QueryServerTestSuite) TestGetCurrentLowestInfererScoreNotFound() {
+	ctx := s.Ctx()
+	req := &types.GetCurrentLowestInfererScoreRequest{TopicId: 999999}
+	_, err := s.EmissionsQueryServer().GetCurrentLowestInfererScore(ctx, req)
+	s.Require().Error(err, "missing lowest inferer score should return an error")
+}
+
 func (s *QueryServerTestSuite) TestGetCurrentLowestForecasterScore() {
 	ctx, keeper, require := s.Ctx(), s.ScoresKeeper(), s.Require()
 
@@ -325,6 +332,13 @@ func (s *QueryServerTestSuite) TestGetCurrentLowestForecasterScore() {
 	)
 }
 
+func (s *QueryServerTestSuite) TestGetCurrentLowestForecasterScoreNotFound() {
+	ctx := s.Ctx()
+	req := &types.GetCurrentLowestForecasterScoreRequest{TopicId: 999999}
+	_, err := s.EmissionsQueryServer().GetCurrentLowestForecasterScore(ctx, req)
+	s.Require().Error(err, "missing lowest forecaster score should return an error")
+}
+
 func (s *QueryServerTestSuite) TestGetCurrentLowestReputerScore() {
 	ctx, keeper, require := s.Ctx(), s.ScoresKeeper(), s.Require()
 
@@ -349,6 +363,13 @@ func (s *QueryServerTestSuite) TestGetCurrentLowestReputerScore() {
 		"The lowest score should be 95",
 		response.Score,
 	)
+}
+
+func (s *QueryServerTestSuite) TestGetCurrentLowestReputerScoreNotFound() {
+	ctx := s.Ctx()
+	req := &types.GetCurrentLowestReputerScoreRequest{TopicId: 999999}
+	_, err := s.EmissionsQueryServer().GetCurrentLowestReputerScore(ctx, req)
+	s.Require().Error(err, "missing lowest reputer score should return an error")
 }
 
 func (s *QueryServerTestSuite) TestGetTopicInitialInfererEmaScore() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
Includes: pagination key length guard, nil-wrap notfound fixes, topic-exists error-order fixes, tests.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. --unit tests passed and fixed too
- [ ] If documented, please describe where. If not, describe why docs are not needed. -- no need
- [ ] Added to `Unreleased` section of `CHANGELOG.md`? -- no need, just fixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded pagination cursor keys to 8 bytes and improved score query errors to avoid panics and return clear NotFound responses. Fixed topic existence error ordering, updated the fuzz invariants patch to match module changes, and added tests.

- **Bug Fixes**
  - Pagination: reject non-8-byte cursor keys with InvalidRequest instead of panicking.
  - Scores queries: return gRPC NotFound with topic ID when lowest score is missing.
  - Topic initial scores: check TopicExists error first; only return NotFound if the topic is truly missing.
  - Fuzz invariants: update test patch to align with current module code and prevent build/apply issues.

<sup>Written for commit dcbc5cb1a64ff2cb957beb781fb493080594ca58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

