### PR TITLE
nonce staking guards, iter close

### DIFF
--- a/x/emissions/keeper/nonces.go
+++ b/x/emissions/keeper/nonces.go
@@ -86,6 +86,9 @@ func (k *NonceKeeper) FulfillWorkerNonce(ctx context.Context, topicId TopicId, n
 	if err := types.ValidateTopicId(topicId); err != nil {
 		return false, errorsmod.Wrap(err, "error validating topic id")
 	}
+	if nonce == nil {
+		return false, errors.New("nil worker nonce provided")
+	}
 	if err := nonce.Validate(); err != nil {
 		return false, errorsmod.Wrap(err, "error validating nonce")
 	}
@@ -121,6 +124,9 @@ func (k *NonceKeeper) FulfillReputerNonce(ctx context.Context, topicId TopicId, 
 	if err := types.ValidateTopicId(topicId); err != nil {
 		return false, errorsmod.Wrap(err, "error validating topic id")
 	}
+	if nonce == nil {
+		return false, errors.New("nil reputer nonce provided")
+	}
 	if err := nonce.Validate(); err != nil {
 		return false, errorsmod.Wrap(err, "error validating nonce")
 	}
@@ -131,6 +137,9 @@ func (k *NonceKeeper) FulfillReputerNonce(ctx context.Context, topicId TopicId, 
 
 	// Check if the nonce is present in the unfulfilled nonces
 	for i, n := range unfulfilledNonces.Nonces {
+		if n == nil || n.ReputerNonce == nil {
+			continue
+		}
 		if n.ReputerNonce.BlockHeight == nonce.BlockHeight {
 			// Remove the nonce from the unfulfilled nonces
 			unfulfilledNonces.Nonces = append(unfulfilledNonces.Nonces[:i], unfulfilledNonces.Nonces[i+1:]...)
@@ -172,6 +181,9 @@ func (k *NonceKeeper) IsWorkerNonceUnfulfilled(ctx context.Context, topicId Topi
 
 // True if nonce is unfulfilled, false otherwise.
 func (k *NonceKeeper) IsReputerNonceUnfulfilled(ctx context.Context, topicId TopicId, nonce *types.Nonce) (isUnfulfilled bool, err error) {
+	if nonce == nil {
+		return false, errors.New("nil reputer nonce provided")
+	}
 	// Get the latest unfulfilled nonces
 	unfulfilledNonces, err := k.GetUnfulfilledReputerNonces(ctx, topicId)
 	if err != nil {
@@ -180,7 +192,7 @@ func (k *NonceKeeper) IsReputerNonceUnfulfilled(ctx context.Context, topicId Top
 
 	// Check if the nonce is present in the unfulfilled nonces
 	for _, n := range unfulfilledNonces.Nonces {
-		if n == nil {
+		if n == nil || n.ReputerNonce == nil {
 			continue
 		}
 		if n.ReputerNonce.BlockHeight == nonce.BlockHeight {
@@ -196,6 +208,9 @@ func (k *NonceKeeper) IsReputerNonceUnfulfilled(ctx context.Context, topicId Top
 func (k *NonceKeeper) AddWorkerNonce(ctx context.Context, topicId TopicId, nonce *types.Nonce) error {
 	if err := types.ValidateTopicId(topicId); err != nil {
 		return errorsmod.Wrap(err, "error validating topic id")
+	}
+	if nonce == nil {
+		return errors.New("nil worker nonce provided")
 	}
 	if err := nonce.Validate(); err != nil {
 		return errorsmod.Wrap(err, "error validating nonce")
@@ -236,6 +251,9 @@ func (k *NonceKeeper) AddReputerNonce(ctx context.Context, topicId TopicId, nonc
 	if err := types.ValidateTopicId(topicId); err != nil {
 		return errorsmod.Wrap(err, "error validating topic id")
 	}
+	if nonce == nil {
+		return errors.New("nil reputer's nonce provided")
+	}
 	if err := nonce.Validate(); err != nil {
 		return errorsmod.Wrap(err, "error validating nonce")
 	}
@@ -243,13 +261,13 @@ func (k *NonceKeeper) AddReputerNonce(ctx context.Context, topicId TopicId, nonc
 	if err != nil {
 		return errorsmod.Wrap(err, "error getting unfulfilled reputer nonces")
 	}
-	if nonce == nil {
-		return errors.New("nil reputer's nonce provided")
-	}
 
 	// Check that input nonce is not already contained in the nonces of this topic
 	// nor that the `associatedWorkerNonce` is already associated with a worker request
 	for _, n := range nonces.Nonces {
+		if n == nil || n.ReputerNonce == nil {
+			continue
+		}
 		// Do nothing if nonce is already in the list
 		if n.ReputerNonce.BlockHeight == nonce.BlockHeight {
 			return nil
@@ -381,10 +399,8 @@ func (k *NonceKeeper) PruneWorkerNonces(ctx context.Context, topicId uint64, blo
 	if err := types.ValidateTopicId(topicId); err != nil {
 		return errorsmod.Wrap(err, "error validating topic id")
 	}
-	nonces, err := k.unfulfilledWorkerNonces.Get(ctx, topicId)
-	if errors.Is(err, collections.ErrNotFound) {
-		return errorsmod.Wrapf(err, "no nonces found to prune for topic %d", topicId)
-	} else if err != nil {
+	nonces, err := k.GetUnfulfilledWorkerNonces(ctx, topicId)
+	if err != nil {
 		return errorsmod.Wrap(err, "error getting unfulfilled worker nonces")
 	}
 
@@ -420,6 +436,9 @@ func (k *NonceKeeper) PruneReputerNonces(ctx context.Context, topicId uint64, bl
 	// Filter Nonces based on block_height
 	filteredNonces := make([]*types.ReputerRequestNonce, 0)
 	for _, nonce := range nonces.Nonces {
+		if nonce == nil || nonce.ReputerNonce == nil {
+			continue
+		}
 		if nonce.ReputerNonce.BlockHeight >= blockHeightThreshold {
 			filteredNonces = append(filteredNonces, nonce)
 		}

--- a/x/emissions/keeper/nonces_test.go
+++ b/x/emissions/keeper/nonces_test.go
@@ -1,8 +1,6 @@
 package keeper_test
 
 import (
-	"cosmossdk.io/collections"
-
 	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
@@ -663,12 +661,17 @@ func (s *KeeperTestSuite) TestPruneWorkerNoncesLogicNoNonces() {
 
 	// Call pruneWorkerNonces
 	err = k.PruneWorkerNonces(s.Ctx(), topicId1, blockHeightThreshold)
-	s.Require().ErrorIs(err, collections.ErrNotFound)
+	s.Require().NoError(err)
 
 	// Check remaining nonces
 	nonces, err := k.GetUnfulfilledWorkerNonces(s.Ctx(), topicId1)
 	s.Require().NoError(err)
 	s.Require().Empty(nonces.Nonces)
+}
+
+func (s *KeeperTestSuite) TestAddReputerNonceNilInput() {
+	err := s.NonceKeeper().AddReputerNonce(s.Ctx(), uint64(1), nil)
+	s.Require().Error(err)
 }
 
 func (s *KeeperTestSuite) TestPruneWorkerNoncesLogicCorrectness() {

--- a/x/emissions/keeper/staking.go
+++ b/x/emissions/keeper/staking.go
@@ -513,6 +513,7 @@ func (k *StakingKeeper) GetDelegateStakeRemovalForDelegatorReputerAndTopicId(
 	if err != nil {
 		return types.DelegateStakeRemovalInfo{}, false, errorsmod.Wrap(err, "error iterating over delegate stake removals by actor")
 	}
+	defer iter.Close()
 	keys, err := iter.Keys()
 	if err != nil {
 		return types.DelegateStakeRemovalInfo{}, false, errorsmod.Wrap(err, "error getting keys")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
Includes: nil guards in nonce paths, safer reputer nonce deref, prune-worker no-op consistency, missing iter.Close().

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- unit tests modified accordingly
- [ ] If documented, please describe where. If not, describe why docs are not needed. -- no need, no func change
- [ ] Added to `Unreleased` section of `CHANGELOG.md`? -- no need , no func change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modularized the emissions keeper into focused sub-keepers and added robust nonce/staking guards to prevent nil derefs and window inconsistencies. No external message or query API changes; improves safety, clarity, and testability.

- **Refactors**
  - Split monolithic Keeper into sub-keepers: Params, Topic, Staking, Scores, Nonce, Regrets, ReputerLoss, Weights, Banking, and ActorPenalties.
  - Rewired Msg/Query servers and tests to use injected sub-keepers and simple getters (e.g., GetParamsKeeper()).
  - Moved EMA score logic, weights, staking, topics, regrets, and nonce management into dedicated files with constructor funcs.

- **Bug Fixes**
  - Added nil input checks and nil-safe iteration across nonce methods (Fulfill/Add/Is*/Prune) to prevent panics; PruneWorkerNonces now no-ops when empty.
  - Closed a missing iterator in staking (GetDelegateStakeRemovalForDelegatorReputerAndTopicId).

<sup>Written for commit 903d5dfb4a6085d0efd7fcb3102f1d7801d59033. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

