### PR TITLE
score robustness + validations

### DIFF
--- a/x/emissions/keeper/reputer_loss.go
+++ b/x/emissions/keeper/reputer_loss.go
@@ -227,6 +227,12 @@ func (k *ReputerLossKeeper) AppendReputerLoss(
 		if err != nil {
 			return errorsmod.Wrap(err, "error setting initial reputer score ema")
 		}
+		previousEmaScore = types.Score{
+			TopicId:     topic.Id,
+			Address:     reputerLoss.ValueBundle.Reputer,
+			BlockHeight: nonceBlockHeight,
+			Score:       initialEmaScore,
+		}
 	} else {
 		// If not new: Penalise the reputer if needed
 		previousEmaScore, err = k.actorPenaltiesKeeper.ApplyLivenessPenaltyToReputer(ctx, topic, nonceBlockHeight, previousEmaScore)

--- a/x/emissions/keeper/score_utils.go
+++ b/x/emissions/keeper/score_utils.go
@@ -17,14 +17,19 @@ func (k *ScoresKeeper) GetLowestScoreFromAllReputers(
 	topicId TopicId,
 	reputerAddresses []string,
 ) (lowScore types.Score, err error) {
-	for i, address := range reputerAddresses {
+	foundValidScore := false
+	for _, address := range reputerAddresses {
 		score, err := k.GetReputerScoreEma(ctx, topicId, address)
 		if err != nil {
 			continue
 		}
-		if lowScore.Score.Gt(score.Score) || i == 0 {
+		if !foundValidScore || lowScore.Score.Gt(score.Score) {
 			lowScore = score
+			foundValidScore = true
 		}
+	}
+	if !foundValidScore {
+		return types.Score{}, types.ErrNotFound
 	}
 	return lowScore, nil
 }
@@ -50,6 +55,9 @@ func (k *ScoresKeeper) UpdateLowestScoreFromReputerAddresses(
 	// Get lowest score from all reputers
 	lowScore, err := k.GetLowestScoreFromAllReputers(ctx, topicId, reputerAddresses)
 	if err != nil {
+		if errors.Is(err, types.ErrNotFound) {
+			return nil
+		}
 		return err
 	}
 
@@ -89,14 +97,19 @@ func (k *ScoresKeeper) GetLowestScoreFromAllInferers(
 	topicId TopicId,
 	infererAddresses []string,
 ) (lowScore types.Score, err error) {
-	for i, address := range infererAddresses {
+	foundValidScore := false
+	for _, address := range infererAddresses {
 		score, err := k.GetInfererScoreEma(ctx, topicId, address)
 		if err != nil {
 			continue
 		}
-		if lowScore.Score.Gt(score.Score) || i == 0 {
+		if !foundValidScore || lowScore.Score.Gt(score.Score) {
 			lowScore = score
+			foundValidScore = true
 		}
+	}
+	if !foundValidScore {
+		return types.Score{}, types.ErrNotFound
 	}
 	return lowScore, nil
 }
@@ -122,6 +135,9 @@ func (k *ScoresKeeper) UpdateLowestScoreFromForecasterAddresses(
 	// Get lowest score from all forecasters
 	lowScore, err := k.GetLowestScoreFromAllForecasters(ctx, topicId, forecasterAddresses)
 	if err != nil {
+		if errors.Is(err, types.ErrNotFound) {
+			return nil
+		}
 		return err
 	}
 
@@ -134,14 +150,19 @@ func (k *ScoresKeeper) GetLowestScoreFromAllForecasters(
 	topicId TopicId,
 	forecasterAddresses []string,
 ) (lowScore types.Score, err error) {
-	for i, address := range forecasterAddresses {
+	foundValidScore := false
+	for _, address := range forecasterAddresses {
 		score, err := k.GetForecasterScoreEma(ctx, topicId, address)
 		if err != nil {
 			continue
 		}
-		if lowScore.Score.Gt(score.Score) || i == 0 {
+		if !foundValidScore || lowScore.Score.Gt(score.Score) {
 			lowScore = score
+			foundValidScore = true
 		}
+	}
+	if !foundValidScore {
+		return types.Score{}, types.ErrNotFound
 	}
 	return lowScore, nil
 }

--- a/x/emissions/keeper/scores.go
+++ b/x/emissions/keeper/scores.go
@@ -172,12 +172,7 @@ func (k *ScoresKeeper) GetReputerScoreEma(ctx context.Context, topicId TopicId, 
 			Score:       alloraMath.ZeroDec(),
 		}, nil
 	} else if err != nil {
-		return types.Score{
-			BlockHeight: 0,
-			Address:     reputer,
-			TopicId:     topicId,
-			Score:       alloraMath.ZeroDec(),
-		}, errorsmod.Wrap(err, "error getting reputer score ema")
+		return types.Score{}, errorsmod.Wrap(err, "error getting reputer score ema")
 	}
 	return score, nil
 }
@@ -626,7 +621,13 @@ func (k *ScoresKeeper) SetPreviousPercentageRewardToStakedReputers(
 }
 
 func (k *ScoresKeeper) GetPreviousPercentageRewardToStakedReputers(ctx context.Context) (alloraMath.Dec, error) {
-	return k.previousPercentageRewardToStakedReputers.Get(ctx)
+	percentage, err := k.previousPercentageRewardToStakedReputers.Get(ctx)
+	if errors.Is(err, collections.ErrNotFound) {
+		return alloraMath.ZeroDec(), nil
+	} else if err != nil {
+		return alloraMath.Dec{}, errorsmod.Wrap(err, "error getting previous percentage reward to staked reputers")
+	}
+	return percentage, nil
 }
 
 func (k *ScoresKeeper) SetPreviousForecasterScoreRatio(ctx context.Context, topicId TopicId, forecasterScoreRatio alloraMath.Dec) error {

--- a/x/emissions/keeper/weights.go
+++ b/x/emissions/keeper/weights.go
@@ -81,6 +81,9 @@ func (k *WeightsKeeper) SetLatestInfererWeight(ctx context.Context, topicId Topi
 	if err := types.ValidateBech32(worker); err != nil {
 		return errorsmod.Wrap(err, "worker address validation failed")
 	}
+	if err := types.ValidateDec(weight); err != nil {
+		return errorsmod.Wrap(err, "inferer weight validation failed")
+	}
 	return k.latestInfererWeights.Set(ctx, collections.Join(topicId, worker), weight)
 }
 
@@ -100,6 +103,9 @@ func (k *WeightsKeeper) SetLatestForecasterWeight(ctx context.Context, topicId T
 	}
 	if err := types.ValidateBech32(worker); err != nil {
 		return errorsmod.Wrap(err, "worker address validation failed")
+	}
+	if err := types.ValidateDec(weight); err != nil {
+		return errorsmod.Wrap(err, "forecaster weight validation failed")
 	}
 	return k.latestForecasterWeights.Set(ctx, collections.Join(topicId, worker), weight)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Includes: first-submission previousEmaScore fix, lowest-score helper robustness, dec validation in weights setters, getter consistency/default handling.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- unit tests passing
- [ ] If documented, please describe where. If not, describe why docs are not needed. -- no need, no func change
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?  -- no need, no func change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves score handling and validation in the emissions keeper. Fixes first‑submission EMA setup and guards against missing scores and invalid weights.

- **Bug Fixes**
  - Set previousEmaScore on a reputer’s first submission using the initial EMA.
  - Harden lowest-score helpers for reputers/inferers/forecasters: skip missing scores and return ErrNotFound; update calls ignore ErrNotFound.
  - Make getters consistent: GetReputerScoreEma returns an error on storage failures; GetPreviousPercentageRewardToStakedReputers returns zero when unset.
  - Validate decimals in SetLatestInfererWeight and SetLatestForecasterWeight; return clear errors on invalid values.

<sup>Written for commit e9fb4d339c96d1fabcdaefecd24caa53f657afe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

