### PR TITLE
bank dedupe and cleanup, guard, log, comments

### DIFF
--- a/x/emissions/keeper/banking.go
+++ b/x/emissions/keeper/banking.go
@@ -24,10 +24,6 @@ type BankingKeeper struct {
 	authKeeper AccountKeeper
 }
 
-func (k *BankingKeeper) GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin {
-	return k.bankKeeper.GetBalance(ctx, addr, denom)
-}
-
 // wrapper around bank keeper SendCoinsFromModuleToAccount
 func (k *BankingKeeper) SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipient ActorId, amt sdk.Coins) error {
 	recipientAddr, err := sdk.AccAddressFromBech32(recipient)
@@ -52,12 +48,15 @@ func (k *BankingKeeper) SendCoinsFromModuleToModule(ctx context.Context, senderM
 }
 
 // wrapper around bank keeper GetBalance
-func (k *BankingKeeper) GetBankBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin {
+func (k *BankingKeeper) GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin {
 	return k.bankKeeper.GetBalance(ctx, addr, denom)
 }
 
 // MoveCoinsFromAlloraRewardsToEcosystem moves funds from the allora rewards account to the ecosystem account
 func (k *BankingKeeper) MoveCoinsFromAlloraRewardsToEcosystem(ctx context.Context, amount alloraMath.Dec) error {
+	if amount.IsNegative() {
+		return errorsmod.Wrap(types.ErrInvalidValue, "amount to move cannot be negative")
+	}
 	if amount.IsZero() {
 		return nil
 	}
@@ -78,7 +77,7 @@ func (k *BankingKeeper) GetTotalRewardToDistribute(ctx context.Context) (alloraM
 	// Get Allora Rewards Account
 	alloraRewardsAccountAddr := k.authKeeper.GetModuleAccount(ctx, types.AlloraRewardsAccountName).GetAddress()
 	// Get Total Allocation
-	totalReward := k.GetBankBalance(
+	totalReward := k.GetBalance(
 		ctx,
 		alloraRewardsAccountAddr,
 		params.DefaultBondDenom).Amount

--- a/x/emissions/keeper/invariants.go
+++ b/x/emissions/keeper/invariants.go
@@ -320,7 +320,7 @@ func StakingInvariantPendingRewardForDelegatorsGreaterThanRewardPerShareMinusRew
 		// first get the balance of the pending reward for delegators account
 		// this is the total amount of rewards that we hold on behalf of delegators
 		alloraPendingAddr := k.authKeeper.GetModuleAccount(ctx, emissionstypes.AlloraPendingRewardForDelegatorAccountName).GetAddress()
-		alloraPendingBankBal := k.bankingKeeper.GetBankBalance(ctx, alloraPendingAddr, params.DefaultBondDenom).Amount
+		alloraPendingBankBal := k.bankingKeeper.GetBalance(ctx, alloraPendingAddr, params.DefaultBondDenom).Amount
 
 		// for every delegator stake position
 		delegatedStakesIter, err := k.stakingKeeper.delegatedStakes.Iterate(ctx, nil)

--- a/x/emissions/keeper/msgserver/msg_server_registrations.go
+++ b/x/emissions/keeper/msgserver/msg_server_registrations.go
@@ -147,7 +147,7 @@ func (ms msgServer) CheckBalanceForRegistration(ctx context.Context, address str
 	if err != nil {
 		return false, fee, err
 	}
-	balance := ms.bk.GetBankBalance(ctx, accAddress, fee.Denom)
+	balance := ms.bk.GetBalance(ctx, accAddress, fee.Denom)
 	success = balance.IsGTE(fee)
 	return success, fee, err
 }

--- a/x/emissions/keeper/msgserver/msg_server_util_payment.go
+++ b/x/emissions/keeper/msgserver/msg_server_util_payment.go
@@ -69,7 +69,7 @@ func checkBalanceAndSendFee(
 	if err != nil {
 		return err
 	}
-	balance := ms.bk.GetBankBalance(ctx, accAddress, appParams.DefaultBondDenom)
+	balance := ms.bk.GetBalance(ctx, accAddress, appParams.DefaultBondDenom)
 	fee := sdk.NewCoin(balance.Denom, amount)
 
 	if balance.IsLT(fee) {

--- a/x/emissions/keeper/scores.go
+++ b/x/emissions/keeper/scores.go
@@ -46,11 +46,11 @@ type ScoresKeeper struct {
 	forecasterScoresByBlock collections.Map[collections.Pair[TopicId, BlockHeight], types.Scores]
 	// map of (topic, block_height, reputer) -> score
 	reputerScoresByBlock collections.Map[collections.Pair[TopicId, BlockHeight], types.Scores]
-	// map of (topic, block_height, worker) -> score
+	// map of (topic, worker) -> score
 	infererScoreEmas collections.Map[collections.Pair[TopicId, ActorId], types.Score]
-	// map of (topic, block_height, worker) -> score
+	// map of (topic, worker) -> score
 	forecasterScoreEmas collections.Map[collections.Pair[TopicId, ActorId], types.Score]
-	// map of (topic, block_height, reputer) -> score
+	// map of (topic, reputer) -> score
 	reputerScoreEmas collections.Map[collections.Pair[TopicId, ActorId], types.Score]
 	// map of (topic, reputer) -> listening coefficient
 	reputerListeningCoefficient collections.Map[collections.Pair[TopicId, ActorId], types.ListeningCoefficient]

--- a/x/emissions/keeper/topic.go
+++ b/x/emissions/keeper/topic.go
@@ -199,7 +199,7 @@ func (k *TopicKeeper) GetTotalSumPreviousTopicWeights(ctx context.Context) (allo
 	if errors.Is(err, collections.ErrNotFound) {
 		return alloraMath.ZeroDec(), nil
 	} else if err != nil {
-		return alloraMath.Dec{}, errorsmod.Wrap(err, "error getting topic fee revenue")
+		return alloraMath.Dec{}, errorsmod.Wrap(err, "error getting total sum of previous topic weights")
 	}
 
 	return sumPreviousWeights, nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Bank deduping, clarity, guards, log / comments fixed.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- unit tests passed. No functionality change.
- [ ] If documented, please describe where. If not, describe why docs are not needed. -- not needed, no functionality change
- [ ] Added to `Unreleased` section of `CHANGELOG.md`? -- not needed, no functionality change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified bank balance lookups under GetBalance and switched all call sites. Added a guard to block negative transfers from rewards to ecosystem, and tightened error text and comments.

- **Refactors**
  - Replaced GetBankBalance with GetBalance and removed the duplicate wrapper.
  - Updated invariants, msgserver, and reward distribution to use GetBalance.
  - Clarified score EMA comments to reflect (topic, actor) keys.

- **Bug Fixes**
  - Prevent negative amounts in MoveCoinsFromAlloraRewardsToEcosystem.
  - More accurate error message in GetTotalSumPreviousTopicWeights.

<sup>Written for commit fc29bddbe0cfd0ebd7f30d2a7391ba504c18c368. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

