### PR TITLE
classification #5 - multi-label `InferenceValues` and conversion logic

### DIFF
--- a/x/emissions/keeper/actor_utils/worker.go
+++ b/x/emissions/keeper/actor_utils/worker.go
@@ -92,7 +92,7 @@ func CloseWorkerNonce(k *keeper.Keeper, ctx sdk.Context, topic types.Topic, nonc
 	activeInfererAddressesMap, activeInferences, err := closeActiveInferencesSet(
 		ctx,
 		k,
-		topic.Id,
+		topic,
 		nonce,
 		activeInfererAddresses,
 	)
@@ -239,16 +239,11 @@ func ProcessAndStoreNetworkInferences(
 func closeActiveInferencesSet(
 	ctx sdk.Context,
 	k *keeper.Keeper,
-	topicId uint64,
+	topic types.Topic,
 	nonce types.Nonce,
 	activeInfererAddresses []string,
 ) (activeInfererAddressesMap map[string]bool, inferences *types.Inferences, err error) {
 	activeInfererAddressesMap = make(map[string]bool, 0)
-
-	topic, err := k.GetTopic(ctx, topicId)
-	if err != nil {
-		return nil, nil, errorsmod.Wrap(err, "failed to get topic")
-	}
 
 	inferences, err = k.GetWorkersLatestInferencesByTopicIdValuesPadded(ctx, topic, nonce.BlockHeight, activeInfererAddresses)
 	if err != nil {
@@ -259,7 +254,7 @@ func closeActiveInferencesSet(
 		activeInfererAddressesMap[inference.Inferer] = true
 	}
 
-	err = k.InsertActiveInferences(ctx, topicId, nonce.BlockHeight, *inferences)
+	err = k.InsertActiveInferences(ctx, topic.Id, nonce.BlockHeight, *inferences)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/x/emissions/keeper/actor_utils/worker.go
+++ b/x/emissions/keeper/actor_utils/worker.go
@@ -243,25 +243,20 @@ func closeActiveInferencesSet(
 	nonce types.Nonce,
 	activeInfererAddresses []string,
 ) (activeInfererAddressesMap map[string]bool, inferences *types.Inferences, err error) {
-	activeInferences := make([]*types.Inference, 0)
 	activeInfererAddressesMap = make(map[string]bool, 0)
 
-	for _, address := range activeInfererAddresses {
-		inference, err := k.GetWorkerLatestInferenceByTopicId(ctx, topicId, address)
-		if err != nil {
-			return nil, nil, err
-		}
-		activeInferences = append(activeInferences, &inference)
-		activeInfererAddressesMap[inference.Inferer] = true
+	topic, err := k.GetTopic(ctx, topicId)
+	if err != nil {
+		return nil, nil, errorsmod.Wrap(err, "failed to get topic")
 	}
 
-	// Ensure deterministic ordering
-	sort.Slice(activeInferences, func(i, j int) bool {
-		return activeInferences[i].Inferer < activeInferences[j].Inferer
-	})
+	inferences, err = k.GetWorkersLatestInferencesByTopicIdValuesPadded(ctx, topic, nonce.BlockHeight, activeInfererAddresses)
+	if err != nil {
+		return nil, nil, err
+	}
 
-	inferences = &types.Inferences{
-		Inferences: activeInferences,
+	for _, inference := range inferences.Inferences {
+		activeInfererAddressesMap[inference.Inferer] = true
 	}
 
 	err = k.InsertActiveInferences(ctx, topicId, nonce.BlockHeight, *inferences)

--- a/x/emissions/keeper/inference_values.go
+++ b/x/emissions/keeper/inference_values.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"sort"
 
 	errorsmod "cosmossdk.io/errors"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -11,28 +10,21 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-type InferenceValues struct {
-	TopicId     uint64
-	BlockHeight int64
-	Worker      string
-	Values      alloraMath.DecArray
-}
+type InferenceValues = alloraMath.DecArray
 
-func (iv InferenceValues) Len() int { return len(iv.Values) }
-
-// ValidateAgainstRegistry verifies that the inference values are consistent
+// ValidateInferenceValues verifies that the inference values are consistent
 // with the provided epoch label registry.
-func (iv InferenceValues) ValidateAgainstRegistry(reg types.EpochLabelRegistry) error {
+func ValidateInferenceValues(iv InferenceValues, reg types.EpochLabelRegistry) error {
 	want := len(reg.GetLabels())
-	if len(iv.Values) != want {
+	if len(iv) != want {
 		return errorsmod.Wrapf(
 			sdkerrors.ErrLogic,
 			"inference values length mismatch: got=%d want=%d",
-			len(iv.Values), want,
+			len(iv), want,
 		)
 	}
-	for i := range iv.Values {
-		if iv.Values[i].IsNaN() || !iv.Values[i].IsFinite() {
+	for i := range iv {
+		if iv[i].IsNaN() || !iv[i].IsFinite() {
 			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid inference value at idx=%d", i)
 		}
 	}
@@ -41,10 +33,9 @@ func (iv InferenceValues) ValidateAgainstRegistry(reg types.EpochLabelRegistry) 
 
 // InferenceValuesFromProto converts a stored Inference proto into the internal
 // InferenceValues representation used by math code.
-func (k *Keeper) InferenceValuesFromProto(
-	ctx context.Context,
+func InferenceValuesFromProto(
 	topic types.Topic,
-	nonce BlockHeight,
+	reg types.EpochLabelRegistry,
 	inf *types.Inference,
 ) (InferenceValues, error) {
 	if inf == nil {
@@ -74,17 +65,8 @@ func (k *Keeper) InferenceValuesFromProto(
 			return InferenceValues{}, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "invalid scalar inference value")
 		}
 
-		return InferenceValues{
-			TopicId:     inf.TopicId,
-			BlockHeight: inf.BlockHeight,
-			Worker:      inf.Inferer,
-			Values:      alloraMath.DecArray{dec},
-		}, nil
+		return alloraMath.DecArray{dec}, nil
 	case types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI:
-		reg, err := k.GetEpochLabelRegistry(ctx, inf.TopicId, nonce)
-		if err != nil {
-			return InferenceValues{}, err
-		}
 		regLen := len(reg.GetLabels())
 		if regLen == 0 {
 			return InferenceValues{}, errorsmod.Wrap(sdkerrors.ErrLogic, "epoch label registry is empty for multi-arity")
@@ -106,35 +88,28 @@ func (k *Keeper) InferenceValuesFromProto(
 			out[i] = zero
 		}
 		copy(out, inf.Values)
-
-		iv := InferenceValues{
-			TopicId:     inf.TopicId,
-			BlockHeight: inf.BlockHeight,
-			Worker:      inf.Inferer,
-			Values:      out,
-		}
-		if err := iv.ValidateAgainstRegistry(reg); err != nil {
+		if err := ValidateInferenceValues(out, reg); err != nil {
 			return InferenceValues{}, err
 		}
-		return iv, nil
+		return out, nil
 	default:
 		return InferenceValues{}, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "output_arity is invalid")
 	}
 }
 
-// ToLabeledValues converts the internal InferenceValues representation into
+// InferenceValuesToLabeledValues converts the internal InferenceValues representation into
 // a slice of LabeledValue suitable for RPC responses or event emission.
-func (iv InferenceValues) ToLabeledValues(reg types.EpochLabelRegistry) ([]*types.LabeledValue, error) {
+func InferenceValuesToLabeledValues(iv InferenceValues, reg types.EpochLabelRegistry) ([]*types.LabeledValue, error) {
 	want := len(reg.GetLabels())
-	if len(iv.Values) != want {
+	if len(iv) != want {
 		return nil, errorsmod.Wrapf(
 			sdkerrors.ErrInvalidRequest,
 			"inference values length mismatch: got=%d want=%d",
-			len(iv.Values), want,
+			len(iv), want,
 		)
 	}
-	out := make([]*types.LabeledValue, 0, len(iv.Values))
-	for i, v := range iv.Values {
+	out := make([]*types.LabeledValue, 0, len(iv))
+	for i, v := range iv {
 		lbl := reg.GetLabels()[i]
 		if lbl == nil {
 			return nil, errorsmod.Wrapf(sdkerrors.ErrLogic, "nil label in registry at idx=%d", i)
@@ -157,7 +132,7 @@ func (k *Keeper) InferenceValuesFromInferencesSnapshot(
 	inferences *types.Inferences,
 ) ([]InferenceValues, error) {
 	if inferences == nil || len(inferences.Inferences) == 0 {
-		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "inferences is nil/empty")
+		return []InferenceValues{}, nil
 	}
 
 	reg, err := k.GetEpochLabelRegistry(ctx, topic.Id, nonce)
@@ -171,21 +146,20 @@ func (k *Keeper) InferenceValuesFromInferencesSnapshot(
 		if inf == nil {
 			return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "nil inference in snapshot")
 		}
-		iv, err := k.InferenceValuesFromProto(ctx, topic, nonce, inf)
+		iv, err := InferenceValuesFromProto(topic, reg, inf)
 		if err != nil {
 			return nil, err
 		}
-		if topic.OutputArity == types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI && len(iv.Values) != regLen {
+		if topic.OutputArity == types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI && len(iv) != regLen {
 			return nil, errorsmod.Wrapf(
 				sdkerrors.ErrLogic,
 				"snapshot inference not padded to registry: worker=%s got=%d want=%d",
-				iv.Worker, len(iv.Values), regLen,
+				inf.Inferer, len(iv), regLen,
 			)
 		}
 		out = append(out, iv)
 	}
 
-	sort.Slice(out, func(i, j int) bool { return out[i].Worker < out[j].Worker })
 	return out, nil
 }
 

--- a/x/emissions/keeper/inference_values.go
+++ b/x/emissions/keeper/inference_values.go
@@ -1,0 +1,223 @@
+package keeper
+
+import (
+	"context"
+	"sort"
+
+	errorsmod "cosmossdk.io/errors"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+)
+
+type InferenceValues struct {
+	TopicId     uint64
+	BlockHeight int64
+	Worker      string
+	Values      alloraMath.DecArray
+}
+
+func (iv InferenceValues) Len() int { return len(iv.Values) }
+
+// ValidateAgainstRegistry verifies that the inference values are consistent
+// with the provided epoch label registry.
+func (iv InferenceValues) ValidateAgainstRegistry(reg types.EpochLabelRegistry) error {
+	want := len(reg.GetLabels())
+	if len(iv.Values) != want {
+		return errorsmod.Wrapf(
+			sdkerrors.ErrLogic,
+			"inference values length mismatch: got=%d want=%d",
+			len(iv.Values), want,
+		)
+	}
+	for i := range iv.Values {
+		if iv.Values[i].IsNaN() || !iv.Values[i].IsFinite() {
+			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid inference value at idx=%d", i)
+		}
+	}
+	return nil
+}
+
+// InferenceValuesFromProto converts a stored Inference proto into the internal
+// InferenceValues representation used by math code.
+func (k *Keeper) InferenceValuesFromProto(
+	ctx context.Context,
+	topic types.Topic,
+	nonce BlockHeight,
+	inf *types.Inference,
+) (InferenceValues, error) {
+	if inf == nil {
+		return InferenceValues{}, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "inference is nil")
+	}
+
+	switch topic.OutputArity {
+	case types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE:
+		if len(inf.Values) > 1 {
+			return InferenceValues{}, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "single-arity inference accepts at most one value")
+		}
+
+		var dec alloraMath.Dec
+		if len(inf.Values) == 1 {
+			dec = inf.Values[0]
+			if !inf.Value.Equal(dec) {
+				return InferenceValues{}, errorsmod.Wrap(
+					sdkerrors.ErrInvalidRequest,
+					"single-arity inference scalar and array mismatch",
+				)
+			}
+		} else {
+			dec = inf.Value
+		}
+
+		if dec.IsNaN() || !dec.IsFinite() {
+			return InferenceValues{}, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "invalid scalar inference value")
+		}
+
+		return InferenceValues{
+			TopicId:     inf.TopicId,
+			BlockHeight: inf.BlockHeight,
+			Worker:      inf.Inferer,
+			Values:      alloraMath.DecArray{dec},
+		}, nil
+	case types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI:
+		reg, err := k.GetEpochLabelRegistry(ctx, inf.TopicId, nonce)
+		if err != nil {
+			return InferenceValues{}, err
+		}
+		regLen := len(reg.GetLabels())
+		if regLen == 0 {
+			return InferenceValues{}, errorsmod.Wrap(sdkerrors.ErrLogic, "epoch label registry is empty for multi-arity")
+		}
+		if len(inf.Values) == 0 {
+			return InferenceValues{}, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "multi-arity inference requires values")
+		}
+		if len(inf.Values) > regLen {
+			return InferenceValues{}, errorsmod.Wrapf(
+				sdkerrors.ErrLogic,
+				"multi-arity inference length exceeds registry: got=%d reg=%d",
+				len(inf.Values), regLen,
+			)
+		}
+
+		zero := alloraMath.ZeroDec()
+		out := make(alloraMath.DecArray, regLen)
+		for i := range out {
+			out[i] = zero
+		}
+		copy(out, inf.Values)
+
+		iv := InferenceValues{
+			TopicId:     inf.TopicId,
+			BlockHeight: inf.BlockHeight,
+			Worker:      inf.Inferer,
+			Values:      out,
+		}
+		if err := iv.ValidateAgainstRegistry(reg); err != nil {
+			return InferenceValues{}, err
+		}
+		return iv, nil
+	default:
+		return InferenceValues{}, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "output_arity is invalid")
+	}
+}
+
+// ToLabeledValues converts the internal InferenceValues representation into
+// a slice of LabeledValue suitable for RPC responses or event emission.
+func (iv InferenceValues) ToLabeledValues(reg types.EpochLabelRegistry) ([]*types.LabeledValue, error) {
+	want := len(reg.GetLabels())
+	if len(iv.Values) != want {
+		return nil, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidRequest,
+			"inference values length mismatch: got=%d want=%d",
+			len(iv.Values), want,
+		)
+	}
+	out := make([]*types.LabeledValue, 0, len(iv.Values))
+	for i, v := range iv.Values {
+		lbl := reg.GetLabels()[i]
+		if lbl == nil {
+			return nil, errorsmod.Wrapf(sdkerrors.ErrLogic, "nil label in registry at idx=%d", i)
+		}
+		out = append(out, &types.LabeledValue{
+			LabelId:   lbl.Id,
+			LabelName: lbl.Name,
+			Value:     v,
+		})
+	}
+	return out, nil
+}
+
+// InferenceValuesFromInferencesSnapshot converts a stored Inferences snapshot
+// (e.g. from allInferences KV store) into a slice of internal InferenceValues.
+func (k *Keeper) InferenceValuesFromInferencesSnapshot(
+	ctx context.Context,
+	topic types.Topic,
+	nonce BlockHeight,
+	inferences *types.Inferences,
+) ([]InferenceValues, error) {
+	if inferences == nil || len(inferences.Inferences) == 0 {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "inferences is nil/empty")
+	}
+
+	reg, err := k.GetEpochLabelRegistry(ctx, topic.Id, nonce)
+	if err != nil {
+		return nil, err
+	}
+	regLen := len(reg.GetLabels())
+
+	out := make([]InferenceValues, 0, len(inferences.Inferences))
+	for _, inf := range inferences.Inferences {
+		if inf == nil {
+			return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "nil inference in snapshot")
+		}
+		iv, err := k.InferenceValuesFromProto(ctx, topic, nonce, inf)
+		if err != nil {
+			return nil, err
+		}
+		if topic.OutputArity == types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI && len(iv.Values) != regLen {
+			return nil, errorsmod.Wrapf(
+				sdkerrors.ErrLogic,
+				"snapshot inference not padded to registry: worker=%s got=%d want=%d",
+				iv.Worker, len(iv.Values), regLen,
+			)
+		}
+		out = append(out, iv)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Worker < out[j].Worker })
+	return out, nil
+}
+
+// GetInferenceValuesAtBlock retrieves all stored inferences for a given
+// (topicId, blockHeight) and converts them into internal InferenceValues.
+func (k *Keeper) GetInferenceValuesAtBlock(
+	ctx context.Context,
+	topic types.Topic,
+	nonce types.BlockHeight,
+	outlierResistant bool,
+) ([]InferenceValues, error) {
+	infs, err := k.GetInferencesAtBlock(ctx, topic.Id, nonce, outlierResistant)
+	if err != nil {
+		return nil, err
+	}
+	return k.InferenceValuesFromInferencesSnapshot(ctx, topic, nonce, infs)
+}
+
+// GetLatestInferenceValues retrieves the most recent stored inferences
+// for a topic and converts them into internal InferenceValues.
+func (k *Keeper) GetLatestInferenceValues(
+	ctx context.Context,
+	topic types.Topic,
+	outlierResistant bool,
+) ([]InferenceValues, types.BlockHeight, error) {
+	infs, bh, err := k.GetLatestTopicInferences(ctx, topic.Id, outlierResistant)
+	if err != nil {
+		return nil, 0, err
+	}
+	ivs, err := k.InferenceValuesFromInferencesSnapshot(ctx, topic, bh, infs)
+	if err != nil {
+		return nil, 0, err
+	}
+	return ivs, bh, nil
+}

--- a/x/emissions/keeper/inference_values_test.go
+++ b/x/emissions/keeper/inference_values_test.go
@@ -1,0 +1,270 @@
+package keeper_test
+
+import (
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+)
+
+func (s *KeeperTestSuite) TestInferenceValuesFromProto() {
+	s.SetupTest()
+
+	ctx := s.Ctx()
+	k := s.EmissionsKeeper()
+
+	creator := s.Addrs(0)
+	topicId := s.SetupTopic(creator)
+	nonce := int64(1)
+
+	w1 := s.AddrsStr(0)
+	w2 := s.AddrsStr(1)
+
+	mustDec := func(x string) alloraMath.Dec { return alloraMath.MustNewDecFromString(x) }
+
+	setArity := func(arity types.TopicOutputArity) types.Topic {
+		topic, err := k.GetTopic(ctx, topicId)
+		s.Require().NoError(err)
+		topic.OutputArity = arity
+		topic.RequireUnity = false
+		topic.UnityTolerance = alloraMath.ZeroDec()
+		err = k.SetTopic(ctx, topicId, topic)
+		s.Require().NoError(err)
+
+		updated, err := k.GetTopic(ctx, topicId)
+		s.Require().NoError(err)
+		return updated
+	}
+
+	registerLabels := func(labels ...string) {
+		for _, l := range labels {
+			_, err := k.RegisterEpochLabel(ctx, topicId, nonce, l)
+			s.Require().NoError(err)
+		}
+	}
+
+	type tc struct {
+		name       string
+		arity      types.TopicOutputArity
+		setup      func()
+		inf        func() *types.Inference
+		wantErrIs  error
+		wantWorker string
+		wantVals   []string
+	}
+
+	cases := []tc{
+		{
+			name:      "nil_inference_rejected",
+			arity:     types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			setup:     nil,
+			inf:       func() *types.Inference { return nil },
+			wantErrIs: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:  "SINGLE_scalar_only_ok",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       mustDec("42"),
+					Values:      nil,
+				}
+			},
+			wantWorker: w1,
+			wantVals:   []string{"42"},
+		},
+		{
+			name:  "SINGLE_values_len1_equal_scalar_ok",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       mustDec("7"),
+					Values:      []alloraMath.Dec{mustDec("7")},
+				}
+			},
+			wantWorker: w1,
+			wantVals:   []string{"7"},
+		},
+		{
+			name:  "SINGLE_values_len1_mismatch_rejected",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       mustDec("1"),
+					Values:      []alloraMath.Dec{mustDec("2")},
+				}
+			},
+			wantErrIs: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:  "SINGLE_values_len_gt_1_rejected",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       mustDec("1"),
+					Values:      []alloraMath.Dec{mustDec("1"), mustDec("2")},
+				}
+			},
+			wantErrIs: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:  "MULTI_empty_registry_rejected",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func() {
+				// do NOT register labels => regLen=0
+			},
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("1")},
+				}
+			},
+			wantErrIs: sdkerrors.ErrLogic,
+		},
+		{
+			name:  "MULTI_empty_values_rejected",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func() {
+				registerLabels("a")
+			},
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      nil,
+				}
+			},
+			wantErrIs: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:  "MULTI_values_len_gt_registry_rejected",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func() {
+				registerLabels("a", "b")
+			},
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("1"), mustDec("2"), mustDec("3")},
+				}
+			},
+			wantErrIs: sdkerrors.ErrLogic,
+		},
+		{
+			name:  "MULTI_exact_len_ok_no_padding",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func() {
+				registerLabels("a", "b", "c")
+			},
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w2,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("10"), mustDec("20"), mustDec("30")},
+				}
+			},
+			wantWorker: w2,
+			wantVals:   []string{"10", "20", "30"},
+		},
+		{
+			name:  "MULTI_shorter_len_pads_to_registry_len",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func() {
+				registerLabels("a", "b", "c", "d", "e")
+			},
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("9"), mustDec("8")}, // => [9,8,0,0,0]
+				}
+			},
+			wantWorker: w1,
+			wantVals:   []string{"9", "8", "0", "0", "0"},
+		},
+		{
+			name:  "MULTI_rejects_invalid_value_in_values",
+			arity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func() {
+				registerLabels("a", "b", "c")
+			},
+			inf: func() *types.Inference {
+				return &types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("1"), alloraMath.NewNaN(), mustDec("3")},
+				}
+			},
+			wantErrIs: sdkerrors.ErrInvalidRequest,
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			s.SetupTest()
+
+			nonce = int64(1)
+
+			registerLabels = func(labels ...string) {
+				for _, l := range labels {
+					_, err := k.RegisterEpochLabel(ctx, topicId, nonce, l)
+					s.Require().NoError(err)
+				}
+			}
+
+			topic := setArity(c.arity)
+
+			if c.setup != nil {
+				c.setup()
+			}
+
+			inf := (*types.Inference)(nil)
+			if c.inf != nil {
+				inf = c.inf()
+			}
+
+			got, err := k.InferenceValuesFromProto(ctx, topic, nonce, inf)
+
+			if c.wantErrIs != nil {
+				s.Require().ErrorIs(err, c.wantErrIs)
+				return
+			}
+			s.Require().NoError(err)
+
+			s.Require().Equal(topicId, got.TopicId)
+			s.Require().Equal(nonce, got.BlockHeight)
+			s.Require().Equal(c.wantWorker, got.Worker)
+
+			s.Require().Equal(len(c.wantVals), len(got.Values))
+			for i := range c.wantVals {
+				s.Require().Equal(c.wantVals[i], got.Values[i].String())
+			}
+		})
+	}
+}

--- a/x/emissions/keeper/inference_values_test.go
+++ b/x/emissions/keeper/inference_values_test.go
@@ -4,6 +4,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
@@ -44,13 +45,12 @@ func (s *KeeperTestSuite) TestInferenceValuesFromProto() {
 	}
 
 	type tc struct {
-		name       string
-		arity      types.TopicOutputArity
-		setup      func()
-		inf        func() *types.Inference
-		wantErrIs  error
-		wantWorker string
-		wantVals   []string
+		name      string
+		arity     types.TopicOutputArity
+		setup     func()
+		inf       func() *types.Inference
+		wantErrIs error
+		wantVals  []string
 	}
 
 	cases := []tc{
@@ -73,8 +73,7 @@ func (s *KeeperTestSuite) TestInferenceValuesFromProto() {
 					Values:      nil,
 				}
 			},
-			wantWorker: w1,
-			wantVals:   []string{"42"},
+			wantVals: []string{"42"},
 		},
 		{
 			name:  "SINGLE_values_len1_equal_scalar_ok",
@@ -88,8 +87,7 @@ func (s *KeeperTestSuite) TestInferenceValuesFromProto() {
 					Values:      []alloraMath.Dec{mustDec("7")},
 				}
 			},
-			wantWorker: w1,
-			wantVals:   []string{"7"},
+			wantVals: []string{"7"},
 		},
 		{
 			name:  "SINGLE_values_len1_mismatch_rejected",
@@ -185,8 +183,7 @@ func (s *KeeperTestSuite) TestInferenceValuesFromProto() {
 					Values:      []alloraMath.Dec{mustDec("10"), mustDec("20"), mustDec("30")},
 				}
 			},
-			wantWorker: w2,
-			wantVals:   []string{"10", "20", "30"},
+			wantVals: []string{"10", "20", "30"},
 		},
 		{
 			name:  "MULTI_shorter_len_pads_to_registry_len",
@@ -203,8 +200,7 @@ func (s *KeeperTestSuite) TestInferenceValuesFromProto() {
 					Values:      []alloraMath.Dec{mustDec("9"), mustDec("8")}, // => [9,8,0,0,0]
 				}
 			},
-			wantWorker: w1,
-			wantVals:   []string{"9", "8", "0", "0", "0"},
+			wantVals: []string{"9", "8", "0", "0", "0"},
 		},
 		{
 			name:  "MULTI_rejects_invalid_value_in_values",
@@ -249,7 +245,10 @@ func (s *KeeperTestSuite) TestInferenceValuesFromProto() {
 				inf = c.inf()
 			}
 
-			got, err := k.InferenceValuesFromProto(ctx, topic, nonce, inf)
+			reg, err := k.GetEpochLabelRegistry(ctx, topicId, nonce)
+			s.Require().NoError(err)
+
+			got, err := keeper.InferenceValuesFromProto(topic, reg, inf)
 
 			if c.wantErrIs != nil {
 				s.Require().ErrorIs(err, c.wantErrIs)
@@ -257,13 +256,9 @@ func (s *KeeperTestSuite) TestInferenceValuesFromProto() {
 			}
 			s.Require().NoError(err)
 
-			s.Require().Equal(topicId, got.TopicId)
-			s.Require().Equal(nonce, got.BlockHeight)
-			s.Require().Equal(c.wantWorker, got.Worker)
-
-			s.Require().Equal(len(c.wantVals), len(got.Values))
+			s.Require().Equal(len(c.wantVals), len(got))
 			for i := range c.wantVals {
-				s.Require().Equal(c.wantVals[i], got.Values[i].String())
+				s.Require().Equal(c.wantVals[i], got[i].String())
 			}
 		})
 	}

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"sort"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
@@ -1868,6 +1869,96 @@ func (k *Keeper) GetWorkerLatestInferenceByTopicId(
 ) (types.Inference, error) {
 	key := collections.Join(topicId, worker)
 	return k.inferences.Get(ctx, key)
+}
+
+// GetWorkersLatestInferencesByTopicIdValuesPadded retrieves the latest inference
+// for each provided worker and guarantees that the returned Inference.Values
+// slices are aligned with the expected shape for the topic.
+//
+// SINGLE topics:
+//   - Ensures Values has length 1.
+//   - If only the scalar Value field is populated (legacy), it is converted
+//     to Values = [Value].
+//   - Value and Values[0] are kept consistent.
+//
+// MULTI topics:
+//   - Pads each inference's Values slice with zeros so that its length matches
+//     the epoch label registry length for (topicId, nonce).
+//   - Returns an error if any inference has more values than the registry.
+//
+// Returned inferences are sorted deterministically by Inferer address.
+func (k *Keeper) GetWorkersLatestInferencesByTopicIdValuesPadded(
+	ctx context.Context,
+	topic types.Topic,
+	nonce BlockHeight,
+	workers []ActorId,
+) (*types.Inferences, error) {
+	active := make([]*types.Inference, 0, len(workers))
+
+	switch topic.OutputArity {
+	case types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE:
+		for _, addr := range workers {
+			inf, err := k.GetWorkerLatestInferenceByTopicId(ctx, topic.Id, addr)
+			if err != nil {
+				return nil, err
+			}
+			if len(inf.Values) > 1 {
+				return nil, errorsmod.Wrapf(
+					sdkerrors.ErrLogic,
+					"worker %s single-arity inference has len(values)>1: got=%d",
+					addr, len(inf.Values),
+				)
+			}
+
+			infCopy := inf
+			if len(infCopy.Values) == 0 {
+				infCopy.Values = []alloraMath.Dec{infCopy.Value}
+			} else {
+				infCopy.Value = infCopy.Values[0]
+			}
+
+			active = append(active, &infCopy)
+		}
+	case types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI:
+		reg, err := k.GetEpochLabelRegistry(ctx, topic.Id, nonce)
+		if err != nil {
+			return nil, err
+		}
+		targetLen := len(reg.GetLabels())
+
+		for _, addr := range workers {
+			inf, err := k.GetWorkerLatestInferenceByTopicId(ctx, topic.Id, addr)
+			if err != nil {
+				return nil, err
+			}
+			if len(inf.Values) > targetLen {
+				return nil, errorsmod.Wrapf(
+					sdkerrors.ErrLogic,
+					"worker %s inference values longer than registry: got=%d registry=%d",
+					addr, len(inf.Values), targetLen,
+				)
+			}
+
+			infCopy := inf
+			active = append(active, &infCopy)
+		}
+
+		zero := alloraMath.ZeroDec()
+		for i := range active {
+			if diff := targetLen - len(active[i].Values); diff > 0 {
+				pad := make([]alloraMath.Dec, diff)
+				for j := range pad {
+					pad[j] = zero
+				}
+				active[i].Values = append(active[i].Values, pad...)
+			}
+		}
+	default:
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "output_arity is invalid")
+	}
+
+	sort.Slice(active, func(i, j int) bool { return active[i].Inferer < active[j].Inferer })
+	return &types.Inferences{Inferences: active}, nil
 }
 
 func (k *Keeper) GetWorkerLatestForecastByTopicId(

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"strings"
@@ -6549,4 +6550,323 @@ func (s *KeeperTestSuite) TestNormalizeInputInference() {
 		s.Require().Equal("a", reg.Labels[0].Name)
 		s.Require().Equal("b", reg.Labels[1].Name)
 	})
+}
+
+func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() {
+	topicId := keeper.TopicId(1)
+	nonce := int64(1)
+	w1 := s.AddrsStr(0)
+	w2 := s.AddrsStr(1)
+
+	type tc struct {
+		name         string
+		outputArity  types.TopicOutputArity
+		setup        func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64)
+		workersOrder []int
+		wantErrIs    error
+		wantValues   map[string][]string
+	}
+
+	mustDec := func(x string) alloraMath.Dec { return alloraMath.MustNewDecFromString(x) }
+
+	setTopic := func(ctx context.Context, k *keeper.Keeper, topicId uint64, arity types.TopicOutputArity) {
+		topic, err := k.GetTopic(ctx, topicId)
+		s.Require().NoError(err)
+		topic.OutputArity = arity
+		topic.RequireUnity = false
+		topic.UnityTolerance = alloraMath.ZeroDec()
+		err = k.SetTopic(ctx, topicId, topic)
+		s.Require().NoError(err)
+	}
+
+	setLatestInf := func(ctx context.Context, k *keeper.Keeper, topicId uint64, inf types.Inference) {
+		err := k.InsertInference(ctx, topicId, inf)
+		s.Require().NoError(err)
+	}
+
+	cases := []tc{
+		{
+			name:        "SINGLE_scalar_only_populates_values_len1",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       mustDec("42"),
+					Values:      nil,
+				})
+			},
+			workersOrder: []int{0},
+			wantValues: map[string][]string{
+				w1: {"42"},
+			},
+		},
+		{
+			name:        "SINGLE_values_len1_used_and_consistent_with_scalar",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       mustDec("7"),
+					Values:      []alloraMath.Dec{mustDec("7")},
+				})
+			},
+			workersOrder: []int{0},
+			wantValues: map[string][]string{
+				w1: {"7"},
+			},
+		},
+		{
+			name:        "SINGLE_scalar_and_values_mismatch_canonicalizes_to_values0",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       mustDec("1"),
+					Values:      []alloraMath.Dec{mustDec("2")},
+				})
+			},
+			workersOrder: []int{0},
+			wantValues: map[string][]string{
+				w1: {"2"},
+			},
+		}, {
+			name:        "SINGLE_rejects_values_len_gt_1",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       mustDec("1"),
+					Values:      []alloraMath.Dec{mustDec("1"), mustDec("2")},
+				})
+			},
+			workersOrder: []int{0},
+			wantErrIs:    sdkerrors.ErrLogic,
+		},
+		{
+			name:        "SINGLE_two_workers_scalar_only_both_values_len1_and_sorted_by_inferer",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       mustDec("42"),
+					Values:      nil,
+				})
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w2,
+					Value:       mustDec("7"),
+					Values:      nil,
+				})
+			},
+			workersOrder: []int{1, 0},
+			wantValues: map[string][]string{
+				w1: {"42"},
+				w2: {"7"},
+			},
+		},
+		{
+			name:        "MULTI_pads_shorter_values_to_registry_len_and_sorts_inferers",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				_, err := k.RegisterEpochLabel(ctx, topicId, nonce, "a")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "b")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "c")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "d")
+				s.Require().NoError(err)
+
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("1"), mustDec("2"), mustDec("3")},
+				})
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w2,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("10"), mustDec("20"), mustDec("0"), mustDec("40")},
+				})
+			},
+			workersOrder: []int{1, 0},
+			wantValues: map[string][]string{
+				w1: {"1", "2", "3", "0"},
+				w2: {"10", "20", "0", "40"},
+			},
+		},
+		{
+			name:        "MULTI_values_longer_than_registry_rejected",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				_, err := k.RegisterEpochLabel(ctx, topicId, nonce, "a")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "b")
+				s.Require().NoError(err)
+
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("1"), mustDec("2"), mustDec("3")},
+				})
+			},
+			workersOrder: []int{0},
+			wantErrIs:    sdkerrors.ErrLogic,
+		}, {
+			name:        "MULTI_registry_len_zero_rejects_any_nonempty_inference_values",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				// do NOT register labels => registry len = 0
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("1")},
+				})
+			},
+			workersOrder: []int{0},
+			wantErrIs:    sdkerrors.ErrLogic,
+		},
+		{
+			name:        "MULTI_registry_len_zero_allows_empty_values_no_padding_needed",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				// registry len = 0
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      nil,
+				})
+			},
+			workersOrder: []int{0},
+			wantValues: map[string][]string{
+				w1: {},
+			},
+		},
+		{
+			name:        "MULTI_pads_multiple_missing_entries_not_just_one",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				_, err := k.RegisterEpochLabel(ctx, topicId, nonce, "a")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "b")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "c")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "d")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "e")
+				s.Require().NoError(err)
+
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("1")}, // should become [1,0,0,0,0]
+				})
+			},
+			workersOrder: []int{0},
+			wantValues: map[string][]string{
+				w1: {"1", "0", "0", "0", "0"},
+			},
+		},
+		{
+			name:        "MULTI_does_not_mutate_stored_inference_when_padding",
+			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+				_, err := k.RegisterEpochLabel(ctx, topicId, nonce, "a")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "b")
+				s.Require().NoError(err)
+				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "c")
+				s.Require().NoError(err)
+
+				setLatestInf(ctx, k, topicId, types.Inference{
+					TopicId:     topicId,
+					BlockHeight: nonce,
+					Inferer:     w1,
+					Value:       alloraMath.ZeroDec(),
+					Values:      []alloraMath.Dec{mustDec("9")}, // stored len=1
+				})
+			},
+			workersOrder: []int{0},
+			wantValues: map[string][]string{
+				w1: {"9", "0", "0"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			s.SetupTest()
+
+			ctx := s.Ctx()
+			k := s.EmissionsKeeper()
+
+			workers := []string{w1, w2}
+
+			setTopic(ctx, k, topicId, c.outputArity)
+
+			if c.setup != nil {
+				c.setup(ctx, k, topicId, nonce)
+			}
+
+			reqWorkers := make([]string, 0, len(c.workersOrder))
+			for _, idx := range c.workersOrder {
+				reqWorkers = append(reqWorkers, workers[idx])
+			}
+
+			topic, err := k.GetTopic(ctx, topicId)
+			s.Require().NoError(err)
+
+			got, err := k.GetWorkersLatestInferencesByTopicIdValuesPadded(ctx, topic, nonce, reqWorkers)
+			if c.wantErrIs != nil {
+				s.Require().ErrorIs(err, c.wantErrIs)
+				return
+			}
+			s.Require().NoError(err)
+			s.Require().NotNil(got)
+
+			for addr, want := range c.wantValues {
+				var found *types.Inference
+				for _, inf := range got.Inferences {
+					if inf.Inferer == addr {
+						found = inf
+						break
+					}
+				}
+				s.Require().NotNil(found)
+				s.Require().Equal(len(want), len(found.Values))
+				for i := range want {
+					s.Require().Equal(want[i], found.Values[i].String())
+				}
+
+				if c.outputArity == types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE {
+					s.Require().Equal(want[0], found.Value.String())
+				} else {
+					s.Require().Equal("0", found.Value.String())
+				}
+			}
+		})
+	}
 }

--- a/x/emissions/keeper/keeper_test.go
+++ b/x/emissions/keeper/keeper_test.go
@@ -6555,16 +6555,14 @@ func (s *KeeperTestSuite) TestNormalizeInputInference() {
 func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() {
 	topicId := keeper.TopicId(1)
 	nonce := int64(1)
-	w1 := s.AddrsStr(0)
-	w2 := s.AddrsStr(1)
 
 	type tc struct {
 		name         string
 		outputArity  types.TopicOutputArity
-		setup        func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64)
+		setup        func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string)
 		workersOrder []int
 		wantErrIs    error
-		wantValues   map[string][]string
+		wantValues   map[int][]string
 	}
 
 	mustDec := func(x string) alloraMath.Dec { return alloraMath.MustNewDecFromString(x) }
@@ -6588,7 +6586,7 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 		{
 			name:        "SINGLE_scalar_only_populates_values_len1",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				setLatestInf(ctx, k, topicId, types.Inference{
 					TopicId:     topicId,
 					BlockHeight: nonce,
@@ -6598,14 +6596,14 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 				})
 			},
 			workersOrder: []int{0},
-			wantValues: map[string][]string{
-				w1: {"42"},
+			wantValues: map[int][]string{
+				0: {"42"},
 			},
 		},
 		{
 			name:        "SINGLE_values_len1_used_and_consistent_with_scalar",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				setLatestInf(ctx, k, topicId, types.Inference{
 					TopicId:     topicId,
 					BlockHeight: nonce,
@@ -6615,14 +6613,14 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 				})
 			},
 			workersOrder: []int{0},
-			wantValues: map[string][]string{
-				w1: {"7"},
+			wantValues: map[int][]string{
+				0: {"7"},
 			},
 		},
 		{
 			name:        "SINGLE_scalar_and_values_mismatch_canonicalizes_to_values0",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				setLatestInf(ctx, k, topicId, types.Inference{
 					TopicId:     topicId,
 					BlockHeight: nonce,
@@ -6632,13 +6630,13 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 				})
 			},
 			workersOrder: []int{0},
-			wantValues: map[string][]string{
-				w1: {"2"},
+			wantValues: map[int][]string{
+				0: {"2"},
 			},
 		}, {
 			name:        "SINGLE_rejects_values_len_gt_1",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				setLatestInf(ctx, k, topicId, types.Inference{
 					TopicId:     topicId,
 					BlockHeight: nonce,
@@ -6653,7 +6651,7 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 		{
 			name:        "SINGLE_two_workers_scalar_only_both_values_len1_and_sorted_by_inferer",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				setLatestInf(ctx, k, topicId, types.Inference{
 					TopicId:     topicId,
 					BlockHeight: nonce,
@@ -6670,15 +6668,15 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 				})
 			},
 			workersOrder: []int{1, 0},
-			wantValues: map[string][]string{
-				w1: {"42"},
-				w2: {"7"},
+			wantValues: map[int][]string{
+				0: {"42"},
+				1: {"7"},
 			},
 		},
 		{
 			name:        "MULTI_pads_shorter_values_to_registry_len_and_sorts_inferers",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				_, err := k.RegisterEpochLabel(ctx, topicId, nonce, "a")
 				s.Require().NoError(err)
 				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "b")
@@ -6704,15 +6702,15 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 				})
 			},
 			workersOrder: []int{1, 0},
-			wantValues: map[string][]string{
-				w1: {"1", "2", "3", "0"},
-				w2: {"10", "20", "0", "40"},
+			wantValues: map[int][]string{
+				0: {"1", "2", "3", "0"},
+				1: {"10", "20", "0", "40"},
 			},
 		},
 		{
 			name:        "MULTI_values_longer_than_registry_rejected",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				_, err := k.RegisterEpochLabel(ctx, topicId, nonce, "a")
 				s.Require().NoError(err)
 				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "b")
@@ -6731,7 +6729,7 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 		}, {
 			name:        "MULTI_registry_len_zero_rejects_any_nonempty_inference_values",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				// do NOT register labels => registry len = 0
 				setLatestInf(ctx, k, topicId, types.Inference{
 					TopicId:     topicId,
@@ -6747,7 +6745,7 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 		{
 			name:        "MULTI_registry_len_zero_allows_empty_values_no_padding_needed",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				// registry len = 0
 				setLatestInf(ctx, k, topicId, types.Inference{
 					TopicId:     topicId,
@@ -6758,14 +6756,14 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 				})
 			},
 			workersOrder: []int{0},
-			wantValues: map[string][]string{
-				w1: {},
+			wantValues: map[int][]string{
+				0: {},
 			},
 		},
 		{
 			name:        "MULTI_pads_multiple_missing_entries_not_just_one",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				_, err := k.RegisterEpochLabel(ctx, topicId, nonce, "a")
 				s.Require().NoError(err)
 				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "b")
@@ -6786,14 +6784,14 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 				})
 			},
 			workersOrder: []int{0},
-			wantValues: map[string][]string{
-				w1: {"1", "0", "0", "0", "0"},
+			wantValues: map[int][]string{
+				0: {"1", "0", "0", "0", "0"},
 			},
 		},
 		{
 			name:        "MULTI_does_not_mutate_stored_inference_when_padding",
 			outputArity: types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64) {
+			setup: func(ctx context.Context, k *keeper.Keeper, topicId uint64, nonce int64, w1, w2 string) {
 				_, err := k.RegisterEpochLabel(ctx, topicId, nonce, "a")
 				s.Require().NoError(err)
 				_, err = k.RegisterEpochLabel(ctx, topicId, nonce, "b")
@@ -6810,8 +6808,8 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 				})
 			},
 			workersOrder: []int{0},
-			wantValues: map[string][]string{
-				w1: {"9", "0", "0"},
+			wantValues: map[int][]string{
+				0: {"9", "0", "0"},
 			},
 		},
 	}
@@ -6823,12 +6821,14 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 			ctx := s.Ctx()
 			k := s.EmissionsKeeper()
 
+			w1 := s.AddrsStr(0)
+			w2 := s.AddrsStr(1)
 			workers := []string{w1, w2}
 
 			setTopic(ctx, k, topicId, c.outputArity)
 
 			if c.setup != nil {
-				c.setup(ctx, k, topicId, nonce)
+				c.setup(ctx, k, topicId, nonce, w1, w2)
 			}
 
 			reqWorkers := make([]string, 0, len(c.workersOrder))
@@ -6847,7 +6847,8 @@ func (s *KeeperTestSuite) TestGetWorkersLatestInferencesByTopicIdValuesPadded() 
 			s.Require().NoError(err)
 			s.Require().NotNil(got)
 
-			for addr, want := range c.wantValues {
+			for workerIdx, want := range c.wantValues {
+				addr := workers[workerIdx]
 				var found *types.Inference
 				for _, inf := range got.Inferences {
 					if inf.Inferer == addr {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

add get methods and conversion logic for multi-label InferenceValues

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/ENGN-5154/5-internal-inference-representation-and-adapters

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a simplified `InferenceValues` (`DecArray`) and adapters that normalize single- and multi-label inferences, padding to the epoch label registry. Worker getters and active-inference aggregation now use padded, deterministically ordered values. Addresses Linear ENGN-5154.

- **New Features**
  - `InferenceValues` is now a `DecArray` with validation (length vs registry, NaN/finite).
  - Converters: proto → internal (SINGLE enforces len≤1 and requires `Value == Values[0]`; MULTI pads with zeros to the registry length, rejects overlong), internal → labeled values; plus getters for block/latest snapshots → `[]InferenceValues`.
  - Added `GetWorkersLatestInferencesByTopicIdValuesPadded`: SINGLE canonicalizes to `Values` len=1 and syncs scalar; MULTI pads to registry length; results are sorted by inferer. `closeActiveInferencesSet` now uses this to build the active inferer map.
  - Tests cover conversion, padding, arity rules, zero-length registry edge cases, and worker getter behavior.

<sup>Written for commit 0d77963f619eba7f094014f0ee68e86902c21549. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

