### PR TITLE
fix one-in forecaster map wiring and remove dead forecast map code

### DIFF
--- a/x/emissions/keeper/inference_synthesis/network_inference_builder.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder.go
@@ -693,7 +693,6 @@ type calcOneInValueArgs struct {
 	AllInferersAreNew                    bool
 	Inferers                             []Inferer
 	InfererToInference                   map[Inferer]*emissions.Inference
-	ForecasterToForecast                 map[Forecaster]*emissions.Forecast
 	ForecasterToForecastImpliedInference map[Forecaster]*emissions.Inference
 	EpsilonTopic                         alloraMath.Dec
 	EpsilonSafeDiv                       alloraMath.Dec
@@ -712,7 +711,9 @@ func calcOneInValue(args calcOneInValueArgs) (
 
 	// In each loop, remove all forecast-implied inferences except one
 	singleForecastImpliedInference := make(map[Worker]*emissions.Inference, 1)
-	singleForecastImpliedInference[args.OneInForecaster] = args.ForecasterToForecastImpliedInference[args.OneInForecaster]
+	if inferred, ok := args.ForecasterToForecastImpliedInference[args.OneInForecaster]; ok && inferred != nil {
+		singleForecastImpliedInference[args.OneInForecaster] = inferred
+	}
 
 	// Get self regret for the forecaster
 	singleForecasterRegret := make(map[Worker]*Regret, 1)
@@ -724,10 +725,6 @@ func calcOneInValue(args calcOneInValueArgs) (
 
 	// get self forecast list
 	singleForecaster := []Worker{args.OneInForecaster}
-
-	// get map of Forecaster to their forecast for the single forecaster
-	singleForecasterToForecast := make(map[Forecaster]*emissions.Forecast, 1)
-	singleForecasterToForecast[args.OneInForecaster] = args.ForecasterToForecast[args.OneInForecaster]
 
 	// Get one-in regrets for the forecaster and the inferers they provided forecasts for
 	infererToRegretForSingleForecaster := make(map[Inferer]*Regret)
@@ -772,7 +769,7 @@ func calcOneInValue(args calcOneInValueArgs) (
 		infererToRegret:                      infererToRegretForSingleForecaster,
 		forecasters:                          singleForecaster,
 		forecasterToRegret:                   singleForecasterRegret,
-		forecasterToForecastImpliedInference: args.ForecasterToForecastImpliedInference,
+		forecasterToForecastImpliedInference: singleForecastImpliedInference,
 		weights:                              weights,
 		epsilonSafeDiv:                       args.EpsilonSafeDiv,
 	})
@@ -824,7 +821,6 @@ func GetOneInForecasterInferences(args GetOneInForecasterInferencesArgs) (
 					AllInferersAreNew:                    args.AllInferersAreNew,
 					Inferers:                             args.Inferers,
 					InfererToInference:                   args.InfererToInference,
-					ForecasterToForecast:                 args.ForecasterToForecast,
 					ForecasterToForecastImpliedInference: args.ForecasterToForecastImpliedInference,
 					EpsilonTopic:                         args.EpsilonTopic,
 					EpsilonSafeDiv:                       args.EpsilonSafeDiv,

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
@@ -726,6 +726,40 @@ func (s *InferenceSynthesisTestSuite) TestCorrectOneInForecasterValuesEpoch4() {
 	s.testCorrectOneInForecasterValuesForEpoch(304)
 }
 
+func (s *InferenceSynthesisTestSuite) TestGetOneInForecasterInferencesHandlesNilForecastImpliedEntry() {
+	ctx, k, logger, topicId, allInferersAreNew,
+		inferers, inferenceByWorker, _,
+		forecasters, forecastByWorker, forecastImpliedInferenceByWorker, _,
+		_, epsilonTopic, epsilonSafeDiv, pNorm, cNorm, _ := s.getEpochValueBundleByEpoch(302)
+
+	s.Require().Greater(len(forecasters), 1)
+	forecastImpliedInferenceByWorker[forecasters[0]] = nil
+
+	s.Require().NotPanics(func() {
+		oneInForecasterValues, err := inferencesynthesis.GetOneInForecasterInferences(
+			inferencesynthesis.GetOneInForecasterInferencesArgs{
+				Ctx:                                  ctx,
+				K:                                    k,
+				Logger:                               logger,
+				TopicId:                              topicId,
+				Inferers:                             inferers,
+				InfererToInference:                   inferenceByWorker,
+				AllInferersAreNew:                    allInferersAreNew,
+				Forecasters:                          forecasters,
+				ForecasterToForecast:                 forecastByWorker,
+				ForecasterToForecastImpliedInference: forecastImpliedInferenceByWorker,
+				EpsilonTopic:                         epsilonTopic,
+				EpsilonSafeDiv:                       epsilonSafeDiv,
+				PNorm:                                pNorm,
+				CNorm:                                cNorm,
+				RegretScalePlusEpsilon:               alloraMath.ZeroDec(),
+			},
+		)
+		s.Require().NoError(err)
+		s.Require().Len(oneInForecasterValues, len(forecasters))
+	})
+}
+
 func (s *InferenceSynthesisTestSuite) TestBuildNetworkInferencesIncompleteData() {
 	k := *s.EmissionsKeeper()
 	ctx := s.Ctx()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

**Summary**
* Use `singleForecastImpliedInference` in `calcOneInValue` so one-in computation is scoped to the selected forecaster.
* Remove unused one-in plumbing (`singleForecasterToForecast` and unused internal arg field).
* Add a regression test for nil forecast-implied entries in one-in forecaster inference path.

**Validation**
go test ./x/emissions/keeper/inference_synthesis -count=1

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. 
Tests pass, added test
- [ ] If documented, please describe where. If not, describe why docs are not needed. 
no need, no func change
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?
no need, no func change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns one-in forecaster computation to the selected forecaster’s forecast-implied inference and remove dead forecast map wiring. Addresses Linear ENGN-5777 by fixing map wiring and hardening nil-entry handling.

- **Bug Fixes**
  - Pass singleForecastImpliedInference into calcWeightedInference for one-in.
  - Guard against nil entries when building the single-forecaster implied inference map.
  - Add regression test to confirm nil forecast-implied entries do not panic.

- **Refactors**
  - Remove singleForecasterToForecast and the ForecasterToForecast arg from calcOneInValueArgs.
  - Simplify one-in path inputs; existing epoch outputs remain unchanged.

<sup>Written for commit e34054d64814eb6a0fec17edfe1dd689a092b4db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

