### PR TITLE
ENGN-6349 EMA-based sortition quantiles + migrate topic quantiles 0.25 to 0.05 …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,11 @@ allora.log
 
 **/.DS_Store
 
+<<<<<<< HEAD
 .agents
 .cursor
 .claude
+=======
+>>>>>>> f31c30fe (pag guard, nil-wrap notfound, error mgmt (#921))
 .worktrees/
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,11 +58,8 @@ allora.log
 
 **/.DS_Store
 
-<<<<<<< HEAD
 .agents
 .cursor
 .claude
-=======
->>>>>>> f31c30fe (pag guard, nil-wrap notfound, error mgmt (#921))
 .worktrees/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Short, high-signal guidance for working in the `allora-chain` repo. Keep context
 
 ## Go Conventions
 - Always `gofmt`/`goimports`; keep `golangci-lint` clean.
+- Keep `nolint` statements where needed, adding a comment on the rationale if none is there.
 - Prefer table-driven tests and explicit dependency injection for easy mocking.
 - Use `sdk.Context.Logger()` for chain logs; avoid noisy logs in consensus paths.
 - Only apply Allora Go Service patterns (brynbellomy errors, sqlc, viper, Gin, zerolog) if editing non-chain services.

--- a/app/upgrades/v0_16_0/topic_quantiles.go
+++ b/app/upgrades/v0_16_0/topic_quantiles.go
@@ -1,0 +1,51 @@
+package v0_16_0
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	alloraMath "github.com/allora-network/allora-chain/math"
+	emissionskeeper "github.com/allora-network/allora-chain/x/emissions/keeper"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+)
+
+var targetActiveTopicQuantile = alloraMath.MustNewDecFromString("0.05")
+
+type topicQuantileMigrationKeeper interface {
+	GetNextTopicId(ctx context.Context) (uint64, error)
+	GetTopic(ctx context.Context, topicId uint64) (emissionstypes.Topic, error)
+	SetTopic(ctx context.Context, topicId uint64, topic emissionstypes.Topic) error
+}
+
+func migrateTopicActiveQuantiles(ctx context.Context, emissionsKeeper *emissionskeeper.Keeper) error {
+	return migrateTopicActiveQuantilesWithTopicKeeper(ctx, emissionsKeeper.GetTopicKeeper())
+}
+
+func migrateTopicActiveQuantilesWithTopicKeeper(ctx context.Context, topicKeeper topicQuantileMigrationKeeper) error {
+	nextTopicID, err := topicKeeper.GetNextTopicId(ctx)
+	if err != nil {
+		return errorsmod.Wrap(err, "failed to get next topic id")
+	}
+
+	for topicID := uint64(1); topicID < nextTopicID; topicID++ {
+		topic, err := topicKeeper.GetTopic(ctx, topicID)
+		if errors.Is(err, emissionstypes.ErrTopicDoesNotExist) {
+			continue
+		}
+		if err != nil {
+			return errorsmod.Wrapf(err, "failed to fetch topic %d", topicID)
+		}
+
+		topic.ActiveInfererQuantile = targetActiveTopicQuantile
+		topic.ActiveForecasterQuantile = targetActiveTopicQuantile
+		topic.ActiveReputerQuantile = targetActiveTopicQuantile
+
+		if err := topicKeeper.SetTopic(ctx, topicID, topic); err != nil {
+			return errorsmod.Wrap(err, fmt.Sprintf("failed to update topic %d quantiles", topicID))
+		}
+	}
+
+	return nil
+}

--- a/app/upgrades/v0_16_0/topic_quantiles.go
+++ b/app/upgrades/v0_16_0/topic_quantiles.go
@@ -1,4 +1,4 @@
-package v0_16_0
+package v0_16_0 //nolint:revive // Upgrade package naming follows version directory convention.
 
 import (
 	"context"

--- a/app/upgrades/v0_16_0/topic_quantiles_test.go
+++ b/app/upgrades/v0_16_0/topic_quantiles_test.go
@@ -1,4 +1,4 @@
-package v0_16_0
+package v0_16_0 //nolint:revive // Upgrade package naming follows version directory convention.
 
 import (
 	"context"
@@ -47,8 +47,10 @@ func (m *mockTopicQuantileMigrationKeeper) SetTopic(_ context.Context, topicID u
 }
 
 func TestMigrateTopicActiveQuantilesWithTopicKeeper(t *testing.T) {
+	//nolint:exhaustruct // Test mock only initializes fields needed by this scenario.
 	mockKeeper := &mockTopicQuantileMigrationKeeper{
 		nextTopicID: 4,
+		//nolint:exhaustruct // Test fixture intentionally sets only quantile fields under test.
 		topics: map[uint64]emissionstypes.Topic{
 			1: {
 				ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.25"),
@@ -78,6 +80,7 @@ func TestMigrateTopicActiveQuantilesWithTopicKeeper(t *testing.T) {
 }
 
 func TestMigrateTopicActiveQuantilesWithTopicKeeperFailsOnNextTopicID(t *testing.T) {
+	//nolint:exhaustruct // Test mock only initializes error path input.
 	mockKeeper := &mockTopicQuantileMigrationKeeper{
 		getErr: errors.New("next topic id failed"),
 	}
@@ -88,6 +91,7 @@ func TestMigrateTopicActiveQuantilesWithTopicKeeperFailsOnNextTopicID(t *testing
 }
 
 func TestMigrateTopicActiveQuantilesWithTopicKeeperFailsOnGetTopic(t *testing.T) {
+	//nolint:exhaustruct // Test mock only initializes fields needed by this scenario.
 	mockKeeper := &mockTopicQuantileMigrationKeeper{
 		nextTopicID: 2,
 		topics:      map[uint64]emissionstypes.Topic{},
@@ -103,8 +107,10 @@ func TestMigrateTopicActiveQuantilesWithTopicKeeperFailsOnGetTopic(t *testing.T)
 }
 
 func TestMigrateTopicActiveQuantilesWithTopicKeeperFailsOnSetTopic(t *testing.T) {
+	//nolint:exhaustruct // Test mock only initializes fields needed by this scenario.
 	mockKeeper := &mockTopicQuantileMigrationKeeper{
 		nextTopicID: 2,
+		//nolint:exhaustruct // Minimal topic fixture to exercise SetTopic failure path.
 		topics: map[uint64]emissionstypes.Topic{
 			1: {},
 		},

--- a/app/upgrades/v0_16_0/topic_quantiles_test.go
+++ b/app/upgrades/v0_16_0/topic_quantiles_test.go
@@ -1,0 +1,120 @@
+package v0_16_0
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+	"github.com/stretchr/testify/require"
+)
+
+type mockTopicQuantileMigrationKeeper struct {
+	nextTopicID uint64
+	topics      map[uint64]emissionstypes.Topic
+	getErr      error
+	getErrByID  map[uint64]error
+	setErrByID  map[uint64]error
+	setCalls    []uint64
+}
+
+func (m *mockTopicQuantileMigrationKeeper) GetNextTopicId(_ context.Context) (uint64, error) {
+	if m.getErr != nil {
+		return 0, m.getErr
+	}
+	return m.nextTopicID, nil
+}
+
+func (m *mockTopicQuantileMigrationKeeper) GetTopic(_ context.Context, topicID uint64) (emissionstypes.Topic, error) {
+	if err, ok := m.getErrByID[topicID]; ok {
+		return emissionstypes.Topic{}, err
+	}
+	topic, ok := m.topics[topicID]
+	if !ok {
+		return emissionstypes.Topic{}, emissionstypes.ErrTopicDoesNotExist
+	}
+	return topic, nil
+}
+
+func (m *mockTopicQuantileMigrationKeeper) SetTopic(_ context.Context, topicID uint64, topic emissionstypes.Topic) error {
+	if err, ok := m.setErrByID[topicID]; ok {
+		return err
+	}
+	m.topics[topicID] = topic
+	m.setCalls = append(m.setCalls, topicID)
+	return nil
+}
+
+func TestMigrateTopicActiveQuantilesWithTopicKeeper(t *testing.T) {
+	mockKeeper := &mockTopicQuantileMigrationKeeper{
+		nextTopicID: 4,
+		topics: map[uint64]emissionstypes.Topic{
+			1: {
+				ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.25"),
+				ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.25"),
+				ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.25"),
+			},
+			3: {
+				ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.25"),
+				ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.25"),
+				ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.25"),
+			},
+		},
+		getErrByID: map[uint64]error{},
+		setErrByID: map[uint64]error{},
+	}
+
+	err := migrateTopicActiveQuantilesWithTopicKeeper(context.Background(), mockKeeper)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint64{1, 3}, mockKeeper.setCalls)
+
+	for _, topicID := range []uint64{1, 3} {
+		topic := mockKeeper.topics[topicID]
+		require.True(t, topic.ActiveInfererQuantile.Equal(targetActiveTopicQuantile))
+		require.True(t, topic.ActiveForecasterQuantile.Equal(targetActiveTopicQuantile))
+		require.True(t, topic.ActiveReputerQuantile.Equal(targetActiveTopicQuantile))
+	}
+}
+
+func TestMigrateTopicActiveQuantilesWithTopicKeeperFailsOnNextTopicID(t *testing.T) {
+	mockKeeper := &mockTopicQuantileMigrationKeeper{
+		getErr: errors.New("next topic id failed"),
+	}
+
+	err := migrateTopicActiveQuantilesWithTopicKeeper(context.Background(), mockKeeper)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get next topic id")
+}
+
+func TestMigrateTopicActiveQuantilesWithTopicKeeperFailsOnGetTopic(t *testing.T) {
+	mockKeeper := &mockTopicQuantileMigrationKeeper{
+		nextTopicID: 2,
+		topics:      map[uint64]emissionstypes.Topic{},
+		getErrByID: map[uint64]error{
+			1: errors.New("get topic failed"),
+		},
+		setErrByID: map[uint64]error{},
+	}
+
+	err := migrateTopicActiveQuantilesWithTopicKeeper(context.Background(), mockKeeper)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to fetch topic 1")
+}
+
+func TestMigrateTopicActiveQuantilesWithTopicKeeperFailsOnSetTopic(t *testing.T) {
+	mockKeeper := &mockTopicQuantileMigrationKeeper{
+		nextTopicID: 2,
+		topics: map[uint64]emissionstypes.Topic{
+			1: {},
+		},
+		getErrByID: map[uint64]error{},
+		setErrByID: map[uint64]error{
+			1: errors.New("set topic failed"),
+		},
+	}
+
+	err := migrateTopicActiveQuantilesWithTopicKeeper(context.Background(), mockKeeper)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to update topic 1 quantiles")
+}

--- a/app/upgrades/v0_16_0/upgrades.go
+++ b/app/upgrades/v0_16_0/upgrades.go
@@ -24,13 +24,17 @@ var Upgrade = upgrades.Upgrade{
 func CreateUpgradeHandler(
 	moduleManager *module.Manager,
 	configurator module.Configurator,
-	_ *keepers.AppKeepers,
+	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
 		sdkCtx.Logger().Info("RUN MIGRATIONS")
 		vm, err := moduleManager.RunMigrations(ctx, configurator, vm)
 		if err != nil {
+			return vm, err
+		}
+
+		if err := migrateTopicActiveQuantiles(ctx, &keepers.EmissionsKeeper); err != nil {
 			return vm, err
 		}
 

--- a/x/emissions/module/rewards/scores.go
+++ b/x/emissions/module/rewards/scores.go
@@ -157,12 +157,12 @@ func GenerateReputerScores(
 		emaScores = append(emaScores, emaScore)
 	}
 
-	// Update topic quantile of instant score
-	topicInstantScoreQuantile, err := getQuantileOfScores(instantScores, topic.ActiveReputerQuantile)
+	// Update topic quantile from EMA scores (used by sortition EMA flow).
+	topicEmaScoreQuantile, err := getQuantileOfScores(emaScores, topic.ActiveReputerQuantile)
 	if err != nil {
 		return nil, err
 	}
-	err = keeper.GetScoresKeeper().SetPreviousTopicQuantileReputerScoreEma(ctx, topicId, topicInstantScoreQuantile)
+	err = keeper.GetScoresKeeper().SetPreviousTopicQuantileReputerScoreEma(ctx, topicId, topicEmaScoreQuantile)
 	if err != nil {
 		return nil, err
 	}
@@ -250,12 +250,12 @@ func GenerateInferenceScores(
 		emaScores = append(emaScores, emaScore)
 	}
 
-	// Update topic quantile of instant score
-	topicInstantScoreQuantile, err := getQuantileOfScores(instantScores, topic.ActiveInfererQuantile)
+	// Update topic quantile from EMA scores (used by sortition EMA flow).
+	topicEmaScoreQuantile, err := getQuantileOfScores(emaScores, topic.ActiveInfererQuantile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error getting quantile of scores")
 	}
-	err = keeper.GetScoresKeeper().SetPreviousTopicQuantileInfererScoreEma(ctx, topicId, topicInstantScoreQuantile)
+	err = keeper.GetScoresKeeper().SetPreviousTopicQuantileInfererScoreEma(ctx, topicId, topicEmaScoreQuantile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error setting previous topic quantile inferer score ema")
 	}
@@ -367,12 +367,12 @@ func GenerateForecastScores(
 		emaScores = append(emaScores, emaScore)
 	}
 
-	// Update topic quantile of instant score
-	topicInstantScoreQuantile, err := getQuantileOfScores(instantScores, topic.ActiveForecasterQuantile)
+	// Update topic quantile from EMA scores (used by sortition EMA flow).
+	topicEmaScoreQuantile, err := getQuantileOfScores(emaScores, topic.ActiveForecasterQuantile)
 	if err != nil {
 		return nil, err
 	}
-	err = keeper.GetScoresKeeper().SetPreviousTopicQuantileForecasterScoreEma(ctx, topicId, topicInstantScoreQuantile)
+	err = keeper.GetScoresKeeper().SetPreviousTopicQuantileForecasterScoreEma(ctx, topicId, topicEmaScoreQuantile)
 	if err != nil {
 		return nil, err
 	}

--- a/x/emissions/module/rewards/scores_test.go
+++ b/x/emissions/module/rewards/scores_test.go
@@ -756,3 +756,170 @@ func (s *RewardsTestSuite) TestCalculateTopicInitialEmaScoreEdgeCases() {
 		})
 	}
 }
+
+func getQuantileScoreFromScores(scores []types.Score, quantile alloraMath.Dec) (alloraMath.Dec, error) {
+	decScores := make([]alloraMath.Dec, 0, len(scores))
+	for _, score := range scores {
+		decScores = append(decScores, score.Score)
+	}
+	return alloraMath.GetQuantileOfDecs(decScores, quantile)
+}
+
+func (s *RewardsTestSuite) TestInfererQuantileStoredFromEmaScores() {
+	topicId := uint64(1)
+	block0 := int64(4000)
+	block1 := int64(4001)
+
+	networkLosses0, err := mockSimpleNetworkLosses(s, topicId, block0, "0.1")
+	s.Require().NoError(err)
+	_, err = rewards.GenerateInferenceScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block0, networkLosses0)
+	s.Require().NoError(err)
+
+	networkLosses1, err := mockSimpleNetworkLosses(s, topicId, block1, "0.2")
+	s.Require().NoError(err)
+	instantScores, err := rewards.GenerateInferenceScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block1, networkLosses1)
+	s.Require().NoError(err)
+
+	topic, err := s.TopicKeeper().GetTopic(s.Ctx(), topicId)
+	s.Require().NoError(err)
+	storedQuantile, err := s.ScoresKeeper().GetPreviousTopicQuantileInfererScoreEma(s.Ctx(), topicId)
+	s.Require().NoError(err)
+
+	emaScores := make([]types.Score, 0, len(instantScores))
+	for _, score := range instantScores {
+		emaScore, err := s.ScoresKeeper().GetInfererScoreEma(s.Ctx(), topicId, score.Address)
+		s.Require().NoError(err)
+		emaScores = append(emaScores, emaScore)
+	}
+
+	expectedEmaQuantile, err := getQuantileScoreFromScores(emaScores, topic.ActiveInfererQuantile)
+	s.Require().NoError(err)
+	s.Require().True(storedQuantile.Equal(expectedEmaQuantile))
+}
+
+func (s *RewardsTestSuite) TestForecasterQuantileStoredFromEmaScores() {
+	topicId := uint64(1)
+	block0 := int64(5000)
+	block1 := int64(5001)
+
+	networkLosses0, err := mockSimpleNetworkLosses(s, topicId, block0, "0.1")
+	s.Require().NoError(err)
+	_, err = rewards.GenerateForecastScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block0, networkLosses0)
+	s.Require().NoError(err)
+
+	networkLosses1, err := mockSimpleNetworkLosses(s, topicId, block1, "0.2")
+	s.Require().NoError(err)
+	instantScores, err := rewards.GenerateForecastScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block1, networkLosses1)
+	s.Require().NoError(err)
+
+	topic, err := s.TopicKeeper().GetTopic(s.Ctx(), topicId)
+	s.Require().NoError(err)
+	storedQuantile, err := s.ScoresKeeper().GetPreviousTopicQuantileForecasterScoreEma(s.Ctx(), topicId)
+	s.Require().NoError(err)
+
+	emaScores := make([]types.Score, 0, len(instantScores))
+	for _, score := range instantScores {
+		emaScore, err := s.ScoresKeeper().GetForecasterScoreEma(s.Ctx(), topicId, score.Address)
+		s.Require().NoError(err)
+		emaScores = append(emaScores, emaScore)
+	}
+
+	expectedEmaQuantile, err := getQuantileScoreFromScores(emaScores, topic.ActiveForecasterQuantile)
+	s.Require().NoError(err)
+	s.Require().True(storedQuantile.Equal(expectedEmaQuantile))
+}
+
+func (s *RewardsTestSuite) TestReputerQuantileStoredFromEmaScores() {
+	epochGet := testutil.GetSimulatedValuesGetterForEpochs()
+	epoch300Get := epochGet[300]
+	epoch301Get := epochGet[301]
+	epoch302Get := epochGet[302]
+	topicId := uint64(1)
+	block0 := int64(6000)
+	block1 := int64(6001)
+
+	reputerAddresses := make([]string, 5)
+	for i := range len(reputerAddresses) {
+		reputerAddresses[i] = s.AddrsStr(13 + i)
+	}
+	infererAddresses := make([]string, 5)
+	for i := range len(infererAddresses) {
+		infererAddresses[i] = s.AddrsStr(5 + i)
+	}
+	forecasterAddresses := make([]string, 3)
+	for i := range len(forecasterAddresses) {
+		forecasterAddresses[i] = s.AddrsStr(10 + i)
+	}
+	reputers := make([]testutil.ReputerKey, 5)
+	for i := range len(reputers) {
+		reputers[i] = testutil.ReputerKey{
+			Address:    s.AddrsStr(13 + i),
+			PrivateKey: s.PrivKeys(13 + i),
+			PubKeyHex:  s.PubKeyHexStr(13 + i),
+		}
+	}
+
+	cosmosOneE18 := inferencesynthesis.CosmosIntOneE18()
+	cosmosOneE18Dec, err := alloraMath.NewDecFromSdkInt(cosmosOneE18)
+	s.Require().NoError(err)
+	for i, addr := range reputerAddresses {
+		reputerStake, err := epoch301Get(fmt.Sprintf("reputer_stake_%d", i)).Mul(cosmosOneE18Dec)
+		s.Require().NoError(err)
+		reputerStakeInt, err := reputerStake.BigInt()
+		s.Require().NoError(err)
+		stake := cosmosMath.NewIntFromBigInt(reputerStakeInt)
+
+		addrBech, err := sdk.AccAddressFromBech32(addr)
+		s.Require().NoError(err)
+		s.MintTokensToAddress(addrBech, stake)
+		err = s.StakingKeeper().AddReputerStake(s.Ctx(), topicId, addr, stake)
+		s.Require().NoError(err)
+		err = s.ScoresKeeper().SetListeningCoefficient(
+			s.Ctx(),
+			topicId,
+			addr,
+			types.ListeningCoefficient{Coefficient: epoch300Get(fmt.Sprintf("reputer_listening_coefficient_%d", i))},
+		)
+		s.Require().NoError(err)
+	}
+
+	reportedLosses0, err := testutil.GetReputersDataFromCsv(
+		topicId,
+		block0,
+		infererAddresses,
+		forecasterAddresses,
+		reputers,
+		epoch301Get,
+	)
+	s.Require().NoError(err)
+	_, err = rewards.GenerateReputerScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block0, reportedLosses0)
+	s.Require().NoError(err)
+
+	reportedLosses1, err := testutil.GetReputersDataFromCsv(
+		topicId,
+		block1,
+		infererAddresses,
+		forecasterAddresses,
+		reputers,
+		epoch302Get,
+	)
+	s.Require().NoError(err)
+	instantScores, err := rewards.GenerateReputerScores(s.Ctx(), *s.EmissionsKeeper(), topicId, block1, reportedLosses1)
+	s.Require().NoError(err)
+
+	topic, err := s.TopicKeeper().GetTopic(s.Ctx(), topicId)
+	s.Require().NoError(err)
+	storedQuantile, err := s.ScoresKeeper().GetPreviousTopicQuantileReputerScoreEma(s.Ctx(), topicId)
+	s.Require().NoError(err)
+
+	emaScores := make([]types.Score, 0, len(instantScores))
+	for _, score := range instantScores {
+		emaScore, err := s.ScoresKeeper().GetReputerScoreEma(s.Ctx(), topicId, score.Address)
+		s.Require().NoError(err)
+		emaScores = append(emaScores, emaScore)
+	}
+
+	expectedEmaQuantile, err := getQuantileScoreFromScores(emaScores, topic.ActiveReputerQuantile)
+	s.Require().NoError(err)
+	s.Require().True(storedQuantile.Equal(expectedEmaQuantile))
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

* Switch sortition quantile source from instantScores to emaScores in reputer/inferer/forecaster score flows.
* Add v0.16.0 migration step to iterate existing topics and set:
** ActiveInfererQuantile = 0.05
** ActiveForecasterQuantile = 0.05
** ActiveReputerQuantile = 0.05
* No proto changes and no API changes.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
-- Added migration unit tests for topic iteration + error paths.
- [x] If documented, please describe where. If not, describe why docs are not needed. -- no need. A change of func in using EMA-based scores, but it does not change the intention.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch sortition quantiles to EMA-based scores for inferers, forecasters, and reputers, and add a v0.16.0 upgrade that sets all topics’ active quantiles to 0.05. Aligns with ENGN-5613 to stabilize selection and help new entrants graduate. No proto/API changes.

- **Refactors**
  - Store previous topic quantiles from EMA scores in all three score flows.
  - Added tests that verify stored quantiles equal EMA-based quantiles; added `nolint` guidance in `AGENTS.md`.

- **Migration**
  - v0.16.0 upgrade updates all topics’ `ActiveInfererQuantile`, `ActiveForecasterQuantile`, and `ActiveReputerQuantile` to 0.05.
  - Handles missing topics gracefully and wraps errors; unit tests cover success and failure paths.

<sup>Written for commit 2c1dfa3c46e017aff11370338403a40c42632bb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

