### PR TITLE
emissions: low-risk cleanup of unresolved review threads

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server.go
+++ b/x/emissions/keeper/msgserver/msg_server.go
@@ -19,8 +19,7 @@ type msgServer struct {
 	nk  *keeper.NonceKeeper
 }
 
-//nolint:exhaustruct
-var _ types.MsgServiceServer = msgServer{}
+var _ types.MsgServiceServer = (*msgServer)(nil)
 
 // NewMsgServerImpl returns an implementation of the module MsgServer interface.
 func NewMsgServerImpl(

--- a/x/emissions/keeper/queryserver/query_server.go
+++ b/x/emissions/keeper/queryserver/query_server.go
@@ -5,8 +5,10 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-//nolint:exhaustruct
-var _ types.QueryServiceServer = queryServer{k: keeper.Keeper{}}
+var (
+	_qs queryServer
+	_   types.QueryServiceServer = _qs
+)
 
 // NewQueryServerImpl returns an implementation of the module QueryServer.
 func NewQueryServerImpl(

--- a/x/emissions/keeper/regrets.go
+++ b/x/emissions/keeper/regrets.go
@@ -40,7 +40,7 @@ type RegretsKeeper struct {
 	latestOneOutInfererInfererNetworkRegrets collections.Map[collections.Triple[TopicId, ActorId, ActorId], types.TimestampedValue]
 	// map of (topicId, oneOutInferer, forecaster) -> regret
 	latestOneOutInfererForecasterNetworkRegrets collections.Map[collections.Triple[TopicId, ActorId, ActorId], types.TimestampedValue]
-	// map of (topicId, oneOutInferer, inferer) -> regret
+	// map of (topicId, oneOutForecaster, inferer) -> regret
 	latestOneOutForecasterInfererNetworkRegrets collections.Map[collections.Triple[TopicId, ActorId, ActorId], types.TimestampedValue]
 	// map of (topicId, oneOutForecaster, forecaster) -> regret
 	latestOneOutForecasterForecasterNetworkRegrets collections.Map[collections.Triple[TopicId, ActorId, ActorId], types.TimestampedValue]

--- a/x/emissions/migrations/v4/migrate.go
+++ b/x/emissions/migrations/v4/migrate.go
@@ -59,7 +59,7 @@ func MigrateStore(ctx sdk.Context, emissionsKeeper keeper.Keeper) error {
 // migrate params for this new version
 // the only change is the addition of MaxStringLength
 func MigrateParams(store storetypes.KVStore, cdc codec.BinaryCodec) error {
-	oldParams := oldV3Types.Params{} //nolint:exhaustruct // populated in unmarshal below
+	var oldParams oldV3Types.Params // populated in unmarshal below
 	oldParamsBytes := store.Get(emissionstypes.ParamsKey)
 	if oldParamsBytes == nil {
 		return errorsmod.Wrapf(emissionstypes.ErrNotFound, "old parameters not found")

--- a/x/emissions/migrations/v5/migrate.go
+++ b/x/emissions/migrations/v5/migrate.go
@@ -59,7 +59,7 @@ func MigrateStore(ctx sdk.Context, emissionsKeeper keeper.Keeper) error {
 // migrate params for this new version
 // the changes are the addition of InitialRegretQuantile,PNormSafeDiv
 func MigrateParams(store storetypes.KVStore, cdc codec.BinaryCodec) error {
-	oldParams := oldV4Types.Params{} //nolint:exhaustruct // empty struct used by cosmos-sdk Unmarshal below
+	var oldParams oldV4Types.Params // empty struct used by cosmos-sdk Unmarshal below
 	oldParamsBytes := store.Get(emissionstypes.ParamsKey)
 	if oldParamsBytes == nil {
 		return errorsmod.Wrapf(emissionstypes.ErrNotFound, "old parameters not found")


### PR DESCRIPTION
## Summary
- Applies only low-risk, non-behavioral cleanups from unresolved PR #919 review threads.
- Replaces composite-literal + `exhaustruct`-nolint patterns with cleaner interface assertion patterns in query/msg server files.
- Uses `var oldParams ...` declarations in v4/v5 migrations for unmarshal-populated structs and fixes a misleading comment in regrets keeper.

## What changed
- `x/emissions/keeper/regrets.go`
  - Corrected comment key label from `oneOutInferer` to `oneOutForecaster` for `latestOneOutForecasterInfererNetworkRegrets`.
- `x/emissions/migrations/v4/migrate.go`
  - Replaced `oldParams := oldV3Types.Params{}` with `var oldParams oldV3Types.Params`.
- `x/emissions/migrations/v5/migrate.go`
  - Replaced `oldParams := oldV4Types.Params{}` with `var oldParams oldV4Types.Params`.
- `x/emissions/keeper/queryserver/query_server.go`
  - Replaced `//nolint:exhaustruct` interface check with zero-value var assertion block.
- `x/emissions/keeper/msgserver/msg_server.go`
  - Replaced `msgServer{}` assertion with `(*msgServer)(nil)`.

## Why this PR is low risk
- No state layout changes.
- No proto/API changes.
- No keeper logic or consensus path behavior changes.
- Changes are limited to comments, declaration style, and compile-time interface assertions.

## Test plan
- `go test ./x/emissions/keeper/... ./x/emissions/migrations/v4 ./x/emissions/migrations/v5`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Low-risk cleanups in `x/emissions` to improve clarity and lint compliance. Uses safer interface assertions, cleans up migration param init, and fixes a misleading comment with no behavior, state, or API changes.

- **Refactors**
  - `keeper/msgserver`: replace `msgServer{}` interface assertion with `(*msgServer)(nil)`.
  - `keeper/queryserver`: replace `//nolint:exhaustruct` composite with zero-value var assertion.
  - `migrations/v4` and `migrations/v5`: use `var oldParams ...` as unmarshal targets.
  - `keeper/regrets`: correct comment label to “oneOutForecaster”.

<sup>Written for commit 1df0aa3509bb41f7fe81afc52ef096901b9e19ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

