### PR TITLE
emissions: normalize inferer regret error return semantics

### DIFF
--- a/x/emissions/keeper/regrets.go
+++ b/x/emissions/keeper/regrets.go
@@ -8,7 +8,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/codec"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
@@ -73,20 +72,14 @@ func (k *RegretsKeeper) GetInfererNetworkRegret(
 	if errors.Is(err, collections.ErrNotFound) {
 		topic, err := k.topicKeeper.GetTopic(ctx, topicId)
 		if err != nil {
-			return types.TimestampedValue{
-				BlockHeight: 0,
-				Value:       alloraMath.ZeroDec(),
-			}, false, errorsmod.Wrap(err, "error getting topic")
+			return types.TimestampedValue{}, false, errorsmod.Wrap(err, "error getting topic")
 		}
 		return types.TimestampedValue{
 			BlockHeight: 0,
 			Value:       topic.InitialRegret,
 		}, true, nil
 	} else if err != nil {
-		return types.TimestampedValue{
-			BlockHeight: 0,
-			Value:       alloraMath.ZeroDec(),
-		}, false, errorsmod.Wrap(err, "error getting inferer network regret")
+		return types.TimestampedValue{}, false, errorsmod.Wrap(err, "error getting inferer network regret")
 	}
 	return regret, false, nil
 }


### PR DESCRIPTION
## Summary
- Addresses one medium-risk unresolved review item from PR #919 by normalizing an inconsistent error-path return shape.
- Keeps scope intentionally narrow to isolate behavior-consistency review from mechanical cleanups.

## What changed
- `x/emissions/keeper/regrets.go`
  - In `GetInfererNetworkRegret`, changed both error paths to return `types.TimestampedValue{}` instead of a populated zero-value payload (`BlockHeight: 0, Value: ZeroDec()`).

## Why
- Other regret getters in this keeper return empty structs on error.
- Returning a populated value alongside an error can lead to accidental value use by callers and inconsistent expectations.

## Risk profile
- No state/proto/API schema changes.
- Behavior change is limited to error return payload shape while preserving returned error.
- Suitable for focused reviewer attention due to semantic consistency impact.

## Test plan
- `go test ./x/emissions/keeper/...`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize error return semantics in `GetInfererNetworkRegret` to return an empty `types.TimestampedValue{}` on error instead of a zero-value payload. Aligns this getter with others in `x/emissions/keeper` and reduces accidental value use; no state/API changes.

<sup>Written for commit 7985bae3b355fea857e7d1c799c36821c0f48716. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

