### PR TITLE
Update Dockerfile and CI workflow to support new release asset naming conventions

### DIFF
--- a/.github/workflows/build_push_upgrader_docker_hub.yml
+++ b/.github/workflows/build_push_upgrader_docker_hub.yml
@@ -41,14 +41,29 @@ jobs:
             exit 1
           fi
 
-          current_url="https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_CURRENT_VERSION}/allorad_linux_amd64"
-          upgrade_url="https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_UPGRADE_VERSION}/allorad_linux_amd64"
+          # Release assets renamed: new = allora-chain_<semver>_linux_amd64; legacy = allorad_linux_amd64
+          check_release_asset() {
+            local ver="$1"
+            local label="$2"
+            local strip="${ver#v}"
+            local base="https://github.com/allora-network/allora-chain/releases/download/${ver}"
+            local url_new="${base}/allora-chain_${strip}_linux_amd64"
+            local url_old="${base}/allorad_linux_amd64"
+            echo "Checking ${label} release asset for ${ver}..."
+            if curl -fsSIL "${url_new}" >/dev/null 2>&1; then
+              echo "OK (new naming): ${url_new}"
+              return 0
+            fi
+            if curl -fsSIL "${url_old}" >/dev/null 2>&1; then
+              echo "OK (legacy naming): ${url_old}"
+              return 0
+            fi
+            echo "ERROR: No linux amd64 asset for ${ver} (tried ${url_new} and ${url_old})" >&2
+            return 1
+          }
 
-          echo "Checking current asset: ${current_url}"
-          curl -fsSIL "${current_url}" >/dev/null
-
-          echo "Checking upgrade asset: ${upgrade_url}"
-          curl -fsSIL "${upgrade_url}" >/dev/null
+          check_release_asset "${ALLORAD_CURRENT_VERSION}" "current"
+          check_release_asset "${ALLORAD_UPGRADE_VERSION}" "upgrade"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/Dockerfile.cosmovisor
+++ b/Dockerfile.cosmovisor
@@ -41,12 +41,19 @@ RUN tar -xvf /tmp/cosmovisor.tar.gz -C /usr/local/bin/ && \
 ARG ALLORAD_CURRENT_VERSION="v0.15.1"
 ARG ALLORAD_UPGRADE_VERSION="v0.16.0"
 
+# New releases use allora-chain_<semver>_linux_amd64; older releases used allorad_linux_amd64
 RUN mkdir -p ${INITIAL_COSMOVISOR_DIR}/genesis/bin && \
-    curl -Lo ${INITIAL_COSMOVISOR_DIR}/genesis/bin/allorad https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_CURRENT_VERSION}/allorad_linux_amd64 && \
+    STRIP="${ALLORAD_CURRENT_VERSION#v}" && \
+    URL_NEW="https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_CURRENT_VERSION}/allora-chain_${STRIP}_linux_amd64" && \
+    URL_OLD="https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_CURRENT_VERSION}/allorad_linux_amd64" && \
+    (curl -fL "${URL_NEW}" -o ${INITIAL_COSMOVISOR_DIR}/genesis/bin/allorad || curl -fL "${URL_OLD}" -o ${INITIAL_COSMOVISOR_DIR}/genesis/bin/allorad) && \
     chmod +x ${INITIAL_COSMOVISOR_DIR}/genesis/bin/allorad
 
 RUN mkdir -p ${INITIAL_COSMOVISOR_DIR}/upgrades/${ALLORAD_UPGRADE_VERSION}/bin && \
-    curl -Lo ${INITIAL_COSMOVISOR_DIR}/upgrades/${ALLORAD_UPGRADE_VERSION}/bin/allorad https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_UPGRADE_VERSION}/allorad_linux_amd64
+    STRIP="${ALLORAD_UPGRADE_VERSION#v}" && \
+    URL_NEW="https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_UPGRADE_VERSION}/allora-chain_${STRIP}_linux_amd64" && \
+    URL_OLD="https://github.com/allora-network/allora-chain/releases/download/${ALLORAD_UPGRADE_VERSION}/allorad_linux_amd64" && \
+    (curl -fL "${URL_NEW}" -o ${INITIAL_COSMOVISOR_DIR}/upgrades/${ALLORAD_UPGRADE_VERSION}/bin/allorad || curl -fL "${URL_OLD}" -o ${INITIAL_COSMOVISOR_DIR}/upgrades/${ALLORAD_UPGRADE_VERSION}/bin/allorad)
 
 VOLUME ${APP_PATH}
 WORKDIR ${APP_PATH}

--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,12 @@ build-local-edits:
 
 build-all-platforms:
 	mkdir -p $(BUILDDIR)/
-	GOOS=linux GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_linux_amd64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=linux GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_linux_arm64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=darwin GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_darwin_amd64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=darwin GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_darwin_arm64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=windows GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_windows_amd64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=windows GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allorad_windows_amd64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=linux GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_linux_amd64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=linux GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_linux_arm64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=darwin GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_darwin_amd64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=darwin GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_darwin_arm64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=windows GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_windows_amd64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=windows GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_windows_arm64 github.com/allora-network/allora-chain/cmd/allorad
 
 lint:
 	@echo "--> Running linter"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ ifeq (,$(VERSION))
   endif
 endif
 
+# Sanitized version for filenames: strip leading v, replace / with -
+BUILD_VERSION := $(subst /,-,$(VERSION:v%=%))
+
 # process build tags
 LEDGER_ENABLED ?= true
 build_tags = netgo
@@ -92,12 +95,12 @@ build-local-edits:
 
 build-all-platforms:
 	mkdir -p $(BUILDDIR)/
-	GOOS=linux GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_linux_amd64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=linux GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_linux_arm64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=darwin GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_darwin_amd64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=darwin GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_darwin_arm64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=windows GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_windows_amd64 github.com/allora-network/allora-chain/cmd/allorad
-	GOOS=windows GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(VERSION:v%=%)_windows_arm64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=linux GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(BUILD_VERSION)_linux_amd64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=linux GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(BUILD_VERSION)_linux_arm64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=darwin GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(BUILD_VERSION)_darwin_amd64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=darwin GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(BUILD_VERSION)_darwin_arm64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=windows GOARCH=amd64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(BUILD_VERSION)_windows_amd64 github.com/allora-network/allora-chain/cmd/allorad
+	GOOS=windows GOARCH=arm64 GOWORK=off go build -mod=readonly  $(BUILD_FLAGS) -o $(BUILDDIR)/allora-chain_$(BUILD_VERSION)_windows_arm64 github.com/allora-network/allora-chain/cmd/allorad
 
 lint:
 	@echo "--> Running linter"


### PR DESCRIPTION
- Modified the Dockerfile to handle both new and legacy naming for the `allorad` binary during installation.
- Updated the GitHub Actions workflow to check for the existence of release assets using the new naming convention, ensuring compatibility with both current and previous versions.

This change enhances the upgrade process by accommodating the transition to the new asset naming scheme.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for new release asset naming `allora-chain_<semver>_linux_amd64` with legacy fallback, and standardize build outputs using a sanitized version. This keeps the upgrader image, CI checks, and release artifacts working during the transition.

- **Bug Fixes**
  - `Dockerfile.cosmovisor`: Download `allorad` using the new URL first, then fallback to the legacy URL for both genesis and upgrade bins; CI adds `check_release_asset` to verify current and upgrade assets using either naming with early failure.

- **Refactors**
  - Makefile: `build-all-platforms` now outputs `allora-chain_<semver>_<os>_<arch>` using `BUILD_VERSION` (strips leading `v`, replaces `/` with `-`), including correct Windows arm64 artifact naming.

<sup>Written for commit 015a38bca505030398b929f5a3e6356a8a8b8467. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

