### PR TITLE
docs: normalize README badges layout and add links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Allora Network
 <p align="center">
-<img src='assets/AlloraLogo.jpeg' width='200'>
-<a href="https://goreportcard.com/badge/github.com/allora-network/allora-chain">
-    <img src="https://goreportcard.com/badge/github.com/allora-network/allora-chain">
-</a>
-</p>
+  <img src="assets/AlloraLogo.jpeg" width="200">
 
-![Docker!](https://img.shields.io/badge/Docker-2CA5E0?style=for-the-badge&logo=docker&logoColor=white)
-![Go!](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
-![Apache License](https://img.shields.io/badge/Apache%20License-D22128?style=for-the-badge&logo=Apache&logoColor=white)
+  <br/>
+
+  <a href="https://goreportcard.com/report/github.com/allora-network/allora-chain">
+    <img src="https://goreportcard.com/badge/github.com/allora-network/allora-chain">
+  </a>
+  <a href="https://hub.docker.com/">
+    <img src="https://img.shields.io/badge/Docker-2CA5E0?logo=docker&logoColor=white">
+  </a>
+  <a href="https://go.dev/">
+    <img src="https://img.shields.io/badge/Go-00ADD8?logo=go&logoColor=white">
+  </a>
+  <a href="https://github.com/allora-network/allora-chain/blob/dev/LICENSE">
+    <img src="https://img.shields.io/badge/Apache%20License-D22128?logo=apache&logoColor=white">
+  </a>
+</p>
 
 The [Allora Network](https://www.allora.network/) is a state-of-the-art protocol that uses decentralized AI and machine learning (ML) to build, extract, and deploy predictions among its participants. It offers actors who wish to use AI predictions a formalized way to obtain the output of state-of-the-art ML models on-chain and to pay the operators of AI/ML nodes who create these predictions. That way, Allora bridges the information gap between data owners, data processors, AI/ML predictors, market analysts, and the end-users or consumers who have the means to execute on these insights.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up the README header by centering and linking the badges to improve readability and consistency. Go Report Card now links to the report page, and badges for Docker, Go, and the Apache License link to their respective pages.

<sup>Written for commit 134706a0df7ba520662e130747561cc88ab0974d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

