### PR TITLE
Fix parameter advertising in autocli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* [#910](https://github.com/allora-network/allora-chain/pull/910) Regret norm to use MAD + adjust quantiles
-* [#919](https://github.com/allora-network/allora-chain/pull/919) Keeper refactor + upgrade testing improvements
+* [#945](https://github.com/allora-network/allora-chain/pull/945) Fix parameter advertising in autocli
 
 ### Deprecated
 

--- a/x/emissions/module/autocli.go
+++ b/x/emissions/module/autocli.go
@@ -1103,7 +1103,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 				{
 					RpcMethod: "FundTopic",
-					Use:       "fund-topic [sender] [topic_id] [amount] [extra_data]",
+					Use:       "fund-topic [sender] [topic_id] [amount]",
 					Short:     "send funds to a topic to pay for inferences",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "sender"},

--- a/x/emissions/module/autocli.go
+++ b/x/emissions/module/autocli.go
@@ -65,7 +65,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 				{
 					RpcMethod: "GetDelegateRewardPerShare",
-					Use:       "delegate-reward-per-share [topic_id] [reputer_address]",
+					Use:       "delegate-reward-per-share [topic_id] [reputer]",
 					Short:     "Get total delegate reward per share stake in a reputer for a topic",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "topic_id"},
@@ -640,7 +640,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 				{
 					RpcMethod: "GetStakeRemovalInfo",
-					Use:       "stake-removal-info [address] [topic_id]",
+					Use:       "stake-removal-info [reputer] [topic_id]",
 					Short:     "Get a pending stake removal for a reputer in a topic",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "reputer"},
@@ -1001,7 +1001,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 				{
 					RpcMethod: "Register",
-					Use:       "register [sender] [topic_ids] [owner] [is_reputer]",
+					Use:       "register [sender] [topic_id] [owner] [is_reputer]",
 					Short:     "Register a new reputer or worker for a topic",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "sender"},
@@ -1021,8 +1021,9 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					},
 				},
 				{
+
 					RpcMethod: "RemoveRegistration",
-					Use:       "remove-registration [sender] [owner] [is_reputer]",
+					Use:       "remove-registration [sender] [topic_id] [is_reputer]",
 					Short:     "Remove a reputer or worker from a topic",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "sender"},
@@ -1083,11 +1084,12 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 				{
 					RpcMethod: "CancelRemoveDelegateStake",
-					Use:       "cancel-remove-delegate-stake [sender] [topic_id] [reputer]",
+					Use:       "cancel-remove-delegate-stake [sender] [topic_id] [delegator] [reputer]",
 					Short:     "Cancel the removal of delegated stake for a delegator staking on a reputer in a topic",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "sender"},
 						{ProtoField: "topic_id"},
+						{ProtoField: "delegator"},
 						{ProtoField: "reputer"},
 					},
 				},


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Fix on fund-topic extra parameter on cli. 
* Also fixes other autocli misalignments.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. 
-- no code changes, just cli. 
- [x] If documented, please describe where. If not, describe why docs are not needed.
-- auto-documented
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `allorad tx emissions fund-topic` help to show 3 args, matching the command. Also aligns several autocli command usages with their RPC signatures to reduce confusion and errors. Addresses Linear ENGN-7431.

- **Bug Fixes**
  - `fund-topic`: removed `[extra_data]`; now `[sender] [topic_id] [amount]` (ENGN-7431).
  - `cancel-remove-delegate-stake`: added `[delegator]`; now `[sender] [topic_id] [delegator] [reputer]`.
  - `delegate-reward-per-share`: `[reputer_address]` → `[reputer]`.
  - `stake-removal-info`: `[address]` → `[reputer]`.
  - `register`: `[topic_ids]` → `[topic_id]`.
  - `remove-registration`: `[owner]` → `[topic_id]`.

<sup>Written for commit 83da41765c829915443a9236da1a15810db6d427. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

