### PR TITLE
Fix dry-run and auto-gas issues. Add keyring simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* [#945](https://github.com/allora-network/allora-chain/pull/945) Fix parameter advertising in autocli
 * [#910](https://github.com/allora-network/allora-chain/pull/946) Fix dry-run and auto-gas issues. Add keyring simulation
+* [#945](https://github.com/allora-network/allora-chain/pull/945) Fix parameter advertising in autocli
+* [#946](https://github.com/allora-network/allora-chain/pull/946) Fix dry-run and auto-gas issues. Add keyring simulation
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* [#910](https://github.com/allora-network/allora-chain/pull/946) Fix dry-run and auto-gas issues. Add keyring simulation
 * [#945](https://github.com/allora-network/allora-chain/pull/945) Fix parameter advertising in autocli
 * [#946](https://github.com/allora-network/allora-chain/pull/946) Fix dry-run and auto-gas issues. Add keyring simulation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * [#945](https://github.com/allora-network/allora-chain/pull/945) Fix parameter advertising in autocli
+* [#910](https://github.com/allora-network/allora-chain/pull/946) Fix dry-run and auto-gas issues. Add keyring simulation
 
 ### Deprecated
 

--- a/cmd/allorad/cmd/root.go
+++ b/cmd/allorad/cmd/root.go
@@ -75,6 +75,14 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
+			// Wrap keyring in simulate mode so that --dry-run combined with
+			// --gas auto does not fail with ".info: key not found". See
+			// simulateKeyring for the full explanation.
+			// Must be AFTER ReadFromClientConfig, which creates a fresh keyring.
+			if clientCtx.Simulate && clientCtx.Keyring != nil {
+				clientCtx = clientCtx.WithKeyring(simulateKeyring{clientCtx.Keyring})
+			}
+
 			// sign mode textual is only available in online mode
 			if !clientCtx.Offline {
 				// This needs to go after ReadFromClientConfig, as that function ets the RPC client needed for SIGN_MODE_TEXTUAL.

--- a/cmd/allorad/cmd/simulate_keyring.go
+++ b/cmd/allorad/cmd/simulate_keyring.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Compile-time check that simulateKeyring satisfies keyring.Keyring.
-var _ keyring.Keyring = simulateKeyring{}
+var _ keyring.Keyring = simulateKeyring{} //nolint:exhaustruct // creating an empty simulateKeyring is valid
 
 // simulateKeyring wraps a keyring.Keyring to gracefully handle empty key name
 // lookups during transaction simulation.

--- a/cmd/allorad/cmd/simulate_keyring.go
+++ b/cmd/allorad/cmd/simulate_keyring.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+)
+
+// Compile-time check that simulateKeyring satisfies keyring.Keyring.
+var _ keyring.Keyring = simulateKeyring{}
+
+// simulateKeyring wraps a keyring.Keyring to gracefully handle empty key name
+// lookups during transaction simulation.
+//
+// When --dry-run is combined with --gas auto, the Cosmos SDK clears the key
+// name (FromName) in simulate mode (client.GetFromFields returns "" for the
+// name when ctx.Simulate is true). However, the gas estimation code path
+// (Factory.getSimPK) still attempts keybase.Key(fromName) when
+// simulateAndExecute is true. With an empty fromName, the underlying keystore
+// appends the ".info" suffix to an empty string and looks up ".info", which
+// does not exist — producing the error: ".info: key not found".
+//
+// This wrapper intercepts Key("") calls and returns a default offline record
+// with a placeholder secp256k1 public key, which is the same default that
+// getSimPK would use if it skipped the keyring lookup. The chain does not
+// verify signatures during gas simulation, so using a placeholder key is safe.
+//
+// Ref: https://github.com/cosmos/cosmos-sdk/issues/11283
+type simulateKeyring struct {
+	keyring.Keyring
+}
+
+func (sk simulateKeyring) Key(uid string) (*keyring.Record, error) {
+	if uid == "" {
+		pk := &secp256k1.PubKey{Key: make([]byte, secp256k1.PubKeySize)}
+		return keyring.NewOfflineRecord("", pk)
+	}
+	return sk.Keyring.Key(uid)
+}

--- a/cmd/allorad/cmd/simulate_keyring_test.go
+++ b/cmd/allorad/cmd/simulate_keyring_test.go
@@ -30,7 +30,7 @@ func TestSimulateKeyring_EmptyUID(t *testing.T) {
 
 	pk, ok := rec.PubKey.GetCachedValue().(cryptotypes.PubKey)
 	require.True(t, ok)
-	require.IsType(t, &secp256k1.PubKey{}, pk)
+	require.IsType(t, &secp256k1.PubKey{}, pk) //nolint:exhaustruct // creating an empty Pubkey for the test check only
 	require.Len(t, pk.Bytes(), secp256k1.PubKeySize)
 }
 

--- a/cmd/allorad/cmd/simulate_keyring_test.go
+++ b/cmd/allorad/cmd/simulate_keyring_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func testCodec() codec.Codec {
+	registry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(registry)
+	return codec.NewProtoCodec(registry)
+}
+
+func TestSimulateKeyring_EmptyUID(t *testing.T) {
+	inner := keyring.NewInMemory(testCodec())
+	sk := simulateKeyring{inner}
+
+	rec, err := sk.Key("")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	pk, ok := rec.PubKey.GetCachedValue().(cryptotypes.PubKey)
+	require.True(t, ok)
+	require.IsType(t, &secp256k1.PubKey{}, pk)
+	require.Len(t, pk.Bytes(), secp256k1.PubKeySize)
+}
+
+func TestSimulateKeyring_ExistingKey_Passthrough(t *testing.T) {
+	inner := keyring.NewInMemory(testCodec())
+	expected, _, err := inner.NewMnemonic("alice", keyring.English, sdk.FullFundraiserPath, "", hd.Secp256k1)
+	require.NoError(t, err)
+
+	sk := simulateKeyring{inner}
+	got, err := sk.Key("alice")
+	require.NoError(t, err)
+	require.Equal(t, expected.Name, got.Name)
+}
+
+func TestSimulateKeyring_NonEmptyUID_Passthrough(t *testing.T) {
+	inner := keyring.NewInMemory(testCodec())
+	sk := simulateKeyring{inner}
+
+	_, err := sk.Key("nonexistent")
+	require.Error(t, err, "non-empty UID should delegate to inner keyring and fail for missing key")
+}
+
+func TestSimulateKeyring_DelegatesOtherMethods(t *testing.T) {
+	inner := keyring.NewInMemory(testCodec())
+	sk := simulateKeyring{inner}
+
+	require.Equal(t, inner.Backend(), sk.Backend())
+
+	recs, err := sk.List()
+	require.NoError(t, err)
+	require.Empty(t, recs)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Fix cli `--dry-run` option's `.info not found` message
  * Introduce keyring simulation with unit testing.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
-  added unit tests
-  confirmed previous behaviour is fixed now using cli 
- [x] If documented, please describe where. If not, describe why docs are not needed.
- no need, just a fix to get the expected behaviour
- [x] Added to `Unreleased` section of `CHANGELOG.md`?



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tx simulation failures with `--dry-run` and `--gas auto` by handling empty key-name lookups, removing the “.info: key not found” error. Restores gas estimation on `allorad tx emissions create-topic` and fulfills ENGN-7430.

- **Bug Fixes**
  - Wrap the client keyring with `simulateKeyring` in simulate mode to return an offline record for empty key names (placeholder `secp256k1` pubkey).
  - Apply wrapping after `ReadFromClientConfig` so the active keyring is used.
  - Added unit tests covering empty UID handling, passthrough behavior, and method delegation.
  - Updated and corrected `CHANGELOG.md` under Changed.

<sup>Written for commit 1f191fef54d8a9c9a6dc6a46393ab00d190dd465. Summary will update on new commits. <a href="https://cubic.dev/pr/allora-network/allora-chain/pull/946?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



