### PR TITLE
Increase p_norm available range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#945](https://github.com/allora-network/allora-chain/pull/945) Fix parameter advertising in autocli
 * [#946](https://github.com/allora-network/allora-chain/pull/946) Fix dry-run and auto-gas issues. Add keyring simulation
+* [#949](https://github.com/allora-network/allora-chain/pull/949) Increase p_norm available range
 
 ### Deprecated
 

--- a/test/integration/topic_distribution_test.go
+++ b/test/integration/topic_distribution_test.go
@@ -25,7 +25,7 @@ func TopicWeightDistributionChecks(m testCommon.TestConfig) {
 	topic1Id := createTestTopic(m, m.AliceAddr, "Topic 1 - Short Epoch", 10) // Example Epoch Length: 10
 	m.T.Logf("Created Topic 1 with ID: %d and Epoch Length: 10", topic1Id)
 
-	// Topic 2: Long Epoch Length
+	// Topic 2: Long Epoch Length (2× short epoch so both churn together when the long topic completes its first epoch)
 	topic2Id := createTestTopic(m, m.AliceAddr, "Topic 2 - Long Epoch", 20) // Example Epoch Length: 20
 	m.T.Logf("Created Topic 2 with ID: %d and Epoch Length: 20", topic2Id)
 

--- a/test/integration/update_params_test.go
+++ b/test/integration/update_params_test.go
@@ -44,7 +44,11 @@ func UpdateParamsChecks(m testCommon.TestConfig) {
 			// These are set for subsequent tests
 			MaxTopReputersToReward: []uint64{24},
 			MinEpochLength:         []int64{1},
-			CNorm:                  nil, // deprecated: keep for exhaustruct; ignored by chain
+			// Default chain value is 1; topic weight distribution needs ≥2 so a short (10) and long (20)
+			// epoch topic can both churn on the same block without one evicting the other from the schedule.
+			// Pushed to 5 for further cases.
+			MaxActiveTopicsPerBlock: []uint64{5},
+			CNorm:                   nil, // deprecated: keep for exhaustruct; ignored by chain, using topic's
 			// don't update the following fields
 			Version:                             nil,
 			MaxSerializedMsgLength:              nil,
@@ -81,7 +85,6 @@ func UpdateParamsChecks(m testCommon.TestConfig) {
 			DataSendingFee:                      nil,
 			EpsilonSafeDiv:                      nil,
 			MaxElementsPerForecast:              nil,
-			MaxActiveTopicsPerBlock:             nil,
 			MaxStringLength:                     nil,
 			InitialRegretQuantile:               nil,
 			PNormSafeDiv:                        nil,

--- a/x/emissions/keeper/msgserver/msg_server_topics_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics_test.go
@@ -621,7 +621,21 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParamsInvalid() {
 		LossMethod:          "mse",
 		AlphaRegret:         alloraMath.MustNewDecFromString("0.1"),
 		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
-		PNorm:               alloraMath.MustNewDecFromString("2.0"),
+		PNorm:               alloraMath.MustNewDecFromString("0.5"),
+		CNorm:               alloraMath.MustNewDecFromString("0.75"),
+	}
+	_, err = msgServer.UpdateTopic(ctx, updateTopicMsg)
+	require.ErrorContains(err, "p-norm")
+
+	// Invalid p_norm (above range)
+	updateTopicMsg = &types.UpdateTopicRequest{
+		Sender:              sender,
+		TopicId:             topicId,
+		Metadata:            "metadata",
+		LossMethod:          "mse",
+		AlphaRegret:         alloraMath.MustNewDecFromString("0.1"),
+		MeritSortitionAlpha: alloraMath.MustNewDecFromString("0.1"),
+		PNorm:               alloraMath.MustNewDecFromString("10.1"),
 		CNorm:               alloraMath.MustNewDecFromString("0.75"),
 	}
 	_, err = msgServer.UpdateTopic(ctx, updateTopicMsg)

--- a/x/emissions/types/params.go
+++ b/x/emissions/types/params.go
@@ -603,18 +603,18 @@ func validatePNormSafeDiv(i alloraMath.Dec) error {
 
 // Whether an alloraDec is between the value of [0, 1] inclusive
 func isAlloraDecBetweenZeroAndOneInclusive(a alloraMath.Dec) bool {
-	return a.Gte(alloraMath.ZeroDec()) && a.Lte(alloraMath.OneDec())
+	return a.Gte(validationZeroDec) && a.Lte(validationOneDec)
 }
 
 // Whether an alloraDec is between the value of (0, 1) exclusive
 func isAlloraDecBetweenZeroAndOneExclusive(a alloraMath.Dec) bool {
-	return a.Gt(alloraMath.ZeroDec()) && a.Lt(alloraMath.OneDec())
+	return a.Gt(validationZeroDec) && a.Lt(validationOneDec)
 }
 
 // Whether an alloraDec is between the values of [0, 1)
 // inclusive on 0 and exclusive on 1
 func isAlloraDecZeroOrLessThanOne(a alloraMath.Dec) bool {
-	return a.Gte(alloraMath.ZeroDec()) && a.Lt(alloraMath.OneDec())
+	return a.Gte(validationZeroDec) && a.Lt(validationOneDec)
 }
 
 // How much workers and reputers must pay to send data.

--- a/x/emissions/types/validations.go
+++ b/x/emissions/types/validations.go
@@ -914,7 +914,7 @@ func (topic Topic) Validate(params Params) error {
 		return errors.Wrap(err, "topic merit sortition alpha is invalid")
 	}
 	if !isAlloraDecZeroOrLessThanOne(topic.MeritSortitionAlpha) {
-		return errors.Wrap(sdkerrors.ErrInvalidType, "topic merit sortition alpha must be between 0 and 1 inclusive")
+		return errors.Wrap(sdkerrors.ErrInvalidType, "topic merit sortition alpha must be greater than or equal to 0 and less than 1")
 	}
 	if err := ValidateDec(topic.ActiveInfererQuantile); err != nil {
 		return errors.Wrap(err, "topic active inferer quantile is invalid")
@@ -1241,7 +1241,7 @@ func (msg *CreateNewTopicRequest) Validate(maxStringLen uint64) error {
 	//	AllowNegative            bool
 
 	if !isAlloraDecZeroOrLessThanOne(msg.MeritSortitionAlpha) {
-		return errors.Wrap(sdkerrors.ErrInvalidRequest, "merit sortition alpha must be between 0 and 1 inclusive")
+		return errors.Wrap(sdkerrors.ErrInvalidRequest, "merit sortition alpha must be greater than or equal to 0 and less than 1")
 	}
 	if !isAlloraDecBetweenZeroAndOneInclusive(msg.ActiveInfererQuantile) {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "active inferer quantile must be between 0 and 1 inclusive")

--- a/x/emissions/types/validations.go
+++ b/x/emissions/types/validations.go
@@ -880,8 +880,8 @@ func (topic Topic) Validate(params Params) error {
 	if err := ValidateDec(topic.PNorm); err != nil {
 		return errors.Wrap(err, "topic p-norm is invalid")
 	}
-	if topic.PNorm.Lt(alloraMath.MustNewDecFromString("2.5")) || topic.PNorm.Gt(alloraMath.MustNewDecFromString("4.5")) {
-		return errors.Wrap(sdkerrors.ErrInvalidType, "topic p-norm must be between 2.5 and 4.5")
+	if topic.PNorm.Lt(alloraMath.MustNewDecFromString("1")) || topic.PNorm.Gt(alloraMath.MustNewDecFromString("10")) {
+		return errors.Wrap(sdkerrors.ErrInvalidType, "topic p-norm must be between 1 and 10")
 	}
 	if err := ValidateDec(topic.Epsilon); err != nil {
 		return errors.Wrap(err, "topic epsilon is invalid")
@@ -1206,8 +1206,8 @@ func (msg *CreateNewTopicRequest) Validate(maxStringLen uint64) error {
 	if msg.AlphaRegret.Lte(alloraMath.ZeroDec()) || msg.AlphaRegret.Gt(alloraMath.OneDec()) || ValidateDec(msg.AlphaRegret) != nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "alpha regret must be greater than 0 and less than or equal to 1")
 	}
-	if msg.PNorm.Lt(alloraMath.MustNewDecFromString("2.5")) || msg.PNorm.Gt(alloraMath.MustNewDecFromString("4.5")) || ValidateDec(msg.PNorm) != nil {
-		return errors.Wrap(sdkerrors.ErrInvalidRequest, "p-norm must be between 2.5 and 4.5")
+	if msg.PNorm.Lt(alloraMath.MustNewDecFromString("1")) || msg.PNorm.Gt(alloraMath.MustNewDecFromString("10")) || ValidateDec(msg.PNorm) != nil {
+		return errors.Wrap(sdkerrors.ErrInvalidRequest, "p-norm must be between 1 and 10")
 	}
 	if msg.CNorm.Lt(alloraMath.MustNewDecFromString("-100")) || msg.CNorm.Gt(alloraMath.MustNewDecFromString("100")) || ValidateDec(msg.CNorm) != nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "c_norm must be between -100 and 100")

--- a/x/emissions/types/validations.go
+++ b/x/emissions/types/validations.go
@@ -12,7 +12,25 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+const (
+	validationMinLossMethodLength       = 1
+	validationMinPositiveIntValue int64 = 1
+	validationMinEpochLastEnded   int64 = 0
+
+	validationZeroDecString     = "0"
+	validationOneDecString      = "1"
+	validationPNormMaxDecString = "10"
+	validationCNormMinDecString = "-100"
+	validationCNormMaxDecString = "100"
+)
+
 var (
+	validationZeroDec     = alloraMath.MustNewDecFromString(validationZeroDecString)
+	validationOneDec      = alloraMath.MustNewDecFromString(validationOneDecString)
+	validationPNormMaxDec = alloraMath.MustNewDecFromString(validationPNormMaxDecString)
+	validationCNormMinDec = alloraMath.MustNewDecFromString(validationCNormMinDecString)
+	validationCNormMaxDec = alloraMath.MustNewDecFromString(validationCNormMaxDecString)
+
 	reputerValueBundleBufferPool       = utils.NewBytesPool(1024, 0)
 	inferenceForecastsBundleBufferPool = utils.NewBytesPool(1024, 0)
 )
@@ -841,22 +859,22 @@ func (topic Topic) Validate(params Params) error {
 	if uint64(len(topic.Metadata)) > params.MaxStringLength {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic metadata invalid")
 	}
-	if len(topic.LossMethod) == 0 || uint64(len(topic.LossMethod)) > params.MaxStringLength {
+	if len(topic.LossMethod) < validationMinLossMethodLength || uint64(len(topic.LossMethod)) > params.MaxStringLength {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic loss method invalid")
 	}
-	if topic.EpochLastEnded < 0 {
+	if topic.EpochLastEnded < validationMinEpochLastEnded {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic epoch last ended cannot be negative")
 	}
-	if topic.EpochLength <= 0 {
+	if topic.EpochLength < validationMinPositiveIntValue {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic epoch length must be greater than zero")
 	}
 	if topic.EpochLength < params.MinEpochLength {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic epoch length must be greater than minimum epoch length")
 	}
-	if topic.WorkerSubmissionWindow == 0 {
+	if topic.WorkerSubmissionWindow < validationMinPositiveIntValue {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic worker submission window must be greater than zero")
 	}
-	if topic.GroundTruthLag <= 0 {
+	if topic.GroundTruthLag < validationMinPositiveIntValue {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic ground truth lag must be greater than zero")
 	}
 	if topic.GroundTruthLag < topic.EpochLength {
@@ -865,7 +883,7 @@ func (topic Topic) Validate(params Params) error {
 	if uint64(topic.GroundTruthLag) > params.MaxUnfulfilledReputerRequests*uint64(topic.EpochLength) {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic ground truth lag cannot be higher than max unfulfilled reputer requests")
 	}
-	if topic.WorkerSubmissionWindow <= 0 {
+	if topic.WorkerSubmissionWindow < validationMinPositiveIntValue {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic worker submission window must be greater than zero")
 	}
 	if topic.WorkerSubmissionWindow > topic.EpochLength {
@@ -874,19 +892,19 @@ func (topic Topic) Validate(params Params) error {
 	if err := ValidateDec(topic.AlphaRegret); err != nil {
 		return errors.Wrap(err, "topic alpha regret is invalid")
 	}
-	if topic.AlphaRegret.Lte(alloraMath.ZeroDec()) || topic.AlphaRegret.Gt(alloraMath.OneDec()) {
+	if topic.AlphaRegret.Lte(validationZeroDec) || topic.AlphaRegret.Gt(validationOneDec) {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic alpha regret must be greater than 0 and less than or equal to 1")
 	}
 	if err := ValidateDec(topic.PNorm); err != nil {
 		return errors.Wrap(err, "topic p-norm is invalid")
 	}
-	if topic.PNorm.Lt(alloraMath.MustNewDecFromString("1")) || topic.PNorm.Gt(alloraMath.MustNewDecFromString("10")) {
+	if topic.PNorm.Lt(validationOneDec) || topic.PNorm.Gt(validationPNormMaxDec) {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic p-norm must be between 1 and 10")
 	}
 	if err := ValidateDec(topic.Epsilon); err != nil {
 		return errors.Wrap(err, "topic epsilon is invalid")
 	}
-	if topic.Epsilon.Lte(alloraMath.ZeroDec()) {
+	if topic.Epsilon.Lte(validationZeroDec) {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic epsilon must be greater than 0")
 	}
 	// no validation on AllowNegative because either it is true or false
@@ -901,25 +919,25 @@ func (topic Topic) Validate(params Params) error {
 	if err := ValidateDec(topic.ActiveInfererQuantile); err != nil {
 		return errors.Wrap(err, "topic active inferer quantile is invalid")
 	}
-	if !isAlloraDecZeroOrLessThanOne(topic.ActiveInfererQuantile) {
+	if !isAlloraDecBetweenZeroAndOneInclusive(topic.ActiveInfererQuantile) {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic active inferer quantile must be between 0 and 1 inclusive")
 	}
 	if err := ValidateDec(topic.ActiveForecasterQuantile); err != nil {
 		return errors.Wrap(err, "topic active forecaster quantile is invalid")
 	}
-	if !isAlloraDecZeroOrLessThanOne(topic.ActiveForecasterQuantile) {
+	if !isAlloraDecBetweenZeroAndOneInclusive(topic.ActiveForecasterQuantile) {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic active forecaster quantile must be between 0 and 1 inclusive")
 	}
 	if err := ValidateDec(topic.ActiveReputerQuantile); err != nil {
 		return errors.Wrap(err, "topic active reputer quantile is invalid")
 	}
-	if !isAlloraDecZeroOrLessThanOne(topic.ActiveReputerQuantile) {
+	if !isAlloraDecBetweenZeroAndOneInclusive(topic.ActiveReputerQuantile) {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic active reputer quantile must be between 0 and 1 inclusive")
 	}
 	if err := ValidateDec(topic.CNorm); err != nil {
 		return errors.Wrap(err, "topic c_norm is invalid")
 	}
-	if topic.CNorm.Lt(alloraMath.MustNewDecFromString("-100")) || topic.CNorm.Gt(alloraMath.MustNewDecFromString("100")) {
+	if topic.CNorm.Lt(validationCNormMinDec) || topic.CNorm.Gt(validationCNormMaxDec) {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic c_norm must be between -100 and 100")
 	}
 
@@ -1188,13 +1206,13 @@ func (msg *CreateNewTopicRequest) Validate(maxStringLen uint64) error {
 		return errors.Wrap(err, "invalid msg Creator address")
 	}
 
-	if len(msg.LossMethod) == 0 || uint64(len(msg.LossMethod)) > maxStringLen {
+	if len(msg.LossMethod) < validationMinLossMethodLength || uint64(len(msg.LossMethod)) > maxStringLen {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "loss method invalid")
 	}
-	if msg.EpochLength <= 0 {
+	if msg.EpochLength < validationMinPositiveIntValue {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "epoch length must be greater than zero")
 	}
-	if msg.WorkerSubmissionWindow == 0 {
+	if msg.WorkerSubmissionWindow < validationMinPositiveIntValue {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "worker submission window must be greater than zero")
 	}
 	if msg.GroundTruthLag < msg.EpochLength {
@@ -1203,16 +1221,16 @@ func (msg *CreateNewTopicRequest) Validate(maxStringLen uint64) error {
 	if msg.WorkerSubmissionWindow > msg.EpochLength {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "worker submission window cannot be higher than epoch length")
 	}
-	if msg.AlphaRegret.Lte(alloraMath.ZeroDec()) || msg.AlphaRegret.Gt(alloraMath.OneDec()) || ValidateDec(msg.AlphaRegret) != nil {
+	if msg.AlphaRegret.Lte(validationZeroDec) || msg.AlphaRegret.Gt(validationOneDec) || ValidateDec(msg.AlphaRegret) != nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "alpha regret must be greater than 0 and less than or equal to 1")
 	}
-	if msg.PNorm.Lt(alloraMath.MustNewDecFromString("1")) || msg.PNorm.Gt(alloraMath.MustNewDecFromString("10")) || ValidateDec(msg.PNorm) != nil {
+	if msg.PNorm.Lt(validationOneDec) || msg.PNorm.Gt(validationPNormMaxDec) || ValidateDec(msg.PNorm) != nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "p-norm must be between 1 and 10")
 	}
-	if msg.CNorm.Lt(alloraMath.MustNewDecFromString("-100")) || msg.CNorm.Gt(alloraMath.MustNewDecFromString("100")) || ValidateDec(msg.CNorm) != nil {
+	if msg.CNorm.Lt(validationCNormMinDec) || msg.CNorm.Gt(validationCNormMaxDec) || ValidateDec(msg.CNorm) != nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "c_norm must be between -100 and 100")
 	}
-	if msg.Epsilon.Lte(alloraMath.ZeroDec()) || msg.Epsilon.IsNaN() || !msg.Epsilon.IsFinite() {
+	if msg.Epsilon.Lte(validationZeroDec) || msg.Epsilon.IsNaN() || !msg.Epsilon.IsFinite() {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "epsilon must be greater than 0")
 	}
 	if uint64(len(msg.Metadata)) > maxStringLen {
@@ -1225,13 +1243,13 @@ func (msg *CreateNewTopicRequest) Validate(maxStringLen uint64) error {
 	if !isAlloraDecZeroOrLessThanOne(msg.MeritSortitionAlpha) {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "merit sortition alpha must be between 0 and 1 inclusive")
 	}
-	if !isAlloraDecZeroOrLessThanOne(msg.ActiveInfererQuantile) {
+	if !isAlloraDecBetweenZeroAndOneInclusive(msg.ActiveInfererQuantile) {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "active inferer quantile must be between 0 and 1 inclusive")
 	}
-	if !isAlloraDecZeroOrLessThanOne(msg.ActiveForecasterQuantile) {
+	if !isAlloraDecBetweenZeroAndOneInclusive(msg.ActiveForecasterQuantile) {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "active forecaster quantile must be between 0 and 1 inclusive")
 	}
-	if !isAlloraDecZeroOrLessThanOne(msg.ActiveReputerQuantile) {
+	if !isAlloraDecBetweenZeroAndOneInclusive(msg.ActiveReputerQuantile) {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "active reputer quantile must be between 0 and 1 inclusive")
 	}
 

--- a/x/emissions/types/validations_test.go
+++ b/x/emissions/types/validations_test.go
@@ -1,11 +1,331 @@
 package types
 
 import (
+	"strings"
 	"testing"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/stretchr/testify/require"
 )
+
+func validCreateNewTopicRequest() *CreateNewTopicRequest {
+	return &CreateNewTopicRequest{
+		Creator:                  "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy",
+		Metadata:                 "metadata",
+		LossMethod:               "mse",
+		EpochLength:              10800,
+		GroundTruthLag:           10800,
+		PNorm:                    alloraMath.MustNewDecFromString("3"),
+		AlphaRegret:              alloraMath.MustNewDecFromString("0.1"),
+		AllowNegative:            false,
+		Epsilon:                  alloraMath.MustNewDecFromString("0.01"),
+		WorkerSubmissionWindow:   10,
+		MeritSortitionAlpha:      alloraMath.MustNewDecFromString("0.1"),
+		ActiveInfererQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		ActiveForecasterQuantile: alloraMath.MustNewDecFromString("0.2"),
+		ActiveReputerQuantile:    alloraMath.MustNewDecFromString("0.2"),
+		EnableWorkerWhitelist:    false,
+		EnableReputerWhitelist:   false,
+		CNorm:                    alloraMath.MustNewDecFromString("0.75"),
+	}
+}
+
+func TestCreateNewTopicRequest_Validate(t *testing.T) {
+	const maxStringLen uint64 = 256
+
+	tests := []struct {
+		name        string
+		mutate      func(*CreateNewTopicRequest)
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "valid request",
+			mutate:      func(*CreateNewTopicRequest) {},
+			wantErr:     false,
+			errContains: "",
+		},
+		{
+			name: "empty loss method",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.LossMethod = ""
+			},
+			wantErr:     true,
+			errContains: "loss method invalid",
+		},
+		{
+			name: "loss method too long",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.LossMethod = strings.Repeat("a", int(maxStringLen)+1)
+			},
+			wantErr:     true,
+			errContains: "loss method invalid",
+		},
+		{
+			name: "metadata too long",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.Metadata = strings.Repeat("a", int(maxStringLen)+1)
+			},
+			wantErr:     true,
+			errContains: "metadata invalid",
+		},
+		{
+			name: "zero epoch length",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.EpochLength = 0
+			},
+			wantErr:     true,
+			errContains: "epoch length must be greater than zero",
+		},
+		{
+			name: "negative epoch length",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.EpochLength = -1
+			},
+			wantErr:     true,
+			errContains: "epoch length must be greater than zero",
+		},
+		{
+			name: "zero worker submission window",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.WorkerSubmissionWindow = 0
+			},
+			wantErr:     true,
+			errContains: "worker submission window must be greater than zero",
+		},
+		{
+			name: "negative worker submission window",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.WorkerSubmissionWindow = -1
+			},
+			wantErr:     true,
+			errContains: "worker submission window must be greater than zero",
+		},
+		{
+			name: "worker submission window greater than epoch length",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.WorkerSubmissionWindow = msg.EpochLength + 1
+			},
+			wantErr:     true,
+			errContains: "worker submission window cannot be higher than epoch length",
+		},
+		{
+			name: "ground truth lag lower than epoch length",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.GroundTruthLag = msg.EpochLength - 1
+			},
+			wantErr:     true,
+			errContains: "ground truth lag cannot be lower than epoch length",
+		},
+		{
+			name: "zero alpha regret",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.AlphaRegret = alloraMath.ZeroDec()
+			},
+			wantErr:     true,
+			errContains: "alpha regret must be greater than 0 and less than or equal to 1",
+		},
+		{
+			name: "negative alpha regret",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.AlphaRegret = alloraMath.MustNewDecFromString("-0.1")
+			},
+			wantErr:     true,
+			errContains: "alpha regret must be greater than 0 and less than or equal to 1",
+		},
+		{
+			name: "alpha regret greater than one",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.AlphaRegret = alloraMath.MustNewDecFromString("1.1")
+			},
+			wantErr:     true,
+			errContains: "alpha regret must be greater than 0 and less than or equal to 1",
+		},
+		{
+			name: "p-norm below one",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.PNorm = alloraMath.MustNewDecFromString("0.9")
+			},
+			wantErr:     true,
+			errContains: "p-norm must be between 1 and 10",
+		},
+		{
+			name: "p-norm above ten",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.PNorm = alloraMath.MustNewDecFromString("10.1")
+			},
+			wantErr:     true,
+			errContains: "p-norm must be between 1 and 10",
+		},
+		{
+			name: "c-norm below negative one hundred",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.CNorm = alloraMath.MustNewDecFromString("-100.1")
+			},
+			wantErr:     true,
+			errContains: "c_norm must be between -100 and 100",
+		},
+		{
+			name: "c-norm above one hundred",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.CNorm = alloraMath.MustNewDecFromString("100.1")
+			},
+			wantErr:     true,
+			errContains: "c_norm must be between -100 and 100",
+		},
+		{
+			name: "zero epsilon",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.Epsilon = alloraMath.ZeroDec()
+			},
+			wantErr:     true,
+			errContains: "epsilon must be greater than 0",
+		},
+		{
+			name: "negative epsilon",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.Epsilon = alloraMath.MustNewDecFromString("-0.1")
+			},
+			wantErr:     true,
+			errContains: "epsilon must be greater than 0",
+		},
+		{
+			name: "negative merit sortition alpha",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.MeritSortitionAlpha = alloraMath.MustNewDecFromString("-0.1")
+			},
+			wantErr:     true,
+			errContains: "merit sortition alpha must be between 0 and 1 inclusive",
+		},
+		{
+			name: "zero merit sortition alpha",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.MeritSortitionAlpha = alloraMath.ZeroDec()
+			},
+			wantErr:     false,
+			errContains: "",
+		},
+		{
+			name: "merit sortition alpha equal to one",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.MeritSortitionAlpha = alloraMath.OneDec()
+			},
+			wantErr:     true,
+			errContains: "merit sortition alpha must be between 0 and 1 inclusive",
+		},
+		{
+			name: "negative active inferer quantile",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveInfererQuantile = alloraMath.MustNewDecFromString("-0.1")
+			},
+			wantErr:     true,
+			errContains: "active inferer quantile must be between 0 and 1 inclusive",
+		},
+		{
+			name: "active inferer quantile equal to zero",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveInfererQuantile = alloraMath.ZeroDec()
+			},
+			wantErr:     false,
+			errContains: "",
+		},
+		{
+			name: "active inferer quantile equal to one",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveInfererQuantile = alloraMath.OneDec()
+			},
+			wantErr:     false,
+			errContains: "",
+		},
+		{
+			name: "active inferer quantile greater than one",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveInfererQuantile = alloraMath.MustNewDecFromString("1.1")
+			},
+			wantErr:     true,
+			errContains: "active inferer quantile must be between 0 and 1 inclusive",
+		},
+		{
+			name: "negative active forecaster quantile",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveForecasterQuantile = alloraMath.MustNewDecFromString("-0.1")
+			},
+			wantErr:     true,
+			errContains: "active forecaster quantile must be between 0 and 1 inclusive",
+		},
+		{
+			name: "active forecaster quantile equal to zero",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveForecasterQuantile = alloraMath.ZeroDec()
+			},
+			wantErr:     false,
+			errContains: "",
+		},
+		{
+			name: "active forecaster quantile equal to one",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveForecasterQuantile = alloraMath.OneDec()
+			},
+			wantErr:     false,
+			errContains: "",
+		},
+		{
+			name: "active forecaster quantile greater than one",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveForecasterQuantile = alloraMath.MustNewDecFromString("1.1")
+			},
+			wantErr:     true,
+			errContains: "active forecaster quantile must be between 0 and 1 inclusive",
+		},
+		{
+			name: "negative active reputer quantile",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveReputerQuantile = alloraMath.MustNewDecFromString("-0.1")
+			},
+			wantErr:     true,
+			errContains: "active reputer quantile must be between 0 and 1 inclusive",
+		},
+		{
+			name: "active reputer quantile equal to zero",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveReputerQuantile = alloraMath.ZeroDec()
+			},
+			wantErr:     false,
+			errContains: "",
+		},
+		{
+			name: "active reputer quantile equal to one",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveReputerQuantile = alloraMath.OneDec()
+			},
+			wantErr:     false,
+			errContains: "",
+		},
+		{
+			name: "active reputer quantile greater than one",
+			mutate: func(msg *CreateNewTopicRequest) {
+				msg.ActiveReputerQuantile = alloraMath.MustNewDecFromString("1.1")
+			},
+			wantErr:     true,
+			errContains: "active reputer quantile must be between 0 and 1 inclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := validCreateNewTopicRequest()
+			tt.mutate(msg)
+
+			err := msg.Validate(maxStringLen)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestInputInference_Validate(t *testing.T) {
 	tests := []struct {

--- a/x/emissions/types/validations_test.go
+++ b/x/emissions/types/validations_test.go
@@ -195,7 +195,7 @@ func TestCreateNewTopicRequest_Validate(t *testing.T) {
 				msg.MeritSortitionAlpha = alloraMath.MustNewDecFromString("-0.1")
 			},
 			wantErr:     true,
-			errContains: "merit sortition alpha must be between 0 and 1 inclusive",
+			errContains: "merit sortition alpha must be greater than or equal to 0 and less than 1",
 		},
 		{
 			name: "zero merit sortition alpha",
@@ -211,7 +211,7 @@ func TestCreateNewTopicRequest_Validate(t *testing.T) {
 				msg.MeritSortitionAlpha = alloraMath.OneDec()
 			},
 			wantErr:     true,
-			errContains: "merit sortition alpha must be between 0 and 1 inclusive",
+			errContains: "merit sortition alpha must be greater than or equal to 0 and less than 1",
 		},
 		{
 			name: "negative active inferer quantile",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
Change valid ranges for p_norm from `2.5-4.5` to `1-10`.
Added a test on upper range boundary

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
-- no need, just increase of the ranges but no change of func.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand p_norm range from 2.5–4.5 to 1–10 per ENGN-5175.

Align active quantiles to [0,1] inclusive (merit alpha [0,1)), centralize constants, tighten error text, add boundary/error tests, set `MaxActiveTopicsPerBlock`=5 in integration tests, and update the CHANGELOG.

<sup>Written for commit 8822e917efb7f3135d58367a96ba5707980f7a23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



