### PR TITLE
DEVOP-586: drop GH_TOKEN --build-arg secret leak

### DIFF
--- a/.github/workflows/build_push_docker_hub.yml
+++ b/.github/workflows/build_push_docker_hub.yml
@@ -46,12 +46,6 @@ jobs:
           fi
 
           # Build a docker container and push it to Docker Hub.
-          # GH_TOKEN was previously passed as a --build-arg, which embeds the
-          # value in image layer metadata (visible via `docker history`/`docker
-          # inspect`) and would persist in the OCI manifest forever. The
-          # Dockerfile declared `ARG GH_TOKEN` but never consumed it (the build
-          # uses public Go modules only), so removing both is safe and closes
-          # the leak. See DEVOP-586.
           docker build --pull -t $DOCKERHUB_USERNAME/$DOCKERHUB_REPOSITORY:$IMAGE_TAG .
           docker push $DOCKERHUB_USERNAME/$DOCKERHUB_REPOSITORY:$IMAGE_TAG
 

--- a/.github/workflows/build_push_docker_hub.yml
+++ b/.github/workflows/build_push_docker_hub.yml
@@ -46,7 +46,13 @@ jobs:
           fi
 
           # Build a docker container and push it to Docker Hub.
-          docker build --pull --build-arg "GH_TOKEN=${{ secrets.GH_READONLY_PAT }}" -t $DOCKERHUB_USERNAME/$DOCKERHUB_REPOSITORY:$IMAGE_TAG .
+          # GH_TOKEN was previously passed as a --build-arg, which embeds the
+          # value in image layer metadata (visible via `docker history`/`docker
+          # inspect`) and would persist in the OCI manifest forever. The
+          # Dockerfile declared `ARG GH_TOKEN` but never consumed it (the build
+          # uses public Go modules only), so removing both is safe and closes
+          # the leak. See DEVOP-586.
+          docker build --pull -t $DOCKERHUB_USERNAME/$DOCKERHUB_REPOSITORY:$IMAGE_TAG .
           docker push $DOCKERHUB_USERNAME/$DOCKERHUB_REPOSITORY:$IMAGE_TAG
 
           # Build and PUSH additional tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.22-bookworm AS builder
 
-ARG GH_TOKEN
-
 ADD . /src
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM golang:1.22-bookworm AS builder
 
+# SECURITY: Do not pass credentials via `--build-arg` / `ARG` -- they are
+# embedded in image metadata (`docker history`, OCI provenance) and leak to
+# anyone with pull access. If a private Go module is ever needed, use a
+# BuildKit secret (`RUN --mount=type=secret,id=...`). See DEVOP-586.
+
 ADD . /src
 WORKDIR /src
 


### PR DESCRIPTION
## Summary

Removes `--build-arg "GH_TOKEN=\${{ secrets.GH_READONLY_PAT }}"` from `build_push_docker_hub.yml` and the matching unused `ARG GH_TOKEN` from `Dockerfile`. Closes the Shai-Hulud-amplifier secret leak path documented in DEVOP-586.

## Why removal instead of BuildKit secret mount

The ticket suggested switching to `--mount=type=secret,id=gh_pat` (BuildKit). That's the correct pattern *if* the Dockerfile actually consumes the token. This one doesn't:

- `Dockerfile` declares `ARG GH_TOKEN` but never references it in any `RUN`.
- `make install` resolves only public Go modules (verified by inspecting `go.mod`: no `allora-network/*` or other private deps).

The token has been entirely dead weight — it adds attack surface (leaks into image layer metadata via `docker history --no-trunc`) and provides zero functional value. Removing it is strictly simpler than refactoring to BuildKit and equally secure.

## Verification

- [x] `Dockerfile` has no remaining `GH_TOKEN` / `GH_READONLY_PAT` reference.
- [x] Workflow has no remaining `--build-arg` or env var passing the secret.
- [x] `go.mod` confirmed all-public deps.
- [ ] CI green (reviewer to confirm).
- [ ] After merge: rotate `GH_READONLY_PAT` (previously-built images on Docker Hub may have it baked in via layer metadata). Audit Harbor projects with pull access to `alloranetwork/allora-chain`.

## Related

- Linear: https://linear.app/alloralabs/issue/DEVOP-586
- Companion PR for `explorer` repo: opened in `allora-network/explorer`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `--build-arg "GH_TOKEN=${{ secrets.GH_READONLY_PAT }}"` from `.github/workflows/build_push_docker_hub.yml` and the unused `ARG GH_TOKEN` from `Dockerfile` to prevent PAT leaks; removed the now-obsolete workflow comment. Added a SECURITY note in `Dockerfile` warning against `--build-arg` secrets and pointing to BuildKit if ever needed; all modules are public, so this completes DEVOP-586.

- **Migration**
  - Rotate `GH_READONLY_PAT` (older images may include it in layer history).
  - Audit Harbor projects with pull access to `alloranetwork/allora-chain` images.

<sup>Written for commit 16f4977a39aea7772c4c019e3f8d34f674228383. Summary will update on new commits. <a href="https://cubic.dev/pr/allora-network/allora-chain/pull/950?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

