### PR TITLE
feat(ci): adopt go-install-hardened workflow (Shai-Hulud defense)

### DIFF
--- a/.github/workflows/go-hardened.yml
+++ b/.github/workflows/go-hardened.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'go.mod'
       - 'go.sum'
+      - 'go.env'
       - '**/*.go'
       - '.github/workflows/go-hardened.yml'
   push:

--- a/.github/workflows/go-hardened.yml
+++ b/.github/workflows/go-hardened.yml
@@ -1,0 +1,18 @@
+name: Go hardened install
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - '**/*.go'
+      - '.github/workflows/go-hardened.yml'
+  push:
+    branches: [main, master, dev, staging]
+permissions:
+  contents: read
+jobs:
+  hardened-install:
+    uses: allora-network/ci-workflows-private/.github/workflows/go-install-hardened.yml@fa8a0e1361216ec0c75e4d822f648248083e229b
+    with:
+      go_version: stable
+      cgo_enabled: '1'

--- a/.github/workflows/go-hardened.yml
+++ b/.github/workflows/go-hardened.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 jobs:
   hardened-install:
-    uses: allora-network/ci-workflows-private/.github/workflows/go-install-hardened.yml@fa8a0e1361216ec0c75e4d822f648248083e229b
+    uses: allora-network/ci-workflows-private/.github/workflows/go-install-hardened.yml@0d80a856ef798b01a39f65cb88a5cf7e74e4ebf9
     with:
       go_version: stable
       cgo_enabled: '1'

--- a/.github/workflows/go-hardened.yml
+++ b/.github/workflows/go-hardened.yml
@@ -15,5 +15,8 @@ jobs:
   hardened-install:
     uses: allora-network/ci-workflows-private/.github/workflows/go-install-hardened.yml@0d80a856ef798b01a39f65cb88a5cf7e74e4ebf9
     with:
-      go_version: stable
+      # Pinned to match the `toolchain` directive in go.mod (and the version
+      # used by golangci-lint.yml). Keeps hardened install checks deterministic
+      # across runs instead of tracking whatever "stable" resolves to.
+      go_version: '1.23.5'
       cgo_enabled: '1'

--- a/.github/workflows/go-hardened.yml
+++ b/.github/workflows/go-hardened.yml
@@ -1,22 +1,37 @@
 name: Go hardened install
 on:
+  # No `paths:` filter on purpose. A path-filtered workflow that is
+  # promoted to a required status check would block PRs that touch
+  # only docs/YAML, because GitHub does not auto-pass path-filtered
+  # required checks. The hardened install completes quickly when the
+  # module cache is warm, so the cost of running on every PR is
+  # acceptable in exchange for safe required-check eligibility.
   pull_request:
-    paths:
-      - 'go.mod'
-      - 'go.sum'
-      - 'go.env'
-      - '**/*.go'
-      - '.github/workflows/go-hardened.yml'
   push:
-    branches: [main, master, dev, staging]
+    branches: [main, dev, release-*]
 permissions:
   contents: read
+# Cancel in-flight hardened-install runs for the same PR when new
+# commits arrive; keep push-event runs (main/dev/release-*) intact.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   hardened-install:
+    # Skip on fork PRs: the reusable workflow lives in a private repo
+    # and a fork PR's GITHUB_TOKEN cannot resolve it, which would
+    # surface as a confusing not-found failure for external
+    # contributors. Internal PRs and push events always run.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     uses: allora-network/ci-workflows-private/.github/workflows/go-install-hardened.yml@0d80a856ef798b01a39f65cb88a5cf7e74e4ebf9
     with:
-      # Pinned to match the `toolchain` directive in go.mod (and the version
-      # used by golangci-lint.yml). Keeps hardened install checks deterministic
-      # across runs instead of tracking whatever "stable" resolves to.
+      # Pinned to match the `toolchain` directive in go.mod. Keeps
+      # the hardened install check deterministic across runs instead
+      # of tracking whatever "stable" resolves to. Sibling workflows
+      # (golangci-lint.yml @ 1.23.6, format_and_test.yml @ 1.22.x)
+      # diverge today; centralizing on go.mod's toolchain is tracked
+      # as a follow-up.
       go_version: '1.23.5'
+      # cosmwasm/wasmvm (a transitive Cosmos SDK dep) requires CGO to
+      # link against libwasmvm; matches the goreleaser build path.
       cgo_enabled: '1'

--- a/go.env
+++ b/go.env
@@ -1,0 +1,5 @@
+# Shai-Hulud defense - Go module integrity pinning.
+# See allora-network/skills (skills/shai-hulud-defense) for rationale.
+GOPROXY=https://proxy.golang.org,direct
+GOSUMDB=sum.golang.org
+GOFLAGS=-mod=readonly

--- a/go.env
+++ b/go.env
@@ -1,5 +1,39 @@
 # Shai-Hulud defense - Go module integrity pinning.
-# See allora-network/skills (skills/shai-hulud-defense) for rationale.
+#
+# This file is documentation/reference only. Go does NOT auto-load a
+# repo-root go.env (only $GOROOT/go.env and $GOENV / ~/.config/go/env
+# are consulted by the `go` toolchain). The values below are enforced
+# in CI by the go-install-hardened reusable workflow (see
+# .github/workflows/go-hardened.yml), which exports them into
+# $GITHUB_ENV before any `go` command runs. Other Go workflows
+# (golangci-lint.yml, format_and_test.yml, goreleaser.yml,
+# build_push_docker_hub.yml) and local developer builds do NOT
+# currently consume this file; wiring them up is tracked separately.
+#
+# Local opt-in: `set -a; . ./go.env; set +a`. WARNING: sourcing
+# locally inherits GOFLAGS=-mod=readonly, which causes `go mod tidy`
+# and `go get` to fail with "updates to go.mod needed". Unset
+# GOFLAGS (or run those commands in a sub-shell) before doing module
+# maintenance.
+#
+# If/when this repo (or a transitive dep) takes on a private module,
+# add `GOPRIVATE=github.com/allora-network/<private-org-or-repo>`
+# rather than disabling GOSUMDB. Do not weaken GOSUMDB wholesale.
+#
+# Rationale skill:
+# https://github.com/allora-network/skills/tree/main/skills/shai-hulud-defense
+
+# Use Google's module proxy (cached, integrity-checked) with a direct
+# VCS fallback for modules the proxy hasn't seen yet (routine for
+# newly tagged or yanked modules). The ",direct" fallback is a known
+# trade-off: in a maintainer-compromise scenario the proxy may serve
+# a cached-clean version while direct would fetch the malicious tag.
+# Drop ",direct" if you want misses to fail loudly instead.
 GOPROXY=https://proxy.golang.org,direct
+
+# Verify every module against the Go checksum database.
 GOSUMDB=sum.golang.org
+
+# Prevent `go build` / `go test` from silently mutating go.mod.
+# See the WARNING above about sourcing this file locally.
 GOFLAGS=-mod=readonly


### PR DESCRIPTION
Adopts the `go-install-hardened.yml` reusable workflow + pins Go env vars in `go.env` for module-integrity safety. Extends the Shai-Hulud supply-chain defense (currently rolled out for npm/PyPI) to Go.\n\n- Reusable workflow: allora-network/ci-workflows-private#17 (SHA-pinned to `fa8a0e1361216ec0c75e4d822f648248083e229b`; will re-pin to `@v1` after merge)\n- Skill: allora-network/skills#69\n- Linear umbrella: "Adopt go-install-hardened.yml across all 11 active Go repos"\n- `cgo_enabled: '1'`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.github/workflows/go-hardened.yml` to run the reusable `go-install-hardened.yml` with `go_version: '1.23.5'` and `cgo_enabled: '1'`, plus `go.env` pinning `GOPROXY`, `GOSUMDB`, and `GOFLAGS=-mod=readonly`. The workflow runs on all PRs and pushes (main/dev/release-*), skips fork PRs, and cancels stale PR runs to make it a safe required check, extending the Shai‑Hulud defense and aligning with the Linear rollout.

- **Bug Fixes**
  - Workflow: re-pinned to the correct reusable workflow; removed `paths` filter; added `concurrency` for PRs; added fork-PR `if` guard; aligned push branches.
  - Policy/docs: expanded `go.env` guidance (local opt-in and `GOFLAGS` caveat), documented `,direct` fallback and `GOPRIVATE` approach.

<sup>Written for commit 615698986e003e7421c57190c5dab3745d117f0e. Summary will update on new commits. <a href="https://cubic.dev/pr/allora-network/allora-chain/pull/951?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

