### PR TITLE
fix: SMELL-03 label default value usage and tests

### DIFF
--- a/x/emissions/keeper/inference_synthesis/forecast_implied.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied.go
@@ -28,6 +28,9 @@ type CalcForecastImpliedInferencesArgs struct {
 	RegretScalePlusEpsilon alloraMath.Dec
 	LabelRegistry          *emissionstypes.EpochLabelRegistry
 	NumLabels              int
+	// LabelDefaultValue is topic.LabelDefaultValue, used to pad unset trailing
+	// slots when converting stored inferences (mirrors keeper semantics).
+	LabelDefaultValue alloraMath.Dec
 }
 
 // Calculate the forecast-implied inferences I_ik given inferences, forecasts and network losses.
@@ -85,7 +88,7 @@ func CalcForecastImpliedInferences(args CalcForecastImpliedInferencesArgs) (map[
 					blockHeight = inf.BlockHeight
 				}
 
-				iv, err := emissionstypes.ConvertInferenceValuesFromProto(args.TopicArity, labels, inf)
+				iv, err := emissionstypes.ConvertInferenceValuesFromProto(args.TopicArity, labels, args.LabelDefaultValue, inf)
 				if err != nil {
 					return nil, err
 				}
@@ -196,7 +199,7 @@ func CalcForecastImpliedInferences(args CalcForecastImpliedInferencesArgs) (map[
 				blockHeight = inf.BlockHeight
 			}
 
-			iv, err := emissionstypes.ConvertInferenceValuesFromProto(args.TopicArity, labels, inf)
+			iv, err := emissionstypes.ConvertInferenceValuesFromProto(args.TopicArity, labels, args.LabelDefaultValue, inf)
 			if err != nil {
 				return nil, err
 			}

--- a/x/emissions/keeper/inference_synthesis/forecast_implied_test.go
+++ b/x/emissions/keeper/inference_synthesis/forecast_implied_test.go
@@ -589,6 +589,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          &registry,
 			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		},
 	)
 	s.Require().NoError(err)
@@ -687,6 +688,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesTwoWorker
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          &registry,
 			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		},
 	)
 	s.Require().NoError(err)
@@ -803,6 +805,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesThreeWork
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          &registry,
 			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		},
 	)
 	s.Require().NoError(err)
@@ -925,6 +928,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch2() {
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          &registry,
 			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		})
 	s.Require().NoError(err)
 	for key, expectedValue := range expected {
@@ -1039,6 +1043,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForcastImpliedInferencesEpoch3() {
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          &registry,
 			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		})
 	s.Require().NoError(err)
 	for key, expectedValue := range expected {
@@ -1133,6 +1138,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesForecaste
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          &registry,
 			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		},
 	)
 	s.Require().NoError(err)
@@ -1213,6 +1219,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesForecaste
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          &registry,
 			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		},
 	)
 	s.Require().NoError(err)
@@ -1332,6 +1339,7 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesMultipleF
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          &registry,
 			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		},
 	)
 	s.Require().NoError(err)
@@ -1361,4 +1369,182 @@ func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesMultipleF
 	s.Require().True(result["forecaster0"].Values[0].IsPositive(), "forecaster0 should have valid result despite missing worker2")
 	s.Require().True(result[s.AddrsStr(1)].Values[0].IsPositive(), "forecaster1 should have valid result despite missing worker1")
 	s.Require().True(result[s.AddrsStr(2)].Values[0].IsPositive(), "forecaster2 should have valid result despite missing worker0")
+}
+
+// TestCalcForecastImpliedInferencesMultiArityPadsWithLabelDefaultValue verifies that
+// the MULTI-arity forecast-implied synthesis pads short stored inference vectors with
+// args.LabelDefaultValue (NOT zero). It uses the MEDIAN branch (AllInferersAreNew=true)
+// so the per-column result is a deterministic median of the padded vectors.
+//
+// Registry has 3 labels; each inferer submits only the first column, so columns 1 and 2
+// are padded with the default (-1). If padding regressed to zero, columns 1 and 2 would
+// be 0 instead of -1 and this test would fail.
+func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesMultiArityPadsWithLabelDefaultValue() {
+	topicId := uint64(1)
+	networkCombinedLoss := alloraMath.MustNewDecFromString("0.5")
+	epsilon := alloraMath.MustNewDecFromString("1e-4")
+	pNorm := alloraMath.MustNewDecFromString("2.0")
+	cNorm := alloraMath.MustNewDecFromString("0.75")
+	labelDefault := alloraMath.MustNewDecFromString("-1")
+
+	inferer0 := "worker0"
+	inferer1 := s.AddrsStr(1)
+
+	// Each inferer submits a single-column (short) vector; the registry has 3 labels.
+	inferenceByWorker := map[string]*emissionstypes.Inference{
+		inferer0: {Values: []alloraMath.Dec{alloraMath.MustNewDecFromString("1")}},
+		inferer1: {Values: []alloraMath.Dec{alloraMath.MustNewDecFromString("2")}},
+	}
+
+	forecasts := &emissionstypes.Forecasts{
+		Forecasts: []*emissionstypes.Forecast{
+			{
+				Forecaster: "forecaster0",
+				ForecastElements: []*emissionstypes.ForecastElement{
+					{Inferer: inferer0, Value: alloraMath.MustNewDecFromString("3")},
+					{Inferer: inferer1, Value: alloraMath.MustNewDecFromString("4")},
+				},
+			},
+		},
+	}
+
+	inferers := []string{inferer0, inferer1}
+	forecasters := []string{"forecaster0"}
+	forecastByWorker := map[string]*emissionstypes.Forecast{"forecaster0": forecasts.Forecasts[0]}
+	zero := alloraMath.ZeroDec()
+	infererRegrets := map[string]*alloraMath.Dec{inferer0: &zero, inferer1: &zero}
+	forecasterRegrets := map[string]*alloraMath.Dec{"forecaster0": &zero}
+
+	registry := emissionstypes.EpochLabelRegistry{
+		TopicId: topicId,
+		EpochId: 1,
+		Labels: []*emissionstypes.TopicLabel{
+			{Id: 1, Name: "a"}, {Id: 2, Name: "b"}, {Id: 3, Name: "c"},
+		},
+	}
+
+	result, err := inferencesynthesis.CalcForecastImpliedInferences(
+		inferencesynthesis.CalcForecastImpliedInferencesArgs{
+			Logger:                 s.Ctx().Logger(),
+			TopicId:                topicId,
+			TopicArity:             emissionstypes.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			AllInferersAreNew:      true, // MEDIAN branch
+			Inferers:               inferers,
+			InfererToInference:     inferenceByWorker,
+			InfererToRegret:        infererRegrets,
+			Forecasters:            forecasters,
+			ForecasterToForecast:   forecastByWorker,
+			ForecasterToRegret:     forecasterRegrets,
+			NetworkCombinedLoss:    &networkCombinedLoss,
+			EpsilonTopic:           epsilon,
+			PNorm:                  pNorm,
+			CNorm:                  cNorm,
+			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
+			LabelRegistry:          &registry,
+			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      labelDefault,
+		},
+	)
+	s.Require().NoError(err)
+
+	got, ok := result["forecaster0"]
+	s.Require().True(ok, "expected forecaster0 in result")
+	s.Require().Len(got.Values, 3)
+
+	// col0 = median(1, 2) = 1.5 ; col1,col2 = median(-1, -1) = -1 (the default, not 0)
+	tol := alloraMath.MustNewDecFromString("0.0001")
+	for i, want := range []string{"1.5", "-1", "-1"} {
+		inDelta, derr := alloraMath.InDelta(alloraMath.MustNewDecFromString(want), got.Values[i], tol)
+		s.Require().NoError(derr)
+		s.Require().True(inDelta, "col %d: want %s got %s", i, want, got.Values[i].String())
+	}
+}
+
+// TestCalcForecastImpliedInferencesMultiArityWeightedPadsWithLabelDefaultValue is the
+// WEIGHTED-branch counterpart of the MEDIAN test above. With AllInferersAreNew=false the
+// synthesis takes the regret-weighted path, exercising the *second*
+// ConvertInferenceValuesFromProto call site (forecast_implied.go ~line 204).
+//
+// Both inferers submit only the first column of a 3-label registry, so columns 1 and 2 are
+// fully padded with the default (-1). A fully-padded column equals the default regardless of
+// the weights (sum(w_i*d)/sum(w_i) == d). The two forecast elements share the same value so
+// the inferers also carry equal weights, making column 0 the plain average (1.5).
+func (s *InferenceSynthesisTestSuite) TestCalcForecastImpliedInferencesMultiArityWeightedPadsWithLabelDefaultValue() {
+	networkCombinedLoss := alloraMath.MustNewDecFromString("0.5")
+	epsilon := alloraMath.MustNewDecFromString("1e-4")
+	pNorm := alloraMath.MustNewDecFromString("2.0")
+	cNorm := alloraMath.MustNewDecFromString("0.75")
+	labelDefault := alloraMath.MustNewDecFromString("-1")
+
+	inferer0 := "worker0"
+	inferer1 := s.AddrsStr(1)
+
+	inferenceByWorker := map[string]*emissionstypes.Inference{
+		inferer0: {Values: []alloraMath.Dec{alloraMath.MustNewDecFromString("1")}},
+		inferer1: {Values: []alloraMath.Dec{alloraMath.MustNewDecFromString("2")}},
+	}
+
+	// Equal forecast-element values => equal regrets => equal weights.
+	forecasts := &emissionstypes.Forecasts{
+		Forecasts: []*emissionstypes.Forecast{
+			{
+				Forecaster: "forecaster0",
+				ForecastElements: []*emissionstypes.ForecastElement{
+					{Inferer: inferer0, Value: alloraMath.MustNewDecFromString("0.4")},
+					{Inferer: inferer1, Value: alloraMath.MustNewDecFromString("0.4")},
+				},
+			},
+		},
+	}
+
+	inferers := []string{inferer0, inferer1}
+	forecasters := []string{"forecaster0"}
+	forecastByWorker := map[string]*emissionstypes.Forecast{"forecaster0": forecasts.Forecasts[0]}
+	zero := alloraMath.ZeroDec()
+	infererRegrets := map[string]*alloraMath.Dec{inferer0: &zero, inferer1: &zero}
+	forecasterRegrets := map[string]*alloraMath.Dec{"forecaster0": &zero}
+
+	registry := emissionstypes.EpochLabelRegistry{
+		TopicId: 1,
+		EpochId: 1,
+		Labels: []*emissionstypes.TopicLabel{
+			{Id: 1, Name: "a"}, {Id: 2, Name: "b"}, {Id: 3, Name: "c"},
+		},
+	}
+
+	result, err := inferencesynthesis.CalcForecastImpliedInferences(
+		inferencesynthesis.CalcForecastImpliedInferencesArgs{
+			Logger:                 s.Ctx().Logger(),
+			TopicId:                1,
+			TopicArity:             emissionstypes.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			AllInferersAreNew:      false, // WEIGHTED branch
+			Inferers:               inferers,
+			InfererToInference:     inferenceByWorker,
+			InfererToRegret:        infererRegrets,
+			Forecasters:            forecasters,
+			ForecasterToForecast:   forecastByWorker,
+			ForecasterToRegret:     forecasterRegrets,
+			NetworkCombinedLoss:    &networkCombinedLoss,
+			EpsilonTopic:           epsilon,
+			PNorm:                  pNorm,
+			CNorm:                  cNorm,
+			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
+			LabelRegistry:          &registry,
+			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      labelDefault,
+		},
+	)
+	s.Require().NoError(err)
+
+	got, ok := result["forecaster0"]
+	s.Require().True(ok, "expected forecaster0 in result")
+	s.Require().Len(got.Values, 3)
+
+	// col0 = equal-weight avg(1, 2) = 1.5 ; col1,col2 fully padded => default -1 (not 0)
+	tol := alloraMath.MustNewDecFromString("0.0001")
+	for i, want := range []string{"1.5", "-1", "-1"} {
+		inDelta, derr := alloraMath.InDelta(alloraMath.MustNewDecFromString(want), got.Values[i], tol)
+		s.Require().NoError(derr)
+		s.Require().True(inDelta, "col %d: want %s got %s", i, want, got.Values[i].String())
+	}
 }

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder.go
@@ -145,6 +145,7 @@ type GetOneOutInfererForecastImpliedInferencesArgs struct {
 	RegretScalePlusEpsilon alloraMath.Dec
 	LabelRegistry          *emissions.EpochLabelRegistry
 	NumLabels              int
+	LabelDefaultValue      alloraMath.Dec
 }
 
 // GetOneOutInfererForecastImpliedInferences calculates what each forecaster's implied inference
@@ -245,6 +246,7 @@ func GetOneOutInfererForecastImpliedInferences(args GetOneOutInfererForecastImpl
 					RegretScalePlusEpsilon: args.RegretScalePlusEpsilon,
 					LabelRegistry:          args.LabelRegistry,
 					NumLabels:              args.NumLabels,
+					LabelDefaultValue:      args.LabelDefaultValue,
 				},
 			)
 			if calcErr != nil {
@@ -384,6 +386,7 @@ type CalcOneOutInfererInferenceArgs struct {
 	RegretScalePlusEpsilon alloraMath.Dec
 	LabelRegistry          *emissions.EpochLabelRegistry
 	NumLabels              int
+	LabelDefaultValue      alloraMath.Dec
 }
 
 // Calculate the one-out inference given a withheld inferer
@@ -467,6 +470,7 @@ func calcOneOutInfererInference(args CalcOneOutInfererInferenceArgs) (
 				RegretScalePlusEpsilon: args.RegretScalePlusEpsilon,
 				LabelRegistry:          args.LabelRegistry,
 				NumLabels:              args.NumLabels,
+				LabelDefaultValue:      args.LabelDefaultValue,
 			},
 		)
 		if err != nil {
@@ -542,6 +546,7 @@ type GetOneOutInfererInferencesArgs struct {
 	RegretScalePlusEpsilon alloraMath.Dec
 	LabelRegistry          *emissions.EpochLabelRegistry
 	NumLabels              int
+	LabelDefaultValue      alloraMath.Dec
 }
 
 // Set all one-out-inferer inferences that are possible given the provided input
@@ -584,6 +589,7 @@ func GetOneOutInfererInferences(args GetOneOutInfererInferencesArgs) (
 				RegretScalePlusEpsilon: args.RegretScalePlusEpsilon,
 				LabelRegistry:          args.LabelRegistry,
 				NumLabels:              args.NumLabels,
+				LabelDefaultValue:      args.LabelDefaultValue,
 			})
 		if err != nil {
 			return []*emissions.OneOutInfererValue{}, errorsmod.Wrapf(err, "GetOneOutInfererInferences() error calculating one-out inferer inferences")
@@ -984,6 +990,7 @@ type CalcNetworkInferencesArgs struct {
 	InferenceBlockHeight                 BlockHeight
 	LabelRegistry                        *emissions.EpochLabelRegistry
 	NumLabels                            int
+	LabelDefaultValue                    alloraMath.Dec
 }
 
 // Calculates all network inferences in the set I_i given historical state (e.g. regrets)
@@ -1098,6 +1105,7 @@ func CalcNetworkInferences(
 			RegretScalePlusEpsilon: args.RegretScalePlusEpsilon,
 			LabelRegistry:          args.LabelRegistry,
 			NumLabels:              args.NumLabels,
+			LabelDefaultValue:      args.LabelDefaultValue,
 		})
 	if err != nil {
 		return &emissions.NetworkInferenceBundle{}, RegretInformedWeights{}, errorsmod.Wrap(err, "CalcNetworkInferences() error calculating one-out inferer inferences")
@@ -1190,6 +1198,7 @@ func CalcNetworkInferences(
 				RegretScalePlusEpsilon: args.RegretScalePlusEpsilon,
 				LabelRegistry:          args.LabelRegistry,
 				NumLabels:              args.NumLabels,
+				LabelDefaultValue:      args.LabelDefaultValue,
 			},
 		)
 		if err != nil {

--- a/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
+++ b/x/emissions/keeper/inference_synthesis/network_inference_builder_test.go
@@ -607,6 +607,7 @@ func (s *InferenceSynthesisTestSuite) testCorrectOneOutInfererValuesForEpoch(epo
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          registry,
 			NumLabels:              len(registry.GetLabels()),
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		})
 	s.Require().NoError(err)
 
@@ -1314,6 +1315,7 @@ func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences() {
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          args.LabelRegistry,
 			NumLabels:              args.NumLabels,
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		})
 	s.Require().NoError(err)
 
@@ -1355,6 +1357,7 @@ func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences() {
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          args.LabelRegistry,
 			NumLabels:              args.NumLabels,
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		})
 	s.Require().NoError(err)
 	s.Require().Empty(emptyResult)
@@ -1387,7 +1390,8 @@ func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences() {
 					Name: "y",
 				}},
 			},
-			NumLabels: 1,
+			NumLabels:         1,
+			LabelDefaultValue: alloraMath.ZeroDec(),
 		})
 	s.Require().NoError(err)
 	s.Require().Empty(singleInfererResult)
@@ -1467,6 +1471,7 @@ func (s *InferenceSynthesisTestSuite) TestGetOneOutInfererImpliedInferences2infe
 			RegretScalePlusEpsilon: alloraMath.ZeroDec(),
 			LabelRegistry:          args.LabelRegistry,
 			NumLabels:              args.NumLabels,
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		},
 	)
 	s.Require().NoError(err)
@@ -1560,6 +1565,7 @@ func (s *InferenceSynthesisTestSuite) referenceOneOutInfererCombinedValue(
 			RegretScalePlusEpsilon: calcArgs.RegretScalePlusEpsilon,
 			LabelRegistry:          calcArgs.LabelRegistry,
 			NumLabels:              calcArgs.NumLabels,
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		},
 	)
 	if err != nil {
@@ -1770,6 +1776,7 @@ func (s *InferenceSynthesisTestSuite) TestOneOutInfererRecomputeExcludesWithheld
 					RegretScalePlusEpsilon: calcArgs.RegretScalePlusEpsilon,
 					LabelRegistry:          calcArgs.LabelRegistry,
 					NumLabels:              calcArgs.NumLabels,
+					LabelDefaultValue:      alloraMath.ZeroDec(),
 				},
 			)
 			s.Require().NoError(err)
@@ -1900,6 +1907,7 @@ func (s *InferenceSynthesisTestSuite) TestOneOutInfererLeakViaSingleElementForec
 			RegretScalePlusEpsilon: calcArgs.RegretScalePlusEpsilon,
 			LabelRegistry:          calcArgs.LabelRegistry,
 			NumLabels:              calcArgs.NumLabels,
+			LabelDefaultValue:      alloraMath.ZeroDec(),
 		},
 	)
 	s.Require().NoError(err)

--- a/x/emissions/keeper/inference_synthesis/network_inferences.go
+++ b/x/emissions/keeper/inference_synthesis/network_inferences.go
@@ -255,6 +255,7 @@ func GetCalcNetworkInferenceArgs(
 		InferenceBlockHeight:                 inferenceBlockHeight,
 		LabelRegistry:                        registry,
 		NumLabels:                            numLabels,
+		LabelDefaultValue:                    topic.LabelDefaultValue,
 	}
 
 	if previousLossesCombinedValue != nil {
@@ -294,6 +295,7 @@ func GetCalcNetworkInferenceArgs(
 				RegretScalePlusEpsilon: regretScalePlusEpsilon,
 				LabelRegistry:          registry,
 				NumLabels:              numLabels,
+				LabelDefaultValue:      topic.LabelDefaultValue,
 			},
 		)
 		if err != nil {

--- a/x/emissions/module/rewards/rewards_multilabel_test.go
+++ b/x/emissions/module/rewards/rewards_multilabel_test.go
@@ -1091,3 +1091,87 @@ func computeExpectedNaiveByLabel(
 	}
 	return out
 }
+
+// TestMultiLabelNonZeroDefaultValuePadsMissingLabels exercises the full
+// submit -> close/compact -> synthesis pipeline for a MULTI topic whose
+// LabelDefaultValue is non-zero. Each worker submits a single, distinct label,
+// so the other two slots must be padded with the default (0.9) rather than 0,
+// both in the stored (compacted) active inferences and in the synthesized
+// naive network inference.
+//
+// Note: this is an end-to-end consistency lock. Because close-time compaction
+// already aligns/pads stored vectors to the registry with LabelDefaultValue,
+// the dedicated regression guards for the conversions padding fix live in the
+// unit tests (TestConvertInferenceValuesFromProto and
+// TestCalcForecastImpliedInferencesMultiArityPadsWithLabelDefaultValue).
+func (s *RewardsTestSuite) TestMultiLabelNonZeroDefaultValuePadsMissingLabels() {
+	require := s.Require()
+
+	const def = "0.9" // distinct from every submitted value so nothing is dropped as "default"
+
+	workerIndexes := testutil.ReturnIndexes(5, 3)
+	reputerIndexes := testutil.ReturnIndexes(0, 3)
+
+	workerValues := []testutil.TestWorkerValue{
+		{Values: []testutil.TestLabeledValue{{Label: "A", Value: "0.1"}}},
+		{Values: []testutil.TestLabeledValue{{Label: "B", Value: "0.2"}}},
+		{Values: []testutil.TestLabeledValue{{Label: "C", Value: "0.3"}}},
+	}
+	workerAddrs := make([]string, len(workerIndexes))
+	for i, idx := range workerIndexes {
+		workerAddrs[i] = s.AddrsStr(idx)
+		workerValues[i].Index = idx
+	}
+
+	topicId, nonce := s.FullTopicPass(
+		workerIndexes,
+		reputerIndexes,
+		testutil.WithOutputArity(types.TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI),
+		testutil.WithLabelCaseSensitive(true),
+		testutil.WithLabelDefaultValue(alloraMath.MustNewDecFromString(def)),
+		testutil.WithWorkerValues(workerValues),
+	)
+
+	topic, err := s.TopicKeeper().GetTopic(s.Ctx(), topicId)
+	require.NoError(err)
+	require.Equal(alloraMath.MustNewDecFromString(def).String(), topic.LabelDefaultValue.String())
+
+	wantNames := []string{"A", "B", "C"}
+	registry, err := s.TopicKeeper().GetEpochLabelRegistry(s.Ctx(), topicId, nonce)
+	require.NoError(err)
+	assertRegistryLabelNames(require, &registry, wantNames)
+
+	// Stored (compacted) active inferences: missing slots padded with the default, not 0.
+	activeInferences, err := s.WorkerKeeper().GetInferencesAtBlock(s.Ctx(), topic, nonce, false)
+	require.NoError(err)
+	assertActiveInferencesMatchExpected(require, activeInferences, map[string][]string{
+		workerAddrs[0]: {"0.1", def, def},
+		workerAddrs[1]: {def, "0.2", def},
+		workerAddrs[2]: {def, def, "0.3"},
+	})
+
+	// Synthesized naive inference reflects the default in the missing slots:
+	//   A = (0.1 + 0.9 + 0.9) / 3,  B = (0.9 + 0.2 + 0.9) / 3,  C = (0.9 + 0.9 + 0.3) / 3
+	bundle, err := s.EmissionsKeeper().GetNetworkInferences(s.Ctx(), topicId, nonce)
+	require.NoError(err)
+	require.NotNil(bundle)
+	assertLabeledValuesMatchNames(require, bundle.NaiveValue, wantNames, "naive value")
+
+	three := alloraMath.MustNewDecFromString("3")
+	avg := func(sum string) string {
+		v, qerr := alloraMath.MustNewDecFromString(sum).Quo(three)
+		require.NoError(qerr)
+		return v.String()
+	}
+	naive := labeledValuesToMap(bundle.NaiveValue)
+	testutil2.InEpsilon5(s.T(), naive["A"], avg("1.9"))
+	testutil2.InEpsilon5(s.T(), naive["B"], avg("2.0"))
+	testutil2.InEpsilon5(s.T(), naive["C"], avg("2.1"))
+
+	// First pass, all-new inferers => equal weights => combined == naive per label.
+	assertLabeledValuesMatchNames(require, bundle.CombinedValue, wantNames, "combined value")
+	combined := labeledValuesToMap(bundle.CombinedValue)
+	for _, label := range wantNames {
+		testutil2.InEpsilon5(s.T(), combined[label], naive[label].String())
+	}
+}

--- a/x/emissions/testutil/test_utils.go
+++ b/x/emissions/testutil/test_utils.go
@@ -216,6 +216,7 @@ type (
 		skipNetworkInferences bool
 		outputArity           types.TopicOutputArity
 		labelCaseSensitive    bool
+		labelDefaultValue     *alloraMath.Dec
 		reputerStake          *cosmosMath.Int
 		accounts              []account
 	}
@@ -324,6 +325,15 @@ func WithOutputArity(outputArity types.TopicOutputArity) Option {
 func WithLabelCaseSensitive(labelCaseSensitive bool) Option {
 	return func(p *customParams) {
 		p.labelCaseSensitive = labelCaseSensitive
+	}
+}
+
+// WithLabelDefaultValue sets the topic's LabelDefaultValue (the value used to
+// pad unset label slots in dense MULTI inference vectors). Defaults to zero when
+// unset. Must be zero unless require_unity is false (enforced by topic validation).
+func WithLabelDefaultValue(labelDefaultValue alloraMath.Dec) Option {
+	return func(p *customParams) {
+		p.labelDefaultValue = &labelDefaultValue
 	}
 }
 
@@ -1155,6 +1165,9 @@ func (s *TestSuite) CreateTopic(opts ...Option) uint64 {
 		newTopicMsg.OutputArity = p.outputArity
 	}
 	newTopicMsg.LabelCaseSensitive = p.labelCaseSensitive
+	if p.labelDefaultValue != nil {
+		newTopicMsg.LabelDefaultValue = *p.labelDefaultValue
+	}
 
 	res, err := s.emissionsMsgServer.CreateNewTopic(s.Ctx(), newTopicMsg)
 	s.Require().NoError(err)

--- a/x/emissions/types/conversions.go
+++ b/x/emissions/types/conversions.go
@@ -339,6 +339,7 @@ func ValueBundleToNetworkInferenceBundle(vb *ValueBundle) *NetworkInferenceBundl
 func ConvertInferenceValuesFromProto(
 	topicArity TopicOutputArity,
 	labels []*TopicLabel,
+	labelDefaultValue alloraMath.Dec,
 	inf *Inference,
 ) (InferenceValues, error) {
 	if inf == nil {
@@ -374,10 +375,13 @@ func ConvertInferenceValuesFromProto(
 			)
 		}
 
-		zero := alloraMath.ZeroDec()
+		// Pad unset trailing slots with topic.LabelDefaultValue (NOT zero): the
+		// rest of the chain (NormalizeInputInference, close-time compaction) treats
+		// an unset label slot as LabelDefaultValue, which may be non-zero when
+		// require_unity is false. Padding with zero here would silently diverge.
 		out := make(alloraMath.DecArray, regLen)
 		for i := range out {
-			out[i] = zero
+			out[i] = labelDefaultValue
 		}
 		copy(out, inf.Values)
 		if err := ValidateInferenceValues(out, labels); err != nil {

--- a/x/emissions/types/conversions_test.go
+++ b/x/emissions/types/conversions_test.go
@@ -248,13 +248,27 @@ func TestConvertInferenceValuesFromProto(t *testing.T) {
 
 	mustDec := func(x string) math.Dec { return math.MustNewDecFromString(x) }
 
+	// labelsN builds a contiguous, 1-based registry of n labels named a, b, c, ...
+	labelNames := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	labelsN := func(n int) []*TopicLabel {
+		out := make([]*TopicLabel, n)
+		var id uint32
+		for i := 0; i < n; i++ {
+			id++
+			out[i] = &TopicLabel{Id: id, Name: labelNames[i]}
+		}
+		return out
+	}
+
 	type tc struct {
-		name      string
-		arity     TopicOutputArity
-		labels    []*TopicLabel
-		inf       *Inference
-		wantErrIs error
-		wantVals  []string
+		name  string
+		arity TopicOutputArity
+		// labelDefault is topic.LabelDefaultValue used to pad unset trailing slots. When unset, it behaves as 0.
+		labelDefault math.Dec
+		labels       []*TopicLabel
+		inf          *Inference
+		wantErrIs    error
+		wantVals     []string
 	}
 
 	cases := []tc{
@@ -266,172 +280,150 @@ func TestConvertInferenceValuesFromProto(t *testing.T) {
 			wantErrIs: sdkerrors.ErrInvalidRequest,
 		},
 		{
-			name:  "SINGLE_scalar_only_ok",
-			arity: TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
-			inf: &Inference{
-				TopicId:     topicId,
-				BlockHeight: nonce,
-				Inferer:     w1,
-				Values:      []math.Dec{mustDec("42")},
-			},
-			wantVals: []string{"42"},
+			// Exercises the switch default branch ("output_arity is invalid").
+			name:      "unspecified_arity_rejected",
+			arity:     TopicOutputArity_TOPIC_OUTPUT_ARITY_UNSPECIFIED,
+			labels:    labelsN(2),
+			inf:       &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("1")}},
+			wantErrIs: sdkerrors.ErrInvalidRequest,
+		},
+		// ---------- SINGLE (default value must be ignored) ----------
+		{
+			name:         "SINGLE_scalar_only_ok",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			labelDefault: mustDec("-7"), // non-zero: must NOT leak into a single-arity result
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("42")}},
+			wantVals:     []string{"42"},
 		},
 		{
-			name:  "SINGLE_values_len1_equal_scalar_ok",
-			arity: TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
-			inf: &Inference{
-				TopicId:     topicId,
-				BlockHeight: nonce,
-				Inferer:     w1,
-				Values:      []math.Dec{mustDec("7")},
-			},
+			name:     "SINGLE_values_len1_ok",
+			arity:    TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			inf:      &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("7")}},
 			wantVals: []string{"7"},
 		},
 		{
-			name:  "SINGLE_values_len_gt_1_rejected",
-			arity: TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
-			inf: &Inference{
-				TopicId:     topicId,
-				BlockHeight: nonce,
-				Inferer:     w1,
-				Values:      []math.Dec{mustDec("1"), mustDec("2")},
-			},
+			name:      "SINGLE_values_len0_rejected",
+			arity:     TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			inf:       &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: nil},
 			wantErrIs: sdkerrors.ErrInvalidRequest,
 		},
 		{
-			name:   "MULTI_empty_registry_rejected",
-			arity:  TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			labels: []*TopicLabel{},
-			inf: &Inference{
-				TopicId:     topicId,
-				BlockHeight: nonce,
-				Inferer:     w1,
-				Values:      []math.Dec{mustDec("1")},
-			},
+			name:      "SINGLE_values_len_gt_1_rejected",
+			arity:     TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			inf:       &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("1"), mustDec("2")}},
+			wantErrIs: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:      "SINGLE_nan_scalar_rejected",
+			arity:     TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE,
+			inf:       &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{math.NewNaN()}},
+			wantErrIs: sdkerrors.ErrInvalidRequest,
+		},
+		// ---------- MULTI guards ----------
+		{
+			name:      "MULTI_empty_registry_rejected",
+			arity:     TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labels:    []*TopicLabel{},
+			inf:       &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("1")}},
 			wantErrIs: sdkerrors.ErrLogic,
 		},
 		{
-			name:  "MULTI_empty_values_rejected",
-			arity: TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			labels: []*TopicLabel{{
-				Id:   1,
-				Name: "a",
-			}},
-			inf: &Inference{
-				TopicId:     topicId,
-				BlockHeight: nonce,
-				Inferer:     w1,
-				Values:      nil,
-			},
+			name:      "MULTI_empty_values_rejected",
+			arity:     TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labels:    labelsN(1),
+			inf:       &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: nil},
 			wantErrIs: sdkerrors.ErrInvalidRequest,
 		},
 		{
-			name:  "MULTI_values_len_gt_registry_rejected",
-			arity: TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			labels: []*TopicLabel{
-				{
-					Id:   1,
-					Name: "a",
-				}, {
-					Id:   2,
-					Name: "b",
-				},
-			},
-			inf: &Inference{
-				TopicId:     topicId,
-				BlockHeight: nonce,
-				Inferer:     w1,
-				Values:      []math.Dec{mustDec("1"), mustDec("2"), mustDec("3")},
-			},
+			name:      "MULTI_values_len_gt_registry_rejected",
+			arity:     TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labels:    labelsN(2),
+			inf:       &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("1"), mustDec("2"), mustDec("3")}},
 			wantErrIs: sdkerrors.ErrLogic,
 		},
+		// ---------- MULTI exact length: default value must NOT leak ----------
 		{
-			name:  "MULTI_exact_len_ok_no_padding",
-			arity: TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			labels: []*TopicLabel{
-				{
-					Id:   1,
-					Name: "a",
-				}, {
-					Id:   2,
-					Name: "b",
-				}, {
-					Id:   3,
-					Name: "c",
-				},
-			},
-			inf: &Inference{
-				TopicId:     topicId,
-				BlockHeight: nonce,
-				Inferer:     w2,
-				Values:      []math.Dec{mustDec("10"), mustDec("20"), mustDec("30")},
-			},
-			wantVals: []string{"10", "20", "30"},
+			name:         "MULTI_exact_len_no_padding_default_ignored",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labelDefault: mustDec("-1"), // exact length => default never used
+			labels:       labelsN(3),
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w2, Values: []math.Dec{mustDec("10"), mustDec("20"), mustDec("30")}},
+			wantVals:     []string{"10", "20", "30"},
+		},
+		// ---------- MULTI padding: the core fix, across several default values ----------
+		{
+			name:         "MULTI_short_pads_with_zero_default_backcompat",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labelDefault: mustDec("0"),
+			labels:       labelsN(5),
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("9"), mustDec("8")}},
+			wantVals:     []string{"9", "8", "0", "0", "0"},
 		},
 		{
-			name:  "MULTI_shorter_len_pads_to_registry_len",
-			arity: TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			labels: []*TopicLabel{
-				{
-					Id:   1,
-					Name: "a",
-				}, {
-					Id:   2,
-					Name: "b",
-				}, {
-					Id:   3,
-					Name: "c",
-				}, {
-					Id:   4,
-					Name: "d",
-				}, {
-					Id:   5,
-					Name: "e",
-				},
-			},
-			inf: &Inference{
-				TopicId:     topicId,
-				BlockHeight: nonce,
-				Inferer:     w1,
-				Values:      []math.Dec{mustDec("9"), mustDec("8")}, // => [9,8,0,0,0]
-			},
-			wantVals: []string{"9", "8", "0", "0", "0"},
+			name:         "MULTI_short_pads_with_negative_default",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labelDefault: mustDec("-1"),
+			labels:       labelsN(5),
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("9"), mustDec("8")}},
+			wantVals:     []string{"9", "8", "-1", "-1", "-1"},
 		},
 		{
-			name:  "MULTI_rejects_invalid_value_in_values",
-			arity: TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
-			labels: []*TopicLabel{
-				{
-					Id:   1,
-					Name: "a",
-				}, {
-					Id:   2,
-					Name: "b",
-				}, {
-					Id:   3,
-					Name: "c",
-				},
-			},
-			inf: &Inference{
-				TopicId:     topicId,
-				BlockHeight: nonce,
-				Inferer:     w1,
-				Values:      []math.Dec{mustDec("1"), math.NewNaN(), mustDec("3")},
-			},
-			wantErrIs: sdkerrors.ErrInvalidRequest,
+			name:         "MULTI_short_pads_with_fractional_default",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labelDefault: mustDec("0.5"),
+			labels:       labelsN(5),
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("9"), mustDec("8")}},
+			wantVals:     []string{"9", "8", "0.5", "0.5", "0.5"},
+		},
+		{
+			name:         "MULTI_short_pads_with_large_positive_default",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labelDefault: mustDec("1000"),
+			labels:       labelsN(4),
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("9"), mustDec("8")}},
+			wantVals:     []string{"9", "8", "1000", "1000"},
+		},
+		{
+			name:         "MULTI_extreme_short_single_value_into_five",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labelDefault: mustDec("-1"),
+			labels:       labelsN(5),
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("9")}},
+			wantVals:     []string{"9", "-1", "-1", "-1", "-1"},
+		},
+		{
+			name:         "MULTI_pad_by_one",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labelDefault: mustDec("3"),
+			labels:       labelsN(3),
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("1"), mustDec("2")}},
+			wantVals:     []string{"1", "2", "3"},
+		},
+		// ---------- MULTI validation still fires after padding ----------
+		{
+			name:         "MULTI_rejects_invalid_provided_value_even_with_valid_default",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labelDefault: mustDec("-1"),
+			labels:       labelsN(3),
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("1"), math.NewNaN(), mustDec("3")}},
+			wantErrIs:    sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:         "MULTI_rejects_nan_default_landing_in_padded_slot",
+			arity:        TopicOutputArity_TOPIC_OUTPUT_ARITY_MULTI,
+			labelDefault: math.NewNaN(), // pads trailing slots with NaN => must be rejected
+			labels:       labelsN(4),
+			inf:          &Inference{TopicId: topicId, BlockHeight: nonce, Inferer: w1, Values: []math.Dec{mustDec("9"), mustDec("8")}},
+			wantErrIs:    sdkerrors.ErrInvalidRequest,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			nonce = int64(1)
-
-			inf := (*Inference)(nil)
-			if c.inf != nil {
-				inf = c.inf
-			}
-
-			got, err := ConvertInferenceValuesFromProto(c.arity, c.labels, inf)
+			// Unset labelDefault is the zero-value Dec (a well-formed 0); it is
+			// never written into a padded slot in the unset cases, so it is safe
+			// to pass through verbatim. Padding cases set labelDefault explicitly.
+			got, err := ConvertInferenceValuesFromProto(c.arity, c.labels, c.labelDefault, c.inf)
 
 			if c.wantErrIs != nil {
 				require.ErrorIs(t, err, c.wantErrIs)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description


###  Summary
Addresses review finding SMELL-03 (P1) on [#942](https://github.com/allora-network/allora-chain/pull/942) ([comment](https://github.com/allora-network/allora-chain/pull/942#discussion_r3388159608)).

ConvertInferenceValuesFromProto right-padded short MULTI-arity inference vectors with alloraMath.ZeroDec(), while the rest of the chain (NormalizeInputInference, close-time CompactRegistryAndRemapInferences) treats an unset label slot as topic.LabelDefaultValue — which may be non-zero when require_unity == false. This PR makes the conversion pad with LabelDefaultValue so the proto→internal representation matches keeper semantics.


###  Severity note (latent, not live)
This is a latent mismatch, not active data corruption. The only callers of ConvertInferenceValuesFromProto run during topic close on compacted inferences — CompactRegistryAndRemapInferences already rebuilds every vector to full registry length, padded with LabelDefaultValue. So at the call site len(values) == len(labels), copy() overwrites the whole slice and the zero-fill is never observed today; the query path returns a stored bundle and never re-synthesizes. It's still worth fixing: the guard silently padded-short / rejected-long, and a unit test asserted the wrong 0 semantic — a correctness landmine for any future on-demand synthesis path.


###  Changes
- x/emissions/types/conversions.go — ConvertInferenceValuesFromProto takes a labelDefaultValue alloraMath.Dec and pads unset trailing slots with it instead of ZeroDec().
- x/emissions/keeper/inference_synthesis/ — threaded topic.LabelDefaultValue through the synthesis args, mirroring the existing NumLabels plumbing, only on the structs that actually reach CalcForecastImpliedInferences (CalcNetworkInferencesArgs, CalcForecastImpliedInferencesArgs, GetOneOutInfererForecastImpliedInferencesArgs, CalcOneOutInfererInferenceArgs / GetOneOutInfererInferencesArgs), sourced from topic.LabelDefaultValue in GetCalcNetworkInferenceArgs.
- x/emissions/testutil/test_utils.go — added a WithLabelDefaultValue topic-setup option for integration tests.
Graceful by design: if a short vector ever reaches the conversion, it degrades to the correct value rather than hard-erroring in EndBlock.


###  Tests
- TestConvertInferenceValuesFromProto rebuilt as a 20-case matrix: SINGLE (default ignored; NaN/Inf rejected), MULTI guards, unspecified-arity (default switch branch), exact-length (no default leak), padding with zero/negative/fractional/large defaults + extreme-short + pad-by-one, and NaN/Inf-default rejected only when it actually lands.
- TestCalcForecastImpliedInferencesMultiArityPadsWithLabelDefaultValue and …WeightedPadsWithLabelDefaultValue — cover both synthesis call sites (MEDIAN and WEIGHTED branches).
- TestMultiLabelNonZeroDefaultValuePadsMissingLabels — end-to-end submit→close→synthesis with a non-zero default, locking the semantic through the full pipeline.
Both synthesis guards are verified to fail on the reverted one-line change (want -1, got 0).


## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use topic `LabelDefaultValue` to pad missing label slots in MULTI inferences and wire it through synthesis and network inference paths. This fixes zero-padding divergence and keeps stored inferences, forecast-implied synthesis, and rewards consistent (addresses SMELL-03).

- **Bug Fixes**
  - `types`: `ConvertInferenceValuesFromProto` pads trailing slots with `LabelDefaultValue` (not zero) and validates padded values; SINGLE arity unchanged.
  - `inference_synthesis`: Plumb `LabelDefaultValue` into `CalcForecastImpliedInferences` and one-out helpers; applies to both MEDIAN and WEIGHTED branches.
  - `network_inferences`: Pass `topic.LabelDefaultValue` into calc args for all synthesis paths.
  - `testutil`: Add `WithLabelDefaultValue` to set non-zero defaults in topic creation.
  - Tests: Add MULTI padding tests for both branches, expand conversion tests to cover various defaults, add end-to-end rewards test for non-zero defaults, and update existing tests to pass `LabelDefaultValue` (zero by default).

<sup>Written for commit 47262208ab21d048cc5a6b42785d6234dc3fcedc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

