### PR TITLE
fix: extra err coverage on nil ReputerValueBundles

### DIFF
--- a/x/emissions/keeper/reputer_loss.go
+++ b/x/emissions/keeper/reputer_loss.go
@@ -416,11 +416,7 @@ func (k *ReputerLossKeeper) GetReputerLossBundlesAtBlock(ctx context.Context, to
 	} else if err != nil {
 		return nil, errorsmod.Wrap(err, "error getting reputer loss bundles at block")
 	}
-	lossBundles := make(types.LossBundles, len(reputerLossBundles.ReputerValueBundles))
-	for i := range reputerLossBundles.ReputerValueBundles {
-		lossBundles[i] = reputerLossBundles.ReputerValueBundles[i].GetValueBundle()
-	}
-	return lossBundles, nil
+	return reputerLossBundles.ToLossBundles(topicId, block)
 }
 
 // Insert a network loss bundle for a topic and block.

--- a/x/emissions/types/reputer.go
+++ b/x/emissions/types/reputer.go
@@ -15,6 +15,28 @@ func (withheldWorkerValue *WithheldWorkerAttributedValue) GetValue() alloramath.
 	return withheldWorkerValue.Value
 }
 
+func (rvb ReputerValueBundles) ToLossBundles(topicId uint64, block int64) (LossBundles, error) {
+	lossBundles := make(LossBundles, len(rvb.ReputerValueBundles))
+	for i, reputerValueBundle := range rvb.ReputerValueBundles {
+		if reputerValueBundle == nil {
+			return nil, errors.Wrapf(
+				sdkerrors.ErrInvalidRequest,
+				"nil reputer value bundle at index %d for topic %d at block %d",
+				i, topicId, block,
+			)
+		}
+		if reputerValueBundle.ValueBundle == nil {
+			return nil, errors.Wrapf(
+				sdkerrors.ErrInvalidRequest,
+				"nil value bundle at index %d for topic %d at block %d",
+				i, topicId, block,
+			)
+		}
+		lossBundles[i] = reputerValueBundle.ValueBundle
+	}
+	return lossBundles, nil
+}
+
 func (rvb *ReputerValueBundles) Validate() error {
 	if rvb == nil || rvb.ReputerValueBundles == nil {
 		return errors.Wrap(sdkerrors.ErrInvalidRequest, "ReputerValueBundles cannot be nil")
@@ -25,7 +47,7 @@ func (rvb *ReputerValueBundles) Validate() error {
 			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "reputer_value_bundle is nil at index %d", i)
 		}
 		if rvb.ReputerValueBundles[i].ValueBundle == nil {
-			continue
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "value bundle is nil at index %d", i)
 		}
 		lbs[i] = rvb.ReputerValueBundles[i].ValueBundle
 	}

--- a/x/emissions/types/reputer_test.go
+++ b/x/emissions/types/reputer_test.go
@@ -17,7 +17,7 @@ func TestReputerValueBundlesToLossBundles(t *testing.T) {
 		block   = int64(100)
 		reputer = "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy"
 	)
-
+	// nolint:exhaustruct
 	validValueBundle := &ValueBundle{
 		TopicId: topicID,
 		ReputerRequestNonce: &ReputerRequestNonce{
@@ -43,6 +43,7 @@ func TestReputerValueBundlesToLossBundles(t *testing.T) {
 				ReputerValueBundles: []*ReputerValueBundle{nil},
 			},
 			wantErr: sdkerrors.ErrInvalidRequest,
+			wantLen: 0,
 		},
 		{
 			name: "nil inner value bundle",
@@ -52,6 +53,7 @@ func TestReputerValueBundlesToLossBundles(t *testing.T) {
 				},
 			},
 			wantErr: sdkerrors.ErrInvalidRequest,
+			wantLen: 0,
 		},
 		{
 			name: "valid bundle",
@@ -60,6 +62,7 @@ func TestReputerValueBundlesToLossBundles(t *testing.T) {
 					{ValueBundle: validValueBundle},
 				},
 			},
+			wantErr: nil,
 			wantLen: 1,
 		},
 	}

--- a/x/emissions/types/reputer_test.go
+++ b/x/emissions/types/reputer_test.go
@@ -1,0 +1,84 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stretchr/testify/require"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+)
+
+func TestReputerValueBundlesToLossBundles(t *testing.T) {
+	t.Parallel()
+
+	const (
+		topicID = uint64(1)
+		block   = int64(100)
+		reputer = "allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy"
+	)
+
+	validValueBundle := &ValueBundle{
+		TopicId: topicID,
+		ReputerRequestNonce: &ReputerRequestNonce{
+			ReputerNonce: &Nonce{BlockHeight: block},
+		},
+		Reputer:       reputer,
+		CombinedValue: alloraMath.ZeroDec(),
+		InfererValues: []*WorkerAttributedValue{
+			{Worker: reputer, Value: alloraMath.ZeroDec()},
+		},
+		NaiveValue: alloraMath.ZeroDec(),
+	}
+
+	tests := []struct {
+		name    string
+		input   ReputerValueBundles
+		wantErr error
+		wantLen int
+	}{
+		{
+			name: "nil reputer value bundle",
+			input: ReputerValueBundles{
+				ReputerValueBundles: []*ReputerValueBundle{nil},
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "nil inner value bundle",
+			input: ReputerValueBundles{
+				ReputerValueBundles: []*ReputerValueBundle{
+					{ValueBundle: nil},
+				},
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "valid bundle",
+			input: ReputerValueBundles{
+				ReputerValueBundles: []*ReputerValueBundle{
+					{ValueBundle: validValueBundle},
+				},
+			},
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.input.ToLossBundles(topicID, block)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, got, tt.wantLen)
+			require.Equal(t, validValueBundle, got[0])
+		})
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Extra coverage for nil `ReputerValueBundles` or `ReputerValueBundles.ValueBundles`


## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- unit tested
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`? -- no need, small fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add nil-guards when converting `ReputerValueBundles` to loss bundles to prevent nil derefs in the rewards path. This fails fast with clear errors and aligns with Linear ENGN-8684’s requirement to block nil ValueBundle propagation.

- **Bug Fixes**
  - Added `ReputerValueBundles.ToLossBundles(topicId, block)` with nil checks and contextual errors; `GetReputerLossBundlesAtBlock` now uses it.
  - Tightened `ReputerValueBundles.Validate` to reject nil `ValueBundle` entries.
  - Added unit tests for nil outer/inner entries and a valid case; annotated with `nolint:exhaustruct` where needed.

<sup>Written for commit 540ddc5ee4f796b3444d327d522be69894006e79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

