### PR TITLE
add mig unit tests to set topic err halt behaviour

### DIFF
--- a/x/emissions/migrations/v15/migrate.go
+++ b/x/emissions/migrations/v15/migrate.go
@@ -169,9 +169,12 @@ func MigrateTopics(ctx sdk.Context, emissionsKeeper keeper.Keeper, store storety
 			continue
 		}
 
-		// Safety check: validate the topic after backfill
+		// Abort the migration if the topic is still invalid after backfill.
+		// Do not skip it: a half-migrated topic would leave state inconsistent
+		// for post-v15 code. Halting is deterministic across validators and
+		// recoverable; such failures will be caught by a pre-upgrade audit.
 		if err := topic.Validate(params); err != nil {
-			return errorsmod.Wrapf(err, "v15 migration: topic %d failed validation after backfill", topic.Id)
+			return errorsmod.Wrapf(err, "MIGRATION V15: topic %d failed validation after backfill", topic.Id)
 		}
 
 		updates = append(updates, kv{
@@ -258,11 +261,31 @@ func migrateInferenceBundles(
 	destStore := prefix.NewStore(store, destPrefix)
 	for _, u := range updates {
 		destStore.Set(u.key, u.value)
-		sourceStore.Delete(u.key)
 	}
+
+	// Retire the legacy source prefix: its bundles are re-written above and it
+	// gains no writer after this cut-over, so drain it whole to leave no stragglers.
+	drainPrefixStore(sourceStore)
 
 	ctx.Logger().Info("MIGRATION V15: network inference bundle migration completed", "store", logName, "entriesUpdated", len(updates))
 	return nil
+}
+
+// drainPrefixStore deletes every key under store, leaving the prefix provably
+// empty so no later path can read, export, prune, or re-migrate a stale entry.
+// Keys are collected before deleting because mutating a store mid-iteration is unsafe.
+func drainPrefixStore(store prefix.Store) {
+	iterator := store.Iterator(nil, nil)
+	defer iterator.Close()
+
+	staleKeys := make([][]byte, 0)
+	for ; iterator.Valid(); iterator.Next() {
+		staleKeys = append(staleKeys, append([]byte(nil), iterator.Key()...))
+	}
+
+	for _, key := range staleKeys {
+		store.Delete(key)
+	}
 }
 
 // kvPair is a raw key/value pending write used by the v15 store migrations.

--- a/x/emissions/migrations/v15/migrate_test.go
+++ b/x/emissions/migrations/v15/migrate_test.go
@@ -170,6 +170,172 @@ func (s *EmissionsV15MigrationTestSuite) TestMigrateTopicsPreservesExistingClass
 	s.Require().True(gotTopic.LabelDefaultValue.Equal(classifTopic.LabelDefaultValue))
 }
 
+// TestMigrateTopicsPreservesExtremeButValidTopic guards against a future change
+// that would clamp or re-tighten the numeric topic bounds inside the migration.
+// A legacy topic sitting at the inclusive edges of the long-standing bounds
+// (p_norm in [1,10], c_norm in [-100,100], alpha_regret in (0,1]) must survive
+// the v15 backfill untouched: those bounds predate v15 and are enforced at topic
+// create/update, so every stored topic already satisfies them and the migration
+// must not reject the legitimate extremes.
+func (s *EmissionsV15MigrationTestSuite) TestMigrateTopicsPreservesExtremeButValidTopic() {
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
+
+	topicStore := prefix.NewStore(store, emissionstypes.TopicsKey)
+	keeper := s.TopicKeeper()
+
+	topics := []v14oldtypes.Topic{
+		s.makeLegacyTopic(func(topic *v14oldtypes.Topic) {
+			topic.Id = 101
+			topic.Creator = s.Addrs(0).String()
+			topic.Metadata = "extreme-high"
+			topic.LossMethod = "mse"
+			topic.EpochLength = 10800
+			topic.EpochLastEnded = 0
+			topic.GroundTruthLag = 10800
+			topic.WorkerSubmissionWindow = 10
+			topic.PNorm = alloraMath.MustNewDecFromString("10")
+			topic.InitialRegret = alloraMath.MustNewDecFromString("0.0001")
+			topic.AlphaRegret = alloraMath.MustNewDecFromString("1")
+			topic.AllowNegative = true
+			topic.Epsilon = alloraMath.MustNewDecFromString("0.00001")
+			topic.MeritSortitionAlpha = alloraMath.MustNewDecFromString("0.1")
+			topic.ActiveInfererQuantile = alloraMath.MustNewDecFromString("0.05")
+			topic.ActiveForecasterQuantile = alloraMath.MustNewDecFromString("0.05")
+			topic.ActiveReputerQuantile = alloraMath.MustNewDecFromString("0.05")
+			topic.CNorm = alloraMath.MustNewDecFromString("100")
+		}),
+		s.makeLegacyTopic(func(topic *v14oldtypes.Topic) {
+			topic.Id = 102
+			topic.Creator = s.Addrs(1).String()
+			topic.Metadata = "extreme-low"
+			topic.LossMethod = "mae"
+			topic.EpochLength = 10800
+			topic.EpochLastEnded = 0
+			topic.GroundTruthLag = 10800
+			topic.WorkerSubmissionWindow = 10
+			topic.PNorm = alloraMath.MustNewDecFromString("1")
+			topic.InitialRegret = alloraMath.MustNewDecFromString("0.0001")
+			// Smallest practical positive value: alpha_regret must be > 0.
+			topic.AlphaRegret = alloraMath.MustNewDecFromString("0.000000000001")
+			topic.AllowNegative = true
+			topic.Epsilon = alloraMath.MustNewDecFromString("0.00001")
+			topic.MeritSortitionAlpha = alloraMath.MustNewDecFromString("0.1")
+			topic.ActiveInfererQuantile = alloraMath.MustNewDecFromString("0.05")
+			topic.ActiveForecasterQuantile = alloraMath.MustNewDecFromString("0.05")
+			topic.ActiveReputerQuantile = alloraMath.MustNewDecFromString("0.05")
+			topic.CNorm = alloraMath.MustNewDecFromString("-100")
+		}),
+	}
+
+	for _, topic := range topics {
+		topicStore.Set(sdk.Uint64ToBigEndian(topic.Id), cdc.MustMarshal(&topic))
+	}
+
+	err := v15.MigrateTopics(s.Ctx(), *s.EmissionsKeeper(), store, cdc)
+	s.Require().NoError(err)
+
+	for _, topic := range topics {
+		gotTopic, err := keeper.GetTopic(s.Ctx(), topic.Id)
+		s.Require().NoError(err)
+
+		// Extreme numeric values survive the migration untouched.
+		s.Require().True(topic.PNorm.Equal(gotTopic.PNorm))
+		s.Require().True(topic.AlphaRegret.Equal(gotTopic.AlphaRegret))
+		s.Require().True(topic.CNorm.Equal(gotTopic.CNorm))
+		s.Require().True(topic.Epsilon.Equal(gotTopic.Epsilon))
+
+		// Classification defaults are still backfilled.
+		s.Require().Equal(emissionstypes.TopicType_TOPIC_TYPE_REGRESSION, gotTopic.TopicType)
+		s.Require().Equal(emissionstypes.TopicOutputArity_TOPIC_OUTPUT_ARITY_SINGLE, gotTopic.OutputArity)
+		s.Require().Equal(emissionstypes.DefaultMaxLabelsPerSubmission, gotTopic.MaxLabelsPerSubmission)
+	}
+}
+
+// TestMigrateTopicsAbortsOnInvalidTopic verifies the migration halts rather than
+// silently skipping when a stored topic fails Topic.Validate after backfill.
+// Topic.Validate gates against the current module params, and some of those
+// bounds (here, the minimum epoch length) are not backfilled by this migration,
+// so a long-lived topic created before a param was tightened can fail the gate.
+// A migration must leave state fully consistent, so such a topic is a
+// state-integrity failure: the migration returns an error (which deterministically
+// halts the upgrade for a coordinated fix) and commits no partial state, not even
+// the valid sibling topic.
+func (s *EmissionsV15MigrationTestSuite) TestMigrateTopicsAbortsOnInvalidTopic() {
+	storageService := s.EmissionsKeeper().GetStorageService()
+	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))
+	cdc := s.EmissionsKeeper().GetBinaryCodec()
+
+	topicStore := prefix.NewStore(store, emissionstypes.TopicsKey)
+	keeper := s.TopicKeeper()
+
+	// Raise MinEpochLength so that a shorter-epoch topic, valid when it was
+	// created, no longer satisfies Topic.Validate at migration time.
+	const minEpochLength = int64(20000)
+	params := emissionstypes.DefaultParams()
+	params.MinEpochLength = minEpochLength
+	store.Set(emissionstypes.ParamsKey, cdc.MustMarshal(&params))
+
+	validTopic := s.makeLegacyTopic(func(topic *v14oldtypes.Topic) {
+		topic.Id = 201
+		topic.Creator = s.Addrs(0).String()
+		topic.Metadata = "valid"
+		topic.LossMethod = "mse"
+		topic.EpochLength = minEpochLength + 1
+		topic.GroundTruthLag = minEpochLength + 1
+		topic.WorkerSubmissionWindow = 10
+		topic.PNorm = alloraMath.MustNewDecFromString("3")
+		topic.InitialRegret = alloraMath.MustNewDecFromString("0.0001")
+		topic.AlphaRegret = alloraMath.MustNewDecFromString("0.1")
+		topic.Epsilon = alloraMath.MustNewDecFromString("0.01")
+		topic.MeritSortitionAlpha = alloraMath.MustNewDecFromString("0.1")
+		topic.ActiveInfererQuantile = alloraMath.MustNewDecFromString("0.05")
+		topic.ActiveForecasterQuantile = alloraMath.MustNewDecFromString("0.05")
+		topic.ActiveReputerQuantile = alloraMath.MustNewDecFromString("0.05")
+		topic.CNorm = alloraMath.MustNewDecFromString("0.75")
+	})
+	invalidTopic := s.makeLegacyTopic(func(topic *v14oldtypes.Topic) {
+		topic.Id = 202
+		topic.Creator = s.Addrs(1).String()
+		topic.Metadata = "epoch-too-short"
+		topic.LossMethod = "mae"
+		topic.EpochLength = minEpochLength - 1 // below the tightened minimum
+		topic.GroundTruthLag = minEpochLength - 1
+		topic.WorkerSubmissionWindow = 10
+		topic.PNorm = alloraMath.MustNewDecFromString("3")
+		topic.InitialRegret = alloraMath.MustNewDecFromString("0.0001")
+		topic.AlphaRegret = alloraMath.MustNewDecFromString("0.1")
+		topic.Epsilon = alloraMath.MustNewDecFromString("0.01")
+		topic.MeritSortitionAlpha = alloraMath.MustNewDecFromString("0.1")
+		topic.ActiveInfererQuantile = alloraMath.MustNewDecFromString("0.05")
+		topic.ActiveForecasterQuantile = alloraMath.MustNewDecFromString("0.05")
+		topic.ActiveReputerQuantile = alloraMath.MustNewDecFromString("0.05")
+		topic.CNorm = alloraMath.MustNewDecFromString("0.75")
+	})
+
+	topicStore.Set(sdk.Uint64ToBigEndian(validTopic.Id), cdc.MustMarshal(&validTopic))
+	topicStore.Set(sdk.Uint64ToBigEndian(invalidTopic.Id), cdc.MustMarshal(&invalidTopic))
+
+	// The migration must abort on the nonconforming topic, naming it and the
+	// failed invariant so recovery is actionable.
+	err := v15.MigrateTopics(s.Ctx(), *s.EmissionsKeeper(), store, cdc)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "topic 202")
+	s.Require().Contains(err.Error(), "epoch length")
+
+	// No partial state is committed: writes are batched after the scan, so an
+	// abort mid-scan leaves every topic in its pre-v15 form, including the valid
+	// sibling that was processed before the failure.
+	gotValid, err := keeper.GetTopic(s.Ctx(), validTopic.Id)
+	s.Require().NoError(err)
+	s.Require().Equal(emissionstypes.TopicType_TOPIC_TYPE_UNSPECIFIED, gotValid.TopicType)
+
+	gotInvalid, err := keeper.GetTopic(s.Ctx(), invalidTopic.Id)
+	s.Require().NoError(err)
+	s.Require().Equal(emissionstypes.TopicType_TOPIC_TYPE_UNSPECIFIED, gotInvalid.TopicType)
+}
+
 func (s *EmissionsV15MigrationTestSuite) TestMigrateParamsBackfillsLabelParams() {
 	storageService := s.EmissionsKeeper().GetStorageService()
 	store := runtime.KVStoreAdapter(storageService.OpenKVStore(s.Ctx()))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
- add unit tests to set the behaviour 
- safe state deletion refactoring into a function.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- this adds unit tests
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests to lock in v15 topic migration behavior and harden store cleanup in `x/emissions/migrations/v15`. Extreme-but-valid topics are preserved; topics that still fail `Validate` after backfill abort the migration with no partial writes, making the failure mode explicit and test-covered for ENGN-8685.

- **Refactors**
  - Extracted `drainPrefixStore` to fully clear legacy inference bundle prefixes after rewrite, avoiding mid-iteration deletes and preventing stale keys.

<sup>Written for commit c64cad3ab336c700291f035bdbb69fa3469ca40e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

