### PR TITLE
fix: weight zero-regret workers instead of dropping inferers

### DIFF
--- a/x/emissions/keeper/inference_synthesis/weight.go
+++ b/x/emissions/keeper/inference_synthesis/weight.go
@@ -194,14 +194,15 @@ func CalcWeightsGivenWorkers(args CalcWeightsGivenWorkersArgs) (RegretInformedWe
 	infererWeights := make(map[Worker]Weight)
 	forecasterWeights := make(map[Worker]Weight)
 
-	// Calculate the weights from the normalized regrets
+	// Calculate the weights from the normalized regrets.
+	// A worker absent from normalizedInfererRegrets is weighted as zero-regret
+	// (the map returns a zero-value Dec), so every requested inferer gets a weight.
+	// This keeps the inferer and forecaster loops symmetric: both treat a missing
+	// regret as zero rather than dropping the worker, which would otherwise shift
+	// sumWeights, the stored normalized weights, and reward distribution in mixed
+	// epochs where some workers have no regret yet.
 	for _, worker := range args.Inferers {
-		regret, ok := normalizedInfererRegrets[worker]
-		if !ok {
-			continue
-		}
-
-		infererWeight, err := CalcWeightFromNormalizedRegret(regret, maxRegret, args.PNorm, args.CNorm)
+		infererWeight, err := CalcWeightFromNormalizedRegret(normalizedInfererRegrets[worker], maxRegret, args.PNorm, args.CNorm)
 		if err != nil {
 			return RegretInformedWeights{}, errorsmod.Wrapf(err, "Error calculating inferer weight")
 		}
@@ -211,6 +212,8 @@ func CalcWeightsGivenWorkers(args CalcWeightsGivenWorkersArgs) (RegretInformedWe
 
 	if len(forecasterRegrets) > 0 {
 		for _, worker := range args.Forecasters {
+			// Symmetric with the inferer loop above: a worker absent from
+			// normalizedForecasterRegrets is weighted as zero-regret rather than dropped.
 			forecasterWeight, err := CalcWeightFromNormalizedRegret(normalizedForecasterRegrets[worker], maxRegret, args.PNorm, args.CNorm)
 			if err != nil {
 				return RegretInformedWeights{}, errorsmod.Wrapf(err, "Error calculating forecaster weight")

--- a/x/emissions/keeper/inference_synthesis/weight.go
+++ b/x/emissions/keeper/inference_synthesis/weight.go
@@ -194,13 +194,9 @@ func CalcWeightsGivenWorkers(args CalcWeightsGivenWorkersArgs) (RegretInformedWe
 	infererWeights := make(map[Worker]Weight)
 	forecasterWeights := make(map[Worker]Weight)
 
-	// Calculate the weights from the normalized regrets.
-	// A worker absent from normalizedInfererRegrets is weighted as zero-regret
-	// (the map returns a zero-value Dec), so every requested inferer gets a weight.
-	// This keeps the inferer and forecaster loops symmetric: both treat a missing
-	// regret as zero rather than dropping the worker, which would otherwise shift
-	// sumWeights, the stored normalized weights, and reward distribution in mixed
-	// epochs where some workers have no regret yet.
+	// Calculate the weights from the normalized regrets. A worker absent from the
+	// map is weighted as zero-regret (zero-value Dec) rather than dropped, keeping
+	// the inferer and forecaster loops symmetric and preserving sumWeights/rewards.
 	for _, worker := range args.Inferers {
 		infererWeight, err := CalcWeightFromNormalizedRegret(normalizedInfererRegrets[worker], maxRegret, args.PNorm, args.CNorm)
 		if err != nil {

--- a/x/emissions/keeper/inference_synthesis/weights_test.go
+++ b/x/emissions/keeper/inference_synthesis/weights_test.go
@@ -397,6 +397,42 @@ func (s *WeightsTestSuite) TestCalcWeightsGivenWorkers() {
 
 			},
 		},
+		{
+			name: "worker missing a regret entry is weighted as zero-regret, symmetric across inferers and forecasters",
+			args: synth.CalcWeightsGivenWorkersArgs{
+				Logger:      s.Ctx().Logger(),
+				Inferers:    []string{s.AddrsStr(0), s.AddrsStr(1)},
+				Forecasters: []string{s.AddrsStr(2), s.AddrsStr(3)},
+				InfererToRegret: map[string]*alloraMath.Dec{
+					s.AddrsStr(0): decPtr("1.0"),
+					// s.AddrsStr(1) intentionally missing
+				},
+				ForecasterToRegret: map[string]*alloraMath.Dec{
+					s.AddrsStr(2): decPtr("1.0"),
+					// s.AddrsStr(3) intentionally missing
+				},
+				EpsilonTopic:           alloraMath.MustNewDecFromString("0.01"),
+				PNorm:                  alloraMath.MustNewDecFromString("3.0"),
+				CNorm:                  alloraMath.MustNewDecFromString("0.75"),
+				RegretScalePlusEpsilon: alloraMath.MustNewDecFromString("1.0"),
+			},
+			expectedError: false,
+			checkResult: func(result synth.RegretInformedWeights) {
+				// No worker is dropped: every requested inferer and forecaster gets a weight.
+				s.Require().Len(result.Inferers, 2)
+				s.Require().Len(result.Forecasters, 2)
+
+				missingInferer := result.Inferers[s.AddrsStr(1)]
+				missingForecaster := result.Forecasters[s.AddrsStr(3)]
+
+				// A missing regret is treated as zero, yielding a real positive weight.
+				s.Require().True(missingInferer.Gt(alloraMath.ZeroDec()))
+				s.Require().True(missingForecaster.Gt(alloraMath.ZeroDec()))
+
+				// Symmetry: a missing inferer and a missing forecaster get identical weights.
+				s.Require().True(missingInferer.Equal(missingForecaster))
+			},
+		},
 		{ //nolint:exhaustruct
 			name: "empty workers should error",
 			args: synth.CalcWeightsGivenWorkersArgs{


### PR DESCRIPTION
## Purpose of Changes and their Description

Fix: realign behaviour on no regret inferes with previous behaviour (and with forecasters)

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- added test 
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat missing regret entries as zero-regret for both inferers and forecasters instead of skipping inferers. Restores symmetry with forecasters and preserves total weights/rewards; addresses ENGN-8689.

- Bug Fixes
  - Updated `CalcWeightsGivenWorkers`: inferers now use `normalizedInfererRegrets[worker]` (zero-value `Dec` if missing) rather than being skipped; behavior matches forecasters.
  - Ensures no worker is dropped; missing entries receive a valid weight derived from zero-regret.
  - Added test covering missing-regret cases for both inferers and forecasters, asserting equal handling and unchanged worker counts.

<sup>Written for commit eddb6dc4819839238345124f777c253429e6068b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

