### PR TITLE
test: add UpdateTopic WSW-guard boundary case at exact close block

### DIFF
--- a/x/emissions/keeper/msgserver/msg_server_topics_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics_test.go
@@ -1400,6 +1400,58 @@ func (s *MsgServerTestSuite) TestUpdateTopicWhitelistAllowedAfterWSWClosed() {
 		"whitelist must be canonicalized on UpdateTopic once the WSW has closed")
 }
 
+// TestUpdateTopicLabelDefaultBlockedAtExactWSWCloseBlock pins the boundary that
+// keeps the guard aligned with worker-nonce closing. The submission window for a
+// nonce at block B with window W spans [B, B+W] inclusive, and the scheduled
+// close for that nonce fires in EndBlock at exactly B+W. At that close,
+// CompactRegistryAndRemapInferences reads the live topic.LabelDefaultValue and
+// whitelist. If UpdateTopic accepted a guarded label-field change at B+W, the
+// close in the same block would compact already-submitted inferences against the
+// changed config. So the guard must still reject at B+W (the last in-window
+// block), not only at heights well inside the window. The sibling
+// TestUpdateTopicWhitelistAllowedAfterWSWClosed asserts the complementary B+W+1
+// case, where the update is allowed and the close can no longer run. Here B=5,
+// W=10, so B+W=15.
+//
+//nolint:exhaustruct
+func (s *MsgServerTestSuite) TestUpdateTopicLabelDefaultBlockedAtExactWSWCloseBlock() {
+	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
+	require := s.Require()
+
+	sender := s.AddrsStr(0)
+	s.WithBlockHeight(10)
+	topicId := s.createTopicForWSWTests(sender)
+	require.NoError(s.TopicKeeper().ActivateTopic(ctx, topicId))
+
+	require.NoError(s.NonceKeeper().AddWorkerNonce(ctx, topicId, &types.Nonce{BlockHeight: 5}))
+	// 5 + 10 = 15: the last block still inside the window and the exact block the
+	// scheduled worker-nonce close fires.
+	s.WithBlockHeight(15)
+	ctx = s.Ctx()
+
+	msg := &types.UpdateTopicRequest{
+		Sender:                 sender,
+		TopicId:                topicId,
+		Metadata:               "wsw test",
+		LossMethod:             "mse",
+		AlphaRegret:            alloraMath.MustNewDecFromString("0.1"),
+		MeritSortitionAlpha:    alloraMath.MustNewDecFromString("0.1"),
+		PNorm:                  alloraMath.MustNewDecFromString("3.0"),
+		CNorm:                  alloraMath.MustNewDecFromString("0.75"),
+		MaxLabelsPerSubmission: 4,
+		LabelWhitelist:         []string{"a", "b", "c"},
+		LabelDefaultValue:      alloraMath.OneDec(), // changed -> must be rejected
+	}
+	_, err := msgServer.UpdateTopic(ctx, msg)
+	require.ErrorIs(err, types.ErrWorkerNonceWindowNotAvailable,
+		"UpdateTopic must reject guarded label fields at the exact window-close block, not only well inside the window")
+	require.ErrorContains(err, "label_default_value")
+	got, err := s.TopicKeeper().GetTopic(ctx, topicId)
+	require.NoError(err)
+	require.True(got.LabelDefaultValue.Equal(alloraMath.ZeroDec()),
+		"LabelDefaultValue must not have changed at the final in-window block")
+}
+
 // TestUpdateTopicRejectsOutOfRangeMaxLabelsPerSubmission documents that
 // UpdateTopic treats max_labels_per_submission as the submitted value, not as
 // "unchanged" or "use module default". Values outside the allowed cap range


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Adds a single unit test (no production change) pinning that UpdateTopic rejects guarded label-field changes at the exact worker-window close block B+W — the boundary between the existing "well inside" (block 6) and "just past" (block 16) cases. Locks the inclusive upper bound that keeps the guard aligned with worker-nonce closing, so an off-by-one regression that would re-open the stored-state concern gets caught.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test to ensure UpdateTopic rejects guarded label-field changes at the exact worker submission window close block (B+W). This pins the inclusive upper bound and prevents off-by-one regressions, keeping `LabelDefaultValue` unchanged at B+W.

<sup>Written for commit 9e74c5936ef1d2ab4311f8ff4a7786479b60cff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

