### PR TITLE
clamp emitted values on events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [#964](https://github.com/allora-network/allora-chain/pull/964) Clamp `Dec` magnitudes in emissions events to keep event payloads compact.
+
 ### Security
 
 ### API Breaking Changes

--- a/math/bounded_dec.go
+++ b/math/bounded_dec.go
@@ -171,6 +171,38 @@ func MustNewCappedBoundedExp40DecFromString(s string) BoundedExp40Dec {
 	return dec
 }
 
+// ClampMagnitude clamps |d| into [minMagnitude, maxMagnitude], keeping the sign.
+// Zero, NaN and non-finite pass through. Total: never errors, so it is safe on
+// the event-emission path. Bounds must be positive with min <= max.
+// Purpose: cap the serialized textual size of a Dec (a tiny value like 1e-38000
+// otherwise expands to a ~38 KB fixed-notation string). Does not touch state.
+func ClampMagnitude(d, minMagnitude, maxMagnitude Dec) Dec {
+	if !d.IsFinite() || d.IsZero() {
+		return d
+	}
+	abs, err := d.Abs()
+	if err != nil {
+		return d
+	}
+	var bound Dec
+	switch {
+	case abs.Lt(minMagnitude):
+		bound = minMagnitude
+	case abs.Gt(maxMagnitude):
+		bound = maxMagnitude
+	default:
+		return d // in range
+	}
+	if !d.IsNegative() {
+		return bound
+	}
+	neg, err := bound.Neg() // restore sign
+	if err != nil {
+		return d
+	}
+	return neg
+}
+
 // Returns the maximum value that can be represented by a BoundedExp40Dec
 func GetMaxPositiveBoundaryExp40Dec() BoundedExp40Dec {
 	return BoundedExp40Dec{dec: maxBoundValue}

--- a/math/clamp_magnitude_test.go
+++ b/math/clamp_magnitude_test.go
@@ -1,0 +1,79 @@
+package math
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/apd/v3"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:exhaustruct // tests construct partial apd/Dec values on purpose
+func TestClampMagnitude(t *testing.T) {
+	dec := MustNewDecFromString
+	minM := dec("1e-40")
+	maxM := dec("1e40")
+
+	// finite cases against the standard [1e-40, 1e40] window
+	cases := []struct {
+		name string
+		in   Dec
+		want Dec
+	}{
+		{"zero", ZeroDec(), ZeroDec()},
+		{"negative zero", dec("-0"), ZeroDec()},
+		{"positive interior", dec("0.5"), dec("0.5")},
+		{"negative interior", dec("-0.5"), dec("-0.5")},
+		{"equal min", minM, minM},
+		{"equal -min", dec("-1e-40"), dec("-1e-40")},
+		{"equal max", maxM, maxM},
+		{"equal -max", dec("-1e40"), dec("-1e40")},
+		{"just below min +", dec("1e-41"), minM},
+		{"just below min -", dec("-1e-41"), dec("-1e-40")},
+		{"just above max +", dec("1e41"), maxM},
+		{"just above max -", dec("-1e41"), dec("-1e40")},
+		{"extreme tiny +", dec("1.5e-37962"), minM},
+		{"extreme tiny -", dec("-1.5e-37962"), dec("-1e-40")},
+		{"extreme huge +", dec("1e37962"), maxM},
+		{"extreme huge -", dec("-1e37962"), dec("-1e40")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClampMagnitude(tc.in, minM, maxM)
+			require.Truef(t, got.Equal(tc.want), "got %s want %s", got.String(), tc.want.String())
+		})
+	}
+
+	t.Run("NaN passes through", func(t *testing.T) {
+		require.True(t, ClampMagnitude(NewNaN(), minM, maxM).IsNaN())
+	})
+
+	t.Run("infinity passes through", func(t *testing.T) {
+		posInf := Dec{dec: apd.Decimal{Form: apd.Infinite}}
+		negInf := Dec{dec: apd.Decimal{Form: apd.Infinite, Negative: true}}
+		require.False(t, ClampMagnitude(posInf, minM, maxM).IsFinite())
+		require.False(t, ClampMagnitude(negInf, minM, maxM).IsFinite())
+	})
+
+	t.Run("degenerate window min==max", func(t *testing.T) {
+		one := dec("1")
+		require.True(t, ClampMagnitude(dec("0.5"), one, one).Equal(one)) // raised
+		require.True(t, ClampMagnitude(dec("2"), one, one).Equal(one))   // lowered
+		require.True(t, ClampMagnitude(one, one, one).Equal(one))        // unchanged
+	})
+
+	t.Run("zero lower bound disables lower clamp", func(t *testing.T) {
+		got := ClampMagnitude(dec("1e-100"), ZeroDec(), maxM)
+		require.True(t, got.Equal(dec("1e-100")))
+	})
+
+	t.Run("input is not mutated", func(t *testing.T) {
+		in := dec("1.5e-37962")
+		snap := dec("1.5e-37962")
+		_ = ClampMagnitude(in, minM, maxM)
+		require.True(t, in.Equal(snap))
+	})
+
+	t.Run("clamped output is short", func(t *testing.T) {
+		require.LessOrEqual(t, len(ClampMagnitude(dec("1.5e-37962"), minM, maxM).String()), 45)
+	})
+}

--- a/x/emissions/README.md
+++ b/x/emissions/README.md
@@ -43,7 +43,7 @@ See `x/emissions/metrics/` for details.
 
 ## Event value representation
 
-`Dec` values placed in emissions events are magnitude-clamped to `[1e-40, 1e40]` so extremely small or large values stay compact when serialized. This shapes event and query output only; consensus state is stored separately and is not clamped, so an event value may differ from the stored value at the extremes. See `ClampMagnitude` and the `clamp*` helpers in `x/emissions/types/events_utils.go`.
+`Dec` values placed in emissions events are magnitude-clamped to `[1e-40, 1e40]` so extremely small or large values stay compact when serialized. This shapes event output only; consensus state is stored separately and is not clamped, so an event value may differ from the stored value at the extremes. See `ClampMagnitude` and the `clamp*` helpers in `x/emissions/types/events_utils.go`.
 
 ## Topic configuration updates (UpdateTopic)
 

--- a/x/emissions/README.md
+++ b/x/emissions/README.md
@@ -41,6 +41,10 @@ query/tx: `allora_emissions_request_total` for occurrences, `allora_emissions_re
 Different labels are applied where appropriate (eg "topic_id", "address", "nonce", etc.)
 See `x/emissions/metrics/` for details.
 
+## Event value representation
+
+`Dec` values placed in emissions events are magnitude-clamped to `[1e-40, 1e40]` so extremely small or large values stay compact when serialized. This shapes event and query output only; consensus state is stored separately and is not clamped, so an event value may differ from the stored value at the extremes. See `ClampMagnitude` and the `clamp*` helpers in `x/emissions/types/events_utils.go`.
+
 ## Topic configuration updates (UpdateTopic)
 
 The `UpdateTopic` tx is intentionally limited to a small set of mutable fields. Today, topic creators can update:

--- a/x/emissions/types/event_utils_clamp_test.go
+++ b/x/emissions/types/event_utils_clamp_test.go
@@ -1,0 +1,167 @@
+package types
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	"github.com/stretchr/testify/require"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+)
+
+// Shared vectors: an input mix and its clamped expectation (window is 1e±40).
+var (
+	cTiny   = alloraMath.MustNewDecFromString("1.5e-37962")
+	cHuge   = alloraMath.MustNewDecFromString("1e50")
+	cMid    = alloraMath.MustNewDecFromString("0.5")
+	cNeg    = alloraMath.MustNewDecFromString("-1.5e-37962")
+	cMin    = alloraMath.MustNewDecFromString("1e-40")
+	cMax    = alloraMath.MustNewDecFromString("1e40")
+	cNegMin = alloraMath.MustNewDecFromString("-1e-40")
+)
+
+func requireDecsEqual(t *testing.T, got, want []alloraMath.Dec) {
+	t.Helper()
+	require.Equal(t, len(want), len(got))
+	for i := range want {
+		require.Truef(t, got[i].Equal(want[i]), "index %d: got %s want %s", i, got[i].String(), want[i].String())
+	}
+}
+
+// Every event constructor carrying a []Dec value field must clamp it.
+//
+//nolint:exhaustruct,forcetypeassert // partial inputs + event type assertions are intentional in tests
+func TestEventClamp_SliceFields(t *testing.T) {
+	actor := ActorType_ACTOR_TYPE_INFERER_UNSPECIFIED
+	addrs := []string{"a", "b", "c", "d"}
+	mix := []alloraMath.Dec{cTiny, cHuge, cMid, cNeg}
+	want := []alloraMath.Dec{cMin, cMax, cMid, cNegMin}
+
+	scoresFrom := func(vs []alloraMath.Dec) []Score {
+		out := make([]Score, len(vs))
+		for i, v := range vs {
+			out[i] = Score{TopicId: 1, BlockHeight: 1, Address: addrs[i], Score: v}
+		}
+		return out
+	}
+	rewardsFrom := func(vs []alloraMath.Dec) []TaskReward {
+		out := make([]TaskReward, len(vs))
+		for i, v := range vs {
+			out[i] = TaskReward{TopicId: 1, Address: addrs[i], Reward: v}
+		}
+		return out
+	}
+	topicRewards := map[uint64]*alloraMath.Dec{}
+	for i := range mix {
+		v := mix[i]
+		topicRewards[uint64(i+1)] = &v
+	}
+
+	cases := []struct {
+		name string
+		got  []alloraMath.Dec
+	}{
+		{"ListeningCoefficientsSet", NewListeningCoefficientsSetEventBase(1, 1, addrs, actor, mix).(*EventListeningCoefficientsSet).Coefficients},
+		{"InfererNetworkRegretSet", NewInfererNetworkRegretSetEventBase(1, 1, addrs, mix).(*EventInfererNetworkRegretSet).Regrets},
+		{"ForecasterNetworkRegretSet", NewForecasterNetworkRegretSetEventBase(1, 1, addrs, mix).(*EventForecasterNetworkRegretSet).Regrets},
+		{"NaiveInfererNetworkRegretSet", NewNaiveInfererNetworkRegretSetEventBase(1, 1, addrs, mix).(*EventNaiveInfererNetworkRegretSet).Regrets},
+		{"InfererWeightsSet", NewInfererWeightsSetEventBase(1, 1, addrs, mix).(*EventInfererWeightsSet).Weights},
+		{"ForecasterWeightsSet", NewForecasterWeightsSetEventBase(1, 1, addrs, mix).(*EventForecasterWeightsSet).Weights},
+		{"NetworkInferenceInfererWeightsSet", NewNetworkInferenceInfererWeightsSetEventBase(1, 1, addrs, mix).(*EventNetworkInferenceInfererWeightsSet).Weights},
+		{"NetworkInferenceForecasterWeightsSet", NewNetworkInferenceForecasterWeightsSetEventBase(1, 1, addrs, mix).(*EventNetworkInferenceForecasterWeightsSet).Weights},
+		{"NetworkInferenceInfererRegretsUsedSet", NewNetworkInferenceInfererRegretsUsedSetEventBase(1, 1, addrs, mix).(*EventNetworkInferenceInfererRegretsUsedSet).Regrets},
+		{"NetworkInferenceForecasterRegretsUsedSet", NewNetworkInferenceForecasterRegretsUsedSetEventBase(1, 1, addrs, mix).(*EventNetworkInferenceForecasterRegretsUsedSet).Regrets},
+		{"ScoresSet", NewScoresSetEventBase(actor, scoresFrom(mix)).(*EventScoresSet).Scores},
+		{"EMAScoresSet", NewEMAScoresSetEventBase(actor, 1, scoresFrom(mix), map[string]bool{}).(*EventEMAScoresSet).Scores},
+		{"RewardsSettled", NewRewardsSetEventBase(actor, 1, 1, rewardsFrom(mix)).(*EventRewardsSettled).Rewards},
+		{"TopicRewardsSet", NewTopicRewardSetEventBase(topicRewards).(*EventTopicRewardsSet).Rewards},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { requireDecsEqual(t, tc.got, want) })
+	}
+}
+
+// Every event constructor carrying a scalar Dec value field must clamp it.
+//
+//nolint:forcetypeassert // event type assertions are intentional in tests
+func TestEventClamp_ScalarFields(t *testing.T) {
+	actor := ActorType_ACTOR_TYPE_INFERER_UNSPECIFIED
+	one := math.NewInt(1)
+	cases := []struct {
+		name string
+		got  alloraMath.Dec
+		want alloraMath.Dec
+	}{
+		{"ForecastTaskScoreSet/tiny", NewForecastTaskScoreSetEventBase(1, cTiny, 1).(*EventForecastTaskScoreSet).Score, cMin},
+		{"TopicInitialRegretSet/huge", NewTopicInitialRegretSetEventBase(1, 1, cHuge).(*EventTopicInitialRegretSet).Regret, cMax},
+		{"TopicInitialEmaScoreSet/negTiny", NewTopicInitialEmaScoreSetEventBase(actor, 1, 1, cNeg).(*EventTopicInitialEmaScoreSet).Score, cNegMin},
+		{"RegretStdNormSet/tiny", NewRegretStdNormSetEventBase(1, 1, cTiny).(*EventRegretStdNormSet).Stdnorm, cMin},
+		{"PreviousPercentageReward/inRange", NewPreviousPercentageRewardToStakedReputersSetEventBase(1, cMid).(*EventPreviousPercentageRewardToStakedReputersSet).Percentage, cMid},
+		{"RewardDelegateStake/huge", NewRewardDelegateStakeEventBase(1, "r", "d", cHuge).(*EventRewardDelegateStake).Amount, cMax},
+		{"TopicWeightUpdated/tiny", NewTopicWeightUpdatedEventBase(1, cTiny, one, one).(*EventTopicWeightUpdated).NewWeight, cMin},
+		{"DelegateRewardShareUpdated/tiny", NewDelegateRewardShareUpdatedEventBase(1, "r", cTiny).(*EventDelegateRewardShareUpdated).RewardPerShare, cMin},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Truef(t, tc.got.Equal(tc.want), "got %s want %s", tc.got.String(), tc.want.String())
+		})
+	}
+}
+
+// Bundle path: arrays and matrices clamp; NaN passes through; empty stays nil.
+//
+//nolint:exhaustruct
+func TestEventClamp_NetworkInferenceBundle(t *testing.T) {
+	nan := alloraMath.NewNaN()
+	labeled := func(vs ...alloraMath.Dec) []*LabeledValue {
+		out := make([]*LabeledValue, len(vs))
+		for i, v := range vs {
+			out[i] = &LabeledValue{LabelName: "l", Value: v}
+		}
+		return out
+	}
+	in := NetworkInferenceBundle{
+		TopicId:       1,
+		Nonce:         1,
+		CombinedValue: labeled(cTiny, cHuge, cMid, cNeg, nan),
+		InfererValues: []*WorkerInference{{Worker: "i1", Values: labeled(cTiny, cHuge)}},
+	}
+	ev := convertNetworkInferenceBundleToEvent(in, false)
+
+	requireDecsEqual(t, ev.CombinedValue[:4], []alloraMath.Dec{cMin, cMax, cMid, cNegMin})
+	require.True(t, ev.CombinedValue[4].IsNaN(), "NaN must pass through")
+	requireDecsEqual(t, ev.InfererValues[0], []alloraMath.Dec{cMin, cMax})
+
+	empty := convertNetworkInferenceBundleToEvent(NetworkInferenceBundle{}, false)
+	require.Nil(t, empty.CombinedValue)
+	require.Nil(t, empty.InfererValues)
+}
+
+// ValueBundle path: scalars, slices, and the NaN-filled one-out matrix.
+//
+//nolint:exhaustruct
+func TestEventClamp_ValueBundle(t *testing.T) {
+	wav := func(w string, v alloraMath.Dec) *WorkerAttributedValue {
+		return &WorkerAttributedValue{Worker: w, Value: v}
+	}
+	bundle := &ValueBundle{
+		CombinedValue: cTiny,
+		NaiveValue:    cHuge,
+		InfererValues: []*WorkerAttributedValue{wav("i1", cTiny), wav("i2", cMid)},
+		OneOutInfererForecasterValues: []*OneOutInfererForecasterValues{
+			{
+				Forecaster:          "f1",
+				OneOutInfererValues: []*WithheldWorkerAttributedValue{{Worker: "i1", Value: cTiny}}, // i2 missing -> NaN
+			},
+		},
+	}
+	evb := ValueBundleToEventValueBundleBase(bundle)
+
+	require.True(t, evb.CombinedValue.Equal(cMin))
+	require.True(t, evb.NaiveValue.Equal(cMax))
+	requireDecsEqual(t, evb.InfererValues, []alloraMath.Dec{cMin, cMid})
+
+	row := evb.OneOutInfererForecasterValues[0]
+	require.True(t, row[0].Equal(cMin), "present cell must be clamped")
+	require.True(t, row[1].IsNaN(), "missing inferer must stay NaN")
+}

--- a/x/emissions/types/events_utils.go
+++ b/x/emissions/types/events_utils.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	"cosmossdk.io/math"
 	"github.com/cosmos/gogoproto/proto"
 
@@ -24,7 +26,7 @@ func NewScoresSetEventBase(actorType ActorType, scores []Score) proto.Message {
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
 		Addresses:   addresses,
-		Scores:      scoreValues,
+		Scores:      clampDecs(scoreValues),
 	}
 }
 
@@ -47,8 +49,9 @@ func NewOutlierResistantNetworkInferencesEventBase(networkInferences NetworkInfe
 }
 
 func convertNetworkInferenceBundleToEvent(b NetworkInferenceBundle, outlierResistant bool) *EventNetworkInferenceBundle {
+	// clamp during extraction: single pass, covers every bundle array/matrix
 	labeledValuesToArray := func(vals []*LabeledValue) alloraMath.DecArray {
-		return convertArray(vals, func(v *LabeledValue) alloraMath.Dec { return v.Value })
+		return convertArray(vals, func(v *LabeledValue) alloraMath.Dec { return clampDec(v.Value) })
 	}
 
 	labelNames := convertArray(b.GetCombinedValue(), func(v *LabeledValue) string { return v.GetLabelName() })
@@ -215,7 +218,7 @@ func NewRewardDelegateStakeEventBase(topicId TopicId, reputer, delegator string,
 		TopicId:   topicId,
 		Reputer:   reputer,
 		Delegator: delegator,
-		Amount:    amount,
+		Amount:    clampDec(amount),
 	}
 }
 
@@ -232,17 +235,18 @@ func ValueBundleToEventValueBundleBase(bundle *ValueBundle) *EventValueBundle {
 	//nolint:exhaustruct
 	evb := &EventValueBundle{
 		ExtraData:     bundle.ExtraData,
-		CombinedValue: bundle.CombinedValue,
-		NaiveValue:    bundle.NaiveValue,
+		CombinedValue: clampDec(bundle.CombinedValue),
+		NaiveValue:    clampDec(bundle.NaiveValue),
 	}
 
-	evb.InfererValues = convertArray(bundle.InfererValues, func(i *WorkerAttributedValue) alloraMath.Dec { return i.GetValue() })
+	// value fields clamp during extraction; address fields are untouched
+	evb.InfererValues = convertArray(bundle.InfererValues, func(i *WorkerAttributedValue) alloraMath.Dec { return clampDec(i.GetValue()) })
 	evb.InfererAddresses = convertArray(bundle.InfererValues, func(i *WorkerAttributedValue) string { return i.GetWorker() })
-	evb.ForecasterValues = convertArray(bundle.ForecasterValues, func(i *WorkerAttributedValue) alloraMath.Dec { return i.GetValue() })
+	evb.ForecasterValues = convertArray(bundle.ForecasterValues, func(i *WorkerAttributedValue) alloraMath.Dec { return clampDec(i.GetValue()) })
 	evb.ForecasterAddresses = convertArray(bundle.ForecasterValues, func(i *WorkerAttributedValue) string { return i.GetWorker() })
-	evb.OneOutInfererValues = convertArray(bundle.OneOutInfererValues, func(i *WithheldWorkerAttributedValue) alloraMath.Dec { return i.GetValue() })
-	evb.OneInForecasterValues = convertArray(bundle.OneInForecasterValues, func(i *WorkerAttributedValue) alloraMath.Dec { return i.GetValue() })
-	evb.OneOutForecasterValues = convertArray(bundle.OneOutForecasterValues, func(i *WithheldWorkerAttributedValue) alloraMath.Dec { return i.GetValue() })
+	evb.OneOutInfererValues = convertArray(bundle.OneOutInfererValues, func(i *WithheldWorkerAttributedValue) alloraMath.Dec { return clampDec(i.GetValue()) })
+	evb.OneInForecasterValues = convertArray(bundle.OneInForecasterValues, func(i *WorkerAttributedValue) alloraMath.Dec { return clampDec(i.GetValue()) })
+	evb.OneOutForecasterValues = convertArray(bundle.OneOutForecasterValues, func(i *WithheldWorkerAttributedValue) alloraMath.Dec { return clampDec(i.GetValue()) })
 
 	lenInf, looif := len(evb.InfererAddresses), len(bundle.OneOutInfererForecasterValues)
 	if lenInf == 0 || looif == 0 {
@@ -265,7 +269,7 @@ func ValueBundleToEventValueBundleBase(bundle *ValueBundle) *EventValueBundle {
 		}
 		for _, cell := range row.OneOutInfererValues {
 			if j, ok := infererIndex[cell.Worker]; ok {
-				oo[j] = cell.Value
+				oo[j] = clampDec(cell.Value)
 			}
 		}
 		evb.OneOutInfererForecasterValues[idx] = oo
@@ -283,6 +287,33 @@ func convertArray[I, O any](in []I, get func(I) O) (out []O) {
 		out[i] = get(v)
 	}
 	return
+}
+
+// Magnitude window for Dec values emitted in events, so tiny/huge computed
+// values don't serialize into oversized strings. Independent of the ingress
+// BoundedExp40Dec guard; shapes event output only, never consensus state.
+const eventDecClampExponent = 40
+
+var (
+	eventDecMinMagnitude = alloraMath.MustNewDecFromString(fmt.Sprintf("1e-%d", eventDecClampExponent))
+	eventDecMaxMagnitude = alloraMath.MustNewDecFromString(fmt.Sprintf("1e%d", eventDecClampExponent))
+)
+
+// clampDec bounds one Dec for event output.
+func clampDec(d alloraMath.Dec) alloraMath.Dec {
+	return alloraMath.ClampMagnitude(d, eventDecMinMagnitude, eventDecMaxMagnitude)
+}
+
+// clampDecs clamps a pre-built slice (params not routed through convertArray).
+func clampDecs(in []alloraMath.Dec) []alloraMath.Dec {
+	if in == nil {
+		return nil
+	}
+	out := make([]alloraMath.Dec, len(in))
+	for i := range in {
+		out[i] = clampDec(in[i])
+	}
+	return out
 }
 
 func NewReputerRegisteredEventBase(topicId TopicId, reputer, owner string) proto.Message {
@@ -465,7 +496,7 @@ func NewTopicReputerWhitelistRemovedEventBase(topicId TopicId, address string) p
 func NewForecastTaskScoreSetEventBase(topicId TopicId, score alloraMath.Dec, nonce int64) proto.Message {
 	return &EventForecastTaskScoreSet{
 		TopicId:          topicId,
-		Score:            score,
+		Score:            clampDec(score),
 		NonceBlockHeight: nonce,
 	}
 }
@@ -486,7 +517,7 @@ func NewEMAScoresSetEventBase(actorType ActorType, nonceBlockHeight BlockHeight,
 		TopicId:   topicId,
 		Nonce:     nonceBlockHeight,
 		Addresses: addresses,
-		Scores:    scoreValues,
+		Scores:    clampDecs(scoreValues),
 		IsActive:  activeArr,
 	}
 }
@@ -507,7 +538,7 @@ func NewRewardsSetEventBase(actorType ActorType, blockHeight, blockHeightTx Bloc
 		TopicId:       topicId,
 		BlockHeight:   blockHeight,
 		Addresses:     addresses,
-		Rewards:       rewardValues,
+		Rewards:       clampDecs(rewardValues),
 		BlockHeightTx: blockHeightTx,
 	}
 }
@@ -520,7 +551,7 @@ func NewTopicRewardSetEventBase(topicRewards map[uint64]*alloraMath.Dec) proto.M
 	}
 	return &EventTopicRewardsSet{
 		TopicIds: ids,
-		Rewards:  rewardValues,
+		Rewards:  clampDecs(rewardValues),
 	}
 }
 
@@ -550,7 +581,7 @@ func NewListeningCoefficientsSetEventBase(topicID uint64, blockHeight int64, add
 		TopicId:      topicID,
 		BlockHeight:  blockHeight,
 		Addresses:    addresses,
-		Coefficients: coefficients,
+		Coefficients: clampDecs(coefficients),
 	}
 }
 
@@ -561,7 +592,7 @@ func NewInfererNetworkRegretSetEventBase(topicID uint64, blockHeight int64, addr
 		TopicId:     topicID,
 		BlockHeight: blockHeight,
 		Addresses:   addresses,
-		Regrets:     regrets,
+		Regrets:     clampDecs(regrets),
 	}
 }
 
@@ -570,7 +601,7 @@ func NewForecasterNetworkRegretSetEventBase(topicID uint64, blockHeight int64, a
 		TopicId:     topicID,
 		BlockHeight: blockHeight,
 		Addresses:   addresses,
-		Regrets:     regrets,
+		Regrets:     clampDecs(regrets),
 	}
 }
 
@@ -579,7 +610,7 @@ func NewNaiveInfererNetworkRegretSetEventBase(topicID uint64, blockHeight int64,
 		TopicId:     topicID,
 		BlockHeight: blockHeight,
 		Addresses:   addresses,
-		Regrets:     regrets,
+		Regrets:     clampDecs(regrets),
 	}
 }
 
@@ -587,7 +618,7 @@ func NewTopicInitialRegretSetEventBase(topicID uint64, blockHeight int64, regret
 	return &EventTopicInitialRegretSet{
 		TopicId:     topicID,
 		BlockHeight: blockHeight,
-		Regret:      regret,
+		Regret:      clampDec(regret),
 	}
 }
 
@@ -596,7 +627,7 @@ func NewTopicInitialEmaScoreSetEventBase(actorType ActorType, topicId uint64, bl
 		ActorType:   actorType,
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
-		Score:       score,
+		Score:       clampDec(score),
 	}
 }
 
@@ -604,7 +635,7 @@ func NewRegretStdNormSetEventBase(topicId uint64, blockHeight int64, stdNorm all
 	return &EventRegretStdNormSet{
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
-		Stdnorm:     stdNorm,
+		Stdnorm:     clampDec(stdNorm),
 	}
 }
 
@@ -613,7 +644,7 @@ func NewInfererWeightsSetEventBase(topicId uint64, blockHeight int64, addresses 
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
 		Addresses:   addresses,
-		Weights:     weights,
+		Weights:     clampDecs(weights),
 	}
 }
 
@@ -622,7 +653,7 @@ func NewForecasterWeightsSetEventBase(topicId uint64, blockHeight int64, address
 		TopicId:     topicId,
 		BlockHeight: blockHeight,
 		Addresses:   addresses,
-		Weights:     weights,
+		Weights:     clampDecs(weights),
 	}
 }
 
@@ -631,7 +662,7 @@ func NewForecasterWeightsSetEventBase(topicId uint64, blockHeight int64, address
 func NewPreviousPercentageRewardToStakedReputersSetEventBase(blockHeight int64, percentage alloraMath.Dec) proto.Message {
 	return &EventPreviousPercentageRewardToStakedReputersSet{
 		BlockHeight: blockHeight,
-		Percentage:  percentage,
+		Percentage:  clampDec(percentage),
 	}
 }
 
@@ -647,7 +678,7 @@ func NewDelegateRewardShareUpdatedEventBase(topicId TopicId, reputer string, rew
 	return &EventDelegateRewardShareUpdated{
 		TopicId:        topicId,
 		Reputer:        reputer,
-		RewardPerShare: rewardPerShare,
+		RewardPerShare: clampDec(rewardPerShare),
 	}
 }
 
@@ -695,7 +726,7 @@ func NewNetworkInferenceInfererWeightsSetEventBase(topicId TopicId, blockHeight 
 		TopicId:          topicId,
 		NonceBlockHeight: blockHeight,
 		Addresses:        addresses,
-		Weights:          weights,
+		Weights:          clampDecs(weights),
 	}
 }
 
@@ -704,7 +735,7 @@ func NewNetworkInferenceForecasterWeightsSetEventBase(topicId TopicId, blockHeig
 		TopicId:          topicId,
 		NonceBlockHeight: blockHeight,
 		Addresses:        addresses,
-		Weights:          weights,
+		Weights:          clampDecs(weights),
 	}
 }
 
@@ -713,7 +744,7 @@ func NewNetworkInferenceInfererRegretsUsedSetEventBase(topicId TopicId, blockHei
 		TopicId:          topicId,
 		NonceBlockHeight: blockHeight,
 		Addresses:        addresses,
-		Regrets:          regrets,
+		Regrets:          clampDecs(regrets),
 	}
 }
 
@@ -722,14 +753,14 @@ func NewNetworkInferenceForecasterRegretsUsedSetEventBase(topicId TopicId, block
 		TopicId:          topicId,
 		NonceBlockHeight: blockHeight,
 		Addresses:        addresses,
-		Regrets:          regrets,
+		Regrets:          clampDecs(regrets),
 	}
 }
 
 func NewTopicWeightUpdatedEventBase(topicId TopicId, newWeight alloraMath.Dec, topicStake math.Int, topicFeeRevenue math.Int) proto.Message {
 	return &EventTopicWeightUpdated{
 		TopicId:         topicId,
-		NewWeight:       newWeight,
+		NewWeight:       clampDec(newWeight),
 		TopicStake:      topicStake,
 		TopicFeeRevenue: topicFeeRevenue,
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

## Summary

Very small or very large `Dec` values produced by the network can serialize into
unnecessarily long strings when emitted in events. This clamps their magnitude at
event-construction time so event payloads stay compact. Event output only —
consensus state and hashing are unaffected.

## Change

- Add `alloraMath.ClampMagnitude(d, min, max Dec) Dec`: clamps `|d|` into a given
  window, preserving sign; zero/NaN/non-finite pass through. It never errors, so
  it is safe on the block-emission path.
- Apply it in `x/emissions/types/events_utils.go` to the `Dec` value fields of
  emissions events, using an event-owned window constant (`[1e-40, 1e40]`). The
  clamp is folded into the existing `convertArray` extraction (single pass).

## Scope

- Events only. State is marshaled separately and unchanged; events are not part of
  the app hash or state-sync snapshots, so there is no migration or
  consensus-version bump. Values already bounded at ingress are left as-is.

## Testing

- Table tests for `ClampMagnitude`: boundaries, sign, zero/NaN/infinity, degenerate
  window, input-not-mutated.
- Table tests over the clamping event constructors and both bundle paths (including
  NaN pass-through and empty→nil).
- `go build ./...`, tests, and `golangci-lint` clean.

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

