### PR TITLE
Calculate topic rewards in a more precise way

### DIFF
--- a/x/emissions/keeper/fenwick.go
+++ b/x/emissions/keeper/fenwick.go
@@ -1,0 +1,169 @@
+package keeper
+
+import (
+	"context"
+	"errors"
+	"math/bits"
+
+	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+)
+
+// lsb returns the least significant set bit of x, i.e. the largest power of 2 dividing x.
+func lsb(x int64) int64 {
+	return x & -x
+}
+
+// bitLength returns the number of bits needed to represent x,
+// i.e. the position of the highest set bit plus one. x must be non-negative.
+func bitLength(x int64) int {
+	return bits.Len64(uint64(x)) //nolint:gosec // G115: x is non-negative by the callers' invariants
+}
+
+// FenwickTree stores a sequence of Dec values under strictly increasing positive
+// int64 indices (e.g. block heights) and computes sums over index ranges in
+// logarithmic time.
+//
+// The indices do not have to be consecutive: values can be appended under any
+// index greater than the last one, and indices that were skipped count as zero.
+// Tree nodes missing from the backing map are also treated as zero, so range
+// sums degrade gracefully (returning partial sums) instead of failing if parts
+// of the history are removed from state.
+type FenwickTree struct {
+	// backing storage: the node at index i holds the sum of the elements
+	// with indices in (i - lsb(i), i]; missing nodes count as zero
+	x collections.Map[int64, alloraMath.Dec]
+}
+
+// NewFenwickTree creates a Fenwick tree backed by a collections map registered
+// under the given prefix and name.
+func NewFenwickTree(sb *collections.SchemaBuilder, prefix collections.Prefix, name string) FenwickTree {
+	return FenwickTree{
+		x: collections.NewMap(sb, prefix, name, collections.Int64Key, alloraMath.DecValue),
+	}
+}
+
+// lastIdx returns the largest index present in the tree,
+// with found = false if the tree is empty.
+func (f FenwickTree) lastIdx(ctx context.Context) (last int64, found bool, err error) {
+	rng := &collections.Range[int64]{}
+	iter, err := f.x.Iterate(ctx, rng.Descending())
+	if err != nil {
+		return 0, false, err
+	}
+	defer iter.Close()
+	if !iter.Valid() {
+		return 0, false, nil
+	}
+	key, err := iter.Key()
+	if err != nil {
+		return 0, false, err
+	}
+	return key, true, nil
+}
+
+// prefixSumWithCap computes the sum of all elements with indices > idx - idx % cap and <= idx.
+// cap is assumed to be a power of 2. Nodes missing from the backing map count as zero.
+func (f FenwickTree) prefixSumWithCap(ctx context.Context, idx int64, cap int64) (alloraMath.Dec, error) {
+	set := idx % cap
+	offset := idx - set
+	result := alloraMath.ZeroDec()
+	for lsb(set) != 0 {
+		value, err := f.x.Get(ctx, offset+set)
+		if err == nil {
+			result, err = result.Add(value)
+			if err != nil {
+				return alloraMath.Dec{}, err
+			}
+		} else if !errors.Is(err, collections.ErrNotFound) {
+			return alloraMath.Dec{}, err
+		}
+		set -= lsb(set)
+	}
+	return result, nil
+}
+
+// Append inserts a value under the given index, which must be positive and
+// strictly greater than every index appended so far.
+func (f FenwickTree) Append(ctx context.Context, idx int64, value alloraMath.Dec) error {
+	if idx <= 0 {
+		return errorsmod.Wrap(types.ErrInvalidValue, "fenwick tree index must be positive")
+	}
+	if err := types.ValidateDec(value); err != nil {
+		return errorsmod.Wrap(err, "fenwick tree value validation failed")
+	}
+
+	// if indices were skipped, fill the nonzero tree nodes in between
+	last, found, err := f.lastIdx(ctx)
+	if err != nil {
+		return err
+	}
+	if found {
+		if idx <= last {
+			return errorsmod.Wrap(types.ErrInvalidValue, "fenwick tree indices must be strictly increasing")
+		}
+		missingIdx := last + lsb(last)
+		for missingIdx < idx {
+			sum, err := f.prefixSumWithCap(ctx, missingIdx-1, lsb(missingIdx))
+			if err != nil {
+				return err
+			}
+			if err := f.x.Set(ctx, missingIdx, sum); err != nil {
+				return err
+			}
+			missingIdx += lsb(missingIdx)
+		}
+	}
+
+	prefixSum, err := f.prefixSumWithCap(ctx, idx-1, lsb(idx))
+	if err != nil {
+		return err
+	}
+	nodeValue, err := value.Add(prefixSum)
+	if err != nil {
+		return err
+	}
+	return f.x.Set(ctx, idx, nodeValue)
+}
+
+// RangeSum computes the sum of the elements with indices in [start, end).
+// Both bounds are clamped to the last appended index, so querying past the
+// end of the sequence sums up to and including the last element.
+func (f FenwickTree) RangeSum(ctx context.Context, start int64, end int64) (alloraMath.Dec, error) {
+	if start <= 0 || end < start {
+		return alloraMath.Dec{}, errorsmod.Wrap(types.ErrInvalidValue, "fenwick tree range start must be positive and no greater than end")
+	}
+	last, found, err := f.lastIdx(ctx)
+	if err != nil {
+		return alloraMath.Dec{}, err
+	}
+	if !found {
+		return alloraMath.ZeroDec(), nil
+	}
+
+	// convert the [start, end) convention to (start, end]
+	if start < last+1 {
+		start--
+	} else {
+		start = last
+	}
+	if end < last+1 {
+		end--
+	} else {
+		end = last
+	}
+
+	cap := int64(1) << bitLength(start^end)
+	endSum, err := f.prefixSumWithCap(ctx, end, cap)
+	if err != nil {
+		return alloraMath.Dec{}, err
+	}
+	startSum, err := f.prefixSumWithCap(ctx, start, cap)
+	if err != nil {
+		return alloraMath.Dec{}, err
+	}
+	return endSum.Sub(startSum)
+}

--- a/x/emissions/keeper/fenwick_test.go
+++ b/x/emissions/keeper/fenwick_test.go
@@ -1,0 +1,117 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/collections"
+	"cosmossdk.io/collections/colltest"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	keeper "github.com/allora-network/allora-chain/x/emissions/keeper"
+)
+
+func newTestFenwickTree(t *testing.T) (keeper.FenwickTree, context.Context) {
+	t.Helper()
+	sk, ctx := colltest.MockStore()
+	sb := collections.NewSchemaBuilder(sk)
+	return keeper.NewFenwickTree(sb, collections.NewPrefix(0), "fenwick"), ctx
+}
+
+func requireRangeSum(t *testing.T, ctx context.Context, f keeper.FenwickTree, start, end, expected int64) {
+	t.Helper()
+	sum, err := f.RangeSum(ctx, start, end)
+	require.NoError(t, err)
+	require.True(t, alloraMath.NewDecFromInt64(expected).Equal(sum),
+		"RangeSum(%d, %d) = %s, expected %d", start, end, sum.String(), expected)
+}
+
+func TestFenwickTreeRangeSum(t *testing.T) {
+	f, ctx := newTestFenwickTree(t)
+
+	elements := map[int64]int64{3: 100, 4: 20, 5: 14, 7: 20, 10: 100, 11: 123}
+	for _, idx := range []int64{3, 4, 5, 7, 10, 11} {
+		require.NoError(t, f.Append(ctx, idx, alloraMath.NewDecFromInt64(elements[idx])))
+	}
+
+	requireRangeSum(t, ctx, f, 1, 1000, 377)
+	requireRangeSum(t, ctx, f, 6, 11, 120)
+	requireRangeSum(t, ctx, f, 8, 10, 0)
+
+	// single-element ranges recover the appended values, with skipped indices counting as zero
+	for idx := int64(1); idx <= 13; idx++ {
+		requireRangeSum(t, ctx, f, idx, idx+1, elements[idx])
+	}
+
+	// both bounds clamp to the last appended index
+	requireRangeSum(t, ctx, f, 11, 5000, 123)
+	requireRangeSum(t, ctx, f, 20, 30, 0)
+}
+
+func TestFenwickTreeEmpty(t *testing.T) {
+	f, ctx := newTestFenwickTree(t)
+
+	sum, err := f.RangeSum(ctx, 1, 100)
+	require.NoError(t, err)
+	require.True(t, sum.IsZero())
+}
+
+func TestFenwickTreeInvalidArguments(t *testing.T) {
+	f, ctx := newTestFenwickTree(t)
+
+	// indices must be positive
+	require.Error(t, f.Append(ctx, 0, alloraMath.OneDec()))
+	require.Error(t, f.Append(ctx, -5, alloraMath.OneDec()))
+
+	require.NoError(t, f.Append(ctx, 5, alloraMath.OneDec()))
+
+	// indices must be strictly increasing
+	require.Error(t, f.Append(ctx, 5, alloraMath.OneDec()))
+	require.Error(t, f.Append(ctx, 4, alloraMath.OneDec()))
+
+	// values must be valid Decs
+	require.Error(t, f.Append(ctx, 6, alloraMath.NewNaN()))
+
+	// range start must be positive and no greater than end
+	_, err := f.RangeSum(ctx, 0, 5)
+	require.Error(t, err)
+	_, err = f.RangeSum(ctx, -1, 5)
+	require.Error(t, err)
+	_, err = f.RangeSum(ctx, 5, 4)
+	require.Error(t, err)
+}
+
+// TestFenwickTreeAgainstNaiveSum appends a sequence with gaps and non-integer
+// values and checks every range sum against a naively computed one.
+func TestFenwickTreeAgainstNaiveSum(t *testing.T) {
+	f, ctx := newTestFenwickTree(t)
+
+	const first, last int64 = 1000, 1128
+	values := make(map[int64]alloraMath.Dec)
+	for idx := first; idx <= last; idx++ {
+		// skip some indices to exercise the gap-filling logic
+		if idx%7 == 3 || idx%11 == 5 {
+			continue
+		}
+		value, err := alloraMath.NewDecFromInt64(idx - 1064).Quo(alloraMath.NewDecFromInt64(16))
+		require.NoError(t, err)
+		values[idx] = value
+		require.NoError(t, f.Append(ctx, idx, value))
+	}
+
+	for start := first - 8; start <= last+8; start++ {
+		naive := alloraMath.ZeroDec()
+		for end := start; end <= last+9; end++ {
+			sum, err := f.RangeSum(ctx, start, end)
+			require.NoError(t, err)
+			require.True(t, naive.Equal(sum),
+				"RangeSum(%d, %d) = %s, expected %s", start, end, sum.String(), naive.String())
+			if value, ok := values[end]; ok {
+				naive, err = naive.Add(value)
+				require.NoError(t, err)
+			}
+		}
+	}
+}

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
@@ -62,6 +63,11 @@ type Keeper struct {
 
 	// Current block emission, set by mint module
 	rewardCurrentBlockEmission collections.Item[cosmosMath.Int]
+
+	// Per-block reward emission divided by the total sum of topic weights,
+	// indexed by block height. Stored as a Fenwick tree so that sums over
+	// block ranges (e.g. a topic's epoch) can be computed in logarithmic time.
+	blockRewardsByTotalWeight FenwickTree
 
 	// NONCES
 	nonceKeeper *NonceKeeper
@@ -132,6 +138,7 @@ func NewKeeper(
 		weightsKeeper:                          wgk,
 		whitelistsKeeper:                       wlk,
 		rewardCurrentBlockEmission:             collections.NewItem(sb, types.RewardCurrentBlockEmissionKey, "reward_current_block_emission", sdk.IntValue),
+		blockRewardsByTotalWeight:              NewFenwickTree(sb, types.BlockRewardsByTotalWeightKey, "block_rewards_by_total_weight"),
 		countInfererInclusionsInTopicActiveSet: collections.NewMap(sb, types.CountInfererInclusionsInTopicKey, "count_inferer_inclusions_in_topic", collections.PairKeyCodec(collections.Uint64Key, collections.StringKey), collections.Uint64Value),
 		countForecasterInclusionsInTopicActiveSet: collections.NewMap(sb, types.CountForecasterInclusionsInTopicKey, "count_forecaster_inclusions_in_topic", collections.PairKeyCodec(collections.Uint64Key, collections.StringKey), collections.Uint64Value),
 		networkInferences:                         collections.NewMap(sb, types.NetworkInferencesKey, "network_inferences", collections.PairKeyCodec(collections.Uint64Key, collections.Int64Key), codec.CollValue[types.ValueBundle](cdc)),
@@ -393,6 +400,20 @@ func (k Keeper) SetRewardCurrentBlockEmission(ctx context.Context, emission cosm
 		return errorsmod.Wrap(types.ErrInvalidValue, "current block emission reward cannot be negative")
 	}
 	return k.rewardCurrentBlockEmission.Set(ctx, emission)
+}
+
+// AppendBlockRewardByTotalWeight records the reward emission per unit of topic
+// weight for a block. Block heights must be appended in strictly increasing
+// order; blocks with a zero value may simply be skipped, as missing entries
+// count as zero when summing.
+func (k *Keeper) AppendBlockRewardByTotalWeight(ctx context.Context, blockHeight BlockHeight, rewardByTotalWeight alloraMath.Dec) error {
+	return k.blockRewardsByTotalWeight.Append(ctx, blockHeight, rewardByTotalWeight)
+}
+
+// SumBlockRewardsByTotalWeight sums the per-unit-weight reward emissions over
+// the block range [startBlock, endBlock).
+func (k *Keeper) SumBlockRewardsByTotalWeight(ctx context.Context, startBlock, endBlock BlockHeight) (alloraMath.Dec, error) {
+	return k.blockRewardsByTotalWeight.RangeSum(ctx, startBlock, endBlock)
 }
 
 func (k *Keeper) GetScoresKeeper() *ScoresKeeper {

--- a/x/emissions/module/abci.go
+++ b/x/emissions/module/abci.go
@@ -79,6 +79,15 @@ func EndBlocker(ctx context.Context, am AppModule) error {
 		return errors.Wrapf(err, "Rewards error")
 	}
 
+	// Commit the topic weights computed above only now that rewards are
+	// distributed: reward calculations must see the weights that were in
+	// effect during the epochs being paid
+	err = rewards.CommitTopicWeights(sdkCtx, am.keeper, weights)
+	if err != nil {
+		sdkCtx.Logger().Error("Error committing topic weights: ", err)
+		return errors.Wrapf(err, "Commit topic weights error")
+	}
+
 	// Close any open windows due this blockHeight
 	workerWindowsToClose := am.keeper.GetNonceKeeper().GetWorkerWindowTopicIds(sdkCtx, blockHeight)
 	if len(workerWindowsToClose.TopicIds) > 0 {

--- a/x/emissions/module/rewards/rewards.go
+++ b/x/emissions/module/rewards/rewards.go
@@ -14,12 +14,11 @@ import (
 
 type CalcTopicRewardsArgs struct {
 	Ctx                             sdk.Context
-	Weights                         map[uint64]*alloraMath.Dec // weights of all active topics in this block
-	SortedTopics                    []uint64                   // topics sorted by weight in descending order
-	SumTopicWeights                 alloraMath.Dec             // sum of all active topic weights
-	TotalAvailableInRewardsTreasury alloraMath.Dec             // Maximum amount of rewards available in treasury
-	EpochLengths                    map[uint64]int64           // epoch lengths for each topic
-	CurrentRewardsEmissionPerBlock  alloraMath.Dec             // Rewards emission per block
+	K                               keeper.Keeper
+	BlockHeight                     BlockHeight
+	SortedTopics                    []uint64         // topics sorted by weight in descending order
+	TotalAvailableInRewardsTreasury alloraMath.Dec   // Maximum amount of rewards available in treasury
+	EpochLengths                    map[uint64]int64 // epoch lengths for each topic
 }
 
 type GenerateRewardsDistributionByTopicParticipantArgs struct {
@@ -50,7 +49,49 @@ type EmitRewardsArgs struct {
 	TotalRevenue cosmosMath.Int
 }
 
+// recordBlockRewardByTotalWeight appends this block's reward emission divided
+// by the total sum of topic weights to the keeper's Fenwick tree. Since this
+// block's topic weight updates are committed only after rewards are
+// distributed, the sum reflects the weights in effect during this block.
+// Nothing is recorded when the emission or the weight sum is zero, as missing
+// entries count as zero when summing over block ranges.
+func recordBlockRewardByTotalWeight(args EmitRewardsArgs) error {
+	currentBlockEmission, err := args.K.GetRewardCurrentBlockEmission(args.Ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get current block emission")
+	}
+	if currentBlockEmission.IsZero() {
+		return nil
+	}
+	totalSumPreviousTopicWeights, err := args.K.GetTopicKeeper().GetTotalSumPreviousTopicWeights(args.Ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get total sum of previous topic weights")
+	}
+	if totalSumPreviousTopicWeights.IsZero() {
+		Logger(args.Ctx).Warn("No topic weights set, skipping block reward by total weight recording")
+		return nil
+	}
+	currentBlockEmissionDec, err := alloraMath.NewDecFromSdkInt(currentBlockEmission)
+	if err != nil {
+		return errors.Wrapf(err, "failed to convert current block emission to decimal")
+	}
+	rewardByTotalWeight, err := currentBlockEmissionDec.Quo(totalSumPreviousTopicWeights)
+	if err != nil {
+		return errors.Wrapf(err, "failed to divide block emission by total sum of topic weights")
+	}
+	return args.K.AppendBlockRewardByTotalWeight(args.Ctx, args.BlockHeight, rewardByTotalWeight)
+}
+
 func EmitRewards(args EmitRewardsArgs) error {
+	// Record this block's reward emission per unit of topic weight, so that
+	// topic rewards can be computed as sums over their epochs' blocks. This
+	// must happen every block, before any early return below, otherwise the
+	// skipped blocks' emissions would never be credited to any topic.
+	err := recordBlockRewardByTotalWeight(args)
+	if err != nil {
+		return errors.Wrapf(err, "failed to record block reward by total weight")
+	}
+
 	// Get current total treasury, to confirm it covers the rewards to give
 	totalRewardTreasury, err := args.K.GetBankingKeeper().GetTotalRewardToDistribute(args.Ctx)
 	if err != nil {
@@ -75,14 +116,6 @@ func EmitRewards(args EmitRewardsArgs) error {
 		sortedRewardableTopics = sortedRewardableTopics[:args.ModuleParams.MaxActiveTopicsPerBlock]
 	}
 
-	// Get the global total sum of previous topic weights
-	totalSumPreviousTopicWeights, err := args.K.GetTopicKeeper().GetTotalSumPreviousTopicWeights(args.Ctx)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get total sum of previous topic weights")
-	}
-	if totalSumPreviousTopicWeights.IsZero() {
-		return errors.Wrapf(types.ErrInvalidReward, "No total weights set, no rewards")
-	}
 	// Get epoch lengths for sorted rewardable topics
 	epochLengths := make(map[uint64]int64)
 	for _, topicId := range sortedRewardableTopics {
@@ -93,27 +126,15 @@ func EmitRewards(args EmitRewardsArgs) error {
 		epochLengths[topicId] = topic.EpochLength
 	}
 
-	// Get current block emission, to be extrapolated to be used in rewards calculation
-	currentBlockEmission, err := args.K.GetRewardCurrentBlockEmission(args.Ctx)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get current block emission")
-	}
-	Logger(args.Ctx).Debug("Current block emission", "currentBlockEmission", currentBlockEmission.String())
-
-	currentBlockEmissionDec, err := alloraMath.NewDecFromSdkInt(currentBlockEmission)
-	if err != nil {
-		return errors.Wrapf(err, "failed to convert current block emission to decimal")
-	}
 	// Revenue (above) is what was earned by topics in this timestep. Rewards are what are actually paid to topics => participants
 	// The reward and revenue calculations are coupled here to minimize excessive compute
 	calcTopicRewardsArgs := CalcTopicRewardsArgs{
 		Ctx:                             args.Ctx,
-		Weights:                         args.Weights,
+		K:                               args.K,
+		BlockHeight:                     args.BlockHeight,
 		SortedTopics:                    sortedRewardableTopics,
-		SumTopicWeights:                 totalSumPreviousTopicWeights,
 		TotalAvailableInRewardsTreasury: totalRewardTreasury,
 		EpochLengths:                    epochLengths,
-		CurrentRewardsEmissionPerBlock:  currentBlockEmissionDec,
 	}
 	topicRewards, err := CalcTopicRewards(calcTopicRewardsArgs)
 	if err != nil {
@@ -237,7 +258,7 @@ func CalcTopicRewards(args CalcTopicRewardsArgs) (
 	err error,
 ) {
 	// General case calculation
-	topicRewards, totalTopicRewardsSum, err := calculateRewardsForCurrentTopics(args)
+	topicRewards, topicWeights, totalTopicRewardsSum, err := calculateRewardsForCurrentTopics(args)
 	if err != nil {
 		return nil, errors.Wrapf(err, "calcTopicRewards: calculate rewards for current topics error")
 	}
@@ -250,7 +271,7 @@ func CalcTopicRewards(args CalcTopicRewardsArgs) (
 			topicId := args.SortedTopics[0]
 			topicRewards[topicId] = &args.TotalAvailableInRewardsTreasury
 		} else {
-			topicRewards, err = calculateRewardsFromWholeTreasury(args)
+			topicRewards, err = calculateRewardsFromWholeTreasury(args, topicWeights)
 			if err != nil {
 				return nil, errors.Wrapf(err, "calcTopicRewards: distribute rewards treasury to current topics error")
 			}
@@ -259,46 +280,60 @@ func CalcTopicRewards(args CalcTopicRewardsArgs) (
 	return topicRewards, nil
 }
 
-// Calculates rewards per-block based on their weights vs all active topics.
-// The notion emission per-block is used to calculate the rewards per-block.
-// Rewards are then calculated per epoch, so topic's epochLength is used to calculate epoch rewards.
-func calculateRewardsForCurrentTopics(args CalcTopicRewardsArgs) (topicRewards map[uint64]*alloraMath.Dec, totalTopicRewardsSum alloraMath.Dec, err error) {
+// Calculates each topic's reward for the epoch ending at this block.
+// Every block credits emission / totalTopicWeight to each unit of topic weight
+// (see recordBlockRewardByTotalWeight); a topic's reward for its epoch is its
+// weight times the sum of these per-unit-weight credits over the epoch's blocks,
+// computed efficiently from the Fenwick tree.
+// The weight used is the one in effect during the epoch being paid, i.e. the
+// stored value: this block's weight update is committed only after rewards are
+// distributed. It is also returned per topic for use in the treasury fallback.
+func calculateRewardsForCurrentTopics(args CalcTopicRewardsArgs) (
+	topicRewards map[uint64]*alloraMath.Dec,
+	topicWeights map[uint64]*alloraMath.Dec,
+	totalTopicRewardsSum alloraMath.Dec,
+	err error,
+) {
 	totalTopicRewardsSum = alloraMath.ZeroDec()
 	topicRewards = make(map[uint64]*alloraMath.Dec)
+	topicWeights = make(map[uint64]*alloraMath.Dec)
 	for _, topicId := range args.SortedTopics {
-		topicWeight := args.Weights[topicId]
-		topicRewardFraction, err := GetTopicRewardFraction(topicWeight, args.SumTopicWeights)
+		topicWeight, _, err := args.K.GetTopicKeeper().GetPreviousTopicWeight(args.Ctx, topicId)
 		if err != nil {
-			return nil, alloraMath.Dec{}, errors.Wrapf(err, "topic reward fraction error")
+			return nil, nil, alloraMath.Dec{}, errors.Wrapf(err, "failed to get previous weight of topic %d", topicId)
 		}
-		if alloraMath.ZeroDec().Equal(topicRewardFraction) {
-			args.Ctx.Logger().Warn("Skipping rewards for topic - zero weights", "topicId", topicId)
-			continue
-		}
-		topicRewardPerBlock, err := GetTopicReward(topicRewardFraction, args.CurrentRewardsEmissionPerBlock)
-		if err != nil {
-			return nil, alloraMath.Dec{}, errors.Wrapf(err, "topic reward error")
-		}
+		topicWeights[topicId] = &topicWeight
 		epochLength := args.EpochLengths[topicId]
 		if epochLength <= 0 {
-			return nil, alloraMath.Dec{}, errors.Wrapf(types.ErrInvalidLengthTopic, "epoch length is nil or zero for topic %d", topicId)
+			return nil, nil, alloraMath.Dec{}, errors.Wrapf(types.ErrInvalidLengthTopic, "epoch length is nil or zero for topic %d", topicId)
 		}
-		epochLengthDec := alloraMath.NewDecFromInt64(epochLength)
-		topicRewardPerEpoch, err := topicRewardPerBlock.Mul(epochLengthDec)
+		// Sum the per-unit-weight credits over the last epochLength blocks,
+		// including the current block's.
+		startBlock := args.BlockHeight - epochLength + 1
+		if startBlock < 1 {
+			startBlock = 1
+		}
+		rewardPerUnitWeight, err := args.K.SumBlockRewardsByTotalWeight(args.Ctx, startBlock, args.BlockHeight+1)
 		if err != nil {
-			return nil, alloraMath.Dec{}, errors.Wrapf(err, "calcTopicRewards:topic reward multiplication with epoch length fraction error")
+			return nil, nil, alloraMath.Dec{}, errors.Wrapf(err, "failed to sum block rewards by total weight for topic %d", topicId)
+		}
+		topicRewardPerEpoch, err := topicWeight.Mul(rewardPerUnitWeight)
+		if err != nil {
+			return nil, nil, alloraMath.Dec{}, errors.Wrapf(err, "calcTopicRewards: topic reward multiplication with reward per unit weight error")
 		}
 		topicRewards[topicId] = &topicRewardPerEpoch
 		totalTopicRewardsSum, err = totalTopicRewardsSum.Add(topicRewardPerEpoch)
 		if err != nil {
-			return nil, alloraMath.Dec{}, errors.Wrapf(err, "calcTopicRewards: total topic rewards sum error")
+			return nil, nil, alloraMath.Dec{}, errors.Wrapf(err, "calcTopicRewards: total topic rewards sum error")
 		}
 	}
-	return topicRewards, totalTopicRewardsSum, nil
+	return topicRewards, topicWeights, totalTopicRewardsSum, nil
 }
 
-// Distributes the whole rewards treasury across the topics based on their factor
-func calculateRewardsFromWholeTreasury(args CalcTopicRewardsArgs) (topicRewards map[uint64]*alloraMath.Dec, err error) {
+// Distributes the whole rewards treasury across the topics based on their factor.
+// The passed weights are the ones used for the general case calculation, i.e.
+// the weights in effect during the epochs being paid.
+func calculateRewardsFromWholeTreasury(args CalcTopicRewardsArgs, topicWeights map[uint64]*alloraMath.Dec) (topicRewards map[uint64]*alloraMath.Dec, err error) {
 	// Factors of each topic, relative to the total factor of topics. Not using weight because already used in this context.
 	topicFactors := make(map[uint64]*alloraMath.Dec)
 	totalTopicFactors := alloraMath.ZeroDec()
@@ -307,7 +342,7 @@ func calculateRewardsFromWholeTreasury(args CalcTopicRewardsArgs) (topicRewards 
 
 	// Calculate topic factors
 	for _, topicId := range args.SortedTopics {
-		topicWeight := args.Weights[topicId]
+		topicWeight := topicWeights[topicId]
 		topicEpochLength := args.EpochLengths[topicId]
 		topicFactor, err := topicWeight.Mul(alloraMath.NewDecFromInt64(topicEpochLength))
 		if err != nil {

--- a/x/emissions/module/rewards/rewards_test.go
+++ b/x/emissions/module/rewards/rewards_test.go
@@ -1159,195 +1159,194 @@ func (s *RewardsTestSuite) TestRewardIncreaseContinuouslyAfterTopicReactivated()
 }
 
 func (s *RewardsTestSuite) TestCalcTopicRewards() {
+	k := s.EmissionsKeeper()
+
+	// stores the weights that are in effect during the epochs being paid
+	setPreviousWeights := func(weights map[uint64]string) {
+		for _, topicId := range alloraMath.GetSortedKeys(weights) {
+			err := k.GetTopicKeeper().SetPreviousTopicWeight(s.Ctx(), topicId, alloraMath.MustNewDecFromString(weights[topicId]))
+			s.Require().NoError(err)
+		}
+	}
+	// records per-unit-weight reward credits; block heights must increase
+	// across the whole test, as the Fenwick tree state is shared by all cases
+	appendBlockRewards := func(blockRewards map[int64]string) {
+		for _, blockHeight := range alloraMath.GetSortedKeys(blockRewards) {
+			err := k.AppendBlockRewardByTotalWeight(s.Ctx(), blockHeight, alloraMath.MustNewDecFromString(blockRewards[blockHeight]))
+			s.Require().NoError(err)
+		}
+	}
+
 	testCases := []struct {
 		name                string
-		setupFunc           func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec)
+		setupFunc           func() rewards.CalcTopicRewardsArgs
 		expectedRewardsFunc func(map[uint64]*alloraMath.Dec) bool
 		expectedError       error
 	}{
 		{
 			name: "Happy path - multiple topics",
-			setupFunc: func() (map[uint64]*alloraMath.Dec,
-				[]uint64,
-				alloraMath.Dec,
-				alloraMath.Dec,
-				map[uint64]int64,
-				alloraMath.Dec) {
-				weights := map[uint64]*alloraMath.Dec{
-					1: testutil.DecPtr("0.5"),
-					2: testutil.DecPtr("0.3"),
-					3: testutil.DecPtr("0.2"),
+			setupFunc: func() rewards.CalcTopicRewardsArgs {
+				setPreviousWeights(map[uint64]string{1: "0.5", 2: "0.3", 3: "0.2"})
+				// 1000 per unit of weight recorded within the epoch (900, 1000]
+				appendBlockRewards(map[int64]string{950: "600.0", 1000: "400.0"})
+				return rewards.CalcTopicRewardsArgs{
+					Ctx:                             s.Ctx(),
+					K:                               *k,
+					BlockHeight:                     1000,
+					SortedTopics:                    []uint64{1, 2, 3},
+					TotalAvailableInRewardsTreasury: alloraMath.MustNewDecFromString("1000.0"),
+					EpochLengths:                    map[uint64]int64{1: 100, 2: 100, 3: 100},
 				}
-				sortedTopics := []uint64{1, 2, 3}
-				sumWeight := alloraMath.MustNewDecFromString("1.0")
-				totalReward := alloraMath.MustNewDecFromString("1000.0")
-				epochLengths := map[uint64]int64{
-					1: 100,
-					2: 100,
-					3: 100,
-				}
-				currentBlockEmission := alloraMath.MustNewDecFromString("10.0")
-				return weights, sortedTopics, sumWeight, totalReward, epochLengths, currentBlockEmission
 			},
-			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
+			expectedRewardsFunc: func(topicRewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
 					1: testutil.DecPtr("500.0"),
 					2: testutil.DecPtr("300.0"),
 					3: testutil.DecPtr("200.0"),
 				}
-				return s.compareRewards(rewards, expected)
+				return s.compareRewards(topicRewards, expected)
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Single topic",
-			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
-				weights := map[uint64]*alloraMath.Dec{
-					1: testutil.DecPtr("1.0"),
+			setupFunc: func() rewards.CalcTopicRewardsArgs {
+				setPreviousWeights(map[uint64]string{1: "1.0"})
+				appendBlockRewards(map[int64]string{1950: "1000.0"})
+				return rewards.CalcTopicRewardsArgs{
+					Ctx:                             s.Ctx(),
+					K:                               *k,
+					BlockHeight:                     2000,
+					SortedTopics:                    []uint64{1},
+					TotalAvailableInRewardsTreasury: alloraMath.MustNewDecFromString("1000.0"),
+					EpochLengths:                    map[uint64]int64{1: 100},
 				}
-				sortedTopics := []uint64{1}
-				sumWeight := alloraMath.MustNewDecFromString("1.0")
-				totalReward := alloraMath.MustNewDecFromString("1000.0")
-				epochLengths := map[uint64]int64{
-					1: 100,
-				}
-				currentBlockEmission := alloraMath.MustNewDecFromString("10.0")
-				return weights, sortedTopics, sumWeight, totalReward, epochLengths, currentBlockEmission
 			},
-			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
+			expectedRewardsFunc: func(topicRewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
 					1: testutil.DecPtr("1000.0"),
 				}
-				return s.compareRewards(rewards, expected)
+				return s.compareRewards(topicRewards, expected)
 			},
 			expectedError: nil,
 		},
 		{
-			name: "Zero total reward",
-			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
-				weights := map[uint64]*alloraMath.Dec{
-					1: testutil.DecPtr("0.5"),
-					2: testutil.DecPtr("0.5"),
+			name: "No recorded block rewards",
+			setupFunc: func() rewards.CalcTopicRewardsArgs {
+				setPreviousWeights(map[uint64]string{1: "0.5", 2: "0.5"})
+				// nothing recorded within the epoch (2900, 3000]
+				return rewards.CalcTopicRewardsArgs{
+					Ctx:                             s.Ctx(),
+					K:                               *k,
+					BlockHeight:                     3000,
+					SortedTopics:                    []uint64{1, 2},
+					TotalAvailableInRewardsTreasury: alloraMath.ZeroDec(),
+					EpochLengths:                    map[uint64]int64{1: 100, 2: 100},
 				}
-				sortedTopics := []uint64{1, 2}
-				sumWeight := alloraMath.MustNewDecFromString("1.0")
-				totalReward := alloraMath.ZeroDec()
-				epochLengths := map[uint64]int64{
-					1: 100,
-					2: 100,
-				}
-				currentBlockEmission := alloraMath.MustNewDecFromString("10.0")
-				return weights, sortedTopics, sumWeight, totalReward, epochLengths, currentBlockEmission
 			},
-			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
+			expectedRewardsFunc: func(topicRewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
 					1: testutil.DecPtr("0"),
 					2: testutil.DecPtr("0"),
 				}
-				return s.compareRewards(rewards, expected)
+				return s.compareRewards(topicRewards, expected)
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Different epoch lengths",
-			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
-				weights := map[uint64]*alloraMath.Dec{
-					1: testutil.DecPtr("0.75"),
-					2: testutil.DecPtr("0.25"),
+			setupFunc: func() rewards.CalcTopicRewardsArgs {
+				setPreviousWeights(map[uint64]string{1: "0.75", 2: "0.25"})
+				// one unit of reward per unit of weight on every block of the
+				// longer epoch: the shorter epoch only sums half of them
+				blockRewards := make(map[int64]string)
+				for blockHeight := int64(3801); blockHeight <= 4000; blockHeight++ {
+					blockRewards[blockHeight] = "1.0"
 				}
-				sortedTopics := []uint64{1, 2}
-				sumWeight := alloraMath.MustNewDecFromString("1")
-				totalReward := alloraMath.MustNewDecFromString("1000.0")
-				epochLengths := map[uint64]int64{
-					1: 100,
-					2: 200,
+				appendBlockRewards(blockRewards)
+				return rewards.CalcTopicRewardsArgs{
+					Ctx:                             s.Ctx(),
+					K:                               *k,
+					BlockHeight:                     4000,
+					SortedTopics:                    []uint64{1, 2},
+					TotalAvailableInRewardsTreasury: alloraMath.MustNewDecFromString("1000.0"),
+					EpochLengths:                    map[uint64]int64{1: 100, 2: 200},
 				}
-				currentBlockEmission := alloraMath.MustNewDecFromString("1.0")
-				return weights, sortedTopics, sumWeight, totalReward, epochLengths, currentBlockEmission
 			},
-			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
+			expectedRewardsFunc: func(topicRewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
 					1: testutil.DecPtr("75"),
 					2: testutil.DecPtr("50"),
 				}
-				return s.compareRewards(rewards, expected)
+				return s.compareRewards(topicRewards, expected)
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Very small weights",
-			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
-				weights := map[uint64]*alloraMath.Dec{
-					1: testutil.DecPtr("0.000000000000000001"),
-					2: testutil.DecPtr("0.000000000000000002"),
+			setupFunc: func() rewards.CalcTopicRewardsArgs {
+				setPreviousWeights(map[uint64]string{
+					1: "0.000000000000000001",
+					2: "0.000000000000000002",
+				})
+				appendBlockRewards(map[int64]string{4950: "1000000000000000000000.0"})
+				return rewards.CalcTopicRewardsArgs{
+					Ctx:                             s.Ctx(),
+					K:                               *k,
+					BlockHeight:                     5000,
+					SortedTopics:                    []uint64{1, 2},
+					TotalAvailableInRewardsTreasury: alloraMath.MustNewDecFromString("3000.0"),
+					EpochLengths:                    map[uint64]int64{1: 100, 2: 100},
 				}
-				sortedTopics := []uint64{1, 2}
-				sumWeight := alloraMath.MustNewDecFromString("0.000000000000000003")
-				totalReward := alloraMath.MustNewDecFromString("1000.0")
-				epochLengths := map[uint64]int64{
-					1: 100,
-					2: 100,
-				}
-				currentBlockEmission := alloraMath.MustNewDecFromString("10.0")
-				return weights, sortedTopics, sumWeight, totalReward, epochLengths, currentBlockEmission
 			},
-			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
+			expectedRewardsFunc: func(topicRewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
-					1: testutil.DecPtr("333.333333333333333333"),
-					2: testutil.DecPtr("666.666666666666666667"),
+					1: testutil.DecPtr("1000.0"),
+					2: testutil.DecPtr("2000.0"),
 				}
-				return s.compareRewards(rewards, expected)
+				return s.compareRewards(topicRewards, expected)
 			},
 			expectedError: nil,
 		},
 		{
-			name: "Mismatched weights and sorted topics",
-			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
-				weights := map[uint64]*alloraMath.Dec{
-					1: testutil.DecPtr("0.5"),
-					2: testutil.DecPtr("0.5"),
+			name: "Missing epoch length",
+			setupFunc: func() rewards.CalcTopicRewardsArgs {
+				setPreviousWeights(map[uint64]string{1: "0.5", 2: "0.5"})
+				return rewards.CalcTopicRewardsArgs{
+					Ctx:                             s.Ctx(),
+					K:                               *k,
+					BlockHeight:                     6000,
+					SortedTopics:                    []uint64{1, 2, 3},
+					TotalAvailableInRewardsTreasury: alloraMath.MustNewDecFromString("1000.0"),
+					EpochLengths:                    map[uint64]int64{1: 100, 2: 100},
 				}
-				sortedTopics := []uint64{1, 2, 3}
-				sumWeight := alloraMath.MustNewDecFromString("1.0")
-				totalReward := alloraMath.MustNewDecFromString("1000.0")
-				epochLengths := map[uint64]int64{
-					1: 100,
-					2: 100,
-				}
-				currentBlockEmission := alloraMath.MustNewDecFromString("10.0")
-				return weights, sortedTopics, sumWeight, totalReward, epochLengths, currentBlockEmission
 			},
-			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
-				return len(rewards) == 2
+			expectedRewardsFunc: func(topicRewards map[uint64]*alloraMath.Dec) bool {
+				return true
 			},
-			expectedError: types.ErrInvalidValue,
+			expectedError: types.ErrInvalidLengthTopic,
 		},
 		{
 			name: "Treasury lower than rewards",
-			setupFunc: func() (map[uint64]*alloraMath.Dec, []uint64, alloraMath.Dec, alloraMath.Dec, map[uint64]int64, alloraMath.Dec) {
-				weights := map[uint64]*alloraMath.Dec{
-					1: testutil.DecPtr("0.5"),
-					2: testutil.DecPtr("0.3"),
-					3: testutil.DecPtr("0.2"),
+			setupFunc: func() rewards.CalcTopicRewardsArgs {
+				setPreviousWeights(map[uint64]string{1: "0.5", 2: "0.3", 3: "0.2"})
+				appendBlockRewards(map[int64]string{6950: "1000.0"})
+				return rewards.CalcTopicRewardsArgs{
+					Ctx:                             s.Ctx(),
+					K:                               *k,
+					BlockHeight:                     7000,
+					SortedTopics:                    []uint64{1, 2, 3},
+					TotalAvailableInRewardsTreasury: alloraMath.MustNewDecFromString("50.0"), // Lower than expected rewards
+					EpochLengths:                    map[uint64]int64{1: 100, 2: 100, 3: 100},
 				}
-				sortedTopics := []uint64{1, 2, 3}
-				sumWeight := alloraMath.MustNewDecFromString("1.0")
-				totalReward := alloraMath.MustNewDecFromString("50.0") // Lower than expected rewards
-				epochLengths := map[uint64]int64{
-					1: 100,
-					2: 100,
-					3: 100,
-				}
-				currentBlockEmission := alloraMath.MustNewDecFromString("1.0")
-				return weights, sortedTopics, sumWeight, totalReward, epochLengths, currentBlockEmission
 			},
-			expectedRewardsFunc: func(rewards map[uint64]*alloraMath.Dec) bool {
+			expectedRewardsFunc: func(topicRewards map[uint64]*alloraMath.Dec) bool {
 				expected := map[uint64]*alloraMath.Dec{
 					1: testutil.DecPtr("25.0"),
 					2: testutil.DecPtr("15.0"),
 					3: testutil.DecPtr("10.0"),
 				}
-				return s.compareRewards(rewards, expected)
+				return s.compareRewards(topicRewards, expected)
 			},
 			expectedError: nil,
 		},
@@ -1355,23 +1354,14 @@ func (s *RewardsTestSuite) TestCalcTopicRewards() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			weights, sortedTopics, sumWeight, totalReward, epochLengths, currentBlockEmission := tc.setupFunc()
-			args := rewards.CalcTopicRewardsArgs{
-				Ctx:                             s.Ctx(),
-				Weights:                         weights,
-				SortedTopics:                    sortedTopics,
-				SumTopicWeights:                 sumWeight,
-				TotalAvailableInRewardsTreasury: totalReward,
-				EpochLengths:                    epochLengths,
-				CurrentRewardsEmissionPerBlock:  currentBlockEmission,
-			}
-			rewards, err := rewards.CalcTopicRewards(args)
+			args := tc.setupFunc()
+			topicRewards, err := rewards.CalcTopicRewards(args)
 
 			if tc.expectedError != nil {
 				s.Require().ErrorIs(err, tc.expectedError)
 			} else {
 				s.Require().NoError(err)
-				s.Require().True(tc.expectedRewardsFunc(rewards))
+				s.Require().True(tc.expectedRewardsFunc(topicRewards))
 			}
 		})
 	}

--- a/x/emissions/module/rewards/topic_rewards.go
+++ b/x/emissions/module/rewards/topic_rewards.go
@@ -14,38 +14,6 @@ import (
 type BlockHeight = int64
 type TopicId = uint64
 
-// The amount of emission rewards to be distributed to a topic
-// E_{t,i} = f_{t,i}*E_i
-// f_{t,i} is the reward fraction for that topic
-// E_i is the reward emission total for that epoch
-func GetTopicReward(
-	topicRewardFraction alloraMath.Dec,
-	totalReward alloraMath.Dec,
-) (alloraMath.Dec, error) {
-	return topicRewardFraction.Mul(totalReward)
-}
-
-// The reward fraction for a topic
-// normalize the topic reward weight
-// f{t,i} = (1 - f_v) * (w_{t,i}) / (∑_t w_{t,i})
-// where f_v is a global parameter set that controls the
-// fraction of total reward emissions for cosmos network validators
-// we don't use f_v here, because by the time the emissions module runs
-// the validator rewards have already been distributed to the fee_collector account
-// (this is done in the mint and then distribution module)
-// w_{t,i} is the weight of topic t
-// and the sum is naturally the total of all the weights for all topics
-func GetTopicRewardFraction(
-	//	f_v alloraMath.Dec,
-	topicWeight *alloraMath.Dec,
-	totalWeight alloraMath.Dec,
-) (alloraMath.Dec, error) {
-	if topicWeight == nil {
-		return alloraMath.ZeroDec(), types.ErrInvalidValue
-	}
-	return (*topicWeight).Quo(totalWeight)
-}
-
 // At the end of epoch, we should update nonce status of active topics, skim the top N by weight.
 // Update worker/reputer nonces, also add reward topic nonce to get reward for this nonce.
 func UpdateNoncesOfActiveTopics(
@@ -123,6 +91,10 @@ func UpdateNoncesOfActiveTopics(
 // Iterates through every active topic, computes its target weight, then exponential moving average to get weight.
 // Returns the total sum of weight, topic revenue, map of all of the weights by topic.
 // Note that the outputted weights are not normalized => not dependent on pan-topic data.
+// The computed weights are NOT persisted here: they only take effect for the
+// next epoch, so they are committed via CommitTopicWeights after this block's
+// rewards have been distributed. Topic fee revenue dripping and topic
+// (in)activation are still applied here.
 func GetAndUpdateActiveTopicWeights(
 	ctx sdk.Context,
 	k keeper.Keeper,
@@ -173,12 +145,8 @@ func GetAndUpdateActiveTopicWeights(
 		if err != nil {
 			return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to get current topic weight")
 		}
-		Logger(ctx).Debug("Setting previous topic weight for topic", "topicId", topic.Id, "weight", weight.String())
-		err = k.GetTopicKeeper().SetPreviousTopicWeight(ctx, topic.Id, weight)
-		if err != nil {
-			return nil, alloraMath.Dec{}, cosmosMath.Int{}, errors.Wrapf(err, "failed to set previous topic weight")
-		}
-		// Emit topic weight updated event
+		// Emit topic weight updated event; the weight is committed to state by
+		// CommitTopicWeights after this block's rewards are distributed
 		types.EmitNewTopicWeightUpdatedEvent(ctx, topic.Id, weight, topicStake, topicFeeRevenue)
 
 		// This revenue will be paid to top active topics of this block (the churnable topics).
@@ -219,4 +187,28 @@ func GetAndUpdateActiveTopicWeights(
 	}
 
 	return weights, sumWeight, totalRevenue, nil
+}
+
+// CommitTopicWeights persists the weights computed by GetAndUpdateActiveTopicWeights,
+// updating the total sum of topic weights along the way. It is called after the
+// block's rewards have been distributed, so that reward calculations see the
+// weights that were in effect during the epochs being paid, and the newly
+// computed weights only take effect from the next block on.
+func CommitTopicWeights(
+	ctx sdk.Context,
+	k keeper.Keeper,
+	weights map[TopicId]*alloraMath.Dec,
+) error {
+	for _, topicId := range alloraMath.GetSortedKeys(weights) {
+		weight := weights[topicId]
+		if weight == nil {
+			return errors.Wrapf(types.ErrInvalidValue, "nil weight for topic %d", topicId)
+		}
+		Logger(ctx).Debug("Setting previous topic weight for topic", "topicId", topicId, "weight", weight.String())
+		err := k.GetTopicKeeper().SetPreviousTopicWeight(ctx, topicId, *weight)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set previous topic weight for topic %d", topicId)
+		}
+	}
+	return nil
 }

--- a/x/emissions/types/keys.go
+++ b/x/emissions/types/keys.go
@@ -126,4 +126,5 @@ var (
 	TopicLabelRegistryKey                     = collections.NewPrefix(106)
 	NetworkInferenceBundleKey                 = collections.NewPrefix(107)
 	OutlierResistantNetworkInferenceBundleKey = collections.NewPrefix(108)
+	BlockRewardsByTotalWeightKey              = collections.NewPrefix(109)
 )


### PR DESCRIPTION
This is a proposed fix for an inaccuracy in how the rewards allocated to a topic are calculated at the end of a topic.

     topicRewardPerEpoch = topicWeight / totalSumPreviousTopicWeights * rewardCurrentBlockEmission * epochLength

This would be correct if all quantities involved were constant throughout the epoch. But in reality, because the epochs of other topics end in the meantime, the normalized topic weight of our topic constantly updates throughout its epoch. A correct implementation would keep track of the normalized topic weight in each block of the epoch, and sum these up, instead of just multiplying the last one of them with `epochLength`. But naively, this would come with a signification computational cost.

This PR is an optimized version of this, which sidesteps the computational. We keep a history of the topic-independent quantity

    blockRewardsByTotalWeight = rewardCurrentBlockEmission / totalSumPreviousTopicWeights

over every block. We hold this in a "Fenwick tree", a type of list which allows to summing over ranges in logarithmic time. Then, at the end of every epoch, we can just compute

    topicRewardPerEpoch = topicWeight * blockRewardsByTotalWeight.rangeSum(height - epoch_length, height)

The details are described in RES-919. 

This PR is not intended to be merged as-is, I haven't even tested it. I just wanted to put this suggestion into code, hoping that it can serve as a starting point for a proper fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compute topic rewards block-by-block using a Fenwick tree to fix inaccuracies when topic weights change mid-epoch. This implements the approach described in RES-919 and keeps reward calculations precise without heavy compute.

- **New Features**
  - Added a per-block record of reward per unit topic weight: `rewardCurrentBlockEmission / totalSumPreviousTopicWeights`, stored in a Fenwick tree for O(log N) range sums.
  - New keeper APIs to append and sum per-unit-weight rewards over block ranges, then multiply by a topic’s weight to get epoch rewards.

- **Bug Fixes**
  - Corrected epoch reward calculation to sum per-block credits over the epoch instead of extrapolating a single value.
  - Deferred committing computed topic weights until after rewards are distributed, ensuring rewards use the weights that were in effect during the paid epochs.

<sup>Written for commit 88eaab1ca71390b00ee472b738cceed4bfec794b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

