### PR TITLE
Add allorad debug-store commands for multistore recovery

### DIFF
--- a/cmd/allorad/cmd/commands.go
+++ b/cmd/allorad/cmd/commands.go
@@ -45,6 +45,7 @@ func initRootCmd(rootCmd *cobra.Command, txConfig client.TxConfig, basicManager 
 		pruning.Cmd(newApp, app.DefaultNodeHome),
 		snapshot.Cmd(newApp),
 		NewInPlaceTestnetCmd(addModuleInitFlags),
+		NewDebugStoreCmd(),
 	)
 
 	server.AddCommands(rootCmd, app.DefaultNodeHome, newApp, appExport, func(startCmd *cobra.Command) {

--- a/cmd/allorad/cmd/debug_store.go
+++ b/cmd/allorad/cmd/debug_store.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"cosmossdk.io/log"
+	storetypes "cosmossdk.io/store/types"
+
+	"cosmossdk.io/store/rootmulti"
+
+	"github.com/allora-network/allora-chain/app"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+)
+
+const (
+	flagRollbackTo = "to"
+	flagYes        = "yes"
+)
+
+// NewDebugStoreCmd returns the `debug-store` command group: read-only diagnostics and a
+// gated recovery path for a multistore left inconsistent by an interrupted migration
+// (the stock `rollback` command panics on such a store because it loads the app with
+// loadLatest=true before it can act).
+func NewDebugStoreCmd() *cobra.Command {
+	cmd := &cobra.Command{ //nolint:exhaustruct // dependency code don't want to change the way it works
+		Use:   "debug-store",
+		Short: "Inspect and recover an application multistore left inconsistent by an interrupted migration",
+	}
+
+	cmd.PersistentFlags().String(flags.FlagHome, app.DefaultNodeHome, "The application home directory")
+	cmd.AddCommand(
+		newDebugStoreInspectCmd(),
+		newDebugStoreCheckTipCmd(),
+		newDebugStoreForceRollbackCmd(),
+	)
+
+	return cmd
+}
+
+func homeFromCmd(cmd *cobra.Command) (string, error) {
+	home, err := cmd.Flags().GetString(flags.FlagHome)
+	if err != nil {
+		return "", err
+	}
+	if home == "" {
+		return "", errors.New("application home not set")
+	}
+	return home, nil
+}
+
+func openApplicationDB(home string) (dbm.DB, error) {
+	vp := viper.New()
+	backend := server.GetAppDBBackend(vp)
+	return dbm.NewDB("application", backend, filepath.Join(home, "data"))
+}
+
+func commitInfoAt(db dbm.DB, version int64) (*storetypes.CommitInfo, error) {
+	bz, err := db.Get([]byte(fmt.Sprintf("s/%d", version)))
+	if err != nil {
+		return nil, err
+	}
+	if bz == nil {
+		return nil, fmt.Errorf("no commitInfo at version %d", version)
+	}
+	var ci storetypes.CommitInfo
+	if err := ci.Unmarshal(bz); err != nil {
+		return nil, err
+	}
+	return &ci, nil
+}
+
+func newDebugStoreInspectCmd() *cobra.Command {
+	return &cobra.Command{ //nolint:exhaustruct // dependency code don't want to change the way it works
+		Use:   "inspect",
+		Short: "Print the store versions recorded at the latest committed height and one height before it",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			home, err := homeFromCmd(cmd)
+			if err != nil {
+				return err
+			}
+
+			db, err := openApplicationDB(home)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			latest := rootmulti.GetLatestVersion(db)
+			cmd.Printf("s/latest = %d\n", latest)
+
+			for _, v := range []int64{latest, latest - 1} {
+				ci, err := commitInfoAt(db, v)
+				if err != nil {
+					cmd.Printf("commitInfo s/%d: %v\n", v, err)
+					continue
+				}
+				cmd.Printf("commitInfo s/%d (version=%d, %d stores):\n", v, ci.Version, len(ci.StoreInfos))
+				for _, si := range ci.StoreInfos {
+					cmd.Printf("    %-24s v%d\n", si.Name, si.CommitId.Version)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// buildUnloadedApp constructs the app with loadLatest=false so store construction
+// (and hence store-key registration) succeeds even when the tip is inconsistent;
+// the caller decides which version to attempt loading via the returned CommitMultiStore.
+func buildUnloadedApp(logger log.Logger, db dbm.DB) (*rootmulti.Store, error) {
+	vp := viper.New()
+	alloraApp, err := app.NewAlloraApp(logger, db, nil, false, vp)
+	if err != nil {
+		return nil, err
+	}
+
+	rms, ok := alloraApp.CommitMultiStore().(*rootmulti.Store)
+	if !ok {
+		return nil, errors.New("app's CommitMultiStore is not a *rootmulti.Store")
+	}
+	return rms, nil
+}
+
+func newDebugStoreCheckTipCmd() *cobra.Command {
+	return &cobra.Command{ //nolint:exhaustruct // dependency code don't want to change the way it works
+		Use:   "check-tip",
+		Short: "Attempt to load every store at the latest committed height, without writing anything",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			home, err := homeFromCmd(cmd)
+			if err != nil {
+				return err
+			}
+
+			db, err := openApplicationDB(home)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			latest := rootmulti.GetLatestVersion(db)
+			logger := log.NewLogger(cmd.OutOrStdout())
+
+			rms, err := buildUnloadedApp(logger, db)
+			if err != nil {
+				return err
+			}
+
+			cmd.Printf("attempting to load all stores at latest=%d ...\n", latest)
+			if err := rms.LoadVersion(latest); err != nil {
+				return fmt.Errorf("load failed at %d: %w", latest, err)
+			}
+			cmd.Printf("load OK — tip %d is consistent and fully loadable\n", latest)
+			return nil
+		},
+	}
+}
+
+func newDebugStoreForceRollbackCmd() *cobra.Command {
+	cmd := &cobra.Command{ //nolint:exhaustruct // dependency code don't want to change the way it works
+		Use:   "force-rollback",
+		Short: "Roll back the multistore to a target version left by an interrupted migration",
+		Long: `Roll back the application multistore to a target version.
+
+This bypasses the stock 'rollback' command, which constructs the app with
+loadLatest=true and panics before it can act if the tip is inconsistent
+(e.g. after an interrupted store migration). By default this only verifies
+that the target version loads cleanly; pass --yes to actually delete
+versions above the target and rewrite s/latest.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			home, err := homeFromCmd(cmd)
+			if err != nil {
+				return err
+			}
+			target, err := cmd.Flags().GetInt64(flagRollbackTo)
+			if err != nil {
+				return err
+			}
+			doWrite, err := cmd.Flags().GetBool(flagYes)
+			if err != nil {
+				return err
+			}
+
+			db, err := openApplicationDB(home)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			latest := rootmulti.GetLatestVersion(db)
+			if target <= 0 || target >= latest {
+				return fmt.Errorf("refusing: target %d must satisfy 0 < target < latest(%d)", target, latest)
+			}
+
+			logger := log.NewLogger(cmd.OutOrStdout())
+			rms, err := buildUnloadedApp(logger, db)
+			if err != nil {
+				return err
+			}
+
+			cmd.Printf("loading all stores at target version %d ...\n", target)
+			if err := rms.LoadVersion(target); err != nil {
+				return fmt.Errorf("LoadVersion(%d) failed: %w", target, err)
+			}
+			cmd.Printf("load OK — every store can be loaded at %d\n", target)
+
+			if !doWrite {
+				cmd.Printf("\ndry run. To roll back (delete versions > %d and set s/latest=%d), re-run with --%s\n",
+					target, target, flagYes)
+				return nil
+			}
+
+			cmd.Printf("rolling back to %d (deleting any versions > %d) ...\n", target, target)
+			if err := rms.RollbackToVersion(target); err != nil {
+				return fmt.Errorf("RollbackToVersion(%d) failed: %w", target, err)
+			}
+			cmd.Printf("done. s/latest is now %d\n", rootmulti.GetLatestVersion(db))
+			return nil
+		},
+	}
+
+	cmd.Flags().Int64(flagRollbackTo, 0, "target version to roll back to (required)")
+	cmd.Flags().Bool(flagYes, false, "perform the rollback instead of only validating the target version loads")
+	_ = cmd.MarkFlagRequired(flagRollbackTo)
+
+	return cmd
+}


### PR DESCRIPTION
## Summary
- An interrupted store migration (e.g. the fast-node "Upgrading IAVL storage" step killed mid-flight) can leave the root multistore's `s/latest` version ahead of a lagging store.
- The stock `rollback` command (wired via `server.AddCommands` → `server.NewRollbackCmd`) constructs the app with `loadLatest=true`, so it panics in `LoadLatestVersion` before it can ever call `RollbackToVersion`. This leaves an affected node unrecoverable via any built-in tool.
- Adds `allorad debug-store {inspect, check-tip, force-rollback}`:
  - `inspect` — read-only dump of `s/latest` and per-store commit-info at the tip and tip-1.
  - `check-tip` — builds the app with `loadLatest=false` (so store construction succeeds regardless of tip consistency) and attempts to load all stores at the latest version, without writing anything.
  - `force-rollback --to N` — same load-and-validate probe at a target version; only writes (deletes versions above target, rewrites `s/latest`) when passed `--yes`.
- Uses the app's real declared store keys (via `app.NewAlloraApp(..., loadLatest=false, ...)` and its `CommitMultiStore()`) rather than inferring stores from on-disk commit-info, so it stays correct if store types/keys change in the future.

## Alternative considered
Hardening the existing `rollback` command itself (constructing the app with `loadLatest=false` and auto-detecting/loading `latest-1` when the tip is inconsistent) would be a cleaner long-term fix and could make this command unnecessary. Open to that direction instead if maintainers prefer it — happy to discuss.

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run ./cmd/allorad/...` — no issues
- [x] `allorad debug-store --help` / subcommand `--help` output reviewed
- [x] `allorad debug-store inspect --home <empty home>` runs without panicking on a home with no application state
- [ ] Exercise `check-tip` / `force-rollback` against a real interrupted-migration data dir (not available in this environment) before relying on it in a live incident

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `allorad debug-store` commands to inspect and safely recover a multistore after an interrupted migration, avoiding the `rollback` panic by loading the app with `loadLatest=false`. Enables dry-run validation and a gated rollback to a target version.

- **New Features**
  - `allorad debug-store inspect` — show `s/latest` and per-store commit-info at tip and tip-1.
  - `allorad debug-store check-tip` — build with `loadLatest=false` and attempt to load all stores at the latest version (read-only).
  - `allorad debug-store force-rollback --to N [--yes]` — validate target version loads; with `--yes`, delete versions above N and set `s/latest=N`.
  - Uses the app’s real store keys via `CommitMultiStore()` for correctness across store changes.

<sup>Written for commit 3a997962f165289730dc0719bbcee0b8409b2550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

