### PR TITLE
fix(deps): patch iavl fast-node cache/commit race causing AppHash divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+* [#980](https://github.com/allora-network/allora-chain/pull/980) Patch a fast-node cache/commit race in `iavl` that caused `AppHash` divergence: the ecosystem treasury account is deleted every block at zero balance, and a concurrent balance query during commit could read its value one block stale, minting the wrong amount and forking the node. Points `iavl` at `github.com/allora-network/iavl` (`v1.2.6` + backport of [cosmos/iavl#1142](https://github.com/cosmos/iavl/pull/1142)). Not consensus-breaking; no migration required.
+
 ### API Breaking Changes
 
 #### Removed

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
-	github.com/cosmos/iavl v1.2.2 // indirect
+	github.com/cosmos/iavl v1.2.6 // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.14.0 // indirect
 	github.com/creachadair/atomicfile v0.3.3 // indirect
@@ -220,3 +220,5 @@ require (
 	nhooyr.io/websocket v1.8.6 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/cosmos/iavl => github.com/allora-network/iavl v1.2.6-allora.1

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/allora-network/iavl v1.2.6-allora.1 h1:W3YPEi6xdZ2gBpWr2ywIhe3gij1uwIWgkIrvS6K8zzs=
+github.com/allora-network/iavl v1.2.6-allora.1/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -368,8 +370,6 @@ github.com/cosmos/gogogateway v1.2.0/go.mod h1:iQpLkGWxYcnCdz5iAdLcRBSw3h7NXeOkZ
 github.com/cosmos/gogoproto v1.4.2/go.mod h1:cLxOsn1ljAHSV527CHOtaIP91kK6cCrZETRBrkzItWU=
 github.com/cosmos/gogoproto v1.7.0 h1:79USr0oyXAbxg3rspGh/m4SWNyoz/GLaAh0QlCe2fro=
 github.com/cosmos/gogoproto v1.7.0/go.mod h1:yWChEv5IUEYURQasfyBW5ffkMHR/90hiHgbNgrtp4j0=
-github.com/cosmos/iavl v1.2.2 h1:qHhKW3I70w+04g5KdsdVSHRbFLgt3yY3qTMd4Xa4rC8=
-github.com/cosmos/iavl v1.2.2/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/cosmos/ibc-go/modules/capability v1.0.1 h1:ibwhrpJ3SftEEZRxCRkH0fQZ9svjthrX2+oXdZvzgGI=
 github.com/cosmos/ibc-go/modules/capability v1.0.1/go.mod h1:rquyOV262nGJplkumH+/LeYs04P3eV8oB7ZM4Ygqk4E=
 github.com/cosmos/ibc-go/v8 v8.7.0 h1:HqhVOkO8bDpClXE81DFQgFjroQcTvtpm0tCS7SQVKVY=


### PR DESCRIPTION
## Purpose of Changes and their Description

Patches a fast-node cache/commit race in `iavl` that caused **`AppHash` divergence** — nodes forking with `wrong Block.Header.AppHash` and only recoverable via rollback/resync.

Root cause is in `iavl`, not our code:
- The ecosystem treasury account is emptied to **zero every block**, and x/bank **deletes** a key at zero balance.
- In `SaveVersion`, `DeleteFastNode` dropped the key from the fast-node cache **immediately** but only *buffered* the on-disk delete until `Commit()`.
- A concurrent point read (an LCD balance query → `GetFastNode` sharing the same nodeDB) in that window missed the cache, reloaded the **stale pre-delete row** from disk, and re-cached it.
- The next block read the stale balance instead of `0`, minted the wrong amount, and forked.

Reproduced live on a testnet node: read balance **40 instead of 0**, minted 40 uallo short. Same signature seen at 50 and 290 uallo on other nodes.

**The change is `go.mod`/`go.sum` only** — no allora-chain code. It points `iavl` at [`allora-network/iavl`](https://github.com/allora-network/iavl) (`v1.2.6` + backport of upstream [cosmos/iavl#1142](https://github.com/cosmos/iavl/pull/1142), "fix race between updating fast node cache and db commit"). #1142 is released only in iavl `v1.2.7+`, which is API-incompatible with our `cosmossdk.io/store v1.1.1`, so it was backported onto `v1.2.6` — the newest tag that still builds with our stack.

**Rollout / safety:** not consensus-breaking. A node that never hit the race computes the identical app hash with or without this change (the fast cache is a read-accelerator over the authoritative tree); only buggy nodes change — they stop forking. No migration, no upgrade handler, no height coordination — dependency bump + rebuild + rolling restart; mixed patched/unpatched fleet is safe during rollout. Already-forked nodes still need a rollback/resync to recover.

**Immediate mitigation, no deploy:** the trigger is a service polling the ecosystem account balance over LCD. Caching or blocking `GET /cosmos/bank/v1beta1/balances/<ecosystem addr>/by_denom` at the gateway removes the trigger while this rolls out.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

_None (incident-driven). Upstream: cosmos/iavl#1142._

## Are these changes tested and documented?

- [x] If tested, please describe how. A deterministic repro test on the fork (`fastnode_poison_test.go`) reproduces the stale read: **fails on unpatched v1.2.6, passes with the fix**, plus two controls (fastnode disabled; no concurrent read). iavl full suite has no regressions vs pristine v1.2.6 (the only local failures are a macOS-only `legacydump` helper-exec issue, identical with/without the patch — pending a Linux/CI run). `allora-chain` builds (`allorad` binary) and `x/mint` tests pass against the fork. Also confirmed live by reproducing the fork on a real testnet node and then verifying the mechanism.
- [x] If documented, please describe where. `CHANGELOG.md` `Unreleased` → `Security`.
- [x] Added to `Unreleased` section of `CHANGELOG.md`? Yes, under `Security` (chain-continuity bug).

## Still Left Todo

- Linux/CI run of the fork's full iavl suite to confirm green (blocked locally by the macOS `legacydump` helper).
- Independent review of the backport is in progress.
- After merge to `dev`: cut the `v0.17` patch release via the `candidate-*` flow.
