### PR TITLE
fix(deps): patch iavl fast-node cache/commit race causing AppHash divergence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
-	github.com/cosmos/iavl v1.2.2 // indirect
+	github.com/cosmos/iavl v1.2.6 // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.14.0 // indirect
 	github.com/creachadair/atomicfile v0.3.3 // indirect
@@ -220,3 +220,5 @@ require (
 	nhooyr.io/websocket v1.8.6 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/cosmos/iavl => github.com/allora-network/iavl v1.2.7-0.20260812160950-4b44ecd55ee8

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/allora-network/iavl v1.2.7-0.20260812160950-4b44ecd55ee8 h1:5bGlb3W44wblUKxLeqlnOwELrFy5IZhWZ07mNiQ3CSs=
+github.com/allora-network/iavl v1.2.7-0.20260812160950-4b44ecd55ee8/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -368,8 +370,6 @@ github.com/cosmos/gogogateway v1.2.0/go.mod h1:iQpLkGWxYcnCdz5iAdLcRBSw3h7NXeOkZ
 github.com/cosmos/gogoproto v1.4.2/go.mod h1:cLxOsn1ljAHSV527CHOtaIP91kK6cCrZETRBrkzItWU=
 github.com/cosmos/gogoproto v1.7.0 h1:79USr0oyXAbxg3rspGh/m4SWNyoz/GLaAh0QlCe2fro=
 github.com/cosmos/gogoproto v1.7.0/go.mod h1:yWChEv5IUEYURQasfyBW5ffkMHR/90hiHgbNgrtp4j0=
-github.com/cosmos/iavl v1.2.2 h1:qHhKW3I70w+04g5KdsdVSHRbFLgt3yY3qTMd4Xa4rC8=
-github.com/cosmos/iavl v1.2.2/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/cosmos/ibc-go/modules/capability v1.0.1 h1:ibwhrpJ3SftEEZRxCRkH0fQZ9svjthrX2+oXdZvzgGI=
 github.com/cosmos/ibc-go/modules/capability v1.0.1/go.mod h1:rquyOV262nGJplkumH+/LeYs04P3eV8oB7ZM4Ygqk4E=
 github.com/cosmos/ibc-go/v8 v8.7.0 h1:HqhVOkO8bDpClXE81DFQgFjroQcTvtpm0tCS7SQVKVY=


### PR DESCRIPTION
## What

Points `iavl` at [`allora-network/iavl`](https://github.com/allora-network/iavl) — **v1.2.6 + a backport of upstream [cosmos/iavl#1142](https://github.com/cosmos/iavl/pull/1142)** ("fix race between updating fast node cache and db commit"). No allora-chain code changes; the entire diff is `go.mod`/`go.sum`.

## The bug (AppHash divergence)

Nodes occasionally forked with `wrong Block.Header.AppHash` and could only recover via rollback/resync. Root cause is in `iavl`, not our code:

- The ecosystem-treasury account is emptied to **zero every block**, and x/bank **deletes** a key at zero balance.
- In `SaveVersion`, `DeleteFastNode` removed the key from the fast-node cache **immediately** but only *buffered* the on-disk delete until `Commit()`.
- A concurrent point read (an LCD balance query → `GetFastNode` sharing the same nodeDB) in that window missed the cache, reloaded the **stale pre-delete row** from disk, and re-cached it.
- The next block read the stale balance instead of `0`, minted the wrong amount, and forked.

Reproduced live: a node read balance **40 instead of 0** and minted 40 uallo short. Same signature seen at 50 and 290 uallo on other nodes.

## The fix

Upstream #1142 defers all fast-node cache mutations until **after** the batch is durable (inside `Commit`, under the same lock as `batch.Write()`), so the cache and the on-disk fast index switch together. Released only in iavl v1.2.7+, which is API-incompatible with our `cosmossdk.io/store v1.1.1` (`WorkingHash` gained a ctx param), so it's backported onto **v1.2.6** — the newest v1.2.x tag that still builds with our stack. The only deviation from upstream is `Lock()` vs `RLock()` (v1.2.6's nodeDB uses `sync.Mutex`, not `RWMutex`).

## Rollout / safety

- **Not consensus-breaking.** A node that never hit the race computes the identical app hash with or without this change (the fast cache is a read-accelerator over the authoritative tree). Only buggy nodes change — they stop forking.
- **No migration, no upgrade handler, no height coordination.** Dependency bump + rebuild + rolling restart. Mixed patched/unpatched fleet during rollout is safe.
- Already-forked nodes still need a rollback/resync to recover, but won't refork once patched.

## Testing

- `fastnode_poison_test.go` on the fork reproduces the stale read deterministically: **fails on unpatched v1.2.6, passes with the fix.** Two controls (fastnode disabled; no concurrent read) pass.
- iavl full suite: no regressions vs pristine v1.2.6 (5 failures are a macOS-only `legacydump` helper-exec issue, identical with/without the patch — a Linux/CI run should be green).
- allora-chain builds and `x/mint` tests pass against the fork.

## Immediate mitigation (no deploy needed)

The trigger is a service polling the ecosystem account balance over LCD. Caching or blocking `GET /cosmos/bank/v1beta1/balances/<ecosystem addr>/by_denom` at the gateway removes the trigger while this rolls out.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points `github.com/cosmos/iavl` to `github.com/allora-network/iavl` (v1.2.6 with a backport of upstream fast-node cache/commit race fix) to stop AppHash divergence. Before, deletes updated the fast-node cache immediately while the on-disk delete was buffered, letting concurrent reads resurrect stale keys; now cache mutations occur after the batch commit under the same lock, keeping cache and disk consistent. Not consensus-breaking: correct nodes keep the same AppHash; only affected nodes stop forking.

**Review & Rollout**
- Diff is `go.mod`/`go.sum` only; adds a `replace` to `github.com/allora-network/iavl` pseudo-version.
- Rebuild and roll nodes; no upgrade handler or height coordination. Mixed patched/unpatched nodes are safe.
- Nodes that already forked must rollback/resync once.

<sup>Written for commit e82f19083a4539e28cc7ef1dec586c770e2eb0bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

