### PR TITLE
fix(deps): patch iavl fast-node cache/commit race causing AppHash divergence (backport #980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+* [#980](https://github.com/allora-network/allora-chain/pull/980) Patch a fast-node cache/commit race in `iavl` that caused `AppHash` divergence: the ecosystem treasury account is deleted every block at zero balance, and a concurrent balance query during commit could read its value one block stale, minting the wrong amount and forking the node. Points `iavl` at `github.com/allora-network/iavl` (`v1.2.6` + backport of [cosmos/iavl#1142](https://github.com/cosmos/iavl/pull/1142)). Not consensus-breaking; no migration required.
+
 ### API Breaking Changes
 
 #### Removed

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
-	github.com/cosmos/iavl v1.2.2 // indirect
+	github.com/cosmos/iavl v1.2.6 // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.14.0 // indirect
 	github.com/creachadair/atomicfile v0.3.3 // indirect
@@ -220,3 +220,5 @@ require (
 	nhooyr.io/websocket v1.8.6 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/cosmos/iavl => github.com/allora-network/iavl v1.2.6-allora.1

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/allora-network/iavl v1.2.6-allora.1 h1:W3YPEi6xdZ2gBpWr2ywIhe3gij1uwIWgkIrvS6K8zzs=
+github.com/allora-network/iavl v1.2.6-allora.1/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -368,8 +370,6 @@ github.com/cosmos/gogogateway v1.2.0/go.mod h1:iQpLkGWxYcnCdz5iAdLcRBSw3h7NXeOkZ
 github.com/cosmos/gogoproto v1.4.2/go.mod h1:cLxOsn1ljAHSV527CHOtaIP91kK6cCrZETRBrkzItWU=
 github.com/cosmos/gogoproto v1.7.0 h1:79USr0oyXAbxg3rspGh/m4SWNyoz/GLaAh0QlCe2fro=
 github.com/cosmos/gogoproto v1.7.0/go.mod h1:yWChEv5IUEYURQasfyBW5ffkMHR/90hiHgbNgrtp4j0=
-github.com/cosmos/iavl v1.2.2 h1:qHhKW3I70w+04g5KdsdVSHRbFLgt3yY3qTMd4Xa4rC8=
-github.com/cosmos/iavl v1.2.2/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/cosmos/ibc-go/modules/capability v1.0.1 h1:ibwhrpJ3SftEEZRxCRkH0fQZ9svjthrX2+oXdZvzgGI=
 github.com/cosmos/ibc-go/modules/capability v1.0.1/go.mod h1:rquyOV262nGJplkumH+/LeYs04P3eV8oB7ZM4Ygqk4E=
 github.com/cosmos/ibc-go/v8 v8.7.0 h1:HqhVOkO8bDpClXE81DFQgFjroQcTvtpm0tCS7SQVKVY=


### PR DESCRIPTION
## Purpose of Changes and their Description

Hotfix backport of #980 onto `candidate-v0.17.1`, for the `v0.17.1` patch release.

Cherry-picked from the merged `dev` commit `2e988328` (the commit carries the `cherry picked from` provenance line). The diff is byte-identical to what was reviewed and merged in #980, except that the `CHANGELOG.md` entry was placed under this branch's existing `### Security` heading — the unrelated `#968`/`#969` entries present in `dev`'s `[Unreleased]` are v0.18-bound and are deliberately not carried over.

**What it fixes:** a fast-node (IAVL flat index) cache/commit race that caused `AppHash` divergence on testnet. `x/mint` drains the ecosystem treasury to exactly zero every block, so `x/bank` *deletes* that balance key each block. In iavl's `SaveVersion`, `DeleteFastNode` evicted the key from `fastNodeCache` immediately while only buffering the on-disk delete until `Commit()`. A concurrent point read (an LCD balance query reaching `GetFastNode` through `GetImmutable`, sharing the same `nodeDB`) inside that window missed the cache, reloaded the stale pre-delete row from disk, and re-cached it. The next block then read the stale balance instead of `0`, minted the wrong amount, and forked the node permanently.

Observed in production on three separate nodes, with the stale value read instead of zero being 290, 50, and 40 uallo respectively.

**No allora-chain code change** — the bug is in iavl. This only repoints the dependency:

```
replace github.com/cosmos/iavl => github.com/allora-network/iavl v1.2.6-allora.1
```

`v1.2.6-allora.1` is tag `v1.2.6` plus a single backported commit: upstream cosmos/iavl#1142 (`146f723`), which defers all fast-node cache mutations until after the batch is durable. Upstream released that fix only in `v1.2.7+`, which is API-incompatible with `cosmossdk.io/store v1.1.1` (`WorkingHash` gained a ctx param), hence the backport onto `v1.2.6`.

**Not consensus-breaking, no migration required.** The fast-node cache is a read accelerator over the authoritative tree, so a node that never hit the race computes an identical app hash with or without this change — patched and unpatched nodes agree, and only forking nodes change behavior.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

- Backport of #980
- Upstream fix: cosmos/iavl#1142

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. — The fork carries a deterministic regression test (`fastnode_poison_test.go`) that drives `SaveVersion`'s steps in order and performs the concurrent read inside the eviction window: it is red on `v1.2.6` (reads the stale value) and green with the fix, plus two controls (fast-node disabled, and no concurrent read). Upstream's own `TestNodeDB_ReadAfterFastNodeDelete` / `TestNodeDB_ReadAfterFastNodeSetAndEvict` were also ported and pass under `-race`. On the chain side, `go build ./...` is clean and the `allorad` binary was built and run from this dependency set.
- [x] If documented, please describe where. If not, describe why docs are not needed. — `CHANGELOG.md`.
- [x] Added to `Unreleased` section of `CHANGELOG.md`? — Yes, under `### Security`.

## Still Left Todo

Nothing. After this merges, `release-v0.17.1` gets cut from `candidate-v0.17.1` and tagged `v0.17.1`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports the upstream `iavl` fast-node cache/commit race fix to prevent `AppHash` divergence during concurrent reads. Old: `DeleteFastNode` evicted the cache before the durable delete, allowing a concurrent read to re-cache stale state; new: fast-node cache mutations are deferred until after commit, eliminating stale reads and forks.

- Backport of #980 to `candidate-v0.17.1`; repins `github.com/cosmos/iavl` to `v1.2.6` and replaces with `github.com/allora-network/iavl v1.2.6-allora.1` (backport of `cosmos/iavl#1142`).
- No consensus change; no migration required.

<sup>Written for commit 6b56136cdf212b510f3b5a819944459c30198068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

