### PR TITLE
Register historical nested pulsar types for tx queries

### DIFF
--- a/x/emissions/api/emissions/v2/codec.go
+++ b/x/emissions/api/emissions/v2/codec.go
@@ -4,7 +4,34 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 )
+
+func init() {
+	// Historical tx queries walk nested (non-Any) fields via gogo proto.MessageType.
+	// These v2 pulsar types are distinct from later gogo structs, so live type URLs
+	// are unchanged.
+	gogoproto.RegisterType((*Nonce)(nil), "emissions.v2.Nonce")
+	gogoproto.RegisterType((*Nonces)(nil), "emissions.v2.Nonces")
+	gogoproto.RegisterType((*ReputerRequestNonce)(nil), "emissions.v2.ReputerRequestNonce")
+	gogoproto.RegisterType((*ReputerRequestNonces)(nil), "emissions.v2.ReputerRequestNonces")
+	gogoproto.RegisterType((*TimestampedValue)(nil), "emissions.v2.TimestampedValue")
+	gogoproto.RegisterType((*Inference)(nil), "emissions.v2.Inference")
+	gogoproto.RegisterType((*Inferences)(nil), "emissions.v2.Inferences")
+	gogoproto.RegisterType((*ForecastElement)(nil), "emissions.v2.ForecastElement")
+	gogoproto.RegisterType((*Forecast)(nil), "emissions.v2.Forecast")
+	gogoproto.RegisterType((*Forecasts)(nil), "emissions.v2.Forecasts")
+	gogoproto.RegisterType((*InferenceForecastBundle)(nil), "emissions.v2.InferenceForecastBundle")
+	gogoproto.RegisterType((*WorkerDataBundle)(nil), "emissions.v2.WorkerDataBundle")
+	gogoproto.RegisterType((*WorkerDataBundles)(nil), "emissions.v2.WorkerDataBundles")
+	gogoproto.RegisterType((*WorkerAttributedValue)(nil), "emissions.v2.WorkerAttributedValue")
+	gogoproto.RegisterType((*WithheldWorkerAttributedValue)(nil), "emissions.v2.WithheldWorkerAttributedValue")
+	gogoproto.RegisterType((*OneOutInfererForecasterValues)(nil), "emissions.v2.OneOutInfererForecasterValues")
+	gogoproto.RegisterType((*ValueBundle)(nil), "emissions.v2.ValueBundle")
+	gogoproto.RegisterType((*ReputerValueBundle)(nil), "emissions.v2.ReputerValueBundle")
+	gogoproto.RegisterType((*ReputerValueBundles)(nil), "emissions.v2.ReputerValueBundles")
+	gogoproto.RegisterType((*OptionalParams)(nil), "emissions.v2.OptionalParams")
+}
 
 //nolint:exhaustruct
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/emissions/api/emissions/v2/codec_test.go
+++ b/x/emissions/api/emissions/v2/codec_test.go
@@ -1,0 +1,84 @@
+package emissionsv2_test
+
+import (
+	"testing"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/codec/unknownproto"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
+
+	v2 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v2"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+)
+
+func TestV2NestedTypesRegisteredWithGogo(t *testing.T) {
+	names := []string{
+		"emissions.v2.Nonce",
+		"emissions.v2.WorkerDataBundle",
+		"emissions.v2.Inference",
+		"emissions.v2.Forecast",
+		"emissions.v2.ForecastElement",
+		"emissions.v2.InferenceForecastBundle",
+		"emissions.v2.ReputerValueBundle",
+		"emissions.v2.ValueBundle",
+		"emissions.v2.OptionalParams",
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			require.NotNil(t, gogoproto.MessageType(name), "gogo registry missing %s", name)
+		})
+	}
+
+	require.Equal(t, "emissions.v10.WorkerDataBundle", gogoproto.MessageName(&emissionstypes.WorkerDataBundle{}))
+	require.Equal(t, "emissions.v3.ReputerValueBundle", gogoproto.MessageName(&emissionstypes.ReputerValueBundle{}))
+}
+
+func TestUnknownProtoWalksV2InsertWorkerPayload(t *testing.T) {
+	msg := &v2.MsgInsertWorkerPayload{
+		Sender: "allo1sender",
+		WorkerDataBundle: &v2.WorkerDataBundle{
+			Worker:  "allo1worker",
+			Nonce:   &v2.Nonce{BlockHeight: 1},
+			TopicId: 1,
+			InferenceForecastsBundle: &v2.InferenceForecastBundle{
+				Inference: &v2.Inference{
+					TopicId:     1,
+					BlockHeight: 1,
+					Inferer:     "allo1worker",
+					Value:       "1.0",
+				},
+			},
+			InferencesForecastsBundleSignature: []byte{0x01},
+			Pubkey:                             "pubkey",
+		},
+	}
+
+	bz, err := protov2.Marshal(msg)
+	require.NoError(t, err)
+	err = unknownproto.RejectUnknownFieldsStrict(bz, (*v2.MsgInsertWorkerPayload)(nil), codectypes.NewInterfaceRegistry())
+	require.NoError(t, err)
+}
+
+func TestUnknownProtoWalksV2InsertReputerPayload(t *testing.T) {
+	//nolint:exhaustruct // historical walk only needs the nested message graph present
+	msg := &v2.MsgInsertReputerPayload{
+		Sender: "allo1sender",
+		ReputerValueBundle: &v2.ReputerValueBundle{
+			ValueBundle: &v2.ValueBundle{
+				TopicId:       1,
+				Reputer:       "allo1reputer",
+				CombinedValue: "1.0",
+				NaiveValue:    "1.0",
+			},
+			Signature: []byte{0x01},
+			Pubkey:    "pubkey",
+		},
+	}
+
+	bz, err := protov2.Marshal(msg)
+	require.NoError(t, err)
+	err = unknownproto.RejectUnknownFieldsStrict(bz, (*v2.MsgInsertReputerPayload)(nil), codectypes.NewInterfaceRegistry())
+	require.NoError(t, err)
+}

--- a/x/emissions/api/emissions/v3/codec.go
+++ b/x/emissions/api/emissions/v3/codec.go
@@ -4,7 +4,25 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 )
+
+func init() {
+	// Historical tx queries walk nested (non-Any) fields via gogo proto.MessageType.
+	// v3–v8 worker payloads nest emissions.v3.WorkerDataBundle; types/ now registers
+	// those worker/inference names as v10. Skip Nonce and ReputerValueBundle — they
+	// are still registered as v3 in types/.
+	gogoproto.RegisterType((*TimestampedValue)(nil), "emissions.v3.TimestampedValue")
+	gogoproto.RegisterType((*Inference)(nil), "emissions.v3.Inference")
+	gogoproto.RegisterType((*Inferences)(nil), "emissions.v3.Inferences")
+	gogoproto.RegisterType((*ForecastElement)(nil), "emissions.v3.ForecastElement")
+	gogoproto.RegisterType((*Forecast)(nil), "emissions.v3.Forecast")
+	gogoproto.RegisterType((*Forecasts)(nil), "emissions.v3.Forecasts")
+	gogoproto.RegisterType((*InferenceForecastBundle)(nil), "emissions.v3.InferenceForecastBundle")
+	gogoproto.RegisterType((*WorkerDataBundle)(nil), "emissions.v3.WorkerDataBundle")
+	gogoproto.RegisterType((*WorkerDataBundles)(nil), "emissions.v3.WorkerDataBundles")
+	gogoproto.RegisterType((*OptionalParams)(nil), "emissions.v3.OptionalParams")
+}
 
 //nolint:exhaustruct
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/emissions/api/emissions/v3/codec_test.go
+++ b/x/emissions/api/emissions/v3/codec_test.go
@@ -1,0 +1,100 @@
+package emissionsv3_test
+
+import (
+	"testing"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/codec/unknownproto"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
+
+	v3 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v3"
+	v4 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v4"
+	_ "github.com/allora-network/allora-chain/x/emissions/api/emissions/v5" // register v5 OptionalParams with gogo
+	_ "github.com/allora-network/allora-chain/x/emissions/api/emissions/v6" // register v6 OptionalParams with gogo
+	_ "github.com/allora-network/allora-chain/x/emissions/api/emissions/v7" // register v7 OptionalParams with gogo
+	v8 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v8"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+)
+
+func TestV3WorkerNestedTypesRegisteredWithGogo(t *testing.T) {
+	names := []string{
+		"emissions.v3.WorkerDataBundle",
+		"emissions.v3.Inference",
+		"emissions.v3.Forecast",
+		"emissions.v3.ForecastElement",
+		"emissions.v3.InferenceForecastBundle",
+		"emissions.v3.OptionalParams",
+		"emissions.v4.OptionalParams",
+		"emissions.v5.OptionalParams",
+		"emissions.v6.OptionalParams",
+		"emissions.v7.OptionalParams",
+		"emissions.v8.OptionalParams",
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			require.NotNil(t, gogoproto.MessageType(name), "gogo registry missing %s", name)
+		})
+	}
+
+	require.Equal(t, "emissions.v10.WorkerDataBundle", gogoproto.MessageName(&emissionstypes.WorkerDataBundle{}))
+	require.Equal(t, "emissions.v10.Inference", gogoproto.MessageName(&emissionstypes.Inference{}))
+	require.Equal(t, "emissions.v3.ReputerValueBundle", gogoproto.MessageName(&emissionstypes.ReputerValueBundle{}))
+	require.Equal(t, "emissions.v3.Nonce", gogoproto.MessageName(&emissionstypes.Nonce{}))
+}
+
+func TestUnknownProtoWalksV3InsertWorkerPayload(t *testing.T) {
+	msg := &v3.MsgInsertWorkerPayload{
+		Sender:           "allo1sender",
+		WorkerDataBundle: testV3WorkerBundle(),
+	}
+
+	bz, err := protov2.Marshal(msg)
+	require.NoError(t, err)
+	err = unknownproto.RejectUnknownFieldsStrict(bz, (*v3.MsgInsertWorkerPayload)(nil), codectypes.NewInterfaceRegistry())
+	require.NoError(t, err)
+}
+
+func TestUnknownProtoWalksV4InsertWorkerPayload(t *testing.T) {
+	msg := &v4.InsertWorkerPayloadRequest{
+		Sender:           "allo1sender",
+		WorkerDataBundle: testV3WorkerBundle(),
+	}
+
+	bz, err := protov2.Marshal(msg)
+	require.NoError(t, err)
+	err = unknownproto.RejectUnknownFieldsStrict(bz, (*v4.InsertWorkerPayloadRequest)(nil), codectypes.NewInterfaceRegistry())
+	require.NoError(t, err)
+}
+
+func TestUnknownProtoWalksV8UpdateParams(t *testing.T) {
+	//nolint:exhaustruct // empty OptionalParams is enough to force the nested type lookup
+	msg := &v8.UpdateParamsRequest{
+		Sender: "allo1sender",
+		Params: &v8.OptionalParams{},
+	}
+
+	bz, err := protov2.Marshal(msg)
+	require.NoError(t, err)
+	err = unknownproto.RejectUnknownFieldsStrict(bz, (*v8.UpdateParamsRequest)(nil), codectypes.NewInterfaceRegistry())
+	require.NoError(t, err)
+}
+
+func testV3WorkerBundle() *v3.WorkerDataBundle {
+	return &v3.WorkerDataBundle{
+		Worker:  "allo1worker",
+		Nonce:   &v3.Nonce{BlockHeight: 1},
+		TopicId: 1,
+		InferenceForecastsBundle: &v3.InferenceForecastBundle{
+			Inference: &v3.Inference{
+				TopicId:     1,
+				BlockHeight: 1,
+				Inferer:     "allo1worker",
+				Value:       "1.0",
+			},
+		},
+		InferencesForecastsBundleSignature: []byte{0x01},
+		Pubkey:                             "pubkey",
+	}
+}

--- a/x/emissions/api/emissions/v4/codec.go
+++ b/x/emissions/api/emissions/v4/codec.go
@@ -4,7 +4,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 )
+
+func init() {
+	// Nested worker/reputer fields on v4 txs are emissions.v3.* (registered in the
+	// v3 package). OptionalParams lives in this package and is no longer in gogo.
+	gogoproto.RegisterType((*OptionalParams)(nil), "emissions.v4.OptionalParams")
+}
 
 //nolint:exhaustruct
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/emissions/api/emissions/v5/codec.go
+++ b/x/emissions/api/emissions/v5/codec.go
@@ -4,7 +4,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 )
+
+func init() {
+	// Nested worker/reputer fields on v5 txs are emissions.v3.* (registered in the
+	// v3 package). OptionalParams lives in this package and is no longer in gogo.
+	gogoproto.RegisterType((*OptionalParams)(nil), "emissions.v5.OptionalParams")
+}
 
 //nolint:exhaustruct
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/emissions/api/emissions/v6/codec.go
+++ b/x/emissions/api/emissions/v6/codec.go
@@ -4,7 +4,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 )
+
+func init() {
+	// Nested worker/reputer fields on v6 txs are emissions.v3.* (registered in the
+	// v3 package). OptionalParams lives in this package and is no longer in gogo.
+	gogoproto.RegisterType((*OptionalParams)(nil), "emissions.v6.OptionalParams")
+}
 
 //nolint:exhaustruct
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/emissions/api/emissions/v7/codec.go
+++ b/x/emissions/api/emissions/v7/codec.go
@@ -4,7 +4,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 )
+
+func init() {
+	// Nested worker/reputer fields on v7 txs are emissions.v3.* (registered in the
+	// v3 package). OptionalParams lives in this package and is no longer in gogo.
+	gogoproto.RegisterType((*OptionalParams)(nil), "emissions.v7.OptionalParams")
+}
 
 //nolint:exhaustruct
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/emissions/api/emissions/v8/codec.go
+++ b/x/emissions/api/emissions/v8/codec.go
@@ -4,7 +4,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 )
+
+func init() {
+	// Nested worker/reputer fields on v8 txs are emissions.v3.* (registered in the
+	// v3 package). OptionalParams lives in this package and is no longer in gogo.
+	gogoproto.RegisterType((*OptionalParams)(nil), "emissions.v8.OptionalParams")
+}
 
 //nolint:exhaustruct
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/emissions/api/emissions/v9/codec.go
+++ b/x/emissions/api/emissions/v9/codec.go
@@ -4,7 +4,25 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 )
+
+func init() {
+	// Historical tx queries walk nested (non-Any) fields via gogo proto.MessageType.
+	// After v10, x/emissions/types registers these names as emissions.v10.*, so
+	// v9 nested payloads fail to decode unless the pulsar types are also in the
+	// gogo registry. These are distinct Go types from the v10 gogo structs, so
+	// the reverse name map for new txs is unchanged.
+	gogoproto.RegisterType((*InputInference)(nil), "emissions.v9.InputInference")
+	gogoproto.RegisterType((*InputInferences)(nil), "emissions.v9.InputInferences")
+	gogoproto.RegisterType((*InputForecastElement)(nil), "emissions.v9.InputForecastElement")
+	gogoproto.RegisterType((*InputForecast)(nil), "emissions.v9.InputForecast")
+	gogoproto.RegisterType((*InputForecasts)(nil), "emissions.v9.InputForecasts")
+	gogoproto.RegisterType((*InputInferenceForecastBundle)(nil), "emissions.v9.InputInferenceForecastBundle")
+	gogoproto.RegisterType((*InputWorkerDataBundle)(nil), "emissions.v9.InputWorkerDataBundle")
+	gogoproto.RegisterType((*InputWorkerDataBundles)(nil), "emissions.v9.InputWorkerDataBundles")
+	gogoproto.RegisterType((*OptionalParams)(nil), "emissions.v9.OptionalParams")
+}
 
 //nolint:exhaustruct
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/emissions/api/emissions/v9/codec_test.go
+++ b/x/emissions/api/emissions/v9/codec_test.go
@@ -1,0 +1,68 @@
+package emissionsv9_test
+
+import (
+	"testing"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/codec/unknownproto"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
+
+	v3 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v3"
+	v9 "github.com/allora-network/allora-chain/x/emissions/api/emissions/v9"
+	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+)
+
+func TestV9NestedTypesRegisteredWithGogo(t *testing.T) {
+	names := []string{
+		"emissions.v9.InputInference",
+		"emissions.v9.InputInferences",
+		"emissions.v9.InputForecastElement",
+		"emissions.v9.InputForecast",
+		"emissions.v9.InputForecasts",
+		"emissions.v9.InputInferenceForecastBundle",
+		"emissions.v9.InputWorkerDataBundle",
+		"emissions.v9.InputWorkerDataBundles",
+		"emissions.v9.OptionalParams",
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			require.NotNil(t, gogoproto.MessageType(name), "gogo registry missing %s", name)
+		})
+	}
+
+	// Registering pulsar types under v9 names must not rename the live v10 gogo types.
+	require.Equal(t, "emissions.v10.InputWorkerDataBundle", gogoproto.MessageName(&emissionstypes.InputWorkerDataBundle{}))
+	require.Equal(t, "emissions.v10.OptionalParams", gogoproto.MessageName(&emissionstypes.OptionalParams{}))
+}
+
+func TestUnknownProtoWalksV9InsertWorkerPayload(t *testing.T) {
+	msg := &v9.InsertWorkerPayloadRequest{
+		Sender: "allo1sender",
+		WorkerDataBundle: &v9.InputWorkerDataBundle{
+			Worker:  "allo1worker",
+			Nonce:   &v3.Nonce{BlockHeight: 1},
+			TopicId: 1,
+			InferenceForecastsBundle: &v9.InputInferenceForecastBundle{
+				Inference: &v9.InputInference{
+					TopicId:     1,
+					BlockHeight: 1,
+					Inferer:     "allo1worker",
+					Value:       "1.0",
+					ExtraData:   nil,
+					Proof:       "",
+				},
+				Forecast: nil,
+			},
+			InferencesForecastsBundleSignature: []byte{0x01},
+			Pubkey:                             "pubkey",
+		},
+	}
+
+	bz, err := protov2.Marshal(msg)
+	require.NoError(t, err)
+
+	err = unknownproto.RejectUnknownFieldsStrict(bz, (*v9.InsertWorkerPayloadRequest)(nil), codectypes.NewInterfaceRegistry())
+	require.NoError(t, err)
+}

--- a/x/mint/api/mint/v1beta1/codec.go
+++ b/x/mint/api/mint/v1beta1/codec.go
@@ -3,7 +3,15 @@ package mintv1beta1
 import (
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 )
+
+func init() {
+	// Historical tx queries walk nested (non-Any) fields via gogo proto.MessageType.
+	// types/ now registers Params as mint.v5.Params, so v1beta1 UpdateParams txs
+	// fail unless the pulsar type is also in the gogo registry.
+	gogoproto.RegisterType((*Params)(nil), "mint.v1beta1.Params")
+}
 
 //nolint:exhaustruct
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/mint/api/mint/v1beta1/codec_test.go
+++ b/x/mint/api/mint/v1beta1/codec_test.go
@@ -1,0 +1,32 @@
+package mintv1beta1_test
+
+import (
+	"testing"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/codec/unknownproto"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
+
+	v1beta1 "github.com/allora-network/allora-chain/x/mint/api/mint/v1beta1"
+	minttypes "github.com/allora-network/allora-chain/x/mint/types"
+)
+
+func TestV1Beta1ParamsRegisteredWithGogo(t *testing.T) {
+	require.NotNil(t, gogoproto.MessageType("mint.v1beta1.Params"))
+	require.Equal(t, "mint.v5.Params", gogoproto.MessageName(&minttypes.Params{}))
+}
+
+func TestUnknownProtoWalksV1Beta1UpdateParams(t *testing.T) {
+	//nolint:exhaustruct // empty Params is enough to force the nested type lookup
+	msg := &v1beta1.MsgUpdateParams{
+		Sender: "allo1sender",
+		Params: &v1beta1.Params{MintDenom: "uallo"},
+	}
+
+	bz, err := protov2.Marshal(msg)
+	require.NoError(t, err)
+	err = unknownproto.RejectUnknownFieldsStrict(bz, (*v1beta1.MsgUpdateParams)(nil), codectypes.NewInterfaceRegistry())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- After the v10 proto bump, `/cosmos/tx/v1beta1/txs` failed to decode pre-upgrade payloads: `unknownproto` looks up nested (non-Any) fields in the gogo registry, but `x/emissions/types` now registers those names as `emissions.v10.*`.
- Register the existing pulsar nested types under their historical names (emissions v2–v9 worker/reputer/params graphs, plus `mint.v1beta1.Params`). These are distinct Go types from the live gogo structs, so new txs still encode as v10 / mint v5.
- Based on `v0.17.1` (`release-v0.17.1`).

## Test plan
- [x] `go test ./x/emissions/api/emissions/v2/ ./x/emissions/api/emissions/v3/ ./x/emissions/api/emissions/v9/ ./x/mint/api/mint/v1beta1/`
- [x] Local in-place-testnet from a mainnet snapshot: `GET /cosmos/tx/v1beta1/txs?query=tx.height=...` returns worker txs instead of the parse error