### PR TITLE
fix(ci): track go-install-hardened @v1 instead of dangling SHA

### DIFF
--- a/.github/workflows/go-hardened.yml
+++ b/.github/workflows/go-hardened.yml
@@ -23,7 +23,7 @@ jobs:
     # surface as a confusing not-found failure for external
     # contributors. Internal PRs and push events always run.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: allora-network/ci-workflows-private/.github/workflows/go-install-hardened.yml@0d80a856ef798b01a39f65cb88a5cf7e74e4ebf9
+    uses: allora-network/ci-workflows-private/.github/workflows/go-install-hardened.yml@v1
     with:
       # Pinned to match the `toolchain` directive in go.mod. Keeps
       # the hardened install check deterministic across runs instead


### PR DESCRIPTION
## Summary

The `go-hardened.yml` workflow was pinned to `@0d80a856` — a dangling commit not reachable from any branch in `ci-workflows-private`. GitHub Actions cannot resolve dangling commit SHAs for cross-repo private workflow calls, causing **100% startup_failure** on every run (0 jobs, empty `referenced_workflows`, "workflow file issue").

## Root cause

PR #17 in `ci-workflows-private` was squash-merged to `main` (not `v1`). The head SHA `0d80a856` became a dangling commit — not on `main`, not on `v1`, not on any branch. GitHub Actions needs the commit to be reachable from a branch or tag to resolve it cross-repo.

## Fix

Switch from `@0d80a856` to `@v1` — the stable release branch. The `v1` version is a strict superset of the pinned commit (71 commits ahead), with additional inputs (`run_veto`, `veto_ref`, `extra_test_flags`), `checkout@v7.0.0` with `persist-credentials: false`, and improved govulncheck JSON parsing. No functional regression.

## Evidence

- 18 recent runs, all 18 failed with "workflow file issue" and 0 jobs
- `referenced_workflows: []` on every run (GitHub could not resolve the reusable workflow)
- SHA `0d80a856` is not an ancestor of `v1`, `main`, or any branch

## Tracking

DEVOP-770 / DEVOP-771

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `.github/workflows/go-hardened.yml` to call `allora-network/ci-workflows-private/.github/workflows/go-install-hardened.yml@v1` instead of a dangling commit so Actions can resolve and run the job. Previously every run failed at startup ("workflow was not found", 0 jobs); now `go-install-hardened` executes on pushes and internal PRs, addressing DEVOP-770.

<sup>Written for commit 3aea03faf479866b83fcc699c0ab241e09ea725d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

