### PR TITLE
prune epoch records on cancel (ENGN-4252)

### DIFF
--- a/x/emissions/keeper/epoch_transitions.go
+++ b/x/emissions/keeper/epoch_transitions.go
@@ -137,13 +137,24 @@ func (k *Keeper) closeReputerWindow(ctx context.Context, epoch types.Epoch) erro
 
 func (k *Keeper) completeEpoch(ctx context.Context, epoch types.Epoch) error {
 	// Losses/weights/TopicRewardNonce are produced in closeReputerWindow via CloseReputerNonce
-	// when submissions exist. During the parallel EndBlocker period, coin payout + prune remain
-	// in rewards.EmitRewards so we do not delete TopicRewardNonce here (that would race EndBlocker).
-	// Mark the topic rewardable as a signal for reward selection.
+	// when submissions exist. Coin payout stays in EndBlocker EmitRewards, which still
+	// needs this epoch's records if TopicRewardNonce matches this start height.
 	if err := k.topicKeeper.SetRewardableTopic(ctx, epoch.TopicId); err != nil {
 		return errorsmod.Wrap(err, "complete epoch: set rewardable topic")
 	}
-	return nil
+	return k.pruneEpochIfNotQueuedForRewards(ctx, epoch)
+}
+
+func (k *Keeper) pruneEpochIfNotQueuedForRewards(ctx context.Context, epoch types.Epoch) error {
+	height := epoch.LegacyNonce().BlockHeight
+	rewardNonce, err := k.topicKeeper.GetTopicRewardNonce(ctx, epoch.TopicId)
+	if err != nil {
+		return err
+	}
+	if rewardNonce == height {
+		return nil
+	}
+	return k.pruneEpochRecords(ctx, epoch.TopicId, height)
 }
 
 func (k *Keeper) cancelEpoch(ctx context.Context, epoch types.Epoch) error {
@@ -169,6 +180,20 @@ func (k *Keeper) cancelEpoch(ctx context.Context, epoch types.Epoch) error {
 			return errorsmod.Wrap(err, "cancel epoch: fulfill reputer nonce")
 		}
 		types.EmitNewReputerSubmissionWindowClosedEvent(ctx, epoch.TopicId, legacyNonce.BlockHeight)
+	}
+
+	rewardNonce, err := k.topicKeeper.GetTopicRewardNonce(ctx, epoch.TopicId)
+	if err != nil {
+		return err
+	}
+	if rewardNonce == legacyNonce.BlockHeight {
+		if err := k.topicKeeper.DeleteTopicRewardNonce(ctx, epoch.TopicId); err != nil {
+			return errorsmod.Wrap(err, "cancel epoch: clear reward nonce")
+		}
+	}
+
+	if err := k.pruneEpochRecords(ctx, epoch.TopicId, legacyNonce.BlockHeight); err != nil {
+		return errorsmod.Wrap(err, "cancel epoch: prune records")
 	}
 
 	return k.unscheduleEpochLifecycle(ctx, epoch)

--- a/x/emissions/keeper/epoch_transitions_test.go
+++ b/x/emissions/keeper/epoch_transitions_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"cosmossdk.io/collections"
+	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 	schedulertypes "github.com/allora-network/allora-chain/x/scheduler/types"
@@ -99,6 +100,34 @@ func (s *KeeperTestSuite) TestEpochFSMCancelFromWorkerSubmissionUnschedulesTasks
 	s.Require().Equal(types.EpochState_WORKER_SUBMISSION, epoch.State)
 
 	legacyNonce := epoch.LegacyNonce()
+	topic, err := s.TopicKeeper().GetTopic(ctx, topicId)
+	s.Require().NoError(err)
+
+	epochInferences := types.Inferences{
+		Inferences: []*types.Inference{
+			{
+				TopicId:     topicId,
+				BlockHeight: legacyNonce.BlockHeight,
+				Values:      []alloraMath.Dec{alloraMath.NewDecFromInt64(1)},
+				Inferer:     s.AddrsStr(0),
+			},
+		},
+	}
+	s.Require().NoError(s.WorkerKeeper().InsertActiveInferences(ctx, topicId, legacyNonce.BlockHeight, epochInferences))
+
+	otherHeight := legacyNonce.BlockHeight + 1
+	otherInferences := types.Inferences{
+		Inferences: []*types.Inference{
+			{
+				TopicId:     topicId,
+				BlockHeight: otherHeight,
+				Values:      []alloraMath.Dec{alloraMath.NewDecFromInt64(2)},
+				Inferer:     s.AddrsStr(1),
+			},
+		},
+	}
+	s.Require().NoError(s.WorkerKeeper().InsertActiveInferences(ctx, topicId, otherHeight, otherInferences))
+
 	s.Require().NoError(s.EmissionsKeeper().CancelEpoch(ctx, topicId, lastNonce))
 
 	_, err = s.EmissionsKeeper().GetEpoch(ctx, topicId, lastNonce)
@@ -107,6 +136,14 @@ func (s *KeeperTestSuite) TestEpochFSMCancelFromWorkerSubmissionUnschedulesTasks
 	workerUnfulfilled, err := s.NonceKeeper().IsWorkerNonceUnfulfilled(ctx, topicId, &legacyNonce)
 	s.Require().NoError(err)
 	s.Require().False(workerUnfulfilled, "cancel must fulfill leftover worker nonce")
+
+	pruned, err := s.WorkerKeeper().GetInferencesAtBlock(ctx, topic, legacyNonce.BlockHeight, false)
+	s.Require().NoError(err)
+	s.Require().Empty(pruned.Inferences, "cancel must prune this epoch's records")
+
+	kept, err := s.WorkerKeeper().GetInferencesAtBlock(ctx, topic, otherHeight, false)
+	s.Require().NoError(err)
+	s.Require().Len(kept.Inferences, 1, "cancel must not prune other epochs' heights")
 
 	taskIDSuffix := fmt.Sprintf(":%d-%d", topicId, lastNonce)
 	for _, taskType := range []string{

--- a/x/emissions/keeper/keeper.go
+++ b/x/emissions/keeper/keeper.go
@@ -410,7 +410,22 @@ func (k *Keeper) PruneRecordsAfterRewards(ctx sdk.Context, topicId TopicId, bloc
 	blockRange := collections.
 		NewPrefixedPairRange[TopicId, BlockHeight](topicId).
 		EndInclusive(blockHeight)
+	return k.clearRecordsInRange(ctx, blockRange)
+}
 
+// pruneEpochRecords deletes inference/loss/network-inference data for one
+// epoch (topicId, start block height). Overlapping epochs keep their own heights.
+func (k *Keeper) pruneEpochRecords(ctx context.Context, topicId TopicId, blockHeight int64) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	defer types.EmitNewPruneRecordsEvent(sdkCtx, blockHeight, topicId)
+	blockRange := collections.
+		NewPrefixedPairRange[TopicId, BlockHeight](topicId).
+		StartInclusive(blockHeight).
+		EndInclusive(blockHeight)
+	return k.clearRecordsInRange(ctx, blockRange)
+}
+
+func (k *Keeper) clearRecordsInRange(ctx context.Context, blockRange *collections.PairRange[uint64, int64]) error {
 	err := k.workerKeeper.PruneInferences(ctx, blockRange)
 	if err != nil {
 		return errorsmod.Wrap(err, "error pruning inferences")


### PR DESCRIPTION
## Summary
- Prune this epoch's inference/loss/network-inference records at `start_block_height` on cancel (exact height, not a range).
- On complete, prune only when `TopicRewardNonce` is not this height so EndBlocker payout still has records.

## Test plan
- [x] `go test ./x/emissions/keeper/ -run 'TestKeeperTestSuite/TestEpochFSM|TestKeeperTestSuite/TestPruneRecordsAfterRewards'`

Stacked on: #978 (ENGN-4250)
Linear: ENGN-4252

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancelling an epoch now prunes that epoch's inference, loss, and network-inference records at the epoch's start block height, so cancelled epochs don't leak stale data. On complete, records are pruned only when the topic's reward nonce isn't at that height, so EndBlocker still has data to pay out.

- New `pruneEpochRecords` deletes records for a single height; overlapping epochs keep their own heights.
- `clearRecordsInRange` is a shared helper for both prune paths.

<sup>Written for commit a409fc4411200c47e41428e091222d6d5e9dc743. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

