### PR TITLE
emissions: drop the 0-sentinel on max_top_inferers_to_reward

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Short, high-signal guidance for working in the `allora-chain` repo. Keep context
 ## Changes That Require Extra Steps
 - Proto/state layout changes: add module migration + tests; bump `ConsensusVersion` and wire upgrades if needed.
 - New module/store keys: update app wiring for store upgrades.
-- Generated files (`*.pb.go`, `*.pulsar.go`): never edit by hand; run codegen.
+- Generated files (`*.pb.go`, `*.pulsar.go`): never edit by hand; run codegen. Never invoke `buf generate`/`protoc-gen-*` directly — local plugin versions drift from what's pinned and produce spurious diffs across unrelated files. Regenerate with `make proto-gen` (or `proto-all` for format+lint+gen) from the module directory (`x/emissions`, `x/mint`, `x/scheduler` each have their own `Makefile` with identical targets). This runs inside Docker (`ghcr.io/cosmos/proto-builder`, pinned version) via `scripts/protocgen.sh`, which also preserves hand-written `codec.go` files under `api/<module>/v*/` and cleans up its own scratch directories — a manual `buf` invocation does none of that. If Docker isn't running, stop and tell the user rather than falling back to local binaries.
 
 ## Minimal Context Strategy
 Start in the module you touch: `x/<module>/keeper`, `x/<module>/types`, `x/<module>/module`.
@@ -66,3 +66,5 @@ This applies to comments you **copy, move, or inherit** as well — e.g. while r
 - Good: `// guards against silent value loss on a second run: the old scalar field was reserved`
 
 Refer to other code by its symbol (function/type name) — that lives in the repo and stays meaningful — rather than by ticket or PR.
+
+Comments describe the code that **stays**, never the code that was removed. When a concept is dropped (a sentinel value, a fallback, a resolution step), delete every mention of it — do not write "X is not a sentinel" or "no value means default"; naming a dead concept keeps it alive for the reader. Do not contrast with other fields, files, or versions ("this matches Y", "unlike genesis") unless the contrast is required to understand the code. Keep comments short; when in doubt, delete — a missing comment is cheaper than a confusing one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,12 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [#968](https://github.com/allora-network/allora-chain/pull/968) Per-topic `max_top_inferers_to_reward` (additive field on `emissions.v10.Topic`): the cap on inferers admitted per topic is now topic-level, set at create/`UpdateTopic` (`0` uses the global default; guarded while a worker submission window is open). Stored caps are kept verbatim, and admission resolves them against the global bounds, so the globals stay live. The emissions v16 migration backfills existing topics, so behavior is unchanged across the `v0.18.0` upgrade.
-* [#969](https://github.com/allora-network/allora-chain/pull/969) New global `min_top_inferers_to_reward` (additive field on `emissions.v9.Params`): a floor for the per-topic inferer cap, so a topic cannot be configured to admit an unreasonably small active set. Create/`UpdateTopic` reject a cap outside `[min, max]`, and admission clamps the effective cap into that range with the ceiling applied last, so it can never exceed the global maximum. Params validation keeps the range well formed by rejecting a floor above the ceiling. It defaults to `5` and is therefore active from the start: a topic whose stored cap is below the floor has it raised at admission, and the v16 migration backfills the param. The floor never gates an epoch, which stays valid even when fewer inferers than the floor take part.
+* [#968](https://github.com/allora-network/allora-chain/pull/968) Per-topic `max_top_inferers_to_reward`, required within the global range, with migration v16
+* [#969](https://github.com/allora-network/allora-chain/pull/969) New global `min_top_inferers_to_reward` as the floor for the per-topic inferer cap (default `5`)
 
 ### Changed
 
-* [#968](https://github.com/allora-network/allora-chain/pull/968) The global `max_top_inferers_to_reward` now rejects zero and serves as the default and live ceiling for the per-topic cap; score-history retention still uses the global value.
+* [#968](https://github.com/allora-network/allora-chain/pull/968) The global `max_top_inferers_to_reward` now rejects zero and serves as the live ceiling for the per-topic cap; score-history retention still uses the global value.
 
 ### Deprecated
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Short, high-signal guidance for working in the `allora-chain` repo. Keep context
 ## Changes That Require Extra Steps
 - Proto/state layout changes: add module migration + tests; bump `ConsensusVersion` and wire upgrades if needed.
 - New module/store keys: update app wiring for store upgrades.
-- Generated files (`*.pb.go`, `*.pulsar.go`): never edit by hand; run codegen.
+- Generated files (`*.pb.go`, `*.pulsar.go`): never edit by hand; run codegen. Never invoke `buf generate`/`protoc-gen-*` directly — local plugin versions drift from what's pinned and produce spurious diffs across unrelated files. Regenerate with `make proto-gen` (or `proto-all` for format+lint+gen) from the module directory (`x/emissions`, `x/mint`, `x/scheduler` each have their own `Makefile` with identical targets). This runs inside Docker (`ghcr.io/cosmos/proto-builder`, pinned version) via `scripts/protocgen.sh`, which also preserves hand-written `codec.go` files under `api/<module>/v*/` and cleans up its own scratch directories — a manual `buf` invocation does none of that. If Docker isn't running, stop and tell the user rather than falling back to local binaries.
 - See `CONTRIBUTING.md` for more details on migrations, protos, upgrades, and complex changes.
 
 ## Minimal Context Strategy
@@ -67,3 +67,5 @@ This applies to comments you **copy, move, or inherit** as well — e.g. while r
 - Good: `// guards against silent value loss on a second run: the old scalar field was reserved`
 
 Refer to other code by its symbol (function/type name) — that lives in the repo and stays meaningful — rather than by ticket or PR.
+
+Comments describe the code that **stays**, never the code that was removed. When a concept is dropped (a sentinel value, a fallback, a resolution step), delete every mention of it — do not write "X is not a sentinel" or "no value means default"; naming a dead concept keeps it alive for the reader. Do not contrast with other fields, files, or versions ("this matches Y", "unlike genesis") unless the contrast is required to understand the code. Keep comments short; when in doubt, delete — a missing comment is cheaper than a confusing one.

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	cosmossdk.io/x/circuit v0.1.1
 	cosmossdk.io/x/evidence v0.1.1
 	cosmossdk.io/x/feegrant v0.1.1
+	cosmossdk.io/x/tx v0.13.7
 	cosmossdk.io/x/upgrade v0.1.4
 	github.com/cockroachdb/apd/v3 v3.2.1
 	github.com/cometbft/cometbft v0.38.21
@@ -69,7 +70,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.5.2 // indirect
 	cloud.google.com/go/iam v1.1.9 // indirect
 	cloud.google.com/go/storage v1.41.0 // indirect
-	cosmossdk.io/x/tx v0.13.7 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.2 // indirect

--- a/test/fuzz/topics_test.go
+++ b/test/fuzz/topics_test.go
@@ -22,8 +22,16 @@ func createTopic(
 	iteration int,
 ) (success bool) {
 	iterLog(m.T, iteration, actor, "creating new topic")
+	ctx := context.Background()
+	paramsResp, err := m.Client.QueryEmissions().GetParams(ctx, &emissionstypes.GetParamsRequest{})
+	failIfOnErr(m.T, data.failOnErr, err)
+	if err != nil {
+		iterFailLog(m.T, iteration, actor, "failed to create topic", "get params error", err)
+		return false
+	}
+
 	createTopicRequest := &emissionstypes.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   paramsResp.Params.MaxTopInferersToReward,
 		Creator:                  actor.addr,
 		Metadata:                 fmt.Sprintf("Created topic iteration %d", iteration),
 		LossMethod:               "mse",
@@ -51,7 +59,6 @@ func createTopic(
 		LabelCaseSensitive:       true,
 	}
 
-	ctx := context.Background()
 	txResp, err := m.Client.BroadcastTx(ctx, actor.acc, createTopicRequest)
 	failIfOnErr(m.T, data.failOnErr, err)
 	if err != nil {

--- a/test/integration/create_topic_test.go
+++ b/test/integration/create_topic_test.go
@@ -40,7 +40,7 @@ func CreateTopic(m testCommon.TestConfig) (topicId uint64) {
 	require.Positive(m.T, topicIdStart.NextTopicId)
 	require.NoError(m.T, err)
 	createTopicRequest := &emissionstypes.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   GetEmissionsParams(m).MaxTopInferersToReward,
 		Creator:                  m.AliceAddr,
 		Metadata:                 "ETH 24h Prediction",
 		LossMethod:               "mse",
@@ -121,7 +121,7 @@ func CreateTopicMultiLabel(m testCommon.TestConfig) (topicId uint64) {
 	require.Positive(m.T, topicIdStart.NextTopicId)
 	require.NoError(m.T, err)
 	createTopicRequest := &emissionstypes.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   GetEmissionsParams(m).MaxTopInferersToReward,
 		Creator:                  m.AliceAddr,
 		Metadata:                 "ETH 24h Prediction",
 		LossMethod:               "mse",

--- a/test/integration/label_registry_classification_test.go
+++ b/test/integration/label_registry_classification_test.go
@@ -36,8 +36,10 @@ func LabelRegistryClassificationChecks(m testCommon.TestConfig) {
 
 	addTopicCreator(m, m.AliceAddr)
 
+	maxTopInferersToReward := GetEmissionsParams(m).MaxTopInferersToReward
 	baseReq := func() *emissionstypes.CreateNewTopicRequest {
 		return &emissionstypes.CreateNewTopicRequest{
+			MaxTopInferersToReward:   maxTopInferersToReward,
 			Creator:                  m.AliceAddr,
 			Metadata:                 "label registry integration",
 			LossMethod:               "mse",
@@ -128,6 +130,7 @@ func LabelRegistryClassificationChecks(m testCommon.TestConfig) {
 		MeritSortitionAlpha:    stored.Topic.MeritSortitionAlpha,
 		PNorm:                  stored.Topic.PNorm,
 		CNorm:                  stored.Topic.CNorm,
+		MaxTopInferersToReward: stored.Topic.MaxTopInferersToReward,
 		MaxLabelsPerSubmission: 5,
 		LabelWhitelist:         stored.Topic.LabelWhitelist,
 		LabelDefaultValue:      alloraMath.ZeroDec(),

--- a/test/integration/topic_distribution_test.go
+++ b/test/integration/topic_distribution_test.go
@@ -166,7 +166,7 @@ func addDelegateStake(m testCommon.TestConfig, delegatorAccount cosmosaccount.Ac
 func createTestTopic(m testCommon.TestConfig, creator string, metadata string, epochLength int64) uint64 {
 	ctx := context.Background()
 	createTopicRequest := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   GetEmissionsParams(m).MaxTopInferersToReward,
 		Creator:                  creator,
 		Metadata:                 metadata,
 		LossMethod:               "mse",

--- a/x/emissions/README.md
+++ b/x/emissions/README.md
@@ -59,7 +59,7 @@ The `UpdateTopic` tx is intentionally limited to a subset of mutable fields. Top
 
 All other topic fields are immutable because they impact state transitions, scheduling/cadence, or other invariants that should remain stable once a topic is created.
 
-`UpdateTopic` is a **full replacement**: every editable field is overwritten by what the message carries, so send the current value back to keep it. An empty `label_whitelist` means *unrestricted*, not *unchanged*, and `max_top_inferers_to_reward` of `0` means *use the global maximum*, not *unchanged*.
+`UpdateTopic` is a **full replacement**: every editable field is overwritten by what the message carries, so send the current value back to keep it. An empty `label_whitelist` means *unrestricted*, not *unchanged*, and `max_top_inferers_to_reward` must be re-sent within the global range to keep it.
 
 ### Constraints
 

--- a/x/emissions/api/emissions/v10/topic.pulsar.go
+++ b/x/emissions/api/emissions/v10/topic.pulsar.go
@@ -5214,10 +5214,9 @@ type Topic struct {
 	LabelCaseSensitive bool `protobuf:"varint,30,opt,name=label_case_sensitive,json=labelCaseSensitive,proto3" json:"label_case_sensitive,omitempty"`
 	// Per-topic cap on inferers admitted to the active set, enforced at
 	// worker-payload insert: an inferer is admitted while the set is below the
-	// cap, otherwise it must out-score the lowest member. Writes through
-	// CreateNewTopic/UpdateTopic store a concrete value (a requested 0 resolves to
-	// the global max_top_inferers_to_reward), and migration backfills legacy
-	// topics; a genesis-supplied 0 is stored as-is and resolves at admission.
+	// cap, otherwise it must out-score the lowest member. CreateNewTopic and
+	// UpdateTopic require it to be within the global range; admission clamps the
+	// stored value into the live global range on every payload.
 	MaxTopInferersToReward uint64 `protobuf:"varint,31,opt,name=max_top_inferers_to_reward,json=maxTopInferersToReward,proto3" json:"max_top_inferers_to_reward,omitempty"`
 }
 

--- a/x/emissions/api/emissions/v10/tx.pulsar.go
+++ b/x/emissions/api/emissions/v10/tx.pulsar.go
@@ -50737,10 +50737,8 @@ type CreateNewTopicRequest struct {
 	// preserved and labels that differ only in case are treated as distinct.
 	// The field is immutable after topic creation.
 	LabelCaseSensitive bool `protobuf:"varint,29,opt,name=label_case_sensitive,json=labelCaseSensitive,proto3" json:"label_case_sensitive,omitempty"`
-	// Per-topic cap on inferers admitted to the active set. 0 means "use the
-	// global max_top_inferers_to_reward": that value is resolved and stored, so
-	// the topic keeps it even if the global changes later. Any other value must
-	// be within the global [min_top_inferers_to_reward, max_top_inferers_to_reward].
+	// Per-topic cap on inferers admitted to the active set. Must be within the
+	// global [min_top_inferers_to_reward, max_top_inferers_to_reward] range.
 	MaxTopInferersToReward uint64 `protobuf:"varint,30,opt,name=max_top_inferers_to_reward,json=maxTopInferersToReward,proto3" json:"max_top_inferers_to_reward,omitempty"`
 }
 
@@ -51007,11 +51005,10 @@ type UpdateTopicRequest struct {
 	// Default value for missing MULTI label slots. Topic keeper rejects
 	// mutations while any worker submission window is open.
 	LabelDefaultValue string `protobuf:"bytes,11,opt,name=label_default_value,json=labelDefaultValue,proto3" json:"label_default_value,omitempty"`
-	// Per-topic cap on inferers admitted to the active set. Full replacement: the
-	// supplied value overwrites the stored one. 0 means "use the global
-	// max_top_inferers_to_reward", resolved and stored; any other value must be
-	// within the global [min_top_inferers_to_reward, max_top_inferers_to_reward].
-	// The keeper rejects this mutation while any worker submission window is open.
+	// Per-topic cap on inferers admitted to the active set. Full replacement,
+	// within the global [min_top_inferers_to_reward, max_top_inferers_to_reward]
+	// range. The keeper rejects a change while any worker submission window is
+	// open.
 	MaxTopInferersToReward uint64 `protobuf:"varint,12,opt,name=max_top_inferers_to_reward,json=maxTopInferersToReward,proto3" json:"max_top_inferers_to_reward,omitempty"`
 }
 

--- a/x/emissions/docs/global-parameters.md
+++ b/x/emissions/docs/global-parameters.md
@@ -93,8 +93,8 @@ Despite the naming symmetry with `max_top_forecasters_to_reward` and `max_top_re
 
 | Path | Behavior |
 |---|---|
-| `CreateNewTopic` / `UpdateTopic` | **Rejects** a non-zero request outside `[min, max]`. `0` means "use `max`" and is resolved to a concrete stored value. |
-| Genesis import | Stores whatever is supplied, **unvalidated** against the range. |
+| `CreateNewTopic` / `UpdateTopic` | **Rejects** a request outside `[min, max]`, `0` included. An accepted value is stored verbatim. |
+| Genesis import | Stores whatever is supplied; `Topic.Validate` does not bound this field against the range for any caller. |
 | Worker payload admission | **Clamps** the stored value into `[min, max]`, with `max` applied last. |
 
 So a request below the floor is an error, but a *stored* value below the floor is silently raised at admission. That asymmetry is intentional: rejecting bad input is useful, but a governance floor raise must not brick topics that were valid when they were written.
@@ -105,7 +105,7 @@ So a request below the floor is an error, but a *stored* value below the floor i
 
 **`max` may not be zero**; `min` may. A zero ceiling would admit nobody and would zero the score-retention window. A zero floor simply means "no floor".
 
-**Raising the floor has a delayed cost.** Topics whose stored cap falls below the new floor keep working — admission raises them — but their owners can no longer resubmit that cap, so any `UpdateTopic` forces the cap to change, which in turn trips the worker-submission-window guard. See [Topic Parameters](topic-parameters.md#max_top_inferers_to_reward).
+**Raising the floor or lowering the ceiling has a delayed cost.** Topics whose stored cap falls outside the new range keep working — admission clamps them — but their owners can no longer resubmit that cap, so any `UpdateTopic` forces the cap to change, which in turn trips the worker-submission-window guard. See [Topic Parameters](topic-parameters.md#max_top_inferers_to_reward).
 
 ### `max_samples_to_scale_scores`
 

--- a/x/emissions/docs/topic-parameters.md
+++ b/x/emissions/docs/topic-parameters.md
@@ -46,7 +46,7 @@ The WSW guard exists because those fields steer active-set admission or label se
 | `max_labels_per_submission` | `uint64` | **Editable (WSW-guarded)** | In `[1, 1024]`. |
 | `label_whitelist` | `[]string` | **Editable (WSW-guarded)** | Empty means unrestricted. Canonicalized before storage. |
 | `label_default_value` | `Dec` | **Editable (WSW-guarded)** | Any finite `Dec`. |
-| `max_top_inferers_to_reward` | `uint64` | **Editable (WSW-guarded)** | `0` means "use the global maximum". See below. |
+| `max_top_inferers_to_reward` | `uint64` | **Editable (WSW-guarded)** | Within the global range. See below. |
 
 ---
 
@@ -94,28 +94,21 @@ All four below are rejected while a worker submission window is open for **any**
 
 Per-topic cap on how many inferers are admitted to the active inference set. At worker-payload insert time an inferer is admitted while the active set is below the cap; otherwise it must out-score the lowest current member.
 
-**`0` is a sentinel meaning "use the global maximum".** It is resolved at write time, so the topic stores a concrete number, not the sentinel:
-
-```
-requested 0  ->  stored as the current global max_top_inferers_to_reward
-```
-
-This pins the topic to the global value **as it was when the topic was written**. A later governance change to the global does not retroactively move it. To re-sync a topic to a new global, send `0` again.
-
-**Accepted range.** A non-zero request must fall within the global `[min_top_inferers_to_reward, max_top_inferers_to_reward]`:
+**Accepted range.** A request must fall within the global `[min_top_inferers_to_reward, max_top_inferers_to_reward]` (query the emissions params for the current range) and is stored as given:
 
 | Request | Result |
 |---|---|
-| `0` | Accepted → stored as the global maximum |
-| `< min_top_inferers_to_reward` | Rejected, `ErrTopicMaxTopInferersToRewardTooSmall` |
+| `< min_top_inferers_to_reward` (`0` included) | Rejected, `ErrTopicMaxTopInferersToRewardTooSmall` |
 | within range | Accepted, stored verbatim |
 | `> max_top_inferers_to_reward` | Rejected, `ErrTopicMaxTopInferersToRewardTooBig` |
 
-**Consequence worth knowing.** Because the floor applies to *requests*, raising the global floor above a topic's stored cap makes that stored value un-resubmittable. Such a topic can still be updated — any value in the new `[min, max]`, or `0` — but it **cannot keep its old cap**. Two knock-on effects:
+**A stored cap does not move with the globals.** Governance moving the range never rewrites a topic; admission clamps the stored value instead.
 
-- Read-modify-write clients break: fetching the topic and resubmitting it verbatim now fails, because the fetched cap is below the new floor.
+**Consequence worth knowing.** Because the range applies to *requests* and updates are full replacements, moving the range so a topic's stored cap falls outside it makes that value un-resubmittable. Such a topic can still be updated — any value in the new `[min, max]` — but it **cannot keep its old cap**. Two knock-on effects:
+
+- Read-modify-write clients break: fetching the topic and resubmitting it verbatim now fails, because the fetched cap is outside the new range.
 - Since the cap is forced to change, the update always trips the WSW guard, so such a topic can only be edited **between** submission windows.
 
-Admission is separately defensive: it re-resolves the stored value through the global range on every payload, so a value below the floor (reachable only via a hand-written genesis) is raised to the floor, and the global maximum is applied last and always wins. The cap can therefore never push the active set past the global-sized score-retention window.
+Admission is separately defensive: it clamps the stored value into the global range on every payload, so a value below the floor is raised to the floor and the global maximum is applied last and always wins. The cap can therefore never push the active set past the global-sized score-retention window.
 
-`Topic.Validate` deliberately does **not** bound this field against the globals. The globals bound *admission*, not storage, so a stored value outside the range stays loadable rather than making the topic unreadable after a governance change.
+`Topic.Validate` deliberately does **not** bound this field against the globals. The globals bound *admission*, not storage, so a governance change cannot make an existing topic fail re-validation when the chain rewrites it.

--- a/x/emissions/keeper/actor_utils/worker_test.go
+++ b/x/emissions/keeper/actor_utils/worker_test.go
@@ -138,7 +138,7 @@ func (s *WorkerTestSuite) TestCloseWorkerNonceFailures() {
 
 	// Create topic using MsgServer
 	newTopicMsg := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 		Creator:                  s.AddrsStr(0),
 		Metadata:                 "test",
 		LossMethod:               "mse",
@@ -198,7 +198,7 @@ func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesCatchesOutliers() 
 
 	// Create topic using MsgServer
 	newTopicMsg := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 		Creator:                  s.AddrsStr(0),
 		Metadata:                 "test",
 		LossMethod:               "mse",
@@ -361,7 +361,7 @@ func (s *WorkerTestSuite) TestProcessAndStoreNetworkInferencesNoOutliers() {
 
 	// Create topic using MsgServer
 	newTopicMsg := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 		Creator:                  s.AddrsStr(0),
 		Metadata:                 "test",
 		LossMethod:               "mse",

--- a/x/emissions/keeper/genesis_test.go
+++ b/x/emissions/keeper/genesis_test.go
@@ -706,25 +706,25 @@ func (s *KeeperTestSuite) TestGenesisSubKeeperTopicRoundTrip() {
 	s.Require().True(genesisState2.LastMedianInferences[0].Dec.Equal(alloraMath.MustNewDecFromString("2.5")))
 }
 
-// TestInitGenesisPreservesZeroMaxTopInferersToReward asserts that an unset (0)
-// per-topic cap is stored verbatim; admission resolves it to the global.
-func (s *KeeperTestSuite) TestInitGenesisPreservesZeroMaxTopInferersToReward() {
+// TestInitGenesisRoundTripsMaxTopInferersToReward asserts that an exported cap
+// is imported unchanged.
+func (s *KeeperTestSuite) TestInitGenesisRoundTripsMaxTopInferersToReward() {
 	ctx := s.Ctx()
 	topic := s.MockTopic()
 	topic.Id = 1
+	topic.MaxTopInferersToReward = 7
 	s.Require().NoError(s.TopicKeeper().SetTopic(ctx, 1, topic))
 
 	genesisState, err := s.EmissionsKeeper().ExportGenesis(ctx)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(genesisState.Topics)
-	genesisState.Topics[0].Topic.MaxTopInferersToReward = 0
 
 	fresh := s.newFreshGenesisSuite()
 	s.Require().NoError(fresh.EmissionsKeeper().InitGenesis(fresh.Ctx(), genesisState))
 
 	got, err := fresh.TopicKeeper().GetTopic(fresh.Ctx(), 1)
 	s.Require().NoError(err)
-	s.Require().Equal(uint64(0), got.MaxTopInferersToReward)
+	s.Require().Equal(uint64(7), got.MaxTopInferersToReward)
 }
 
 // TestInitGenesisPreservesMaxTopInferersBelowGlobalMin asserts that a topic cap

--- a/x/emissions/keeper/msgserver/msg_server_topic_max_inferers_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topic_max_inferers_test.go
@@ -72,6 +72,7 @@ func (s *MsgServerTestSuite) baseCapUpdateMsg(sender string, topicId uint64) *ty
 		MaxLabelsPerSubmission: types.DefaultMaxLabelsPerSubmission,
 		LabelWhitelist:         nil,
 		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 }
 
@@ -92,21 +93,19 @@ func (s *MsgServerTestSuite) baseWSWUpdateMsg(sender string, topicId uint64) *ty
 		MaxLabelsPerSubmission: 4,
 		LabelWhitelist:         []string{"a", "b", "c"},
 		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 }
 
-// request value 0 stores the global default.
-func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersDefaultsToGlobal() {
+// A request below the floor is rejected, 0 included.
+func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersZeroRejected() {
 	sender := s.AddrsStr(0)
-	topicId, err := s.createTopicWithCap(sender, 0)
-	s.Require().NoError(err)
-	got, err := s.TopicKeeper().GetTopic(s.Ctx(), topicId)
-	s.Require().NoError(err)
-	s.Require().Equal(types.DefaultParams().MaxTopInferersToReward, got.MaxTopInferersToReward)
+	_, err := s.createTopicWithCap(sender, 0)
+	s.Require().ErrorIs(err, types.ErrTopicMaxTopInferersToRewardTooSmall)
 }
 
-// request value 0 resolves against the live global, not a compile-time constant.
-func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersDefaultReadsLiveGlobal() {
+// The range is read from the live params, not from the module defaults.
+func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersRangeReadsLiveGlobal() {
 	ctx := s.Ctx()
 	params, err := s.EmissionsKeeper().GetParams(ctx)
 	s.Require().NoError(err)
@@ -114,7 +113,10 @@ func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersDefaultReadsLiveGlobal
 	s.Require().NoError(s.EmissionsKeeper().SetParams(ctx, params))
 
 	sender := s.AddrsStr(0)
-	topicId, err := s.createTopicWithCap(sender, 0)
+	_, err = s.createTopicWithCap(sender, 21)
+	s.Require().ErrorIs(err, types.ErrTopicMaxTopInferersToRewardTooBig)
+
+	topicId, err := s.createTopicWithCap(sender, 20)
 	s.Require().NoError(err)
 	got, err := s.TopicKeeper().GetTopic(ctx, topicId)
 	s.Require().NoError(err)
@@ -140,6 +142,31 @@ func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersExplicitValues() {
 	s.Require().Equal(global, gotMax.MaxTopInferersToReward)
 }
 
+// The stored cap is the requested value and does not move with the globals.
+func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersStoredVerbatimAndPinned() {
+	ctx := s.Ctx()
+	sender := s.AddrsStr(0)
+	requested := uint64(12) // strictly inside the default [5, 32] range
+
+	topicId, err := s.createTopicWithCap(sender, requested)
+	s.Require().NoError(err)
+	got, err := s.TopicKeeper().GetTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(requested, got.MaxTopInferersToReward)
+
+	for _, ceiling := range []uint64{64, 20} {
+		params := types.DefaultParams()
+		params.MaxTopInferersToReward = ceiling
+		s.Require().NoError(s.ParamsKeeper().SetParams(ctx, params))
+
+		got, err = s.TopicKeeper().GetTopic(ctx, topicId)
+		s.Require().NoError(err)
+		s.Require().Equal(requested, got.MaxTopInferersToReward)
+		s.Require().Equal(requested, types.EffectiveMaxTopInferersToReward(
+			got.MaxTopInferersToReward, params.MinTopInferersToReward, ceiling))
+	}
+}
+
 // an explicit value above the global ceiling is rejected.
 func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersAboveGlobalRejected() {
 	sender := s.AddrsStr(0)
@@ -148,8 +175,7 @@ func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersAboveGlobalRejected() 
 	s.Require().ErrorIs(err, types.ErrTopicMaxTopInferersToRewardTooBig)
 }
 
-// an explicit value below the global floor is rejected; 0 still resolves to the
-// global ceiling because it means "use the default".
+// any value below the global floor is rejected, 0 included.
 func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersBelowGlobalMinRejected() {
 	sender := s.AddrsStr(0)
 	params := types.DefaultParams()
@@ -159,11 +185,8 @@ func (s *MsgServerTestSuite) TestCreateTopicMaxTopInferersBelowGlobalMinRejected
 	_, err := s.createTopicWithCap(sender, 9)
 	s.Require().ErrorIs(err, types.ErrTopicMaxTopInferersToRewardTooSmall)
 
-	id, err := s.createTopicWithCap(sender, 0)
-	s.Require().NoError(err)
-	got, err := s.TopicKeeper().GetTopic(s.Ctx(), id)
-	s.Require().NoError(err)
-	s.Require().Equal(params.MaxTopInferersToReward, got.MaxTopInferersToReward)
+	_, err = s.createTopicWithCap(sender, 0)
+	s.Require().ErrorIs(err, types.ErrTopicMaxTopInferersToRewardTooSmall)
 }
 
 // UpdateTopic applies the same floor as creation.
@@ -222,90 +245,76 @@ func (s *MsgServerTestSuite) TestUpdateTopicMaxTopInferersUnchangedDuringWindow(
 	s.Require().NoError(err)
 }
 
-// sending 0 during an open window resolves to the current global (== stored),
-// so it is a no-op and is allowed. This proves default-resolution runs before
-// change-detection.
-func (s *MsgServerTestSuite) TestUpdateTopicMaxTopInferersZeroResolvesBeforeChangeDetectionDuringWindow() {
-	sender := s.AddrsStr(0)
-	ctx, topicId := s.setupActiveTopicWithOpenWSW(sender)
-	msgServer := s.EmissionsMsgServer()
-	msg := s.baseWSWUpdateMsg(sender, topicId) // MaxTopInferersToReward left 0
-	_, err := msgServer.UpdateTopic(ctx, msg)
-	s.Require().NoError(err)
-	got, err := s.TopicKeeper().GetTopic(ctx, topicId)
-	s.Require().NoError(err)
-	s.Require().Equal(types.DefaultParams().MaxTopInferersToReward, got.MaxTopInferersToReward)
-}
-
-// with no open window, sending 0 resets the cap to the global default.
-func (s *MsgServerTestSuite) TestUpdateTopicMaxTopInferersZeroResetsToGlobalDefault() {
+// UpdateTopic applies the same floor as creation, 0 included.
+func (s *MsgServerTestSuite) TestUpdateTopicMaxTopInferersZeroRejected() {
 	sender := s.AddrsStr(0)
 	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
-	topicId, err := s.createTopicWithCap(sender, 10) // inactive
+	topicId, err := s.createTopicWithCap(sender, 10) // inactive, no window
 	s.Require().NoError(err)
-	msg := s.baseCapUpdateMsg(sender, topicId) // MaxTopInferersToReward left 0 -> reset to default
+
+	msg := s.baseCapUpdateMsg(sender, topicId)
+	msg.MaxTopInferersToReward = 0
 	_, err = msgServer.UpdateTopic(ctx, msg)
-	s.Require().NoError(err)
+	s.Require().ErrorIs(err, types.ErrTopicMaxTopInferersToRewardTooSmall)
+
+	// The rejection wrote nothing.
 	got, err := s.TopicKeeper().GetTopic(ctx, topicId)
 	s.Require().NoError(err)
-	s.Require().Equal(types.DefaultParams().MaxTopInferersToReward, got.MaxTopInferersToReward)
+	s.Require().Equal(uint64(10), got.MaxTopInferersToReward)
 }
 
-// Sending 0 usually changes nothing, because it means "use the global" and the
-// topic is already holding that exact number. But if governance raised the
-// global in the meantime, the very same 0 now asks for a bigger number, so it
-// counts as a real change and the open-window guard turns it away.
-func (s *MsgServerTestSuite) TestUpdateTopicMaxTopInferersZeroBlockedWhenGlobalMovedDuringWindow() {
+// Resubmitting the stored cap is a no-op for the open-window guard, also after
+// the global ceiling has moved.
+func (s *MsgServerTestSuite) TestUpdateTopicMaxTopInferersResubmitSameCapDuringWindowAllowed() {
 	sender := s.AddrsStr(0)
 	// A live topic with a worker submission window currently open.
 	ctx, topicId := s.setupActiveTopicWithOpenWSW(sender)
 	msgServer := s.EmissionsMsgServer()
 
-	// The topic starts out holding exactly the global value.
 	stored, err := s.TopicKeeper().GetTopic(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(types.DefaultParams().MaxTopInferersToReward, stored.MaxTopInferersToReward)
 
-	// Governance raises the global; the topic still holds the old number.
+	// Governance raises the ceiling; the topic keeps its own value.
 	params := types.DefaultParams()
 	params.MaxTopInferersToReward = stored.MaxTopInferersToReward + 8
 	s.Require().NoError(s.ParamsKeeper().SetParams(ctx, params))
 
-	msg := s.baseWSWUpdateMsg(sender, topicId) // cap left 0 -> now the raised global
+	msg := s.baseWSWUpdateMsg(sender, topicId)
+	msg.MaxTopInferersToReward = stored.MaxTopInferersToReward
 	_, err = msgServer.UpdateTopic(ctx, msg)
-	// A different value than the stored one, so this reads as a change mid-window.
-	s.Require().ErrorIs(err, types.ErrWorkerNonceWindowNotAvailable)
-	s.Require().ErrorContains(err, "max_top_inferers_to_reward")
+	s.Require().NoError(err)
 
-	// The rejection wrote nothing.
 	got, err := s.TopicKeeper().GetTopic(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(stored.MaxTopInferersToReward, got.MaxTopInferersToReward)
 }
 
-// Sending 0 does not replay whatever the global was back when the topic was
-// created; it looks the global up again at update time. So a topic can be
-// re-synced to a global that has moved since, simply by sending 0 again -- with
-// no worker window open, the new value is written.
-func (s *MsgServerTestSuite) TestUpdateTopicMaxTopInferersZeroReresolvesToLiveGlobal() {
+// A cap above the old ceiling is accepted once the ceiling has been raised.
+func (s *MsgServerTestSuite) TestUpdateTopicMaxTopInferersCanRaiseCapAfterCeilingRaised() {
 	sender := s.AddrsStr(0)
 	ctx, msgServer := s.Ctx(), s.EmissionsMsgServer()
-	// Created with 0, so the topic stores today's global. Inactive: no window.
-	topicId, err := s.createTopicWithCap(sender, 0)
+	created := types.DefaultParams().MaxTopInferersToReward
+	topicId, err := s.createTopicWithCap(sender, created) // inactive: no window
 	s.Require().NoError(err)
 
-	// Governance moves the global out from under the topic.
-	raised := types.DefaultParams().MaxTopInferersToReward + 8
+	// Governance raises the ceiling out from under the topic.
+	raised := created + 8
 	params := types.DefaultParams()
 	params.MaxTopInferersToReward = raised
 	s.Require().NoError(s.ParamsKeeper().SetParams(ctx, params))
 
-	msg := s.baseCapUpdateMsg(sender, topicId) // cap left 0 a second time
+	// The stored cap did not move by itself.
+	got, err := s.TopicKeeper().GetTopic(ctx, topicId)
+	s.Require().NoError(err)
+	s.Require().Equal(created, got.MaxTopInferersToReward)
+
+	msg := s.baseCapUpdateMsg(sender, topicId)
+	msg.MaxTopInferersToReward = raised
 	_, err = msgServer.UpdateTopic(ctx, msg)
 	s.Require().NoError(err)
 
-	// The topic followed the global rather than keeping its creation-time value.
-	got, err := s.TopicKeeper().GetTopic(ctx, topicId)
+	got, err = s.TopicKeeper().GetTopic(ctx, topicId)
 	s.Require().NoError(err)
 	s.Require().Equal(raised, got.MaxTopInferersToReward)
 }

--- a/x/emissions/keeper/msgserver/msg_server_topics.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics.go
@@ -12,25 +12,22 @@ import (
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
 
-// resolveMaxTopInferersToReward rejects a create/update request outside the
-// global [min, max] range, then resolves it to the concrete value to store via
-// types.EffectiveMaxTopInferersToReward.
-func resolveMaxTopInferersToReward(requested, globalMin, globalMax uint64) (uint64, error) {
+// validateMaxTopInferersToReward rejects a create/update request outside the
+// global [min, max] range.
+func validateMaxTopInferersToReward(requested, globalMin, globalMax uint64) error {
 	if requested > globalMax {
-		return 0, errorsmod.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrTopicMaxTopInferersToRewardTooBig,
 			"requested %d exceeds global maximum %d", requested, globalMax,
 		)
 	}
-	// 0 means "use the global maximum", so it is resolved rather than rejected;
-	// the value it resolves to is >= the floor by construction.
-	if requested != 0 && requested < globalMin {
-		return 0, errorsmod.Wrapf(
+	if requested < globalMin {
+		return errorsmod.Wrapf(
 			types.ErrTopicMaxTopInferersToRewardTooSmall,
 			"requested %d is below global minimum %d", requested, globalMin,
 		)
 	}
-	return types.EffectiveMaxTopInferersToReward(requested, globalMin, globalMax), nil
+	return nil
 }
 
 func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.CreateNewTopicRequest) (_ *types.CreateNewTopicResponse, err error) {
@@ -66,9 +63,8 @@ func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.CreateNewTopi
 	if uint64(msg.GroundTruthLag) > params.MaxUnfulfilledReputerRequests*uint64(msg.EpochLength) {
 		return nil, types.ErrGroundTruthLagTooBig
 	}
-	maxTopInferersToReward, err := resolveMaxTopInferersToReward(
-		msg.MaxTopInferersToReward, params.MinTopInferersToReward, params.MaxTopInferersToReward)
-	if err != nil {
+	if err := validateMaxTopInferersToReward(
+		msg.MaxTopInferersToReward, params.MinTopInferersToReward, params.MaxTopInferersToReward); err != nil {
 		return nil, err
 	}
 
@@ -108,10 +104,8 @@ func (ms msgServer) CreateNewTopic(ctx context.Context, msg *types.CreateNewTopi
 		LabelDefaultValue:      msg.LabelDefaultValue,
 		// LabelCaseSensitive is immutable after creation (UpdateTopic never
 		// changes it because updatedTopic is derived from the existing topic).
-		LabelCaseSensitive: msg.LabelCaseSensitive,
-		// Per-topic inferer cap, resolved above (0 -> global default, bounded by
-		// the global ceiling). Always stored as a concrete value >= 1.
-		MaxTopInferersToReward: maxTopInferersToReward,
+		LabelCaseSensitive:     msg.LabelCaseSensitive,
+		MaxTopInferersToReward: msg.MaxTopInferersToReward,
 	}
 	_, err = ms.tk.IncrementTopicId(ctx)
 	if err != nil {
@@ -164,9 +158,8 @@ func (ms msgServer) UpdateTopic(ctx context.Context, msg *types.UpdateTopicReque
 		return nil, errorsmod.Wrap(sdkerrors.ErrUnauthorized, "not permitted to modify topic")
 	}
 
-	maxTopInferersToReward, err := resolveMaxTopInferersToReward(
-		msg.MaxTopInferersToReward, params.MinTopInferersToReward, params.MaxTopInferersToReward)
-	if err != nil {
+	if err := validateMaxTopInferersToReward(
+		msg.MaxTopInferersToReward, params.MinTopInferersToReward, params.MaxTopInferersToReward); err != nil {
 		return nil, err
 	}
 
@@ -177,10 +170,9 @@ func (ms msgServer) UpdateTopic(ctx context.Context, msg *types.UpdateTopicReque
 	updatedTopic.MeritSortitionAlpha = msg.MeritSortitionAlpha
 	updatedTopic.PNorm = msg.PNorm
 	updatedTopic.CNorm = msg.CNorm
-	// Per-topic inferer cap: full replacement, with 0 resolving to the global
-	// maximum. The keeper's UpdateTopic rejects this change while a worker
-	// submission window is open (see the guarded-fields set there).
-	updatedTopic.MaxTopInferersToReward = maxTopInferersToReward
+	// Full replacement; the keeper's UpdateTopic rejects a change while a worker
+	// submission window is open.
+	updatedTopic.MaxTopInferersToReward = msg.MaxTopInferersToReward
 	// Label registry settings: always apply the requested value. The keeper
 	// rejects unsafe mutations while a worker submission window is open and
 	// canonicalizes the whitelist before persistence.

--- a/x/emissions/keeper/msgserver/msg_server_topics_test.go
+++ b/x/emissions/keeper/msgserver/msg_server_topics_test.go
@@ -322,7 +322,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicSuccess() {
 	// Create a topic first
 	s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
 	createTopicMsg := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 		Creator:                  sender,
 		Metadata:                 "Original metadata",
 		LossMethod:               "mse",
@@ -360,7 +360,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicSuccess() {
 
 	// Update topic with new values
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "Updated metadata",
@@ -423,7 +423,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicRejectsMaxLabelsPerSubmissionOutOfRa
 			require.NoError(err)
 
 			updateTopicMsg := &types.UpdateTopicRequest{
-				MaxTopInferersToReward: 0,
+				MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 				Sender:                 sender,
 				TopicId:                createResult.TopicId,
 				Metadata:               originalTopic.Metadata,
@@ -470,7 +470,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicRejectsLabelWhitelistAboveMax() {
 	}
 
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                createResult.TopicId,
 		Metadata:               originalTopic.Metadata,
@@ -513,7 +513,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicRejectsNonzeroLabelDefaultValueWhenR
 	require.NotNil(createResult)
 
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                createResult.TopicId,
 		Metadata:               "Updated metadata",
@@ -544,7 +544,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNotTopicCreator() {
 	// Create a topic
 	s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
 	createTopicMsg := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 		Creator:                  sender,
 		Metadata:                 "Original metadata",
 		LossMethod:               "mse",
@@ -578,7 +578,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNotTopicCreator() {
 
 	// Try to update topic with different user
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 otherUser,
 		TopicId:                topicId,
 		Metadata:               "Updated metadata",
@@ -605,7 +605,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNonexistentTopic() {
 	nonexistentTopicId := uint64(999)
 
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                nonexistentTopicId,
 		Metadata:               "Updated metadata",
@@ -634,7 +634,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicValidationInvalidFields() {
 
 	// Test empty loss method
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "valid metadata",
@@ -654,7 +654,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicValidationInvalidFields() {
 
 	// Test too long loss method
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "valid metadata",
@@ -674,7 +674,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicValidationInvalidFields() {
 
 	// Test too long metadata
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               strings.Repeat("a", 257),
@@ -706,7 +706,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicSuccessfulUpdate() {
 
 	// Create a topic first
 	createTopicMsg := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 		Creator:                  sender,
 		Metadata:                 "original metadata",
 		LossMethod:               "mse",
@@ -746,7 +746,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicSuccessfulUpdate() {
 
 	// Test successful update
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "updated metadata",
@@ -784,7 +784,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParams() {
 
 	s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
 	createTopicMsg := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 		Creator:                  sender,
 		Metadata:                 "Original metadata",
 		LossMethod:               "mse",
@@ -816,7 +816,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParams() {
 	topicId := createResult.TopicId
 
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "Original metadata",
@@ -841,7 +841,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParams() {
 
 	// Test updating CNorm with valid values
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "Original metadata",
@@ -863,7 +863,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParams() {
 
 	// Test updating CNorm to boundary value -100
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "Original metadata",
@@ -885,7 +885,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParams() {
 
 	// Test updating CNorm to boundary value 100
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "Original metadata",
@@ -911,7 +911,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParams() {
 	s.WithBlockHeight(50)
 	ctx = s.Ctx()
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "Original metadata",
@@ -937,7 +937,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParamsInvalid() {
 
 	// Invalid alpha_regret (<=0)
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "metadata",
@@ -955,7 +955,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParamsInvalid() {
 
 	// Invalid merit_sortition_alpha (>1)
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "metadata",
@@ -973,7 +973,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParamsInvalid() {
 
 	// Invalid p_norm (below range)
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "metadata",
@@ -991,7 +991,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParamsInvalid() {
 
 	// Invalid c_norm (below -100)
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "metadata",
@@ -1009,7 +1009,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicNumericParamsInvalid() {
 
 	// Invalid c_norm (above 100)
 	updateTopicMsg = &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "metadata",
@@ -1036,7 +1036,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicMeritSortitionBlockedWhenWorkerWindo
 	s.WithBlockHeight(10)
 	s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
 	createTopicMsg := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 		Creator:                  sender,
 		Metadata:                 "Original metadata",
 		LossMethod:               "mse",
@@ -1077,7 +1077,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicMeritSortitionBlockedWhenWorkerWindo
 	ctx = s.Ctx()
 
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "Original metadata",
@@ -1109,7 +1109,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicMeritSortitionInactiveIgnoresWindow(
 	// Topic inactive by default
 	s.MintTokensToAddress(senderAddr, types.DefaultParams().CreateTopicFee)
 	createTopicMsg := &types.CreateNewTopicRequest{
-		MaxTopInferersToReward:   0,
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 		Creator:                  sender,
 		Metadata:                 "Original metadata",
 		LossMethod:               "mse",
@@ -1147,7 +1147,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicMeritSortitionInactiveIgnoresWindow(
 	ctx = s.Ctx()
 
 	updateTopicMsg := &types.UpdateTopicRequest{
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 		Sender:                 sender,
 		TopicId:                topicId,
 		Metadata:               "Original metadata",
@@ -1204,6 +1204,7 @@ func (s *MsgServerTestSuite) createTopicForWSWTests(sender string) uint64 {
 		MaxLabelsPerSubmission:   4,
 		LabelWhitelist:           []string{"a", "b", "c"},
 		LabelDefaultValue:        alloraMath.ZeroDec(),
+		MaxTopInferersToReward:   types.DefaultParams().MaxTopInferersToReward,
 	}
 	resp, err := msgServer.CreateNewTopic(ctx, create)
 	require.NoError(err)
@@ -1256,8 +1257,9 @@ func (s *MsgServerTestSuite) TestSetTopicCanonicalizesLabelWhitelist() {
 		MaxLabelsPerSubmission:   types.DefaultMaxLabelsPerSubmission,
 		// Whitespace and case collapse under the default case-insensitive
 		// canonicalizer; a canonical duplicate should be rejected.
-		LabelWhitelist:    []string{"  Foo  ", "foo"},
-		LabelDefaultValue: alloraMath.ZeroDec(),
+		LabelWhitelist:         []string{"  Foo  ", "foo"},
+		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.CreateNewTopic(ctx, create)
 	require.ErrorIs(err, types.ErrInvalidLabelName, "canonical duplicate must be rejected at SetTopic")
@@ -1300,6 +1302,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicMaxLabelsBlockedWhenWorkerWindowOpen
 		MaxLabelsPerSubmission: 8, // changed -> must be rejected
 		LabelWhitelist:         []string{"a", "b", "c"},
 		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.ErrorIs(err, types.ErrWorkerNonceWindowNotAvailable)
@@ -1338,6 +1341,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicWhitelistBlockedWhenWorkerWindowOpen
 		MaxLabelsPerSubmission: 4,
 		LabelWhitelist:         []string{"a", "b"}, // changed: dropped "c"
 		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.ErrorIs(err, types.ErrWorkerNonceWindowNotAvailable)
@@ -1376,6 +1380,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicLabelDefaultBlockedWhenWorkerWindowO
 		MaxLabelsPerSubmission: 4,
 		LabelWhitelist:         []string{"a", "b", "c"},
 		LabelDefaultValue:      alloraMath.OneDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.ErrorIs(err, types.ErrWorkerNonceWindowNotAvailable)
@@ -1418,6 +1423,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicWhitelistAllowedAfterWSWClosed() {
 		MaxLabelsPerSubmission: 8,
 		LabelWhitelist:         []string{"  A  ", "b/c"},
 		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.NoError(err)
@@ -1469,6 +1475,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicLabelDefaultBlockedAtExactWSWCloseBl
 		MaxLabelsPerSubmission: 4,
 		LabelWhitelist:         []string{"a", "b", "c"},
 		LabelDefaultValue:      alloraMath.OneDec(), // changed -> must be rejected
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.ErrorIs(err, types.ErrWorkerNonceWindowNotAvailable,
@@ -1515,6 +1522,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicRejectsOutOfRangeMaxLabelsPerSubmiss
 				CNorm:                  alloraMath.MustNewDecFromString("0.75"),
 				MaxLabelsPerSubmission: tc.cap,
 				LabelWhitelist:         nil,
+				MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 			}
 			_, err := msgServer.UpdateTopic(ctx, msg)
 			require.ErrorIs(err, sdkerrors.ErrInvalidRequest)
@@ -1553,6 +1561,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicFullPayloadClearsLabelWhitelist() {
 		CNorm:                  alloraMath.MustNewDecFromString("0.75"),
 		MaxLabelsPerSubmission: 8,
 		LabelWhitelist:         nil,
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.NoError(err)
@@ -1602,6 +1611,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicWSWLockBlocksWhenOlderNonceStillWith
 		MaxLabelsPerSubmission: 8, // changed -> must be rejected
 		LabelWhitelist:         []string{"a", "b", "c"},
 		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.ErrorIs(err, types.ErrWorkerNonceWindowNotAvailable,
@@ -1635,6 +1645,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicAllowsNonGuardedFieldsDuringOpenWSW(
 		MaxLabelsPerSubmission: 4,
 		LabelWhitelist:         []string{"a", "b", "c"},
 		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.NoError(err)
@@ -1672,6 +1683,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicWSWLockListsAllChangedGuardedFields(
 		MaxLabelsPerSubmission: 8,
 		LabelWhitelist:         []string{"a", "b"},
 		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.ErrorIs(err, types.ErrWorkerNonceWindowNotAvailable)
@@ -1706,6 +1718,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicWSWLockListsAllFourGuardedFields() {
 		MaxLabelsPerSubmission: 8,
 		LabelWhitelist:         []string{"a", "b"},
 		LabelDefaultValue:      alloraMath.OneDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.ErrorIs(err, types.ErrWorkerNonceWindowNotAvailable)
@@ -1743,6 +1756,7 @@ func (s *MsgServerTestSuite) TestUpdateTopicWhitelistCosmeticChangeAllowedDuring
 		MaxLabelsPerSubmission: 4,
 		LabelWhitelist:         []string{"  a  ", "b", "c"},
 		LabelDefaultValue:      alloraMath.ZeroDec(),
+		MaxTopInferersToReward: types.DefaultParams().MaxTopInferersToReward,
 	}
 	_, err := msgServer.UpdateTopic(ctx, msg)
 	require.NoError(err)

--- a/x/emissions/keeper/msgserver/msg_server_worker_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_worker_payload.go
@@ -128,10 +128,8 @@ func (ms msgServer) processWorkerInferencePayload(
 		return err
 	}
 
-	// Re-resolve the stored cap into the global [min, max] on every payload: a
-	// value outside the range (genesis-supplied, or left behind by a governance
-	// change) is clamped rather than trusted, keeping the active set within the
-	// global-sized score-retention window.
+	// Clamp the stored cap into the global [min, max] on every payload, keeping
+	// the active set within the global-sized score-retention window.
 	maxTopInferersToReward := types.EffectiveMaxTopInferersToReward(
 		topic.MaxTopInferersToReward,
 		moduleParams.MinTopInferersToReward,

--- a/x/emissions/keeper/worker.go
+++ b/x/emissions/keeper/worker.go
@@ -537,7 +537,9 @@ func (k *WorkerKeeper) PlanInferenceAdmission(
 		return plan, nil
 	}
 
-	if previousEmaScore.Score.Gt(lowestEmaScore.Score) {
+	// Eviction needs a member to evict; with an empty set and no open slot
+	// (cap 0) nobody is admitted.
+	if len(workerAddresses) > 0 && previousEmaScore.Score.Gt(lowestEmaScore.Score) {
 		plan.Kind = InferenceAdmissionEvictLowest
 	}
 	return plan, nil

--- a/x/emissions/keeper/worker_admission_zero_cap_test.go
+++ b/x/emissions/keeper/worker_admission_zero_cap_test.go
@@ -1,0 +1,69 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+)
+
+// An effective cap of 0 is reachable only when the global floor is 0.
+// This test covers the case where the global floor is 0 and the topic cap is 0,
+// and how it affects the admission of new inferers.
+//
+// Nobody is admitted into an empty active set; an already over-full set
+// still allows the usual net-zero swap.
+func (s *KeeperTestSuite) TestPlanInferenceAdmissionZeroCap() {
+	s.Require().Equal(uint64(0), types.EffectiveMaxTopInferersToReward(0, 0, 32))
+
+	type tc struct {
+		name     string
+		setup    func(ctx sdk.Context, topicId uint64, inferer string)
+		wantKind keeper.InferenceAdmissionKind
+	}
+	cases := []tc{
+		{
+			name:     "first_submission_empty_set_not_admitted",
+			setup:    func(sdk.Context, uint64, string) {},
+			wantKind: keeper.InferenceAdmissionNotAdmitted,
+		},
+		{
+			name: "experienced_worker_empty_set_not_admitted",
+			setup: func(ctx sdk.Context, topicId uint64, inferer string) {
+				score := types.Score{TopicId: topicId, BlockHeight: 1, Address: inferer, Score: alloraMath.NewDecFromInt64(50)}
+				s.Require().NoError(s.ScoresKeeper().SetInfererScoreEma(ctx, topicId, inferer, score))
+			},
+			wantKind: keeper.InferenceAdmissionNotAdmitted,
+		},
+		{
+			name: "over_full_set_and_higher_score_plans_eviction",
+			setup: func(ctx sdk.Context, topicId uint64, inferer string) {
+				active := s.AddrsStr(1)
+				activeScore := types.Score{TopicId: topicId, BlockHeight: 1, Address: active, Score: alloraMath.NewDecFromInt64(10)}
+				candidateScore := types.Score{TopicId: topicId, BlockHeight: 1, Address: inferer, Score: alloraMath.NewDecFromInt64(100)}
+				s.Require().NoError(s.ScoresKeeper().SetInfererScoreEma(ctx, topicId, active, activeScore))
+				s.Require().NoError(s.ScoresKeeper().SetInfererScoreEma(ctx, topicId, inferer, candidateScore))
+				s.Require().NoError(s.ScoresKeeper().SetLowestInfererScoreEma(ctx, topicId, activeScore))
+				s.Require().NoError(s.WorkerKeeper().AddActiveInferer(ctx, topicId, active))
+			},
+			wantKind: keeper.InferenceAdmissionEvictLowest,
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			s.SetupTest()
+			ctx := s.Ctx()
+			topicId := s.CreateTopic()
+			topic, err := s.TopicKeeper().GetTopic(ctx, topicId)
+			s.Require().NoError(err)
+			inferer := s.AddrsStr(0)
+			c.setup(ctx, topicId, inferer)
+
+			plan, err := s.WorkerKeeper().PlanInferenceAdmission(ctx, topic, types.BlockHeight(10), inferer, 0)
+			s.Require().NoError(err)
+			s.Require().Equal(c.wantKind, plan.Kind)
+		})
+	}
+}

--- a/x/emissions/migrations/v16/migrate.go
+++ b/x/emissions/migrations/v16/migrate.go
@@ -44,10 +44,10 @@ func MigrateStore(ctx sdk.Context, emissionsKeeper keeper.Keeper) error {
 
 // MigrateParams backfills Params.MinTopInferersToReward, which an existing chain
 // decodes as zero. Zero means "no floor", so this installs one where there was
-// none; it changes no admission outcome at upgrade time only because
-// MigrateTopics has already raised every topic cap to the ceiling. A non-zero
-// value is left alone: an unset field is indistinguishable from a deliberate
-// zero, so only the zero case is backfilled.
+// none. It changes no admission outcome at upgrade time because MigrateTopics
+// runs first and has already set every topic cap to the ceiling, which is at or
+// above this floor. A non-zero value is left alone: an unset field is
+// indistinguishable from a deliberate zero, so only the zero case is backfilled.
 func MigrateParams(ctx sdk.Context, emissionsKeeper keeper.Keeper) error {
 	params, err := emissionsKeeper.GetParams(ctx)
 	if err != nil {
@@ -129,16 +129,13 @@ func MigrateTopics(ctx sdk.Context, emissionsKeeper keeper.Keeper, store storety
 		}
 		topic.MaxTopInferersToReward = backfillValue
 
-		// No per-topic re-validation here: the backfilled cap equals the
-		// current global Params.MaxTopInferersToReward, which is exactly the
-		// value Topic.Validate treats as the ceiling, so the new field is
-		// valid by construction (>= 1 and <= the global) regardless of any
-		// other field on the topic. Running full Topic.Validate would also
-		// re-check unrelated, param-dependent fields (e.g. ground-truth-lag
-		// vs epoch-length bounds) that a pre-existing dormant topic could
-		// violate after some other param was tightened over time; halting the
-		// whole chain upgrade for a reason unrelated to this backfill is
-		// avoided by deliberately skipping that broader check.
+		// No per-topic re-validation here: Topic.Validate does not bound this
+		// field, so the backfill cannot fail on it. Running full Topic.Validate
+		// would also re-check unrelated, param-dependent fields (e.g.
+		// ground-truth-lag vs epoch-length bounds) that a pre-existing dormant
+		// topic could violate after some other param was tightened over time;
+		// halting the whole chain upgrade for a reason unrelated to this
+		// backfill is avoided by skipping that broader check.
 
 		updates = append(updates, kv{
 			key:   append([]byte(nil), iterator.Key()...),

--- a/x/emissions/module/autocli.go
+++ b/x/emissions/module/autocli.go
@@ -967,10 +967,9 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Long: `Add a new topic to the network.
 
 max_top_inferers_to_reward caps how many inferers are admitted to the topic's
-active set. Pass 0 to use the global max_top_inferers_to_reward: the current
-global value is resolved and stored. The topic keeps that number even if the
-global changes later - but is effectively clamped to the global range.
-Any other value must lie within the global [min_top_inferers_to_reward, max_top_inferers_to_reward] range.`,
+active set. It must lie within the global
+[min_top_inferers_to_reward, max_top_inferers_to_reward] range; query the
+emissions params to see the current range.`,
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "creator"},
 						{ProtoField: "metadata"},
@@ -1011,11 +1010,10 @@ creation.
 Fields sent here REPLACE the stored values — there is no "leave as-is". In
 particular an empty label_whitelist sets the topic to UNRESTRICTED instead of
 preserving the current one, so re-send the full list to keep a restriction.
-A max_top_inferers_to_reward of 0 means "use the global max_top_inferers_to_reward":
-the current global value is resolved and stored. Any other value must lie within
-the global [min_top_inferers_to_reward, max_top_inferers_to_reward] range, so a
-topic whose stored cap is below a raised floor cannot resubmit that cap — it must
-send 0 or a value at or above the floor to change any other field.
+max_top_inferers_to_reward must lie within the global
+[min_top_inferers_to_reward, max_top_inferers_to_reward] range. Because it is a
+full replacement, a topic whose stored cap sits outside the current range must
+send a value inside it to change any other field.
 
 The keeper rejects these label changes and max_top_inferers_to_reward changes
 while a worker submission window is open.`,

--- a/x/emissions/proto/emissions/v10/topic.proto
+++ b/x/emissions/proto/emissions/v10/topic.proto
@@ -87,10 +87,9 @@ message Topic {
   bool label_case_sensitive = 30;
   // Per-topic cap on inferers admitted to the active set, enforced at
   // worker-payload insert: an inferer is admitted while the set is below the
-  // cap, otherwise it must out-score the lowest member. Writes through
-  // CreateNewTopic/UpdateTopic store a concrete value (a requested 0 resolves to
-  // the global max_top_inferers_to_reward), and migration backfills legacy
-  // topics; a genesis-supplied 0 is stored as-is and resolves at admission.
+  // cap, otherwise it must out-score the lowest member. CreateNewTopic and
+  // UpdateTopic require it to be within the global range; admission clamps the
+  // stored value into the live global range on every payload.
   uint64 max_top_inferers_to_reward = 31;
 }
 

--- a/x/emissions/proto/emissions/v10/tx.proto
+++ b/x/emissions/proto/emissions/v10/tx.proto
@@ -357,10 +357,8 @@ message CreateNewTopicRequest {
   // preserved and labels that differ only in case are treated as distinct.
   // The field is immutable after topic creation.
   bool label_case_sensitive = 29;
-  // Per-topic cap on inferers admitted to the active set. 0 means "use the
-  // global max_top_inferers_to_reward": that value is resolved and stored, so
-  // the topic keeps it even if the global changes later. Any other value must
-  // be within the global [min_top_inferers_to_reward, max_top_inferers_to_reward].
+  // Per-topic cap on inferers admitted to the active set. Must be within the
+  // global [min_top_inferers_to_reward, max_top_inferers_to_reward] range.
   uint64 max_top_inferers_to_reward = 30;
 }
 
@@ -409,11 +407,10 @@ message UpdateTopicRequest {
     (gogoproto.customtype) = "github.com/allora-network/allora-chain/math.Dec",
     (gogoproto.nullable) = false
   ];
-  // Per-topic cap on inferers admitted to the active set. Full replacement: the
-  // supplied value overwrites the stored one. 0 means "use the global
-  // max_top_inferers_to_reward", resolved and stored; any other value must be
-  // within the global [min_top_inferers_to_reward, max_top_inferers_to_reward].
-  // The keeper rejects this mutation while any worker submission window is open.
+  // Per-topic cap on inferers admitted to the active set. Full replacement,
+  // within the global [min_top_inferers_to_reward, max_top_inferers_to_reward]
+  // range. The keeper rejects a change while any worker submission window is
+  // open.
   uint64 max_top_inferers_to_reward = 12;
 }
 

--- a/x/emissions/testutil/test_utils.go
+++ b/x/emissions/testutil/test_utils.go
@@ -1218,6 +1218,10 @@ func (s *TestSuite) MockTopic() types.Topic {
 
 func (s *TestSuite) MockTopicMsg() *types.CreateNewTopicRequest {
 	topic := s.MockTopic()
+	// Read the live ceiling rather than the module default so the mock stays
+	// valid in tests that move the global max_top_inferers_to_reward.
+	params, err := s.ParamsKeeper().GetParams(s.Ctx())
+	s.Require().NoError(err)
 	return &types.CreateNewTopicRequest{
 		Creator:                  topic.Creator,
 		Metadata:                 topic.Metadata,
@@ -1243,10 +1247,7 @@ func (s *TestSuite) MockTopicMsg() *types.CreateNewTopicRequest {
 		MaxLabelsPerSubmission:   topic.MaxLabelsPerSubmission,
 		LabelWhitelist:           topic.LabelWhitelist,
 		LabelDefaultValue:        topic.LabelDefaultValue,
-		// Leave the per-topic inferer cap unset (0) so CreateNewTopic resolves it
-		// to the live global default. This keeps the mock valid in tests that
-		// lower the global max_top_inferers_to_reward below the module default.
-		MaxTopInferersToReward: 0,
+		MaxTopInferersToReward:   params.MaxTopInferersToReward,
 	}
 }
 

--- a/x/emissions/types/params_test.go
+++ b/x/emissions/types/params_test.go
@@ -201,9 +201,8 @@ func TestParamsValidate_RejectsZeroMaxCanonicalLabelByteLength(t *testing.T) {
 	require.Error(t, p.Validate())
 }
 
-// TestValidateMaxTopInferersToReward exercises the hardened global bound: zero
-// is rejected because the global value is the ceiling and default for the
-// per-topic Topic.MaxTopInferersToReward, and any positive value is accepted.
+// TestValidateMaxTopInferersToReward: zero is rejected because the global value
+// is the ceiling for Topic.MaxTopInferersToReward; any positive value is accepted.
 func TestValidateMaxTopInferersToReward(t *testing.T) {
 	cases := []struct {
 		name string

--- a/x/emissions/types/topic.pb.go
+++ b/x/emissions/types/topic.pb.go
@@ -124,10 +124,9 @@ type Topic struct {
 	LabelCaseSensitive bool `protobuf:"varint,30,opt,name=label_case_sensitive,json=labelCaseSensitive,proto3" json:"label_case_sensitive,omitempty"`
 	// Per-topic cap on inferers admitted to the active set, enforced at
 	// worker-payload insert: an inferer is admitted while the set is below the
-	// cap, otherwise it must out-score the lowest member. Writes through
-	// CreateNewTopic/UpdateTopic store a concrete value (a requested 0 resolves to
-	// the global max_top_inferers_to_reward), and migration backfills legacy
-	// topics; a genesis-supplied 0 is stored as-is and resolves at admission.
+	// cap, otherwise it must out-score the lowest member. CreateNewTopic and
+	// UpdateTopic require it to be within the global range; admission clamps the
+	// stored value into the live global range on every payload.
 	MaxTopInferersToReward uint64 `protobuf:"varint,31,opt,name=max_top_inferers_to_reward,json=maxTopInferersToReward,proto3" json:"max_top_inferers_to_reward,omitempty"`
 }
 

--- a/x/emissions/types/tx.pb.go
+++ b/x/emissions/types/tx.pb.go
@@ -473,10 +473,8 @@ type CreateNewTopicRequest struct {
 	// preserved and labels that differ only in case are treated as distinct.
 	// The field is immutable after topic creation.
 	LabelCaseSensitive bool `protobuf:"varint,29,opt,name=label_case_sensitive,json=labelCaseSensitive,proto3" json:"label_case_sensitive,omitempty"`
-	// Per-topic cap on inferers admitted to the active set. 0 means "use the
-	// global max_top_inferers_to_reward": that value is resolved and stored, so
-	// the topic keeps it even if the global changes later. Any other value must
-	// be within the global [min_top_inferers_to_reward, max_top_inferers_to_reward].
+	// Per-topic cap on inferers admitted to the active set. Must be within the
+	// global [min_top_inferers_to_reward, max_top_inferers_to_reward] range.
 	MaxTopInferersToReward uint64 `protobuf:"varint,30,opt,name=max_top_inferers_to_reward,json=maxTopInferersToReward,proto3" json:"max_top_inferers_to_reward,omitempty"`
 }
 
@@ -691,11 +689,10 @@ type UpdateTopicRequest struct {
 	// Default value for missing MULTI label slots. Topic keeper rejects
 	// mutations while any worker submission window is open.
 	LabelDefaultValue github_com_allora_network_allora_chain_math.Dec `protobuf:"bytes,11,opt,name=label_default_value,json=labelDefaultValue,proto3,customtype=github.com/allora-network/allora-chain/math.Dec" json:"label_default_value"`
-	// Per-topic cap on inferers admitted to the active set. Full replacement: the
-	// supplied value overwrites the stored one. 0 means "use the global
-	// max_top_inferers_to_reward", resolved and stored; any other value must be
-	// within the global [min_top_inferers_to_reward, max_top_inferers_to_reward].
-	// The keeper rejects this mutation while any worker submission window is open.
+	// Per-topic cap on inferers admitted to the active set. Full replacement,
+	// within the global [min_top_inferers_to_reward, max_top_inferers_to_reward]
+	// range. The keeper rejects a change while any worker submission window is
+	// open.
 	MaxTopInferersToReward uint64 `protobuf:"varint,12,opt,name=max_top_inferers_to_reward,json=maxTopInferersToReward,proto3" json:"max_top_inferers_to_reward,omitempty"`
 }
 

--- a/x/emissions/types/validations.go
+++ b/x/emissions/types/validations.go
@@ -981,15 +981,12 @@ const (
 	maxTopicUnityTolerance = "0.01"
 )
 
-// EffectiveMaxTopInferersToReward resolves a per-topic cap into the global
-// range: 0 means "use the global maximum", the minimum raises it, and the
-// maximum is applied last so it always wins. Applying the ceiling last keeps the
-// active set within the global-sized score-retention window even if the range is
-// inverted, which params validation already prevents.
+// EffectiveMaxTopInferersToReward clamps a stored per-topic cap into the global
+// range: the minimum raises it, and the maximum is applied last so it always
+// wins. Applying the ceiling last keeps the active set within the global-sized
+// score-retention window even if the range is inverted, which params validation
+// already prevents.
 func EffectiveMaxTopInferersToReward(topicCap, globalMin, globalMax uint64) uint64 {
-	if topicCap == 0 {
-		topicCap = globalMax
-	}
 	if topicCap < globalMin {
 		topicCap = globalMin
 	}
@@ -1088,10 +1085,10 @@ func (topic Topic) Validate(params Params) error {
 	if topic.CNorm.Lt(validationCNormMinDec) || topic.CNorm.Gt(validationCNormMaxDec) {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "topic c_norm must be between -100 and 100")
 	}
-	// The per-topic inferer cap is deliberately not bounded by the globals here:
-	// they bound admission, not storage, so a governance change cannot make an
-	// existing topic unloadable. Any stored value, including zero, is valid at
-	// rest and is resolved by EffectiveMaxTopInferersToReward when used.
+	// MaxTopInferersToReward is not bounded by the globals here: they bound
+	// admission, not storage, so a governance change cannot make an existing
+	// topic fail re-validation on write. EffectiveMaxTopInferersToReward clamps
+	// the stored value when it is used.
 	if err := ValidateClassificationConsistency(
 		topic.TopicType,
 		topic.OutputArity,

--- a/x/emissions/types/validations_test.go
+++ b/x/emissions/types/validations_test.go
@@ -1259,13 +1259,15 @@ func TestEffectiveMaxTopInferersToReward(t *testing.T) {
 		name                                 string
 		topicCap, globalMin, globalMax, want uint64
 	}{
-		{"zero uses global max", 0, 1, 32, 32},
+		// A cap below the floor is raised to it; with no floor it stays as stored.
+		{"zero raised to global min", 0, 1, 32, 1},
+		{"zero with a floor raised to that floor", 0, 10, 32, 10},
+		{"zero with no floor stays zero", 0, 0, 32, 0},
 		{"within range preserved", 10, 1, 32, 10},
 		{"equal to global max", 32, 1, 32, 32},
 		{"above global max clamped", 40, 1, 32, 32},
 		{"below global min raised", 3, 10, 32, 10},
 		{"equal to global min", 10, 10, 32, 10},
-		{"zero with a floor still uses global max", 0, 10, 32, 32},
 		{"no floor", 10, 0, 32, 10},
 		// With the default floor: below it is raised, within the range is kept,
 		// above the ceiling is clamped.


### PR DESCRIPTION


## Purpose of Changes and their Description

`Topic.max_top_inferers_to_reward` treated `0` as a sentinel meaning "use the global maximum," but the sentinel was resolved on some write paths and persisted on others: `CreateNewTopic`/`UpdateTopic` resolved it to a concrete value at write time, while `InitGenesis` stored it verbatim. Two topics that declared the same `0` could end up with different stored state, and a stored `0` made the worker-submission-window guard reject unrelated field updates (comparing the raw stored `0` against the resolved request).

This PR removes the sentinel instead of reconciling the write paths: `0` is now an ordinary value.

- `CreateNewTopic`/`UpdateTopic` reject any request outside `[min_top_inferers_to_reward, max_top_inferers_to_reward]`, `0` included — no special-casing.
- The accepted value is stored verbatim on every write path, including genesis import.
- `EffectiveMaxTopInferersToReward` clamps the stored value into the global range only at admission time (worker-payload insertion), ceiling applied last. It no longer maps `0 → global max`.
- Fixed a latent bug this change surfaced: with a cap of `0` (reachable only if governance sets the floor to `0`) and an empty active set, `PlanInferenceAdmission` planned an eviction with no member to evict, which would have failed the tx. Admission now falls through to "not admitted" when the active set is empty.
- Comments and docs (`README.md`, `docs/topic-parameters.md`, `docs/global-parameters.md`, proto comments, autocli help, `CHANGELOG.md`) rewritten to state the rule directly, with no "sentinel"/"network default" framing — that concept never shipped (v0.18.0 is unreleased) and doesn't need explaining.

This revises the still-unreleased `#968`, not a public behavior change: the CHANGELOG entry for `#968` is edited in place rather than adding a "Changed" bullet.

**Known limitation, not fixed here:** there is no longer a way to say "track the network default," and `UpdateTopic`'s full-replacement semantics mean a topic whose stored cap falls outside a since-moved global range still can't resubmit its own cap without also changing it — which still trips the WSW guard. This is a narrower version of the original problem's Consequence 2; it's called out in `docs/global-parameters.md` and `docs/topic-parameters.md` rather than solved.

**Also out of scope, flagged for a follow-up ticket:** `Topic.Validate` has several checks that depend on live params (`MaxStringLength`, `MinEpochLength`, `MaxUnfulfilledReputerRequests`, `MaxTopicLabelWhitelistSize`) and runs in consensus on every epoch close via `SetTopic` (`UpdateTopicEpochLastEnded`/`UpdateTopicInitialRegret`). A governance param change can make an existing topic fail re-validation there, and the failure is swallowed with a `Warn` + `continue` in `rewards/topic_rewards.go`, silently stopping that topic's epoch closes and worker-nonce openings. This is why a range check against the globals was deliberately *not* added to `Topic.Validate` for `max_top_inferers_to_reward` in this PR.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

[ENGN-9102](https://linear.app/alloralabs/issue/ENGN-9102/max-top-inferers-to-reward-the-0-sentinel-resolves-differently)

## Are these changes tested and documented?

- [x] Tested: unit tests updated across `keeper`, `keeper/msgserver`, `types`, `migrations/v16` for the removed-sentinel behavior (create/update reject `0`, genesis round-trips a cap verbatim, stored cap doesn't move with the globals). Added `TestPlanInferenceAdmissionZeroCap` covering the empty-active-set eviction edge case. Full suite passes (`keeper`, `msgserver`, `types`, `migrations/v2`–`v16`, `module`, `module/rewards`) plus `golangci-lint`.
- [x] Documented: `x/emissions/README.md`, `x/emissions/docs/topic-parameters.md`, `x/emissions/docs/global-parameters.md`, proto field comments, and `autocli.go` CLI help updated to match.
- [x] `CHANGELOG.md` `#968` entry edited in place (unreleased); no new entry needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `0` sentinel on `max_top_inferers_to_reward` so topics can no longer diverge based on how they were written: previously `0` meant "use the global maximum" but resolved differently on different write paths, and now `0` is rejected like any out-of-range value. Fixes ENGN-9102.

**Behavior changes**
- `CreateNewTopic`/`UpdateTopic` reject any cap outside the global `[min_top_inferers_to_reward, max_top_inferers_to_reward]` range, `0` included, and store accepted values verbatim on every write path.
- `EffectiveMaxTopInferersToReward` no longer maps `0` to the global max; it clamps the stored value into the live range only at admission.
- Admission falls through to "not admitted" when the active set is empty, fixing a latent eviction failure when the cap is `0`.
- Known limitation: a stored cap outside a since-moved range can't be resubmitted without changing it, so updating any other field on such a topic trips the worker-submission-window guard.
- Proto comments, CLI help, docs, and the `CHANGELOG` entry for #968 rewritten to drop the sentinel framing.

<sup>Written for commit 481df7ae8dcc57cc4557089a9a9fdb7f8fae420c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

