### PR TITLE
ENGN-9363 fix: open the reputer submission window at the end of the reveal epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+### Security
+
+* The reputer submission window now opens at the end of the epoch in which ground truth is revealed (`nonce + ground_truth_lag + extraLag`) rather than at the revelation itself. Previously, on a topic whose `ground_truth_lag` was not a whole multiple of `epoch_length`, a nonce's window opened `extraLag` blocks before the *previous* nonce closed on the epoch grid. A reputer submitting in that gap stored a bundle for the newer nonce, and because reputer loss bundles are keyed by `(topic, reputer)` with no nonce, closing the older nonce read that bundle, discarded every report on the block-height check and failed with `Sum weight for loss is 0`. The topic then produced no further network losses and, since `SetTopicRewardNonce` is only reached on success, paid no rewards — permanently, with every transaction still reporting success. Topics whose lag divides evenly were unaffected (`extraLag` is zero for them). **This changes transaction acceptance and therefore requires a coordinated upgrade height.** No store migration; `ConsensusVersion` is unchanged.
+
 ### Added
 
 * [#968](https://github.com/allora-network/allora-chain/pull/968) Per-topic `max_top_inferers_to_reward` (additive field on `emissions.v10.Topic`): the cap on inferers admitted per topic is now topic-level, set at create/`UpdateTopic` (`0` uses the global default; guarded while a worker submission window is open). Stored caps are kept verbatim, and admission resolves them against the global bounds, so the globals stay live. The emissions v16 migration backfills existing topics, so behavior is unchanged across the `v0.18.0` upgrade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,10 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
-### Security
-
-* The reputer submission window now opens at the end of the epoch in which ground truth is revealed (`nonce + ground_truth_lag + extraLag`) rather than at the revelation itself. Previously, on a topic whose `ground_truth_lag` was not a whole multiple of `epoch_length`, a nonce's window opened `extraLag` blocks before the *previous* nonce closed on the epoch grid. A reputer submitting in that gap stored a bundle for the newer nonce, and because reputer loss bundles are keyed by `(topic, reputer)` with no nonce, closing the older nonce read that bundle, discarded every report on the block-height check and failed with `Sum weight for loss is 0`. The topic then produced no further network losses and, since `SetTopicRewardNonce` is only reached on success, paid no rewards — permanently, with every transaction still reporting success. Topics whose lag divides evenly were unaffected (`extraLag` is zero for them). **This changes transaction acceptance and therefore requires a coordinated upgrade height.** No store migration; `ConsensusVersion` is unchanged.
-
 ### Added
 
 * [#968](https://github.com/allora-network/allora-chain/pull/968) Per-topic `max_top_inferers_to_reward` (additive field on `emissions.v10.Topic`): the cap on inferers admitted per topic is now topic-level, set at create/`UpdateTopic` (`0` uses the global default; guarded while a worker submission window is open). Stored caps are kept verbatim, and admission resolves them against the global bounds, so the globals stay live. The emissions v16 migration backfills existing topics, so behavior is unchanged across the `v0.18.0` upgrade.
@@ -86,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+* The reputer submission window now opens at the end of the epoch in which ground truth is revealed (`nonce + ground_truth_lag + extraLag`) rather than at the revelation itself. Previously, on a topic whose `ground_truth_lag` was not a whole multiple of `epoch_length`, a nonce's window opened `extraLag` blocks before the *previous* nonce closed on the epoch grid. A reputer submitting in that gap stored a bundle for the newer nonce, and because reputer loss bundles are keyed by `(topic, reputer)` with no nonce, closing the older nonce read that bundle, discarded every report on the block-height check and failed with `Sum weight for loss is 0`. The topic then produced no further network losses and, since `SetTopicRewardNonce` is only reached on success, paid no rewards — permanently, with every transaction still reporting success. Topics whose lag divides evenly were unaffected (`extraLag` is zero for them). **This changes transaction acceptance and therefore requires a coordinated upgrade height.** No store migration; `ConsensusVersion` is unchanged.
 * [#980](https://github.com/allora-network/allora-chain/pull/980) Patch a fast-node cache/commit race in `iavl` that caused `AppHash` divergence: the ecosystem treasury account is deleted every block at zero balance, and a concurrent balance query during commit could read its value one block stale, minting the wrong amount and forking the node. Points `iavl` at `github.com/allora-network/iavl` (`v1.2.6` + backport of [cosmos/iavl#1142](https://github.com/cosmos/iavl/pull/1142)). Not consensus-breaking; no migration required.
 
 ### API Breaking Changes

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Data is submitted by workers and reputers within the allowed submission windows.
 
 For workers, the submission window is defined at the topic level, as the blocks starting at `nonce.BlockHeight` and ending at `nonce.BlockHeight + topic.WorkerSubmissionWindow`. 
 
-For reputers, the submission window starts at `(nonce.BlockHeight + topic.GroundTruthLag)` and it lasts 1 `topic.EpochLength` + any remaining additional lag until end of epoch, only applying when `topic.GroundTruthLag` and `topic.EpochLength` are not multiples, and calculated as `(topic.EpochLength - (topic.GroundTruthLag % topic.EpochLength))`.
+For reputers, the submission window opens at the end of the epoch in which ground truth is revealed, not at the revelation itself: it starts at `(nonce.BlockHeight + topic.GroundTruthLag + extraLag)` and lasts 1 `topic.EpochLength`, where `extraLag` is the distance from the revelation to the end of that epoch — `(topic.EpochLength - (topic.GroundTruthLag % topic.EpochLength))`, and zero when `topic.GroundTruthLag` is a whole multiple of `topic.EpochLength`. Waiting for the epoch boundary is what keeps consecutive windows from overlapping: a nonce is closed on the epoch grid, so opening the next window at the revelation would let a reputer submit for it while the previous nonce is still open.
 
 Both windows are inclusive of start and end boundaries.
 

--- a/x/emissions/README.md
+++ b/x/emissions/README.md
@@ -17,7 +17,7 @@ Key Features:
 
 The module provides queries to check which nonces are currently open for submission:
 
-- **`GetOpenReputerSubmissionWindows`**: Returns only the reputer nonces that are currently open for submission. A nonce is considered open if the current block height is within its submission window (from when ground truth is revealed until the window closes).
+- **`GetOpenReputerSubmissionWindows`**: Returns only the reputer nonces that are currently open for submission. A nonce is considered open if the current block height is within its submission window (from the end of the epoch in which ground truth is revealed, until the window closes one epoch later).
   
   - Endpoint: `/emissions/v9/open_reputer_submission_windows/{topic_id}`
   - CLI: `allorad query emissions open-reputer-submission-windows [topic_id]`

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
@@ -69,14 +69,18 @@ func (ms msgServer) InsertReputerPayload(ctx context.Context, msg *types.InsertR
 		return nil, errorsmod.Wrapf(types.ErrUnfulfilledNonceNotFound, "reputer nonce")
 	}
 
-	withinWindow, err := keeper.BlockWithinReputerSubmissionWindowOfNonce(topic, *nonce, blockHeight)
+	// Take the bounds once and compare, rather than asking the predicate and then
+	// recomputing the bounds for the message: the previous message named neither
+	// the true start (it omitted extraLag) nor the true end (it used EpochLength*2).
+	windowStart, windowEnd, err := keeper.ReputerSubmissionWindowBounds(topic, *nonce)
 	if err != nil {
 		return nil, err
-	} else if !withinWindow {
+	}
+	if blockHeight < windowStart || blockHeight > windowEnd {
 		return nil, errorsmod.Wrapf(
 			types.ErrReputerNonceWindowNotAvailable,
 			"Reputer window not open for topic: %d, current block %d, start window: %d, end window: %d",
-			topicId, blockHeight, nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag, nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag+topic.EpochLength*2,
+			topicId, blockHeight, windowStart, windowEnd,
 		)
 	}
 

--- a/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
+++ b/x/emissions/keeper/msgserver/msg_server_reputer_payload.go
@@ -69,9 +69,7 @@ func (ms msgServer) InsertReputerPayload(ctx context.Context, msg *types.InsertR
 		return nil, errorsmod.Wrapf(types.ErrUnfulfilledNonceNotFound, "reputer nonce")
 	}
 
-	// Take the bounds once and compare, rather than asking the predicate and then
-	// recomputing the bounds for the message: the previous message named neither
-	// the true start (it omitted extraLag) nor the true end (it used EpochLength*2).
+	// Use the same bounds for admission and the rejection message.
 	windowStart, windowEnd, err := keeper.ReputerSubmissionWindowBounds(topic, *nonce)
 	if err != nil {
 		return nil, err

--- a/x/emissions/keeper/queryserver/query_server_topics.go
+++ b/x/emissions/keeper/queryserver/query_server_topics.go
@@ -306,9 +306,7 @@ func (qs queryServer) GetReputerSubmissionWindowStatus(ctx context.Context, req 
 	var earliestFutureNonce *types.ReputerRequestNonce
 
 	for _, nonce := range nonces.Nonces {
-		// Must come from the shared helper: this response tells clients when to
-		// submit, so computing the bounds separately here is how the query ends
-		// up advertising a window the msg server rejects.
+		// Use the same bounds advertised and enforced by transaction admission.
 		windowStart, windowEnd, err := keeper.ReputerSubmissionWindowBounds(topic, *nonce)
 		if err != nil {
 			return nil, err

--- a/x/emissions/keeper/queryserver/query_server_topics.go
+++ b/x/emissions/keeper/queryserver/query_server_topics.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	"github.com/allora-network/allora-chain/x/emissions/metrics"
 
 	"github.com/allora-network/allora-chain/x/emissions/types"
@@ -303,14 +304,15 @@ func (qs queryServer) GetReputerSubmissionWindowStatus(ctx context.Context, req 
 
 	var latestActiveNonce *types.ReputerRequestNonce
 	var earliestFutureNonce *types.ReputerRequestNonce
-	extraLag := topic.GroundTruthLag % topic.EpochLength
-	if extraLag != 0 {
-		extraLag = topic.EpochLength - extraLag
-	}
 
 	for _, nonce := range nonces.Nonces {
-		windowStart := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag
-		windowEnd := windowStart + extraLag + topic.EpochLength
+		// Must come from the shared helper: this response tells clients when to
+		// submit, so computing the bounds separately here is how the query ends
+		// up advertising a window the msg server rejects.
+		windowStart, windowEnd, err := keeper.ReputerSubmissionWindowBounds(topic, *nonce)
+		if err != nil {
+			return nil, err
+		}
 
 		if currentBlockHeight >= windowStart && currentBlockHeight <= windowEnd {
 			// Current active window: find the most recent active nonce
@@ -336,8 +338,10 @@ func (qs queryServer) GetReputerSubmissionWindowStatus(ctx context.Context, req 
 
 	// Calculate next window from the earliest future reputer nonce found
 	if earliestFutureNonce != nil {
-		nextReputerStart := earliestFutureNonce.ReputerNonce.BlockHeight + topic.GroundTruthLag
-		nextReputerEnd := nextReputerStart + extraLag + topic.EpochLength
+		nextReputerStart, nextReputerEnd, err := keeper.ReputerSubmissionWindowBounds(topic, *earliestFutureNonce)
+		if err != nil {
+			return nil, err
+		}
 		response.NextWindowStartBlock = nextReputerStart
 		response.NextWindowEndBlock = nextReputerEnd
 	}

--- a/x/emissions/keeper/queryserver/query_server_topics_test.go
+++ b/x/emissions/keeper/queryserver/query_server_topics_test.go
@@ -488,11 +488,7 @@ func (s *QueryServerTestSuite) TestGetReputerSubmissionWindowStatus() {
 	s.Require().NoError(err)
 	s.Require().True(isActive)
 
-	// Create multiple reputer nonces to test "latest active nonce" selection.
-	// The window opens at the end of the epoch in which ground truth is revealed,
-	// so it is [nonce+GroundTruthLag+extraLag, +EpochLength] -- see
-	// keeper.ReputerSubmissionWindowBounds. Opening at the reveal itself would let
-	// a nonce's window start before the previous nonce closes.
+	// Create overlapping windows to verify latest-active-nonce selection.
 	// extraLag = EpochLength - (GroundTruthLag % EpochLength) = 20 - (30 % 20) = 10
 
 	reputerNonce1 := &types.Nonce{BlockHeight: 0}  // Window [40, 60] (0+30+10, +20)
@@ -506,9 +502,7 @@ func (s *QueryServerTestSuite) TestGetReputerSubmissionWindowStatus() {
 	err = s.NonceKeeper().AddReputerNonce(ctx, topicId, reputerNonce3)
 	s.Require().NoError(err)
 
-	// Set current block to be within multiple reputer windows. 50 keeps two
-	// nonces active (nonce1 and nonce2) with a third still in the future, so this
-	// still exercises "latest of several active" rather than a single match.
+	// Block 50 is inside the first two windows and before the third.
 	currentBlock = int64(50) // Within windows [40,60] and [45,65]
 	s.WithBlockHeight(currentBlock)
 	ctx = s.Ctx()

--- a/x/emissions/keeper/queryserver/query_server_topics_test.go
+++ b/x/emissions/keeper/queryserver/query_server_topics_test.go
@@ -488,13 +488,16 @@ func (s *QueryServerTestSuite) TestGetReputerSubmissionWindowStatus() {
 	s.Require().NoError(err)
 	s.Require().True(isActive)
 
-	// Create multiple reputer nonces to test "latest active nonce" selection
-	// Reputer windows: [nonce + GroundTruthLag, nonce + GroundTruthLag + extraLag + EpochLength]
+	// Create multiple reputer nonces to test "latest active nonce" selection.
+	// The window opens at the end of the epoch in which ground truth is revealed,
+	// so it is [nonce+GroundTruthLag+extraLag, +EpochLength] -- see
+	// keeper.ReputerSubmissionWindowBounds. Opening at the reveal itself would let
+	// a nonce's window start before the previous nonce closes.
 	// extraLag = EpochLength - (GroundTruthLag % EpochLength) = 20 - (30 % 20) = 10
 
-	reputerNonce1 := &types.Nonce{BlockHeight: 0}  // Window [30, 60] (0+30 to 0+30+10+20)
-	reputerNonce2 := &types.Nonce{BlockHeight: 5}  // Window [35, 65] (5+30 to 5+30+10+20)
-	reputerNonce3 := &types.Nonce{BlockHeight: 20} // Window [50, 80] (20+30 to 20+30+10+20)
+	reputerNonce1 := &types.Nonce{BlockHeight: 0}  // Window [40, 60] (0+30+10, +20)
+	reputerNonce2 := &types.Nonce{BlockHeight: 5}  // Window [45, 65] (5+30+10, +20)
+	reputerNonce3 := &types.Nonce{BlockHeight: 20} // Window [60, 80] (20+30+10, +20)
 
 	err = s.NonceKeeper().AddReputerNonce(ctx, topicId, reputerNonce1)
 	s.Require().NoError(err)
@@ -503,8 +506,10 @@ func (s *QueryServerTestSuite) TestGetReputerSubmissionWindowStatus() {
 	err = s.NonceKeeper().AddReputerNonce(ctx, topicId, reputerNonce3)
 	s.Require().NoError(err)
 
-	// Set current block to be within multiple reputer windows
-	currentBlock = int64(40) // Within windows [30,60] and [35,65]
+	// Set current block to be within multiple reputer windows. 50 keeps two
+	// nonces active (nonce1 and nonce2) with a third still in the future, so this
+	// still exercises "latest of several active" rather than a single match.
+	currentBlock = int64(50) // Within windows [40,60] and [45,65]
 	s.WithBlockHeight(currentBlock)
 	ctx = s.Ctx()
 
@@ -513,11 +518,11 @@ func (s *QueryServerTestSuite) TestGetReputerSubmissionWindowStatus() {
 	s.Require().NoError(err)
 	s.Require().True(response.IsOpen)
 	s.Require().Equal(reputerNonce2.BlockHeight, response.CurrentNonceBlockHeight) // Should be latest active
-	s.Require().Equal(int64(35), response.WindowStartBlock)                        // 5 + 30
-	s.Require().Equal(int64(65), response.WindowEndBlock)                          // 35 + 10 + 20
+	s.Require().Equal(int64(45), response.WindowStartBlock)                        // 5 + 30 + 10
+	s.Require().Equal(int64(65), response.WindowEndBlock)                          // 45 + 20
 
-	// Next window: [20+30, 20+30+10+20] = [50, 80]
-	expectedNextStart := int64(50) // From reputerNonce3 (BlockHeight=20)
+	// Next window: [20+30+10, +20] = [60, 80]
+	expectedNextStart := int64(60) // From reputerNonce3 (BlockHeight=20)
 	expectedNextEnd := int64(80)
 
 	response, err = queryServer.GetReputerSubmissionWindowStatus(ctx, req)

--- a/x/emissions/keeper/topic_activation.go
+++ b/x/emissions/keeper/topic_activation.go
@@ -317,7 +317,29 @@ func (k *TopicKeeper) ActivateTopic(ctx context.Context, topicId TopicId) error 
 			return errorsmod.Wrap(err, "failed to set total sum of previous topic weights")
 		}
 	}
+	k.emitOpenReputerSubmissionWindowEvents(ctx, topic)
 	return nil
+}
+
+func (k *TopicKeeper) emitOpenReputerSubmissionWindowEvents(ctx context.Context, topic types.Topic) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	nonces, err := k.nonceKeeper.GetUnfulfilledReputerNonces(ctx, topic.Id)
+	if err != nil {
+		sdkCtx.Logger().Warn("Failed to get unfulfilled reputer nonces after topic activation", "topicId", topic.Id, "error", err)
+		return
+	}
+
+	block := sdkCtx.BlockHeight()
+	for _, nonce := range nonces.Nonces {
+		windowStart, windowEnd, err := ReputerSubmissionWindowBounds(topic, *nonce)
+		if err != nil {
+			sdkCtx.Logger().Warn("Failed to compute reputer submission window after topic activation", "topicId", topic.Id, "error", err)
+			continue
+		}
+		if block >= windowStart && block < windowEnd {
+			types.EmitNewReputerSubmissionWindowOpenedEvent(ctx, topic.Id, nonce.ReputerNonce.BlockHeight, windowEnd)
+		}
+	}
 }
 
 // Inactivate the topic

--- a/x/emissions/keeper/topic_activation_test.go
+++ b/x/emissions/keeper/topic_activation_test.go
@@ -164,3 +164,34 @@ func (s *KeeperTestSuite) TestInactivateTopicWithoutMinWeightReset_EmptyBlockLis
 	s.Require().NoError(err)
 	s.Require().Empty(retrievedTopics.TopicIds, "Block should still have no active topics")
 }
+
+func (s *KeeperTestSuite) TestActivateTopicEmitsOpenReputerWindowEvent() {
+	ctx := s.Ctx()
+	k := s.TopicKeeper()
+	topic := s.MockTopic()
+	topic.Id = 9_000_004
+	topic.EpochLength = 100
+	topic.GroundTruthLag = 130
+	nonce := types.Nonce{BlockHeight: 1000}
+
+	err := k.SetTopic(ctx, topic.Id, topic)
+	s.Require().NoError(err)
+	err = s.NonceKeeper().AddReputerNonce(ctx, topic.Id, &nonce)
+	s.Require().NoError(err)
+
+	s.WithBlockHeight(1250)
+	eventStart := len(s.Ctx().EventManager().Events())
+	err = k.ActivateTopic(s.Ctx(), topic.Id)
+	s.Require().NoError(err)
+
+	openedEvents := 0
+	for _, event := range s.Ctx().EventManager().Events()[eventStart:] {
+		if event.Type == "emissions.v10.EventReputerSubmissionWindowOpened" {
+			openedEvents++
+		}
+	}
+	s.Require().Equal(1, openedEvents)
+
+	err = k.InactivateTopic(s.Ctx(), topic.Id)
+	s.Require().NoError(err)
+}

--- a/x/emissions/keeper/window_boundaries.go
+++ b/x/emissions/keeper/window_boundaries.go
@@ -27,22 +27,29 @@ func BlockWithinWorkerSubmissionWindowOfNonce(topic types.Topic, nonce types.Non
 // Return true if the nonce is within the reputer submission window for the topic
 // Inclusive of the start block height and of the end block height
 func BlockWithinReputerSubmissionWindowOfNonce(topic types.Topic, nonce types.ReputerRequestNonce, blockHeight int64) (bool, error) {
-	// extraLag is the difference between the point at which the gt_lag is revealed and the end of epoch.
+	lowerBound, upperBound, err := ReputerSubmissionWindowBounds(topic, nonce)
+	if err != nil {
+		return false, err
+	}
+	return lowerBound <= blockHeight && blockHeight <= upperBound, nil
+}
+
+// ReputerSubmissionWindowBounds returns the inclusive block range in which a
+// reputer payload for this nonce is accepted. Callers that need to report the
+// window (error messages, queries) must use this rather than recomputing it:
+// the bounds were previously spelled out in four places, and the one that drifted
+// is what allowed consecutive windows to overlap.
+func ReputerSubmissionWindowBounds(topic types.Topic, nonce types.ReputerRequestNonce) (int64, int64, error) {
 	extraLag := topic.GroundTruthLag % topic.EpochLength
 	if extraLag != 0 {
 		extraLag = topic.EpochLength - extraLag
 	}
-	// The block at which ground truth is revealed
 	revealedGroundTruthBlock := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag
-
-	// Allow 1 EpochLength + any extra lag as defined above.
 	if revealedGroundTruthBlock > math.MaxInt64-(extraLag+topic.EpochLength) {
-		return false, errorsmod.Wrapf(types.ErrInvalidValue,
-			"nonce block height %d is too high, adding window %d would overflow",
-			nonce.ReputerNonce.BlockHeight,
-			topic.WorkerSubmissionWindow)
+		return 0, 0, errorsmod.Wrapf(types.ErrInvalidValue,
+			"nonce block height %d is too high, adding the submission window would overflow",
+			nonce.ReputerNonce.BlockHeight)
 	}
-	lowerBound := revealedGroundTruthBlock
-	upperBound := revealedGroundTruthBlock + extraLag + topic.EpochLength
-	return lowerBound <= blockHeight && blockHeight <= upperBound, nil
+	lowerBound := revealedGroundTruthBlock + extraLag
+	return lowerBound, lowerBound + topic.EpochLength, nil
 }

--- a/x/emissions/keeper/window_boundaries.go
+++ b/x/emissions/keeper/window_boundaries.go
@@ -35,10 +35,8 @@ func BlockWithinReputerSubmissionWindowOfNonce(topic types.Topic, nonce types.Re
 }
 
 // ReputerSubmissionWindowBounds returns the inclusive block range in which a
-// reputer payload for this nonce is accepted. Callers that need to report the
-// window (error messages, queries) must use this rather than recomputing it:
-// the bounds were previously spelled out in four places, and the one that drifted
-// is what allowed consecutive windows to overlap.
+// reputer payload for this nonce is accepted. Admission, query, and lifecycle
+// code must use these bounds to remain consistent.
 func ReputerSubmissionWindowBounds(topic types.Topic, nonce types.ReputerRequestNonce) (int64, int64, error) {
 	extraLag := topic.GroundTruthLag % topic.EpochLength
 	if extraLag != 0 {

--- a/x/emissions/keeper/window_boundaries_test.go
+++ b/x/emissions/keeper/window_boundaries_test.go
@@ -96,7 +96,7 @@ func (s *KeeperTestSuite) TestBlockWithinReputerSubmissionWindowOfNonce() {
 			nonce: types.ReputerRequestNonce{
 				ReputerNonce: &types.Nonce{BlockHeight: 1000},
 			},
-			blockHeight:      1150,
+			blockHeight:      1250,
 			expectedInWindow: true,
 			expectedErr:      nil,
 			description:      "Block is within window when GTLag > EpochLength and not divisible, Block within window",
@@ -110,10 +110,10 @@ func (s *KeeperTestSuite) TestBlockWithinReputerSubmissionWindowOfNonce() {
 			nonce: types.ReputerRequestNonce{
 				ReputerNonce: &types.Nonce{BlockHeight: 1000},
 			},
-			blockHeight:      1129,
+			blockHeight:      1199,
 			expectedInWindow: false,
 			expectedErr:      nil,
-			description:      "Block is within window when GTLag > EpochLength and not divisible, Lower boundary out",
+			description:      "Block is one before the window opens; the window opens at the end of the reveal epoch, not at the reveal",
 		},
 		{
 			name: "GTLag not divisible by EpochLength - Lower boundary in",
@@ -124,10 +124,57 @@ func (s *KeeperTestSuite) TestBlockWithinReputerSubmissionWindowOfNonce() {
 			nonce: types.ReputerRequestNonce{
 				ReputerNonce: &types.Nonce{BlockHeight: 1000},
 			},
-			blockHeight:      1130,
+			blockHeight:      1200,
 			expectedInWindow: true,
 			expectedErr:      nil,
-			description:      "Block is within window when GTLag > EpochLength and not divisible, Lower boundary in",
+			description:      "Block is exactly when the window opens: revealedGroundTruthBlock + extraLag",
+		},
+		{
+			// Regression: this block sits inside the old window
+			// (revealedGroundTruthBlock = 1130) but before the next epoch boundary
+			// at 1200. Accepting a submission here let a reputer file for this nonce
+			// while the PREVIOUS nonce was still open, and because lossBundles is
+			// keyed by (topic, reputer) only, the previous nonce's close then read
+			// this bundle, discarded every report on the height check and failed
+			// permanently with "Sum weight for loss is 0".
+			name: "GTLag not divisible by EpochLength - reveal block is not yet the window",
+			topic: types.Topic{ //nolint:exhaustruct
+				EpochLength:    100,
+				GroundTruthLag: 130,
+			},
+			nonce: types.ReputerRequestNonce{
+				ReputerNonce: &types.Nonce{BlockHeight: 1000},
+			},
+			blockHeight:      1130,
+			expectedInWindow: false,
+			expectedErr:      nil,
+			description:      "Ground truth is revealed at 1130 but the window only opens at the epoch boundary 1200",
+		},
+		{
+			// The window must not open before the previous nonce closes. The previous
+			// nonce (1000-100=900) closes at 900+130+70+100 = 1200, exactly where
+			// this nonce's window opens -- the same boundary convention topics with
+			// an evenly-dividing GroundTruthLag already follow.
+			//
+			// Not literally zero overlap: DeliverTx runs before EndBlock, so at the
+			// shared block 1200 the next nonce is already accepted while the previous
+			// one closes. That single-block exposure is pre-existing and identical on
+			// evenly-dividing topics, so this restores the existing convention rather
+			// than eliminating the residual. Closing it needs either a nonce-aware
+			// reset in CloseReputerNonce or a +1 that shifts every topic's boundary,
+			// both of which deserve their own change.
+			name: "GTLag not divisible by EpochLength - window opens exactly when the previous nonce closes",
+			topic: types.Topic{ //nolint:exhaustruct
+				EpochLength:    100,
+				GroundTruthLag: 130,
+			},
+			nonce: types.ReputerRequestNonce{
+				ReputerNonce: &types.Nonce{BlockHeight: 900},
+			},
+			blockHeight:      1199,
+			expectedInWindow: true,
+			expectedErr:      nil,
+			description:      "Previous nonce is still open at 1199 and closes at 1200, where the next nonce opens",
 		},
 		{
 			name: "GTLag not divisible by EpochLength - Upper boundary in",
@@ -430,6 +477,90 @@ func (s *KeeperTestSuite) TestBlockWithinWorkerSubmissionWindowOfNonce() {
 				s.Require().NoError(err)
 				s.Require().Equal(tt.expectedInWindow, result, tt.description)
 			}
+		})
+	}
+}
+
+// ReputerSubmissionWindowBounds is the single source of truth for the reputer
+// window -- the predicate, the msg server's error message and the topic query
+// server all derive from it -- so its arithmetic and its overflow guard need
+// pinning directly, not only through the predicate.
+func (s *KeeperTestSuite) TestReputerSubmissionWindowBounds() {
+	tests := []struct {
+		name          string
+		topic         types.Topic
+		nonceHeight   int64
+		expectedStart int64
+		expectedEnd   int64
+		expectedErr   error
+		description   string
+	}{
+		{
+			name:          "aligned lag opens at the reveal",
+			topic:         types.Topic{EpochLength: 100, GroundTruthLag: 100}, //nolint:exhaustruct
+			nonceHeight:   1000,
+			expectedStart: 1100,
+			expectedEnd:   1200,
+			description:   "extraLag is 0, so the reveal block is already an epoch boundary",
+		},
+		{
+			name:          "fractional lag waits for the end of the reveal epoch",
+			topic:         types.Topic{EpochLength: 100, GroundTruthLag: 130}, //nolint:exhaustruct
+			nonceHeight:   1000,
+			expectedStart: 1200,
+			expectedEnd:   1300,
+			description:   "reveal is 1130, extraLag 70, so the window opens at 1200",
+		},
+		{
+			// The production shape that surfaced the overlap: 3388 % 35 = 28,
+			// so extraLag is 7 and the window used to open 7 blocks before the
+			// previous nonce closed.
+			name:          "production-shaped fractional lag",
+			topic:         types.Topic{EpochLength: 35, GroundTruthLag: 3388}, //nolint:exhaustruct
+			nonceHeight:   1_000_000,
+			expectedStart: 1_003_395,
+			expectedEnd:   1_003_430,
+			description:   "window is exactly one epoch long and starts on the grid",
+		},
+		{
+			// Note the guard adds GroundTruthLag before testing, so a nonce close
+			// enough to MaxInt64 that the addition itself wraps slips past it. That
+			// is pre-existing and unreachable -- it needs a block height around
+			// 9e18, versus ~1e7 in practice -- so this pins the guard as written
+			// rather than widening the change.
+			name:        "overflow is rejected",
+			topic:       types.Topic{EpochLength: 100, GroundTruthLag: 100}, //nolint:exhaustruct
+			nonceHeight: math.MaxInt64 - 150,
+			expectedErr: types.ErrInvalidValue,
+			description: "adding the window must not wrap",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			start, end, err := keeper.ReputerSubmissionWindowBounds(
+				tt.topic,
+				types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: tt.nonceHeight}},
+			)
+			if tt.expectedErr != nil {
+				s.Require().Error(err)
+				s.Require().ErrorIs(err, tt.expectedErr, tt.description)
+				return
+			}
+			s.Require().NoError(err)
+			s.Require().Equal(tt.expectedStart, start, tt.description)
+			s.Require().Equal(tt.expectedEnd, end, tt.description)
+			// The window is always exactly one epoch wide.
+			s.Require().Equal(tt.topic.EpochLength, end-start, tt.description)
+			// And it must not open before the previous nonce closes: the previous
+			// nonce (this one minus an epoch) closes at exactly this start.
+			prevStart, prevEnd, err := keeper.ReputerSubmissionWindowBounds(
+				tt.topic,
+				types.ReputerRequestNonce{ReputerNonce: &types.Nonce{BlockHeight: tt.nonceHeight - tt.topic.EpochLength}},
+			)
+			s.Require().NoError(err)
+			s.Require().Equal(start, prevEnd, "previous window must end exactly where this one starts")
+			s.Require().Less(prevStart, start, tt.description)
 		})
 	}
 }

--- a/x/emissions/keeper/window_boundaries_test.go
+++ b/x/emissions/keeper/window_boundaries_test.go
@@ -130,13 +130,6 @@ func (s *KeeperTestSuite) TestBlockWithinReputerSubmissionWindowOfNonce() {
 			description:      "Block is exactly when the window opens: revealedGroundTruthBlock + extraLag",
 		},
 		{
-			// Regression: this block sits inside the old window
-			// (revealedGroundTruthBlock = 1130) but before the next epoch boundary
-			// at 1200. Accepting a submission here let a reputer file for this nonce
-			// while the PREVIOUS nonce was still open, and because lossBundles is
-			// keyed by (topic, reputer) only, the previous nonce's close then read
-			// this bundle, discarded every report on the height check and failed
-			// permanently with "Sum weight for loss is 0".
 			name: "GTLag not divisible by EpochLength - reveal block is not yet the window",
 			topic: types.Topic{ //nolint:exhaustruct
 				EpochLength:    100,
@@ -151,18 +144,6 @@ func (s *KeeperTestSuite) TestBlockWithinReputerSubmissionWindowOfNonce() {
 			description:      "Ground truth is revealed at 1130 but the window only opens at the epoch boundary 1200",
 		},
 		{
-			// The window must not open before the previous nonce closes. The previous
-			// nonce (1000-100=900) closes at 900+130+70+100 = 1200, exactly where
-			// this nonce's window opens -- the same boundary convention topics with
-			// an evenly-dividing GroundTruthLag already follow.
-			//
-			// Not literally zero overlap: DeliverTx runs before EndBlock, so at the
-			// shared block 1200 the next nonce is already accepted while the previous
-			// one closes. That single-block exposure is pre-existing and identical on
-			// evenly-dividing topics, so this restores the existing convention rather
-			// than eliminating the residual. Closing it needs either a nonce-aware
-			// reset in CloseReputerNonce or a +1 that shifts every topic's boundary,
-			// both of which deserve their own change.
 			name: "GTLag not divisible by EpochLength - window opens exactly when the previous nonce closes",
 			topic: types.Topic{ //nolint:exhaustruct
 				EpochLength:    100,
@@ -481,10 +462,7 @@ func (s *KeeperTestSuite) TestBlockWithinWorkerSubmissionWindowOfNonce() {
 	}
 }
 
-// ReputerSubmissionWindowBounds is the single source of truth for the reputer
-// window -- the predicate, the msg server's error message and the topic query
-// server all derive from it -- so its arithmetic and its overflow guard need
-// pinning directly, not only through the predicate.
+// TestReputerSubmissionWindowBounds verifies shared window arithmetic and overflow handling.
 func (s *KeeperTestSuite) TestReputerSubmissionWindowBounds() {
 	tests := []struct {
 		name          string
@@ -501,6 +479,7 @@ func (s *KeeperTestSuite) TestReputerSubmissionWindowBounds() {
 			nonceHeight:   1000,
 			expectedStart: 1100,
 			expectedEnd:   1200,
+			expectedErr:   nil,
 			description:   "extraLag is 0, so the reveal block is already an epoch boundary",
 		},
 		{
@@ -509,30 +488,26 @@ func (s *KeeperTestSuite) TestReputerSubmissionWindowBounds() {
 			nonceHeight:   1000,
 			expectedStart: 1200,
 			expectedEnd:   1300,
+			expectedErr:   nil,
 			description:   "reveal is 1130, extraLag 70, so the window opens at 1200",
 		},
 		{
-			// The production shape that surfaced the overlap: 3388 % 35 = 28,
-			// so extraLag is 7 and the window used to open 7 blocks before the
-			// previous nonce closed.
 			name:          "production-shaped fractional lag",
 			topic:         types.Topic{EpochLength: 35, GroundTruthLag: 3388}, //nolint:exhaustruct
 			nonceHeight:   1_000_000,
 			expectedStart: 1_003_395,
 			expectedEnd:   1_003_430,
+			expectedErr:   nil,
 			description:   "window is exactly one epoch long and starts on the grid",
 		},
 		{
-			// Note the guard adds GroundTruthLag before testing, so a nonce close
-			// enough to MaxInt64 that the addition itself wraps slips past it. That
-			// is pre-existing and unreachable -- it needs a block height around
-			// 9e18, versus ~1e7 in practice -- so this pins the guard as written
-			// rather than widening the change.
-			name:        "overflow is rejected",
-			topic:       types.Topic{EpochLength: 100, GroundTruthLag: 100}, //nolint:exhaustruct
-			nonceHeight: math.MaxInt64 - 150,
-			expectedErr: types.ErrInvalidValue,
-			description: "adding the window must not wrap",
+			name:          "overflow is rejected",
+			topic:         types.Topic{EpochLength: 100, GroundTruthLag: 100}, //nolint:exhaustruct
+			nonceHeight:   math.MaxInt64 - 150,
+			expectedStart: 0,
+			expectedEnd:   0,
+			expectedErr:   types.ErrInvalidValue,
+			description:   "adding the window must not wrap",
 		},
 	}
 

--- a/x/emissions/module/rewards/nonce_management.go
+++ b/x/emissions/module/rewards/nonce_management.go
@@ -15,14 +15,24 @@ func UpdateReputerNonce(ctx sdk.Context, k keeper.Keeper, topic types.Topic, blo
 		ctx.Logger().Warn("Error getting unfulfilled worker nonces", "error", err)
 		return err
 	}
-	extraLag := topic.GroundTruthLag % topic.EpochLength
-	if extraLag != 0 {
-		extraLag = topic.EpochLength - extraLag
-	}
 	for _, nonce := range nonces.Nonces {
-		if block >= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag && block <= nonce.ReputerNonce.BlockHeight+topic.GroundTruthLag+extraLag {
-			windowEndBlock := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag + extraLag + topic.EpochLength
-			types.EmitNewReputerSubmissionWindowOpenedEvent(ctx, topic.Id, nonce.ReputerNonce.BlockHeight, windowEndBlock)
+		// Must match keeper.ReputerSubmissionWindowBounds, the single source of
+		// truth for when a submission is actually accepted. This used to be its
+		// own formula ending at +extraLag instead of the window's real start
+		// (+extraLag was folded into the acceptance lower bound to close a
+		// permanent-trap bug -- see CHANGELOG). On an uninterrupted epoch grid the
+		// two formulas coincide, but a topic that was inactivated and reactivated
+		// gets a new churn schedule with no relation to an existing nonce's grid
+		// (topic_activation.go), so a reactivated topic could hit a block inside
+		// the old range and announce the window open while it was still rejecting
+		// submissions until the true start.
+		windowStart, windowEnd, err := keeper.ReputerSubmissionWindowBounds(topic, *nonce)
+		if err != nil {
+			ctx.Logger().Warn("Error computing reputer submission window bounds", "error", err)
+			continue
+		}
+		if block == windowStart {
+			types.EmitNewReputerSubmissionWindowOpenedEvent(ctx, topic.Id, nonce.ReputerNonce.BlockHeight, windowEnd)
 		}
 		// Check if current blockheight has reached the blockheight of the nonce + groundTruthLag + epochLength
 		// This means one epochLength is allowed for reputation responses to be sent since ground truth is revealed.

--- a/x/emissions/module/rewards/nonce_management.go
+++ b/x/emissions/module/rewards/nonce_management.go
@@ -15,37 +15,29 @@ func UpdateReputerNonce(ctx sdk.Context, k keeper.Keeper, topic types.Topic, blo
 		ctx.Logger().Warn("Error getting unfulfilled worker nonces", "error", err)
 		return err
 	}
+	var updateErr error
 	for _, nonce := range nonces.Nonces {
-		// Must match keeper.ReputerSubmissionWindowBounds, the single source of
-		// truth for when a submission is actually accepted. This used to be its
-		// own formula ending at +extraLag instead of the window's real start
-		// (+extraLag was folded into the acceptance lower bound to close a
-		// permanent-trap bug -- see CHANGELOG). On an uninterrupted epoch grid the
-		// two formulas coincide, but a topic that was inactivated and reactivated
-		// gets a new churn schedule with no relation to an existing nonce's grid
-		// (topic_activation.go), so a reactivated topic could hit a block inside
-		// the old range and announce the window open while it was still rejecting
-		// submissions until the true start.
-		windowStart, windowEnd, err := keeper.ReputerSubmissionWindowBounds(topic, *nonce)
-		if err != nil {
-			ctx.Logger().Warn("Error computing reputer submission window bounds", "error", err)
+		windowStart, windowEnd, boundsErr := keeper.ReputerSubmissionWindowBounds(topic, *nonce)
+		if boundsErr != nil {
+			ctx.Logger().Warn("Error computing reputer submission window bounds", "error", boundsErr)
+			updateErr = boundsErr
 			continue
 		}
-		if block == windowStart {
+		// Active topics are processed once per epoch, so this half-open interval
+		// emits at most once and attributes a shared boundary to the newer nonce.
+		if block >= windowStart && block < windowEnd {
 			types.EmitNewReputerSubmissionWindowOpenedEvent(ctx, topic.Id, nonce.ReputerNonce.BlockHeight, windowEnd)
 		}
-		// Check if current blockheight has reached the blockheight of the nonce + groundTruthLag + epochLength
-		// This means one epochLength is allowed for reputation responses to be sent since ground truth is revealed.
-		closingReputerNonceMinBlockHeight := nonce.ReputerNonce.BlockHeight + topic.GroundTruthLag + topic.EpochLength
-		if block >= closingReputerNonceMinBlockHeight {
-			ctx.Logger().Debug("ABCI EndBlocker: Closing reputer nonce", "topic", topic.Id, "nonce", nonce, "min", closingReputerNonceMinBlockHeight)
-			err = allorautils.CloseReputerNonce(&k, ctx, topic, *nonce.ReputerNonce)
-			if err != nil {
-				ctx.Logger().Error("Error closing reputer nonce", "error", err)
+		if block >= windowEnd {
+			ctx.Logger().Debug("ABCI EndBlocker: Closing reputer nonce", "topic", topic.Id, "nonce", nonce, "min", windowEnd)
+			closeErr := allorautils.CloseReputerNonce(&k, ctx, topic, *nonce.ReputerNonce)
+			if closeErr != nil {
+				ctx.Logger().Error("Error closing reputer nonce", "error", closeErr)
+				updateErr = closeErr
 			}
 		}
 	}
-	return err
+	return updateErr
 }
 
 // Prune reputer and worker nonces

--- a/x/emissions/module/rewards/nonce_management_test.go
+++ b/x/emissions/module/rewards/nonce_management_test.go
@@ -2,11 +2,77 @@ package rewards_test
 
 import (
 	"cosmossdk.io/collections"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	actorutils "github.com/allora-network/allora-chain/x/emissions/keeper/actor_utils"
+	"github.com/allora-network/allora-chain/x/emissions/module/rewards"
 	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	"github.com/allora-network/allora-chain/x/emissions/types"
 )
+
+func countReputerSubmissionWindowOpenedEvents(s *RewardsTestSuite, eventStart int) int {
+	count := 0
+	for _, event := range s.Ctx().EventManager().Events()[eventStart:] {
+		if event.Type == "emissions.v10.EventReputerSubmissionWindowOpened" {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *RewardsTestSuite) TestUpdateReputerNonceWaitsUntilWindowEnd() {
+	topic := s.MockTopic()
+	topic.Id = 9_000_001
+	topic.EpochLength = 100
+	topic.GroundTruthLag = 130
+	nonce := types.Nonce{BlockHeight: 1000}
+
+	err := s.NonceKeeper().AddReputerNonce(s.Ctx(), topic.Id, &nonce)
+	s.Require().NoError(err)
+
+	oldCloseBlock := nonce.BlockHeight + topic.GroundTruthLag + topic.EpochLength
+	s.WithBlockHeight(oldCloseBlock)
+	err = rewards.UpdateReputerNonce(s.Ctx(), *s.EmissionsKeeper(), topic, oldCloseBlock)
+	s.Require().NoError(err)
+
+	unfulfilled, err := s.NonceKeeper().IsReputerNonceUnfulfilled(s.Ctx(), topic.Id, &nonce)
+	s.Require().NoError(err)
+	s.Require().True(unfulfilled)
+}
+
+func (s *RewardsTestSuite) TestUpdateReputerNonceReturnsCloseError() {
+	topic := s.MockTopic()
+	topic.Id = 9_000_002
+	topic.EpochLength = 100
+	topic.GroundTruthLag = 100
+	nonce := types.Nonce{BlockHeight: 1000}
+
+	err := s.NonceKeeper().AddReputerNonce(s.Ctx(), topic.Id, &nonce)
+	s.Require().NoError(err)
+
+	windowEnd := nonce.BlockHeight + topic.GroundTruthLag + topic.EpochLength
+	s.WithBlockHeight(windowEnd)
+	err = rewards.UpdateReputerNonce(s.Ctx(), *s.EmissionsKeeper(), topic, windowEnd)
+	s.Require().ErrorIs(err, sdkerrors.ErrNotFound)
+}
+
+func (s *RewardsTestSuite) TestUpdateReputerNonceEmitsMissedOpenEventWithinWindow() {
+	topic := s.MockTopic()
+	topic.Id = 9_000_003
+	topic.EpochLength = 100
+	topic.GroundTruthLag = 130
+	nonce := types.Nonce{BlockHeight: 1000}
+
+	err := s.NonceKeeper().AddReputerNonce(s.Ctx(), topic.Id, &nonce)
+	s.Require().NoError(err)
+
+	eventStart := len(s.Ctx().EventManager().Events())
+	block := int64(1250)
+	s.WithBlockHeight(block)
+	err = rewards.UpdateReputerNonce(s.Ctx(), *s.EmissionsKeeper(), topic, block)
+	s.Require().NoError(err)
+	s.Require().Equal(1, countReputerSubmissionWindowOpenedEvents(s, eventStart))
+}
 
 // Test defer execution of CloseReputerNonce
 func (s *RewardsTestSuite) TestCloseReputerNonceTest_DeferExecWhenError() {


### PR DESCRIPTION
## Bug

Reputer submission windows overlap when a topic's `ground_truth_lag` is not a whole multiple of `epoch_length`. `extraLag = epoch_length - (ground_truth_lag % epoch_length)` (zero when it divides evenly).

`UpdateReputerNonce` closes a nonce on the topic's own epoch grid, at the first grid block `>= nonce+ground_truth_lag+epoch_length`, which for an uninterrupted grid is exactly `nonce+ground_truth_lag+extraLag+epoch_length`. But the reputer submission window's *lower* bound (`BlockWithinReputerSubmissionWindowOfNonce`) was `nonce+ground_truth_lag` — `extraLag` blocks *before* that. So the next nonce's window opened while the previous nonce was still open.

A reputer submitting during that overlap stores its bundle for the *newer* nonce. `lossBundles` is keyed `(topic_id, reputer)` with no nonce, so when the *older* nonce closes, `CloseReputerNonce` reads that bundle, `CalcNetworkLosses` skips every report whose `ReputerRequestNonce.BlockHeight` doesn't match the nonce being closed, `SumWeight` stays zero, and it fails permanently with `"Sum weight for loss is 0"`. The topic then never produces `EventNetworkLossSet` again, and since `SetTopicRewardNonce` is only reached on success, it pays no further rewards. Every reputer transaction still succeeds, because it's accepted for the *next* nonce — the failure is silent except for this error.

Topics with an evenly-dividing lag never see this (`extraLag == 0`), which is why it doesn't affect all topics.

## Live confirmation

Grepped a running testnet validator's own logs just now (not simulated):

```json
{"level":"warn","expected":10839023,"actual":10839077,"reputer":"allo1…905s9ps","message":"Reputer bundle has incorrect block height"}
{"level":"error","topicId":69,"nonce":{"block_height":10839023},"error":"Error normalizing combined loss: Sum weight for loss is 0: fraction: divide by zero","message":"Error occurred before finalization in CloseReputerNonce, attempting cleanup anyway"}
{"level":"error","error":"Error normalizing combined loss: Sum weight for loss is 0: fraction: divide by zero","message":"Error closing reputer nonce"}
```

`actual - expected` equals the topic's own `epoch_length` in every occurrence (54 for topic 69 above). Firing repeatedly, live, on testnet topics 38, 41, 42, 64 and 69 (93 occurrences in one log pull). Also confirmed via chain state: for these topics, the bundle stored under any recently-closed nonce carries `reputer_nonce.block_height == closed_nonce + epoch_length`; topics with an evenly-dividing lag show `0`. Mainnet currently has no topic with a fractional lag, so it isn't exposed today, but nothing prevents creating one.

## Fix

`x/emissions/keeper/window_boundaries.go`: `lowerBound := revealedGroundTruthBlock + extraLag`. The window now opens at the end of the epoch in which ground truth is revealed, matching where the previous nonce actually closes, rather than at the revelation itself.

Extracted the bounds into one function, `ReputerSubmissionWindowBounds`, since the formula was previously duplicated across four call sites and the one that drifted (the acceptance lower bound) is what caused this:
- The topic query server (`GetReputerSubmissionWindowStatus`) was still computing the old bound and would have advertised a window as open that the message server rejects — fixed to use the shared helper.
- The "window not open" error message previously reported wrong bounds unconditionally (start omitted `extraLag`, end used `epoch_length*2` instead of `epoch_length`) — now reports the real bounds.
- The window-opened event previously used its own separate range (`[reveal, reveal+extraLag]`) that no longer aligns with the fixed acceptance start after a topic is reactivated with a shifted epoch grid — an executable test reproduces the exact gap (event fires at a block where a submission would still be rejected) and the fix makes the event fire only at the true window start.

## Testing

- 3 pre-existing test expectations in `window_boundaries_test.go` re-derived for the new bounds (moved, not weakened — verified each old assertion still has a home); added regression cases for the overlap itself and the event/accept-gap.
- Query server test re-derived for the same reason.
- New `ReputerSubmissionWindowBounds` unit tests, including the invariant that consecutive windows tile with no gap and no overlap (`prevWindowEnd == thisWindowStart`).
- Mutation-tested: reverting the lower-bound change fails the keeper and queryserver suites.
- Full suite: `go test ./x/emissions/...` — 21/21 packages pass.
- End-to-end: drove the real `EndBlocker` and message servers over many epochs for a fractional-lag topic on `origin/dev` (traps, matching production) vs this branch (does not trap); an aligned-lag control is unchanged on both.

## Known residual, disclosed rather than hidden

A one-block overlap remains at the exact close/open boundary block, because `DeliverTx` executes before `EndBlock` in the same block — a transaction for the next nonce can still be included in the same block that closes the previous one. This is not new: it already exists identically on every topic whose lag divides evenly, and this PR does not change that shared behavior. Closing it fully would need either a nonce-aware reset in `CloseReputerNonce` or shifting every topic's boundary by one block, both bigger changes deserving their own review.

## Consensus impact

This changes transaction acceptance (`MsgInsertReputerPayload` succeeds/fails differently at some block heights than before), so it requires a coordinated upgrade height. No store migration; `ConsensusVersion` is unchanged. `CHANGELOG.md` flags it under `### Security`.
