### PR TITLE
ENGN-9339 Topic weight totalsum substraction error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 Short, high-signal guidance for working in the `allora-chain` repo. Keep context small and only load extra docs when needed.
 
 ## Quick Rules (Apply To Most Changes)
+- Worktree/branch names: descriptive, problem-named; never random word-pairs.
 - Determinism: no `time.Now()`/`rand`, no map-order dependence, no floats in consensus; use `alloraMath.Dec`/`sdk.Int`/`sdk.Dec` and stable iteration.
 - State access: keepers are the only state access point; no IO, goroutines, or non-determinism inside keepers.
 - Validation: `ValidateBasic` + keeper stateful checks; use `sdkerrors/errorsmod` for typed errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* [#994](https://github.com/allora-network/allora-chain/pull/TBD) Fix bug on accumulated topic weight sum which could drift when unstaking from an inactive topic.
+* [#994](https://github.com/allora-network/allora-chain/pull/994) Fix bug on accumulated topic weight sum which could drift when unstaking from an inactive topic.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [#TBD](https://github.com/allora-network/allora-chain/pull/TBD) Fix bug on accumulated topic weight sum which could drift when unstaking from an inactive topic.
+
 ### Security
 
 * [#980](https://github.com/allora-network/allora-chain/pull/980) Patch a fast-node cache/commit race in `iavl` that caused `AppHash` divergence: the ecosystem treasury account is deleted every block at zero balance, and a concurrent balance query during commit could read its value one block stale, minting the wrong amount and forking the node. Points `iavl` at `github.com/allora-network/iavl` (`v1.2.6` + backport of [cosmos/iavl#1142](https://github.com/cosmos/iavl/pull/1142)). Not consensus-breaking; no migration required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* [#TBD](https://github.com/allora-network/allora-chain/pull/TBD) Fix bug on accumulated topic weight sum which could drift when unstaking from an inactive topic.
+* [#994](https://github.com/allora-network/allora-chain/pull/TBD) Fix bug on accumulated topic weight sum which could drift when unstaking from an inactive topic.
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 Short, high-signal guidance for working in the `allora-chain` repo. Keep context small and only load extra docs when needed.
 
 ## Quick Rules (Apply To Most Changes)
+- Worktree/branch names: descriptive, problem-named; never random word-pairs.
 - Determinism: no `time.Now()`/`rand`, no map-order dependence, no floats in consensus; use `alloraMath.Dec`/`sdk.Int`/`sdk.Dec` and stable iteration.
 - State access: keepers are the only state access point; no IO, goroutines, or non-determinism inside keepers.
 - Validation: `ValidateBasic` + keeper stateful checks; use `sdkerrors/errorsmod` for typed errors.

--- a/test/fuzz/inferences_test.go
+++ b/test/fuzz/inferences_test.go
@@ -203,7 +203,8 @@ func createWorkerDataBundle(
 	}
 	infererAddress := inferer.addr
 	infererValue := alloraMath.MustNewBoundedExp40Dec(alloraMath.NewDecFromInt64(int64(m.Client.Rand.Intn(300) + 3000)))
-	infererValues := []*emissionstypes.InputLabeledValue{{Value: infererValue}}
+	// Single-arity submissions must carry the canonical sentinel label.
+	infererValues := []*emissionstypes.InputLabeledValue{{Label: emissionstypes.SingleArityCanonicalLabel, Value: infererValue}}
 
 	workerDataBundle := &emissionstypes.InputWorkerDataBundle{
 		Worker: infererAddress,

--- a/x/emissions/keeper/invariants.go
+++ b/x/emissions/keeper/invariants.go
@@ -19,6 +19,7 @@ func RegisterInvariants(ir sdk.InvariantRegistry, k *Keeper) {
 	ir.RegisterRoute(emissionstypes.ModuleName, "stake-removals-length-same", StakingInvariantLenStakeRemovalsSame(*k))
 	ir.RegisterRoute(emissionstypes.ModuleName, "stake-sum-delegated-stakes", StakingInvariantDelegatedStakes(*k))
 	ir.RegisterRoute(emissionstypes.ModuleName, "pending-reward-for-delegators-equal-reward-per-share-minus-reward-debt", StakingInvariantPendingRewardForDelegatorsGreaterThanRewardPerShareMinusRewardDebt(*k))
+	ir.RegisterRoute(emissionstypes.ModuleName, "total-sum-previous-topic-weights-equal-active-topics-sum", TopicInvariantTotalSumPreviousTopicWeightsEqualActiveTopicsSum(*k))
 }
 
 // AllInvariants is a convience function to run all invariants in the emissions module.
@@ -39,7 +40,57 @@ func AllInvariants(k Keeper) sdk.Invariant {
 		if res, stop := StakingInvariantPendingRewardForDelegatorsGreaterThanRewardPerShareMinusRewardDebt(k)(ctx); stop {
 			return res, stop
 		}
+		if res, stop := TopicInvariantTotalSumPreviousTopicWeightsEqualActiveTopicsSum(k)(ctx); stop {
+			return res, stop
+		}
 		return "", false
+	}
+}
+
+// TopicInvariantTotalSumPreviousTopicWeightsEqualActiveTopicsSum checks that
+// totalSumPreviousTopicWeights equals the sum of the stored previous weights
+// of the topics in the active set. Inactive topics keep their stored weight
+// but must not be counted.
+func TopicInvariantTotalSumPreviousTopicWeightsEqualActiveTopicsSum(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		iter, err := k.topicKeeper.activeTopics.Iterate(ctx, nil)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get active topics iterator: %v", err))
+		}
+		defer iter.Close()
+
+		activeSum := alloraMath.ZeroDec()
+		for ; iter.Valid(); iter.Next() {
+			topicId, err := iter.Key()
+			if err != nil {
+				panic(fmt.Sprintf("failed to get active topic id: %v", err))
+			}
+			weight, noPrior, err := k.topicKeeper.GetPreviousTopicWeight(ctx, topicId)
+			if err != nil {
+				panic(fmt.Sprintf("failed to get previous topic weight for topic %d: %v", topicId, err))
+			}
+			if noPrior {
+				continue
+			}
+			activeSum, err = activeSum.Add(weight)
+			if err != nil {
+				panic(fmt.Sprintf("failed to add previous topic weight for topic %d: %v", topicId, err))
+			}
+		}
+
+		totalSum, err := k.topicKeeper.GetTotalSumPreviousTopicWeights(ctx)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get total sum of previous topic weights: %v", err))
+		}
+		broken := !totalSum.Equal(activeSum)
+		return sdk.FormatInvariant(
+			emissionstypes.ModuleName,
+			"total sum of previous topic weights equal sum over active topics",
+			fmt.Sprintf("TotalSumPreviousTopicWeights: %s | Sum of previous weights of active topics: %s",
+				totalSum.String(),
+				activeSum.String(),
+			),
+		), broken
 	}
 }
 

--- a/x/emissions/keeper/invariants_test.go
+++ b/x/emissions/keeper/invariants_test.go
@@ -1,0 +1,89 @@
+package keeper_test
+
+import (
+	cosmosMath "cosmossdk.io/math"
+
+	alloraMath "github.com/allora-network/allora-chain/math"
+	"github.com/allora-network/allora-chain/x/emissions/keeper"
+	"github.com/allora-network/allora-chain/x/emissions/testutil"
+	"github.com/allora-network/allora-chain/x/emissions/types"
+)
+
+// TestTopicInvariantTotalSumPreviousTopicWeightsEqualActiveTopicsSum walks a topic through
+// activation, inactivation and a stake removal while inactive, checking the invariant holds at
+// every step, and then checks that a corrupted total is detected.
+func (s *KeeperTestSuite) TestTopicInvariantTotalSumPreviousTopicWeightsEqualActiveTopicsSum() {
+	ctx := s.Ctx()
+	k := s.TopicKeeper()
+	invariant := keeper.TopicInvariantTotalSumPreviousTopicWeightsEqualActiveTopicsSum(*s.EmissionsKeeper())
+	reputerAddr := s.AddrsStr(0)
+	stakeAmount := cosmosMath.NewInt(1000)
+	epochLength := int64(100)
+
+	params := types.DefaultParams()
+	params.TopicRewardAlpha = alloraMath.MustNewDecFromString("0.5")
+	params.TopicRewardStakeImportance = alloraMath.OneDec()
+	params.TopicRewardFeeRevenueImportance = alloraMath.OneDec()
+	params.MaxActiveTopicsPerBlock = 2
+	err := s.ParamsKeeper().SetParams(ctx, params)
+	s.Require().NoError(err)
+
+	assertHolds := func(step string) {
+		msg, broken := invariant(ctx)
+		s.Require().False(broken, "invariant broken after %s: %s", step, msg)
+	}
+
+	assertHolds("empty state")
+
+	stayingTopicId := s.CreateTopic(testutil.WithEpochLength(epochLength), testutil.WithWorkerSubmissionWindow(epochLength))
+	churnedTopicId := s.CreateTopic(testutil.WithEpochLength(epochLength), testutil.WithWorkerSubmissionWindow(epochLength))
+	for _, topicId := range []uint64{stayingTopicId, churnedTopicId} {
+		err = k.ActivateTopic(ctx, topicId)
+		s.Require().NoError(err)
+		err = s.StakingKeeper().AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
+		s.Require().NoError(err)
+		err = k.AddTopicFeeRevenue(ctx, topicId, cosmosMath.NewInt(100))
+		s.Require().NoError(err)
+		weight, _, _, err := k.GetCurrentTopicWeight(
+			ctx, topicId, epochLength,
+			params.TopicRewardAlpha, params.TopicRewardStakeImportance, params.TopicRewardFeeRevenueImportance, params.BlocksPerMonth,
+		)
+		s.Require().NoError(err)
+		err = k.SetPreviousTopicWeight(ctx, topicId, weight)
+		s.Require().NoError(err)
+	}
+	assertHolds("two active topics with weights")
+
+	err = k.InactivateTopic(ctx, churnedTopicId)
+	s.Require().NoError(err)
+	assertHolds("inactivation")
+
+	moduleParams, err := s.ParamsKeeper().GetParams(ctx)
+	s.Require().NoError(err)
+	endBlock := ctx.BlockHeight() + moduleParams.RemoveStakeDelayWindow
+	err = s.StakingKeeper().SetStakeRemoval(ctx, types.StakeRemovalInfo{
+		TopicId:               churnedTopicId,
+		Reputer:               reputerAddr,
+		Amount:                stakeAmount,
+		BlockRemovalStarted:   ctx.BlockHeight(),
+		BlockRemovalCompleted: endBlock,
+	})
+	s.Require().NoError(err)
+	err = s.StakingKeeper().RemoveReputerStake(ctx, endBlock, churnedTopicId, reputerAddr, stakeAmount)
+	s.Require().NoError(err)
+	assertHolds("stake removal from inactive topic")
+
+	err = k.ActivateTopic(ctx, churnedTopicId)
+	s.Require().NoError(err)
+	assertHolds("reactivation")
+
+	// A drifted total must be reported.
+	totalSum, err := k.GetTotalSumPreviousTopicWeights(ctx)
+	s.Require().NoError(err)
+	drifted, err := totalSum.Add(alloraMath.OneDec())
+	s.Require().NoError(err)
+	err = k.SetTotalSumPreviousTopicWeights(ctx, drifted)
+	s.Require().NoError(err)
+	_, broken := invariant(ctx)
+	s.Require().True(broken, "a drifted total sum must break the invariant")
+}

--- a/x/emissions/keeper/topic.go
+++ b/x/emissions/keeper/topic.go
@@ -473,6 +473,31 @@ func (k *TopicKeeper) SetActiveTopics(ctx context.Context, topicId TopicId) erro
 	return k.activeTopics.Set(ctx, topicId)
 }
 
+// IsTopicInActiveSet reports whether the topic is a member of the active topic set.
+// Membership in this set is what decides whether the topic's previous weight is
+// counted in totalSumPreviousTopicWeights.
+func (k *TopicKeeper) IsTopicInActiveSet(ctx context.Context, topicId TopicId) (bool, error) {
+	return k.activeTopics.Has(ctx, topicId)
+}
+
+// GetActiveTopicIds returns the members of the active topic set in ascending id order.
+func (k *TopicKeeper) GetActiveTopicIds(ctx context.Context) ([]TopicId, error) {
+	iter, err := k.activeTopics.Iterate(ctx, nil)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to iterate active topics")
+	}
+	defer iter.Close()
+	topicIds := make([]TopicId, 0)
+	for ; iter.Valid(); iter.Next() {
+		topicId, err := iter.Key()
+		if err != nil {
+			return nil, errorsmod.Wrap(err, "failed to get active topic id")
+		}
+		topicIds = append(topicIds, topicId)
+	}
+	return topicIds, nil
+}
+
 // wrapper for set operation around blockToActiveTopics
 func (k *TopicKeeper) SetBlockToActiveTopics(ctx context.Context, block BlockHeight, topicIds types.TopicIds) error {
 	if err := types.ValidateBlockHeight(block); err != nil {
@@ -531,8 +556,11 @@ func (k *TopicKeeper) GetNextPossibleChurningBlockByTopicId(ctx context.Context,
 	return block, block >= currentBlock, nil
 }
 
-// UpdateTopicWeightAfterStakeChange updates the topic weight and total sum of previous topic weights
-// after a stake change occurs, if there is no prior topic weight. This is used by both RemoveReputerStake and RemoveDelegateStake.
+// UpdateTopicWeightAfterStakeChange recomputes the topic weight after a stake change and stores it
+// as the previous topic weight. The total sum of previous topic weights is only adjusted for topics
+// in the active set: an inactive topic already had its weight removed from the sum on inactivation
+// and only keeps the stored value for reactivation, so touching the sum again would subtract it twice.
+// Topics that never had a weight are left untouched.
 func (k *TopicKeeper) UpdateTopicWeightAfterStakeChange(
 	ctx context.Context,
 	topicId TopicId,
@@ -575,9 +603,21 @@ func (k *TopicKeeper) UpdateTopicWeightAfterStakeChange(
 		return errorsmod.Wrap(err, "error calculating new topic weight")
 	}
 
-	// Update previous topic weight and total sum
-	if err := k.SetPreviousTopicWeight(ctx, topicId, newWeight); err != nil {
-		return errorsmod.Wrapf(err, "Setting previous topic weight failed")
+	isActive, err := k.IsTopicInActiveSet(ctx, topicId)
+	if err != nil {
+		return errorsmod.Wrap(err, "error checking topic active set membership")
+	}
+	if isActive {
+		if err := k.SetPreviousTopicWeight(ctx, topicId, newWeight); err != nil {
+			return errorsmod.Wrapf(err, "Setting previous topic weight failed")
+		}
+	} else {
+		if err := types.ValidateDec(newWeight); err != nil {
+			return errorsmod.Wrap(err, "weight validation failed")
+		}
+		if err := k.previousTopicWeight.Set(ctx, topicId, newWeight); err != nil {
+			return errorsmod.Wrap(err, "Setting previous topic weight of inactive topic failed")
+		}
 	}
 
 	// Emit topic weight updated event

--- a/x/emissions/keeper/topic_test.go
+++ b/x/emissions/keeper/topic_test.go
@@ -696,6 +696,207 @@ func (s *KeeperTestSuite) TestRemoveTopicFromPreviousTopicWeights() {
 	s.Require().True(finalTotalSum.Equal(newTotalSum), "Total sum should remain unchanged after removing non-existent topic")
 }
 
+// TestUpdateTopicWeightAfterStakeChangeOnInactiveTopic verifies that removing stake from an
+// inactive topic refreshes its stored weight but does not touch totalSumPreviousTopicWeights.
+// Inactivation already removed the topic's weight from the sum while keeping the stored value
+// for reactivation, so a stake removal must not subtract it a second time.
+func (s *KeeperTestSuite) TestUpdateTopicWeightAfterStakeChangeOnInactiveTopic() {
+	stakeAmount := cosmosMath.NewInt(1000)
+	feeRevenue := cosmosMath.NewInt(100)
+	epochLength := int64(100)
+
+	testCases := []struct {
+		name        string
+		addStake    func(topicId uint64)
+		removeStake func(topicId uint64)
+	}{
+		{
+			name: "reputer stake removal",
+			addStake: func(topicId uint64) {
+				err := s.StakingKeeper().AddReputerStake(s.Ctx(), topicId, s.AddrsStr(0), stakeAmount)
+				s.Require().NoError(err)
+			},
+			removeStake: func(topicId uint64) {
+				ctx := s.Ctx()
+				moduleParams, err := s.ParamsKeeper().GetParams(ctx)
+				s.Require().NoError(err)
+				endBlock := ctx.BlockHeight() + moduleParams.RemoveStakeDelayWindow
+				err = s.StakingKeeper().SetStakeRemoval(ctx, types.StakeRemovalInfo{
+					TopicId:               topicId,
+					Reputer:               s.AddrsStr(0),
+					Amount:                stakeAmount,
+					BlockRemovalStarted:   ctx.BlockHeight(),
+					BlockRemovalCompleted: endBlock,
+				})
+				s.Require().NoError(err)
+				err = s.StakingKeeper().RemoveReputerStake(ctx, endBlock, topicId, s.AddrsStr(0), stakeAmount)
+				s.Require().NoError(err)
+			},
+		},
+		{
+			name: "delegate stake removal",
+			addStake: func(topicId uint64) {
+				err := s.StakingKeeper().AddDelegateStake(s.Ctx(), topicId, s.AddrsStr(1), s.AddrsStr(0), stakeAmount)
+				s.Require().NoError(err)
+			},
+			removeStake: func(topicId uint64) {
+				ctx := s.Ctx()
+				moduleParams, err := s.ParamsKeeper().GetParams(ctx)
+				s.Require().NoError(err)
+				endBlock := ctx.BlockHeight() + moduleParams.RemoveStakeDelayWindow
+				err = s.StakingKeeper().SetDelegateStakeRemoval(ctx, types.DelegateStakeRemovalInfo{
+					BlockRemovalStarted:   ctx.BlockHeight(),
+					BlockRemovalCompleted: endBlock,
+					TopicId:               topicId,
+					Delegator:             s.AddrsStr(1),
+					Reputer:               s.AddrsStr(0),
+					Amount:                stakeAmount,
+				})
+				s.Require().NoError(err)
+				err = s.StakingKeeper().RemoveDelegateStake(ctx, endBlock, topicId, s.AddrsStr(1), s.AddrsStr(0), stakeAmount)
+				s.Require().NoError(err)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			ctx := s.Ctx()
+			k := s.TopicKeeper()
+
+			params := types.DefaultParams()
+			params.TopicRewardAlpha = alloraMath.MustNewDecFromString("0.5")
+			params.TopicRewardStakeImportance = alloraMath.OneDec()
+			params.TopicRewardFeeRevenueImportance = alloraMath.OneDec()
+			// Both topics must fit in the active set, otherwise activating the second churns the first.
+			params.MaxActiveTopicsPerBlock = 2
+			err := s.ParamsKeeper().SetParams(ctx, params)
+			s.Require().NoError(err)
+
+			// Two active topics so the sum is non-trivial: one stays active, one gets inactivated.
+			stayingTopicId := s.CreateTopic(testutil.WithEpochLength(epochLength), testutil.WithWorkerSubmissionWindow(epochLength))
+			churnedTopicId := s.CreateTopic(testutil.WithEpochLength(epochLength), testutil.WithWorkerSubmissionWindow(epochLength))
+			for _, topicId := range []uint64{stayingTopicId, churnedTopicId} {
+				err = k.ActivateTopic(ctx, topicId)
+				s.Require().NoError(err)
+				tc.addStake(topicId)
+				err = k.AddTopicFeeRevenue(ctx, topicId, feeRevenue)
+				s.Require().NoError(err)
+				weight, _, _, err := k.GetCurrentTopicWeight(
+					ctx, topicId, epochLength,
+					params.TopicRewardAlpha, params.TopicRewardStakeImportance, params.TopicRewardFeeRevenueImportance, params.BlocksPerMonth,
+				)
+				s.Require().NoError(err)
+				err = k.SetPreviousTopicWeight(ctx, topicId, weight)
+				s.Require().NoError(err)
+			}
+
+			churnedWeight, noPrior, err := k.GetPreviousTopicWeight(ctx, churnedTopicId)
+			s.Require().NoError(err)
+			s.Require().False(noPrior)
+			s.Require().False(churnedWeight.IsZero())
+
+			sumWhileBothActive, err := k.GetTotalSumPreviousTopicWeights(ctx)
+			s.Require().NoError(err)
+
+			err = k.InactivateTopic(ctx, churnedTopicId)
+			s.Require().NoError(err)
+			sumAfterInactivation, err := k.GetTotalSumPreviousTopicWeights(ctx)
+			s.Require().NoError(err)
+			expectedAfterInactivation, err := sumWhileBothActive.Sub(churnedWeight)
+			s.Require().NoError(err)
+			s.Require().Equal(expectedAfterInactivation.String(), sumAfterInactivation.String(),
+				"inactivation must remove the topic weight from the sum exactly once")
+
+			tc.removeStake(churnedTopicId)
+
+			sumAfterRemoval, err := k.GetTotalSumPreviousTopicWeights(ctx)
+			s.Require().NoError(err)
+			s.Require().Equal(sumAfterInactivation.String(), sumAfterRemoval.String(),
+				"stake removal on an inactive topic must not change the sum")
+
+			refreshedWeight, noPrior, err := k.GetPreviousTopicWeight(ctx, churnedTopicId)
+			s.Require().NoError(err)
+			s.Require().False(noPrior, "stored weight must be kept for reactivation")
+			s.Require().NotEqual(churnedWeight.String(), refreshedWeight.String(),
+				"stored weight must reflect the reduced stake")
+
+			// Reactivation re-adds exactly the refreshed stored weight.
+			err = k.ActivateTopic(ctx, churnedTopicId)
+			s.Require().NoError(err)
+			sumAfterReactivation, err := k.GetTotalSumPreviousTopicWeights(ctx)
+			s.Require().NoError(err)
+			expectedAfterReactivation, err := sumAfterInactivation.Add(refreshedWeight)
+			s.Require().NoError(err)
+			s.Require().Equal(expectedAfterReactivation.String(), sumAfterReactivation.String())
+		})
+	}
+}
+
+// TestRemoveStakeFromInactiveTopicWhenSumIsSmaller covers the case where the stale stored
+// weight exceeds the current sum. A second subtraction would drive the sum negative and make
+// the stake removal fail permanently, so the removal must succeed and leave the sum untouched.
+func (s *KeeperTestSuite) TestRemoveStakeFromInactiveTopicWhenSumIsSmaller() {
+	ctx := s.Ctx()
+	k := s.TopicKeeper()
+	reputerAddr := s.AddrsStr(0)
+	stakeAmount := cosmosMath.NewInt(1000)
+	epochLength := int64(100)
+
+	params := types.DefaultParams()
+	params.TopicRewardAlpha = alloraMath.MustNewDecFromString("0.5")
+	params.TopicRewardStakeImportance = alloraMath.OneDec()
+	params.TopicRewardFeeRevenueImportance = alloraMath.OneDec()
+	params.MaxActiveTopicsPerBlock = 2
+	err := s.ParamsKeeper().SetParams(ctx, params)
+	s.Require().NoError(err)
+
+	// Single topic: after inactivation the sum is zero while the stored weight is not.
+	topicId := s.CreateTopic(testutil.WithEpochLength(epochLength), testutil.WithWorkerSubmissionWindow(epochLength))
+	err = k.ActivateTopic(ctx, topicId)
+	s.Require().NoError(err)
+	err = s.StakingKeeper().AddReputerStake(ctx, topicId, reputerAddr, stakeAmount)
+	s.Require().NoError(err)
+	err = k.AddTopicFeeRevenue(ctx, topicId, cosmosMath.NewInt(100))
+	s.Require().NoError(err)
+	weight, _, _, err := k.GetCurrentTopicWeight(
+		ctx, topicId, epochLength,
+		params.TopicRewardAlpha, params.TopicRewardStakeImportance, params.TopicRewardFeeRevenueImportance, params.BlocksPerMonth,
+	)
+	s.Require().NoError(err)
+	err = k.SetPreviousTopicWeight(ctx, topicId, weight)
+	s.Require().NoError(err)
+
+	err = k.InactivateTopic(ctx, topicId)
+	s.Require().NoError(err)
+	sum, err := k.GetTotalSumPreviousTopicWeights(ctx)
+	s.Require().NoError(err)
+	s.Require().True(sum.IsZero())
+
+	moduleParams, err := s.ParamsKeeper().GetParams(ctx)
+	s.Require().NoError(err)
+	endBlock := ctx.BlockHeight() + moduleParams.RemoveStakeDelayWindow
+	err = s.StakingKeeper().SetStakeRemoval(ctx, types.StakeRemovalInfo{
+		TopicId:               topicId,
+		Reputer:               reputerAddr,
+		Amount:                stakeAmount,
+		BlockRemovalStarted:   ctx.BlockHeight(),
+		BlockRemovalCompleted: endBlock,
+	})
+	s.Require().NoError(err)
+
+	err = s.StakingKeeper().RemoveReputerStake(ctx, endBlock, topicId, reputerAddr, stakeAmount)
+	s.Require().NoError(err, "stake removal must not fail because of the topic weight bookkeeping")
+
+	remaining, err := s.StakingKeeper().GetStakeReputerAuthority(ctx, topicId, reputerAddr)
+	s.Require().NoError(err)
+	s.Require().True(remaining.IsZero())
+	sum, err = k.GetTotalSumPreviousTopicWeights(ctx)
+	s.Require().NoError(err)
+	s.Require().True(sum.IsZero(), "an inactive topic must not contribute to the sum")
+}
+
 // TestUpdateTopic_RejectsLabelCaseSensitiveChange pins the keeper-level guard
 // that LabelCaseSensitive is immutable after topic creation. The msgserver
 // rebuilds updatedTopic from the stored topic, so this branch is only reachable

--- a/x/emissions/migrations/v16/migrate.go
+++ b/x/emissions/migrations/v16/migrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/allora-network/allora-chain/x/emissions/keeper"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
@@ -19,7 +20,9 @@ import (
 // parameter. Existing topics decode this new field as zero and are backfilled
 // with the current on-chain global value so their admission behavior is
 // unchanged after the upgrade. It also backfills the new
-// Params.MinTopInferersToReward floor.
+// Params.MinTopInferersToReward floor and recomputes totalSumPreviousTopicWeights
+// from the active topic set so any drift accumulated by the incremental
+// bookkeeping is cleared.
 func MigrateStore(ctx sdk.Context, emissionsKeeper keeper.Keeper) error {
 	ctx.Logger().Info("STARTING EMISSIONS MODULE MIGRATION FROM VERSION 15 TO VERSION 16")
 	storageService := emissionsKeeper.GetStorageService()
@@ -38,7 +41,62 @@ func MigrateStore(ctx sdk.Context, emissionsKeeper keeper.Keeper) error {
 		return err
 	}
 
+	if err := MigrateTotalSumPreviousTopicWeights(ctx, emissionsKeeper); err != nil {
+		ctx.Logger().Error("ERROR INVOKING MIGRATION HANDLER MigrateTotalSumPreviousTopicWeights() FROM VERSION 15 TO VERSION 16")
+		return err
+	}
+
 	ctx.Logger().Info("MIGRATION EMISSIONS MODULE FROM VERSION 15 TO VERSION 16 COMPLETE")
+	return nil
+}
+
+// MigrateTotalSumPreviousTopicWeights recomputes totalSumPreviousTopicWeights as the
+// sum of the stored previous weights of the topics in the active set. The accumulator
+// is otherwise only ever adjusted incrementally, so an earlier bookkeeping error (such as
+// subtracting an inactive topic's weight twice on stake removal) persists in state after
+// the code is fixed. Recomputing from the active set is idempotent and a no-op when the
+// accumulator is already consistent.
+func MigrateTotalSumPreviousTopicWeights(ctx sdk.Context, emissionsKeeper keeper.Keeper) error {
+	topicKeeper := emissionsKeeper.GetTopicKeeper()
+
+	activeTopicIds, err := topicKeeper.GetActiveTopicIds(ctx)
+	if err != nil {
+		return errorsmod.Wrap(err, "MIGRATION V16: failed to get active topic ids")
+	}
+
+	recomputed := alloraMath.ZeroDec()
+	for _, topicId := range activeTopicIds {
+		weight, noPrior, err := topicKeeper.GetPreviousTopicWeight(ctx, topicId)
+		if err != nil {
+			return errorsmod.Wrapf(err, "MIGRATION V16: failed to get previous weight of topic %d", topicId)
+		}
+		if noPrior {
+			continue
+		}
+		recomputed, err = recomputed.Add(weight)
+		if err != nil {
+			return errorsmod.Wrapf(err, "MIGRATION V16: failed to add previous weight of topic %d", topicId)
+		}
+	}
+
+	current, err := topicKeeper.GetTotalSumPreviousTopicWeights(ctx)
+	if err != nil {
+		return errorsmod.Wrap(err, "MIGRATION V16: failed to get total sum of previous topic weights")
+	}
+	if current.Equal(recomputed) {
+		ctx.Logger().Info("MIGRATION V16: total sum of previous topic weights already consistent", "value", current.String())
+		return nil
+	}
+
+	if err := topicKeeper.SetTotalSumPreviousTopicWeights(ctx, recomputed); err != nil {
+		return errorsmod.Wrap(err, "MIGRATION V16: failed to set recomputed total sum of previous topic weights")
+	}
+	ctx.Logger().Info(
+		"MIGRATION V16: total sum of previous topic weights recomputed from active topics",
+		"previous", current.String(),
+		"recomputed", recomputed.String(),
+		"activeTopics", len(activeTopicIds),
+	)
 	return nil
 }
 

--- a/x/emissions/migrations/v16/migrate_test.go
+++ b/x/emissions/migrations/v16/migrate_test.go
@@ -11,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 
+	alloraMath "github.com/allora-network/allora-chain/math"
 	v16 "github.com/allora-network/allora-chain/x/emissions/migrations/v16"
 	"github.com/allora-network/allora-chain/x/emissions/testutil"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
@@ -305,4 +306,81 @@ func (s *EmissionsV16MigrationTestSuite) TestMigrateStoreWithZeroCeilingAndFloor
 	s.Require().NoError(err)
 	s.Require().Equal(emissionstypes.DefaultParams().MaxTopInferersToReward, repaired.MaxTopInferersToReward)
 	s.Require().Equal(emissionstypes.DefaultMinTopInferersToReward, repaired.MinTopInferersToReward)
+}
+
+// seedTopicWeights creates the given topics, activates the ones flagged active and
+// stores a distinct previous weight for every topic. It returns the sum of the
+// weights of the active topics, which is what the accumulator must equal.
+func (s *EmissionsV16MigrationTestSuite) seedTopicWeights(active []bool) alloraMath.Dec {
+	params, err := s.EmissionsKeeper().GetParams(s.Ctx())
+	s.Require().NoError(err)
+	params.MaxActiveTopicsPerBlock = uint64(len(active))
+	s.Require().NoError(s.EmissionsKeeper().SetParams(s.Ctx(), params))
+
+	expected := alloraMath.ZeroDec()
+	for i, isActive := range active {
+		topicId := s.CreateTopic()
+		weight := alloraMath.NewDecFromInt64(int64((i + 1) * 100))
+		if isActive {
+			s.Require().NoError(s.TopicKeeper().ActivateTopic(s.Ctx(), topicId))
+			expected, err = expected.Add(weight)
+			s.Require().NoError(err)
+		}
+		s.Require().NoError(s.TopicKeeper().SetPreviousTopicWeight(s.Ctx(), topicId, weight))
+		if !isActive {
+			// Mirror inactivation bookkeeping: the weight stays stored but leaves the sum.
+			s.Require().NoError(s.TopicKeeper().RemoveTopicFromPreviousTopicWeights(s.Ctx(), topicId))
+		}
+	}
+	return expected
+}
+
+func (s *EmissionsV16MigrationTestSuite) totalSum() alloraMath.Dec {
+	total, err := s.TopicKeeper().GetTotalSumPreviousTopicWeights(s.Ctx())
+	s.Require().NoError(err)
+	return total
+}
+
+// a drifted accumulator is reset to the sum over active topics; inactive topics
+// keep their stored weight but do not count.
+func (s *EmissionsV16MigrationTestSuite) TestMigrateTotalSumPreviousTopicWeightsRepairsDrift() {
+	expected := s.seedTopicWeights([]bool{true, false, true})
+	s.Require().Equal(expected.String(), s.totalSum().String())
+
+	drifted, err := expected.Sub(alloraMath.NewDecFromInt64(150))
+	s.Require().NoError(err)
+	s.Require().NoError(s.TopicKeeper().SetTotalSumPreviousTopicWeights(s.Ctx(), drifted))
+
+	s.Require().NoError(v16.MigrateTotalSumPreviousTopicWeights(s.Ctx(), *s.EmissionsKeeper()))
+	s.Require().Equal(expected.String(), s.totalSum().String())
+}
+
+// a consistent accumulator is left as is and a second run changes nothing.
+func (s *EmissionsV16MigrationTestSuite) TestMigrateTotalSumPreviousTopicWeightsIdempotent() {
+	expected := s.seedTopicWeights([]bool{true, true})
+
+	s.Require().NoError(v16.MigrateTotalSumPreviousTopicWeights(s.Ctx(), *s.EmissionsKeeper()))
+	s.Require().Equal(expected.String(), s.totalSum().String())
+	s.Require().NoError(v16.MigrateTotalSumPreviousTopicWeights(s.Ctx(), *s.EmissionsKeeper()))
+	s.Require().Equal(expected.String(), s.totalSum().String())
+}
+
+// with no active topics the accumulator is reset to zero.
+func (s *EmissionsV16MigrationTestSuite) TestMigrateTotalSumPreviousTopicWeightsNoActiveTopics() {
+	s.seedTopicWeights([]bool{false, false})
+	s.Require().NoError(s.TopicKeeper().SetTotalSumPreviousTopicWeights(s.Ctx(), alloraMath.NewDecFromInt64(42)))
+
+	s.Require().NoError(v16.MigrateTotalSumPreviousTopicWeights(s.Ctx(), *s.EmissionsKeeper()))
+	s.Require().True(s.totalSum().IsZero())
+}
+
+// the top-level MigrateStore entry point also repairs the accumulator.
+func (s *EmissionsV16MigrationTestSuite) TestMigrateStoreRepairsTotalSumPreviousTopicWeights() {
+	expected := s.seedTopicWeights([]bool{true, false})
+	drifted, err := expected.Add(alloraMath.NewDecFromInt64(7))
+	s.Require().NoError(err)
+	s.Require().NoError(s.TopicKeeper().SetTotalSumPreviousTopicWeights(s.Ctx(), drifted))
+
+	s.Require().NoError(v16.MigrateStore(s.Ctx(), *s.EmissionsKeeper()))
+	s.Require().Equal(expected.String(), s.totalSum().String())
 }


### PR DESCRIPTION
## Purpose of Changes and their Description

`totalSumPreviousTopicWeights` (the cross-topic denominator used to split block emissions) was decremented twice when reputer or delegator stake was removed from an **inactive** topic. Inactivation already subtracts the topic's stored weight from the sum but keeps the stored value for reactivation; `UpdateTopicWeightAfterStakeChange` then called `SetPreviousTopicWeight`, which does `sum - oldStored + new`, subtracting the stale weight a second time. The sum ends up undercounted, every active topic is over-paid, and once `sum < staleWeight` the removal itself fails with "total sum of previous topic weights cannot be negative", blocking the withdrawal.

Changes:
- `UpdateTopicWeightAfterStakeChange` now branches on active-set membership (new `IsTopicInActiveSet`): active topics keep the current behaviour; inactive topics only refresh the stored weight and leave the sum untouched. Membership in `activeTopics` is what the sum tracks, so that is the predicate used (not the churning-block based `IsTopicActive`).
- New invariant `TopicInvariantTotalSumPreviousTopicWeightsEqualActiveTopicsSum` (`sum == Σ previousTopicWeight over active topics`), registered and added to `AllInvariants` so the fuzzer's `invariants.patch` evaluates it every EndBlock.
- v16 migration: `MigrateTotalSumPreviousTopicWeights` recomputes the sum from the active set. Idempotent and a no-op when consistent; no extra `ConsensusVersion` bump (v16 is unreleased). Mainnet showed exact equality at three heights, so this is defensive against the window until v0.18.0 ships.
- `scripts/measure_total_topic_weights_drift.sh`: queries the accumulator and the recomputed sum at a pinned height and reports drift.
- Fuzz harness: worker inferences now carry the canonical single-arity label `"y"` (required since #942; the harness had silently rotted).

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

- ENGN-9339
- Sibling fix on the activation path (double add): ENGN-9368

## Are these changes tested and documented?

- [x] Tested. Keeper tests `TestUpdateTopicWeightAfterStakeChangeOnInactiveTopic` (reputer and delegate paths; reproduced the exact double subtraction before the fix) and `TestRemoveStakeFromInactiveTopicWhenSumIsSmaller` (confirms the blocked-withdrawal aggravation); invariant test covering activation → inactivation → stake removal → reactivation plus corrupted-sum detection; four v16 migration tests (repairs drift, idempotent, no active topics, full `MigrateStore`). Mainnet drift measured at heights 10644471, 10844471 and 10853630: zero. Fuzz campaign (300 iterations, 861 blocks, invariants patch applied) with 0 invariant panics; note the inactive-topic stake-removal path was not reached by the fuzzer and is covered by the deterministic tests only.
- [x] Documented in code comments (`UpdateTopicWeightAfterStakeChange`, the invariant, the migration). No user-facing docs needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`.

## Still Left Todo

- Replace `#TBD` in the CHANGELOG entry with this PR number.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the double subtraction of `totalSumPreviousTopicWeights` when stake is removed from an inactive topic (ENGN-9339). Inactivation removes the topic's stored weight from the sum but keeps it for reactivation, and stake removal then subtracted that stale weight a second time, undercounting the emissions denominator and eventually blocking the withdrawal once the sum went negative. Stake removals on inactive topics now refresh only the stored weight and leave the accumulator untouched; active topics keep the existing behavior.

**Bug Fixes**
- `UpdateTopicWeightAfterStakeChange` branches on active-set membership (`IsTopicInActiveSet`): active topics update the sum, inactive topics do not.
- Adds `TopicInvariantTotalSumPreviousTopicWeightsEqualActiveTopicsSum`, registered in `AllInvariants`, asserting the accumulator equals the sum over active topics.
- Fuzz harness worker inferences now carry the canonical single-arity label `"y"`.

**Migration**
- v16 `MigrateTotalSumPreviousTopicWeights` recomputes the accumulator from the active set and is idempotent; mainnet showed no drift, so it is defensive.

<sup>Written for commit 97cde8ca686bfc7190cb4d98a04d023a1f8558e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-chain/pull/994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

